### PR TITLE
Remove deploy-preview job from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,24 +165,3 @@ jobs:
           API_BASE: http://localhost:5050
         run: |
           node --test tests/auth-security.test.js || true
-
-  deploy-preview:
-    name: Deploy Preview
-    runs-on: ubuntu-latest
-    needs: [integration-test]
-    if: github.event_name == 'pull_request'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Deploy preview comment
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '## CI Passed\n\nAll checks passed. Ready to merge when approved.'
-            })


### PR DESCRIPTION
The GitHub Actions token lacks permission to post PR comments. Removed this optional cosmetic feature to prevent CI failures.

https://claude.ai/code/session_01Y1HNXoxDSexeLJEroosv6Z