### PR TITLE
Fix frontend-backend connection by adding NEXT_PUBLIC_SOCKET_URL

### DIFF
--- a/concord-frontend/Dockerfile
+++ b/concord-frontend/Dockerfile
@@ -19,9 +19,11 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-# Build argument for API URL
+# Build arguments for API and Socket URLs
 ARG NEXT_PUBLIC_API_URL=http://localhost:5050
+ARG NEXT_PUBLIC_SOCKET_URL=http://localhost:5050
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_SOCKET_URL=$NEXT_PUBLIC_SOCKET_URL
 
 # Build Next.js app
 RUN npm run build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       dockerfile: Dockerfile
       args:
         - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-https://concord-os.org}
+        - NEXT_PUBLIC_SOCKET_URL=${NEXT_PUBLIC_SOCKET_URL:-https://concord-os.org}
     container_name: concord-frontend
     restart: unless-stopped
     environment:


### PR DESCRIPTION
The frontend websocket was falling back to localhost:5050 because NEXT_PUBLIC_SOCKET_URL was not being set during Docker build.

https://claude.ai/code/session_01Y1HNXoxDSexeLJEroosv6Z