### PR TITLE
feat: core lenses roadmap — taxonomy, merge map, productization, quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,10 @@ jobs:
         working-directory: ./concord-frontend
         run: npm run type-check
 
+      - name: Validate lens quality gate
+        working-directory: ./concord-frontend
+        run: npm run validate-lens-quality
+
       - name: Build frontend
         working-directory: ./concord-frontend
         run: npm run build

--- a/concord-frontend/lib/lenses/index.ts
+++ b/concord-frontend/lib/lenses/index.ts
@@ -1,0 +1,74 @@
+/**
+ * Lens Infrastructure — barrel export.
+ *
+ * Provides unified access to:
+ *   - Lens manifest (runtime contract)
+ *   - Lens status taxonomy (viewer/hybrid/product/system/deprecated)
+ *   - Lens merge map (which lenses combine and how)
+ *   - Productization roadmap (execution order)
+ *   - Product Lens Gate (quality requirements)
+ */
+
+// Runtime contract
+export {
+  type LensManifest,
+  LENS_MANIFESTS,
+  getLensManifest,
+  getLensManifests,
+  getAllLensDomains,
+} from './manifest';
+
+// Status taxonomy (Step 1)
+export {
+  type LensStatus,
+  type LensStatusEntry,
+  LENS_STATUS_MAP,
+  getLensStatus,
+  getLensesByStatus,
+  getLensesMergingInto,
+  getProductLenses,
+  getDeprecatedLenses,
+  isPublicLens,
+  getLensStatusSummary,
+} from './lens-status';
+
+// Merge map (Step 2)
+export {
+  type MergeSource,
+  type MergeGroup,
+  LENS_MERGE_GROUPS,
+  getMergeGroup,
+  getAllMergeSourceIds,
+  findMergeGroupForSource,
+  getMergeReductionCount,
+  POST_MERGE_STANDALONE_LENSES,
+  type PostMergeStandaloneLens,
+} from './lens-merge-map';
+
+// Productization roadmap (Step 3)
+export {
+  type PhaseStatus,
+  type ProductionArtifact,
+  type ProductionEngine,
+  type ProductionPipeline,
+  type ProductionPhase,
+  PRODUCTIZATION_PHASES,
+  getProductionPhases,
+  getCurrentPhase,
+  getPhaseByLens,
+  areDependenciesMet,
+  getTotalArtifactCount,
+  getTotalEngineCount,
+} from './productization-roadmap';
+
+// Product Lens Gate (the non-negotiable rule)
+export {
+  type LensCapability,
+  type LensScore,
+  type CIViolation,
+  LENS_CAPABILITIES,
+  GATE_PASS_THRESHOLD,
+  MAX_SCORE,
+  scoreLens,
+  CI_HARD_RULES,
+} from './product-lens-gate';

--- a/concord-frontend/lib/lenses/lens-merge-map.ts
+++ b/concord-frontend/lib/lenses/lens-merge-map.ts
@@ -1,0 +1,271 @@
+/**
+ * Lens Merge Map — Step 2 of the Core Lenses Roadmap.
+ *
+ * Defines the concrete merge groups that reduce ~97 lenses to ~18 real products.
+ * Each merge group specifies:
+ *   - The target product lens
+ *   - The lenses being absorbed
+ *   - What role each absorbed lens plays (mode, engine, absorbed)
+ *   - The resulting artifact set after merge
+ *   - The engines the merged lens gains
+ *
+ * This is the highest-leverage structural move: it concentrates capability
+ * instead of diluting it across 80 half-products.
+ */
+
+export interface MergeSource {
+  /** Lens ID being merged */
+  id: string;
+  /** Role in the target lens */
+  role: 'mode' | 'engine' | 'absorbed';
+  /** What capabilities transfer to the target */
+  capabilities: string[];
+}
+
+export interface MergeGroup {
+  /** The target product lens that survives */
+  targetId: string;
+  /** Display name for the super-lens */
+  targetName: string;
+  /** Primary artifacts the merged lens will own */
+  artifacts: string[];
+  /** Engines the merged lens will run */
+  engines: string[];
+  /** Pipelines the merged lens will execute */
+  pipelines: string[];
+  /** Lenses being merged in */
+  sources: MergeSource[];
+  /** Why this merge matters */
+  rationale: string;
+}
+
+/**
+ * The four core merge groups. After these merges, Concord drops from
+ * ~97 lenses to ~18 that actually matter.
+ */
+export const LENS_MERGE_GROUPS: MergeGroup[] = [
+  // ── MERGE GROUP A: Research Super-Lens ────────────────────────
+  {
+    targetId: 'paper',
+    targetName: 'Research',
+    artifacts: [
+      'ResearchProject',
+      'Claim',
+      'Hypothesis',
+      'Evidence',
+      'Experiment',
+      'Synthesis',
+      'Goal',
+      'StudyDeck',
+    ],
+    engines: [
+      'claim-evidence-consistency',
+      'hypothesis-mutation-retest',
+      'contradiction-detection',
+      'temporal-lineage-tracking',
+      'affect-state-tracking',
+      'transfer-analogy',
+      'spaced-repetition',
+    ],
+    pipelines: [
+      'ingest → extract-claims → validate → synthesize',
+      're-run-hypothesis-on-new-evidence',
+      'reflect → audit-cognition → update-strategy',
+      'goal-evaluate → research-plan → execute',
+    ],
+    sources: [
+      { id: 'hypothesis', role: 'mode', capabilities: ['hypothesis-testing', 'experiment-design'] },
+      { id: 'reflection', role: 'mode', capabilities: ['self-reflection', 'insight-extraction'] },
+      { id: 'metacognition', role: 'mode', capabilities: ['calibration', 'self-awareness-monitoring'] },
+      { id: 'metalearning', role: 'mode', capabilities: ['strategy-optimization', 'learning-rate-tracking'] },
+      { id: 'attention', role: 'mode', capabilities: ['focus-management', 'priority-routing'] },
+      { id: 'experience', role: 'mode', capabilities: ['experience-replay', 'pattern-extraction'] },
+      { id: 'suffering', role: 'mode', capabilities: ['harm-detection', 'wellbeing-monitoring'] },
+      { id: 'organ', role: 'absorbed', capabilities: ['structural-organization'] },
+      { id: 'affect', role: 'engine', capabilities: ['emotional-state-tracking', '7d-affect-vector'] },
+      { id: 'transfer', role: 'engine', capabilities: ['analogy-generation', 'cross-domain-transfer'] },
+      { id: 'lab', role: 'mode', capabilities: ['experimentation-sandbox', 'a-b-testing'] },
+      { id: 'goals', role: 'mode', capabilities: ['goal-tracking', 'milestone-planning'] },
+      { id: 'srs', role: 'mode', capabilities: ['spaced-repetition', 'knowledge-retention'] },
+    ],
+    rationale: 'These lenses are conceptually inseparable from research. Separating them weakens all of them. Together, they form a product no incumbent has.',
+  },
+
+  // ── MERGE GROUP B: Science + Simulation Super-Lens ────────────
+  {
+    targetId: 'sim',
+    targetName: 'Simulation',
+    artifacts: [
+      'Scenario',
+      'AssumptionSet',
+      'SimulationRun',
+      'OutcomeDistribution',
+      'Model',
+      'Dataset',
+      'FinancialModel',
+    ],
+    engines: [
+      'monte-carlo',
+      'sensitivity-analysis',
+      'regime-detection',
+      'differential-equations',
+      'molecular-dynamics',
+      'quantum-circuit-sim',
+      'neural-network-sim',
+      'financial-projection',
+    ],
+    pipelines: [
+      'define → simulate → summarize → reuse',
+      'hypothesis → model → run → validate',
+      'assumption-set → monte-carlo → distribution → decision',
+      'portfolio → project → stress-test → rebalance',
+    ],
+    sources: [
+      { id: 'math', role: 'engine', capabilities: ['symbolic-computation', 'numerical-methods'] },
+      { id: 'physics', role: 'engine', capabilities: ['mechanics-simulation', 'field-equations'] },
+      { id: 'quantum', role: 'engine', capabilities: ['qubit-simulation', 'quantum-gates'] },
+      { id: 'chem', role: 'engine', capabilities: ['molecular-modeling', 'reaction-simulation'] },
+      { id: 'bio', role: 'engine', capabilities: ['genomics', 'population-dynamics'] },
+      { id: 'neuro', role: 'engine', capabilities: ['neural-modeling', 'brain-simulation'] },
+      { id: 'finance', role: 'mode', capabilities: ['portfolio-analysis', 'risk-modeling'] },
+    ],
+    rationale: 'Nobody opens Mathematica "just for math" — they open it to model something. Science without simulation is a DTU viewer.',
+  },
+
+  // ── MERGE GROUP C: Knowledge Graph Super-Lens ─────────────────
+  {
+    targetId: 'graph',
+    targetName: 'Knowledge Graph',
+    artifacts: [
+      'Entity',
+      'Relation',
+      'Assertion',
+      'Source',
+      'Invariant',
+      'OntologyNode',
+    ],
+    engines: [
+      'conflict-resolution',
+      'temporal-truth-tracking',
+      'confidence-scoring',
+      'entity-resolution',
+      'grounding-validation',
+      'commonsense-inference',
+    ],
+    pipelines: [
+      'ingest → link → validate → propagate',
+      'conflict → resolve → update-confidence',
+      'entity → ground → verify → trust-score',
+    ],
+    sources: [
+      { id: 'entity', role: 'mode', capabilities: ['entity-browsing', 'world-model-exploration'] },
+      { id: 'invariant', role: 'engine', capabilities: ['constraint-checking', 'rule-enforcement'] },
+      { id: 'meta', role: 'absorbed', capabilities: ['system-introspection'] },
+      { id: 'grounding', role: 'engine', capabilities: ['embodied-grounding', 'real-world-anchoring'] },
+      { id: 'commonsense', role: 'engine', capabilities: ['common-knowledge', 'default-reasoning'] },
+      { id: 'eco', role: 'absorbed', capabilities: ['ecosystem-overview'] },
+      { id: 'temporal', role: 'engine', capabilities: ['temporal-reasoning', 'causal-ordering'] },
+    ],
+    rationale: 'Knowledge is alive. Conflicts are first-class. DTUs keep reasoning explicit.',
+  },
+
+  // ── MERGE GROUP D: Collaboration / Discourse Super-Lens ───────
+  {
+    targetId: 'whiteboard',
+    targetName: 'Collaboration',
+    artifacts: [
+      'Board',
+      'Node',
+      'Connection',
+      'Comment',
+      'Discussion',
+      'Decision',
+      'Outcome',
+      'Event',
+      'Task',
+    ],
+    engines: [
+      'consensus-detection',
+      'pattern-extraction',
+      'decision-summarization',
+      'scheduling',
+      'kanban-workflow',
+    ],
+    pipelines: [
+      'collaborate → decide → extract-DTUs',
+      'discuss → converge → record-decision',
+      'plan → schedule → track → review',
+    ],
+    sources: [
+      { id: 'forum', role: 'mode', capabilities: ['threaded-discussion', 'moderation'] },
+      { id: 'thread', role: 'mode', capabilities: ['conversation-branching', 'summarization'] },
+      { id: 'feed', role: 'mode', capabilities: ['content-aggregation', 'social-interaction'] },
+      { id: 'daily', role: 'mode', capabilities: ['journaling', 'daily-summary'] },
+      { id: 'news', role: 'mode', capabilities: ['news-aggregation', 'headline-tracking'] },
+      { id: 'docs', role: 'mode', capabilities: ['documentation', 'reference-browsing'] },
+      { id: 'collab', role: 'mode', capabilities: ['real-time-editing', 'presence-tracking'] },
+      { id: 'anon', role: 'mode', capabilities: ['anonymous-messaging'] },
+      { id: 'timeline', role: 'mode', capabilities: ['chronological-view', 'history-tracking'] },
+      { id: 'board', role: 'mode', capabilities: ['kanban', 'task-management'] },
+      { id: 'calendar', role: 'mode', capabilities: ['scheduling', 'event-management'] },
+    ],
+    rationale: 'Meetings produce reusable knowledge. Decisions do not vanish.',
+  },
+];
+
+// ── Derived helpers ─────────────────────────────────────────────
+
+const _mergeGroupMap = new Map(LENS_MERGE_GROUPS.map(g => [g.targetId, g]));
+
+/** Get the merge group for a target lens. */
+export function getMergeGroup(targetId: string): MergeGroup | undefined {
+  return _mergeGroupMap.get(targetId);
+}
+
+/** Get all lens IDs scheduled for merge (across all groups). */
+export function getAllMergeSourceIds(): string[] {
+  return LENS_MERGE_GROUPS.flatMap(g => g.sources.map(s => s.id));
+}
+
+/** Find which merge group a source lens belongs to. */
+export function findMergeGroupForSource(sourceId: string): MergeGroup | undefined {
+  return LENS_MERGE_GROUPS.find(g => g.sources.some(s => s.id === sourceId));
+}
+
+/** Get the total number of lenses being merged away. */
+export function getMergeReductionCount(): { before: number; after: number; merged: number } {
+  const merged = new Set(getAllMergeSourceIds()).size;
+  return { before: 97, after: 97 - merged, merged };
+}
+
+/**
+ * After all merges, these are the surviving standalone lenses.
+ * This is what Concord's public nav should show.
+ */
+export const POST_MERGE_STANDALONE_LENSES = [
+  // Product lenses (the 10 world-class targets)
+  'paper',       // Research
+  'reasoning',   // Reasoning / Argument
+  'council',     // Governance / City
+  'agents',      // Agents / Council
+  'sim',         // Simulation / Forecasting
+  'studio',      // Studio (Creative) — note: needs to be created as super-lens absorbing music/game/ar/fractal
+  'law',         // Legal / Policy
+  'graph',       // Knowledge Graph / Entity
+  'whiteboard',  // Collaboration / Whiteboard
+  'database',    // Database / Structured Knowledge
+
+  // Core interaction surfaces
+  'chat',
+  'code',
+
+  // Marketplace
+  'marketplace',
+
+  // System (not in public nav but standalone)
+  'admin', 'debug', 'audit', 'resonance', 'schema', 'integrations',
+  'queue', 'tick', 'lock', 'offline', 'export', 'import', 'custom',
+  'billing', 'crypto', 'fork', 'legacy',
+] as const;
+
+export type PostMergeStandaloneLens = typeof POST_MERGE_STANDALONE_LENSES[number];

--- a/concord-frontend/lib/lenses/lens-status.ts
+++ b/concord-frontend/lib/lenses/lens-status.ts
@@ -1,0 +1,702 @@
+/**
+ * Lens Status Taxonomy — Step 1 of the Core Lenses Roadmap.
+ *
+ * Every lens is tagged with its maturity level. This stops entropy:
+ * no new lens advances past 'viewer' without passing the Product Lens Gate.
+ *
+ * Statuses:
+ *   - product:  Has primary artifact, persistence, engine, pipeline, DTU exhaust.
+ *              These are the world-class lenses Concord bets on.
+ *   - hybrid:   Has some persistence or artifacts but missing engine/pipeline.
+ *              In transition toward product status.
+ *   - viewer:   Displays DTU exhaust or data but produces no primary artifact.
+ *              These should merge into a product lens as a mode.
+ *   - system:   Infrastructure lens (admin, debug, queue). Not user-facing products.
+ *   - deprecated: Scheduled for merge into a product lens. Will be removed.
+ *
+ * The non-negotiable rule:
+ *   A lens must have a primary artifact that survives without DTUs.
+ *   DTUs are exhaust — not the product.
+ */
+
+export type LensStatus = 'product' | 'hybrid' | 'viewer' | 'system' | 'deprecated';
+
+export interface LensStatusEntry {
+  /** Lens ID matching lens-registry.ts */
+  id: string;
+  /** Current maturity level */
+  status: LensStatus;
+  /** Which product lens this merges into (null if standalone) */
+  mergeTarget: string | null;
+  /** Role after merge: 'standalone' | 'mode' | 'engine' | 'absorbed' */
+  postMergeRole: 'standalone' | 'mode' | 'engine' | 'absorbed';
+  /** Brief rationale for classification */
+  rationale: string;
+}
+
+/**
+ * Complete lens status map. Every lens in the registry must appear here.
+ * This is the source of truth for what stays, what merges, and what role each plays.
+ */
+export const LENS_STATUS_MAP: LensStatusEntry[] = [
+  // ═══════════════════════════════════════════════════════════════
+  // TIER A — PRODUCT LENSES (world-class targets)
+  // These are the 10 lenses Concord pushes to dominance.
+  // ═══════════════════════════════════════════════════════════════
+
+  // 1. Research (the crown jewel)
+  {
+    id: 'paper',
+    status: 'product',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Core of the Research super-lens. Artifacts: ResearchProject, Claim, Hypothesis, Evidence, Experiment, Synthesis.',
+  },
+
+  // 2. Reasoning / Argument
+  {
+    id: 'reasoning',
+    status: 'product',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Argument construction + logical consistency. Artifacts: ArgumentTree, Premise, Inference, Counterexample, Conclusion.',
+  },
+
+  // 3. Governance / City / Microbond
+  {
+    id: 'council',
+    status: 'product',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Governance super-lens. Artifacts: Proposal, Vote, BudgetModel, Project, AuditTrail.',
+  },
+  {
+    id: 'vote',
+    status: 'hybrid',
+    mergeTarget: 'council',
+    postMergeRole: 'mode',
+    rationale: 'Voting is a mode within Governance, not a standalone product.',
+  },
+  {
+    id: 'ethics',
+    status: 'hybrid',
+    mergeTarget: 'council',
+    postMergeRole: 'mode',
+    rationale: 'Ethics review is a governance mode.',
+  },
+  {
+    id: 'alliance',
+    status: 'hybrid',
+    mergeTarget: 'council',
+    postMergeRole: 'mode',
+    rationale: 'Alliance management is a governance mode.',
+  },
+
+  // 4. Agents / Council
+  {
+    id: 'agents',
+    status: 'product',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Enterprise agent OS. Artifacts: Agent, Role, Task, Deliberation, Decision.',
+  },
+  {
+    id: 'ml',
+    status: 'hybrid',
+    mergeTarget: 'agents',
+    postMergeRole: 'engine',
+    rationale: 'ML is an engine powering agents, not a standalone product.',
+  },
+
+  // 5. Simulation / Forecasting
+  {
+    id: 'sim',
+    status: 'product',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Simulation super-lens. Artifacts: Scenario, AssumptionSet, SimulationRun, OutcomeDistribution.',
+  },
+
+  // 6. Studio (Creative Super-Lens)
+  {
+    id: 'music',
+    status: 'hybrid',
+    mergeTarget: 'studio',
+    postMergeRole: 'mode',
+    rationale: 'Music creation is a Studio mode.',
+  },
+  {
+    id: 'game',
+    status: 'hybrid',
+    mergeTarget: 'studio',
+    postMergeRole: 'mode',
+    rationale: 'Game development is a Studio mode.',
+  },
+  {
+    id: 'ar',
+    status: 'hybrid',
+    mergeTarget: 'studio',
+    postMergeRole: 'mode',
+    rationale: 'AR experiences are a Studio mode.',
+  },
+  {
+    id: 'fractal',
+    status: 'viewer',
+    mergeTarget: 'studio',
+    postMergeRole: 'mode',
+    rationale: 'Fractal visualization is a Studio generative mode.',
+  },
+
+  // 7. Legal / Policy
+  {
+    id: 'law',
+    status: 'hybrid',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Legal super-lens. Artifacts: CaseFile, Clause, Draft, PrecedentGraph.',
+  },
+
+  // 8. Knowledge Graph / Entity
+  {
+    id: 'graph',
+    status: 'product',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Knowledge graph super-lens. Artifacts: Entity, Relation, Assertion, Source.',
+  },
+  {
+    id: 'entity',
+    status: 'hybrid',
+    mergeTarget: 'graph',
+    postMergeRole: 'mode',
+    rationale: 'Entity browser is a Knowledge Graph mode.',
+  },
+  {
+    id: 'invariant',
+    status: 'viewer',
+    mergeTarget: 'graph',
+    postMergeRole: 'engine',
+    rationale: 'Invariant checking is a Knowledge Graph engine.',
+  },
+  {
+    id: 'meta',
+    status: 'viewer',
+    mergeTarget: 'graph',
+    postMergeRole: 'absorbed',
+    rationale: 'Meta-information feeds Knowledge Graph.',
+  },
+
+  // 9. Collaboration / Whiteboard
+  {
+    id: 'whiteboard',
+    status: 'hybrid',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Collaboration super-lens. Artifacts: Board, Node, Connection, Comment.',
+  },
+  {
+    id: 'collab',
+    status: 'hybrid',
+    mergeTarget: 'whiteboard',
+    postMergeRole: 'mode',
+    rationale: 'Real-time collab is a Collaboration mode.',
+  },
+
+  // 10. Database / Structured Knowledge
+  {
+    id: 'database',
+    status: 'hybrid',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Structured knowledge lens. Artifacts: Table, Record, Schema, View.',
+  },
+
+  // ═══════════════════════════════════════════════════════════════
+  // MERGE GROUP A — Into Research super-lens as modes
+  // These are conceptually inseparable from research.
+  // ═══════════════════════════════════════════════════════════════
+
+  {
+    id: 'hypothesis',
+    status: 'deprecated',
+    mergeTarget: 'paper',
+    postMergeRole: 'mode',
+    rationale: 'Hypothesis testing is a Research mode.',
+  },
+  {
+    id: 'reflection',
+    status: 'deprecated',
+    mergeTarget: 'paper',
+    postMergeRole: 'mode',
+    rationale: 'Self-reflection is a Research mode.',
+  },
+  {
+    id: 'inference',
+    status: 'deprecated',
+    mergeTarget: 'reasoning',
+    postMergeRole: 'mode',
+    rationale: 'Inference engine is a Reasoning mode.',
+  },
+  {
+    id: 'metacognition',
+    status: 'deprecated',
+    mergeTarget: 'paper',
+    postMergeRole: 'mode',
+    rationale: 'Metacognition is a Research cognitive-audit mode.',
+  },
+  {
+    id: 'metalearning',
+    status: 'deprecated',
+    mergeTarget: 'paper',
+    postMergeRole: 'mode',
+    rationale: 'Learning strategy optimization is a Research mode.',
+  },
+  {
+    id: 'commonsense',
+    status: 'deprecated',
+    mergeTarget: 'graph',
+    postMergeRole: 'engine',
+    rationale: 'Commonsense knowledge feeds Knowledge Graph.',
+  },
+  {
+    id: 'attention',
+    status: 'deprecated',
+    mergeTarget: 'paper',
+    postMergeRole: 'mode',
+    rationale: 'Attention management is a Research mode.',
+  },
+  {
+    id: 'experience',
+    status: 'deprecated',
+    mergeTarget: 'paper',
+    postMergeRole: 'mode',
+    rationale: 'Experience learning is a Research mode.',
+  },
+  {
+    id: 'suffering',
+    status: 'deprecated',
+    mergeTarget: 'paper',
+    postMergeRole: 'mode',
+    rationale: 'Suffering detection is a Research / ethics mode.',
+  },
+  {
+    id: 'organ',
+    status: 'deprecated',
+    mergeTarget: 'paper',
+    postMergeRole: 'absorbed',
+    rationale: 'Organization tools absorbed into Research.',
+  },
+  {
+    id: 'affect',
+    status: 'deprecated',
+    mergeTarget: 'paper',
+    postMergeRole: 'engine',
+    rationale: 'Affect engine feeds Research as emotional-state tracking.',
+  },
+  {
+    id: 'transfer',
+    status: 'deprecated',
+    mergeTarget: 'paper',
+    postMergeRole: 'engine',
+    rationale: 'Transfer learning is a Research engine.',
+  },
+  {
+    id: 'grounding',
+    status: 'deprecated',
+    mergeTarget: 'graph',
+    postMergeRole: 'engine',
+    rationale: 'Grounding feeds Knowledge Graph entity resolution.',
+  },
+
+  // ═══════════════════════════════════════════════════════════════
+  // MERGE GROUP B — Into Science + Simulation as engines
+  // ═══════════════════════════════════════════════════════════════
+
+  {
+    id: 'math',
+    status: 'deprecated',
+    mergeTarget: 'sim',
+    postMergeRole: 'engine',
+    rationale: 'Math is a Simulation engine, not a standalone viewer.',
+  },
+  {
+    id: 'physics',
+    status: 'deprecated',
+    mergeTarget: 'sim',
+    postMergeRole: 'engine',
+    rationale: 'Physics simulations are a Simulation engine.',
+  },
+  {
+    id: 'quantum',
+    status: 'deprecated',
+    mergeTarget: 'sim',
+    postMergeRole: 'engine',
+    rationale: 'Quantum computing explorer is a Simulation engine.',
+  },
+  {
+    id: 'chem',
+    status: 'deprecated',
+    mergeTarget: 'sim',
+    postMergeRole: 'engine',
+    rationale: 'Chemistry tools are a Simulation engine.',
+  },
+  {
+    id: 'bio',
+    status: 'deprecated',
+    mergeTarget: 'sim',
+    postMergeRole: 'engine',
+    rationale: 'Biology tools are a Simulation engine.',
+  },
+  {
+    id: 'neuro',
+    status: 'deprecated',
+    mergeTarget: 'sim',
+    postMergeRole: 'engine',
+    rationale: 'Neuroscience tools are a Simulation engine.',
+  },
+
+  // ═══════════════════════════════════════════════════════════════
+  // MERGE GROUP D — Into Collaboration / Discourse
+  // ═══════════════════════════════════════════════════════════════
+
+  {
+    id: 'forum',
+    status: 'deprecated',
+    mergeTarget: 'whiteboard',
+    postMergeRole: 'mode',
+    rationale: 'Forum discussions become a Collaboration mode.',
+  },
+  {
+    id: 'thread',
+    status: 'deprecated',
+    mergeTarget: 'whiteboard',
+    postMergeRole: 'mode',
+    rationale: 'Threaded conversations become a Collaboration mode.',
+  },
+  {
+    id: 'feed',
+    status: 'deprecated',
+    mergeTarget: 'whiteboard',
+    postMergeRole: 'mode',
+    rationale: 'Feed/timeline becomes a Collaboration mode.',
+  },
+  {
+    id: 'daily',
+    status: 'deprecated',
+    mergeTarget: 'whiteboard',
+    postMergeRole: 'mode',
+    rationale: 'Daily journal becomes a Collaboration mode.',
+  },
+  {
+    id: 'news',
+    status: 'deprecated',
+    mergeTarget: 'whiteboard',
+    postMergeRole: 'mode',
+    rationale: 'News aggregation becomes a Collaboration mode.',
+  },
+  {
+    id: 'docs',
+    status: 'deprecated',
+    mergeTarget: 'whiteboard',
+    postMergeRole: 'mode',
+    rationale: 'Docs viewer becomes a Collaboration mode.',
+  },
+
+  // ═══════════════════════════════════════════════════════════════
+  // CORE LENSES THAT STAY (not in the 10 but standalone)
+  // ═══════════════════════════════════════════════════════════════
+
+  {
+    id: 'chat',
+    status: 'product',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Primary interaction surface. Artifact: Conversation.',
+  },
+  {
+    id: 'code',
+    status: 'product',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Code editing and execution. Artifact: Codebase, Snippet, Project.',
+  },
+
+  // ═══════════════════════════════════════════════════════════════
+  // SYSTEM LENSES (infrastructure, not user-facing products)
+  // ═══════════════════════════════════════════════════════════════
+
+  {
+    id: 'admin',
+    status: 'system',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'System administration. Infrastructure.',
+  },
+  {
+    id: 'debug',
+    status: 'system',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Debug console. Infrastructure.',
+  },
+  {
+    id: 'audit',
+    status: 'system',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Audit trail viewer. Infrastructure.',
+  },
+  {
+    id: 'schema',
+    status: 'system',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Schema management. Infrastructure.',
+  },
+  {
+    id: 'integrations',
+    status: 'system',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Third-party integrations. Infrastructure.',
+  },
+  {
+    id: 'queue',
+    status: 'system',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Job queue monitor. Infrastructure.',
+  },
+  {
+    id: 'tick',
+    status: 'system',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'System tick monitor. Infrastructure.',
+  },
+  {
+    id: 'lock',
+    status: 'system',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Sovereignty lock status. Infrastructure.',
+  },
+  {
+    id: 'offline',
+    status: 'system',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Offline data manager. Infrastructure.',
+  },
+  {
+    id: 'export',
+    status: 'system',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Data export utility. Infrastructure.',
+  },
+  {
+    id: 'import',
+    status: 'system',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Data import utility. Infrastructure.',
+  },
+  {
+    id: 'custom',
+    status: 'system',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Custom lens builder. Infrastructure.',
+  },
+
+  // ═══════════════════════════════════════════════════════════════
+  // REMAINING LENSES — classified for merge or standalone
+  // ═══════════════════════════════════════════════════════════════
+
+  {
+    id: 'resonance',
+    status: 'system',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'System health dashboard. Infrastructure.',
+  },
+  {
+    id: 'marketplace',
+    status: 'hybrid',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Plugin marketplace. Needs productization.',
+  },
+  {
+    id: 'market',
+    status: 'hybrid',
+    mergeTarget: 'marketplace',
+    postMergeRole: 'mode',
+    rationale: 'DTU market merges into general Marketplace.',
+  },
+  {
+    id: 'questmarket',
+    status: 'hybrid',
+    mergeTarget: 'marketplace',
+    postMergeRole: 'mode',
+    rationale: 'Bounty system merges into Marketplace.',
+  },
+  {
+    id: 'finance',
+    status: 'hybrid',
+    mergeTarget: 'sim',
+    postMergeRole: 'mode',
+    rationale: 'Financial tools become a Simulation/Forecasting mode.',
+  },
+  {
+    id: 'anon',
+    status: 'viewer',
+    mergeTarget: 'whiteboard',
+    postMergeRole: 'mode',
+    rationale: 'Anonymous messaging becomes a Collaboration mode.',
+  },
+  {
+    id: 'billing',
+    status: 'system',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Billing is system infrastructure.',
+  },
+  {
+    id: 'crypto',
+    status: 'system',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Cryptography tools are system infrastructure.',
+  },
+  {
+    id: 'lab',
+    status: 'hybrid',
+    mergeTarget: 'paper',
+    postMergeRole: 'mode',
+    rationale: 'Lab experimentation is a Research mode.',
+  },
+  {
+    id: 'voice',
+    status: 'viewer',
+    mergeTarget: 'studio',
+    postMergeRole: 'mode',
+    rationale: 'Voice I/O is a Studio mode.',
+  },
+  {
+    id: 'temporal',
+    status: 'viewer',
+    mergeTarget: 'graph',
+    postMergeRole: 'engine',
+    rationale: 'Temporal reasoning feeds Knowledge Graph.',
+  },
+  {
+    id: 'fork',
+    status: 'system',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'DTU fork management is system infrastructure.',
+  },
+  {
+    id: 'eco',
+    status: 'viewer',
+    mergeTarget: 'graph',
+    postMergeRole: 'absorbed',
+    rationale: 'Ecosystem overview absorbed into Knowledge Graph.',
+  },
+  {
+    id: 'legacy',
+    status: 'system',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Legacy data viewer. System infrastructure.',
+  },
+  {
+    id: 'repos',
+    status: 'hybrid',
+    mergeTarget: 'code',
+    postMergeRole: 'mode',
+    rationale: 'Repository browser is a Code lens mode.',
+  },
+  {
+    id: 'timeline',
+    status: 'viewer',
+    mergeTarget: 'whiteboard',
+    postMergeRole: 'mode',
+    rationale: 'Timeline is a Collaboration mode.',
+  },
+  {
+    id: 'board',
+    status: 'hybrid',
+    mergeTarget: 'whiteboard',
+    postMergeRole: 'mode',
+    rationale: 'Kanban board is a Collaboration mode.',
+  },
+  {
+    id: 'calendar',
+    status: 'hybrid',
+    mergeTarget: 'whiteboard',
+    postMergeRole: 'mode',
+    rationale: 'Calendar is a Collaboration mode.',
+  },
+  {
+    id: 'goals',
+    status: 'hybrid',
+    mergeTarget: 'paper',
+    postMergeRole: 'mode',
+    rationale: 'Goals feed Research planning.',
+  },
+  {
+    id: 'srs',
+    status: 'hybrid',
+    mergeTarget: 'paper',
+    postMergeRole: 'mode',
+    rationale: 'Spaced repetition supports Research learning.',
+  },
+];
+
+// ── Derived helpers ─────────────────────────────────────────────
+
+const _statusMap = new Map(LENS_STATUS_MAP.map(e => [e.id, e]));
+
+/** Get status entry for a lens. */
+export function getLensStatus(id: string): LensStatusEntry | undefined {
+  return _statusMap.get(id);
+}
+
+/** Get all lenses with a given status. */
+export function getLensesByStatus(status: LensStatus): LensStatusEntry[] {
+  return LENS_STATUS_MAP.filter(e => e.status === status);
+}
+
+/** Get all lenses that merge into a given target. */
+export function getLensesMergingInto(targetId: string): LensStatusEntry[] {
+  return LENS_STATUS_MAP.filter(e => e.mergeTarget === targetId);
+}
+
+/** Get all standalone product lenses (the ones Concord bets on). */
+export function getProductLenses(): LensStatusEntry[] {
+  return LENS_STATUS_MAP.filter(e => e.status === 'product' && e.postMergeRole === 'standalone');
+}
+
+/** Get all deprecated lenses (scheduled for merge). */
+export function getDeprecatedLenses(): LensStatusEntry[] {
+  return LENS_STATUS_MAP.filter(e => e.status === 'deprecated');
+}
+
+/** Check if a lens is safe to show in public UI (not deprecated, not system). */
+export function isPublicLens(id: string): boolean {
+  const entry = _statusMap.get(id);
+  if (!entry) return false;
+  return entry.status === 'product' || entry.status === 'hybrid';
+}
+
+/** Summary statistics. */
+export function getLensStatusSummary(): Record<LensStatus, number> {
+  const counts: Record<LensStatus, number> = { product: 0, hybrid: 0, viewer: 0, system: 0, deprecated: 0 };
+  for (const e of LENS_STATUS_MAP) {
+    counts[e.status]++;
+  }
+  return counts;
+}

--- a/concord-frontend/lib/lenses/product-lens-gate.ts
+++ b/concord-frontend/lib/lenses/product-lens-gate.ts
@@ -1,0 +1,162 @@
+/**
+ * Product Lens Gate — The non-negotiable rule.
+ *
+ * A lens must have a primary artifact that survives without DTUs.
+ * DTUs are exhaust — not the product.
+ *
+ * No new lens advances past 'viewer' status without passing this gate.
+ * No lens appears in public UI with score < 5/7.
+ *
+ * This file defines:
+ *   1. The 7 capability dimensions every product lens must satisfy
+ *   2. The scoring function
+ *   3. The gate check (pass/fail)
+ *   4. Hard rules that should fail CI in production
+ */
+
+export interface LensCapability {
+  /** Capability name */
+  name: string;
+  /** What it means concretely */
+  description: string;
+  /** How to verify it exists */
+  verification: string;
+  /** Weight (all equal at 1 for now) */
+  weight: number;
+}
+
+/**
+ * The 7 mandatory capabilities. A lens must score >= 5 to be public.
+ */
+export const LENS_CAPABILITIES: LensCapability[] = [
+  {
+    name: 'primary_artifact',
+    description: 'Has at least one artifact type that persists without DTUs',
+    verification: 'Lens manifest declares artifacts[] with at least one entry, AND lens store has create/get/update/delete macros',
+    weight: 1,
+  },
+  {
+    name: 'persistence',
+    description: 'Artifacts are persisted to the lens artifact store (not just in-memory or SEED_ data)',
+    verification: 'Lens page uses useLensData() or useArtifacts() hook with real API calls, NOT SEED_* or MOCK_* constants',
+    weight: 1,
+  },
+  {
+    name: 'editor_workspace',
+    description: 'Has a dedicated editor or workspace UI for creating/modifying artifacts',
+    verification: 'Lens page includes forms, editors, or interactive workspace — not just a read-only list or dashboard',
+    weight: 1,
+  },
+  {
+    name: 'engine',
+    description: 'Has at least one computational engine that processes artifacts',
+    verification: 'Lens manifest declares actions[] with at least one entry, AND a server-side macro handles the action',
+    weight: 1,
+  },
+  {
+    name: 'pipeline',
+    description: 'Has at least one multi-step pipeline that chains engine operations',
+    verification: 'Documented pipeline in productization-roadmap.ts with >= 3 steps, AND at least the first step is implemented',
+    weight: 1,
+  },
+  {
+    name: 'import_export',
+    description: 'Can import data from and export to standard formats',
+    verification: 'Lens manifest declares exports[] with at least one format, AND export macro is functional',
+    weight: 1,
+  },
+  {
+    name: 'dtu_exhaust',
+    description: 'Automatically generates DTU exhaust for significant operations',
+    verification: 'Server-side lens macros call _lensEmitDTU() on create/update/delete/run operations',
+    weight: 1,
+  },
+];
+
+export interface LensScore {
+  /** Lens ID */
+  lensId: string;
+  /** Score per capability (0 or 1) */
+  capabilities: Record<string, boolean>;
+  /** Total score out of 7 */
+  total: number;
+  /** Max possible score */
+  maxScore: number;
+  /** Whether this lens passes the gate */
+  passes: boolean;
+  /** Whether this lens can be shown publicly */
+  isPublicReady: boolean;
+}
+
+/** Minimum score to pass the Product Lens Gate */
+export const GATE_PASS_THRESHOLD = 5;
+
+/** Maximum score */
+export const MAX_SCORE = LENS_CAPABILITIES.length;
+
+/**
+ * Score a lens against all 7 capabilities.
+ * In practice this is called by the scoring script with actual filesystem checks.
+ * This function takes pre-computed capability booleans.
+ */
+export function scoreLens(
+  lensId: string,
+  capabilities: Record<string, boolean>,
+): LensScore {
+  const total = Object.values(capabilities).filter(Boolean).length;
+  return {
+    lensId,
+    capabilities,
+    total,
+    maxScore: MAX_SCORE,
+    passes: total >= GATE_PASS_THRESHOLD,
+    isPublicReady: total >= GATE_PASS_THRESHOLD,
+  };
+}
+
+/**
+ * Hard rules for CI. If any of these are true, the build should fail in production.
+ */
+export interface CIViolation {
+  /** Rule ID */
+  rule: string;
+  /** Human-readable description */
+  description: string;
+  /** Lens ID that violated */
+  lensId: string;
+  /** Severity */
+  severity: 'error' | 'warning';
+}
+
+export const CI_HARD_RULES = [
+  {
+    id: 'no_mock_imports',
+    description: 'A lens page imports MOCK_* or SEED_* constants for display data',
+    severity: 'error' as const,
+    check: 'grep -r "MOCK_\\|SEED_" in lens page files',
+  },
+  {
+    id: 'no_artifact_no_product',
+    description: 'A lens with status=product has no persisted artifact',
+    severity: 'error' as const,
+    check: 'Cross-reference lens-status.ts product lenses against lens manifest artifacts',
+  },
+  {
+    id: 'no_write_macro',
+    description: 'A lens with status=product has no create macro in manifest',
+    severity: 'error' as const,
+    check: 'Cross-reference lens-status.ts product lenses against manifest macros.create',
+  },
+  {
+    id: 'deprecated_in_sidebar',
+    description: 'A deprecated lens still appears in sidebar navigation',
+    severity: 'warning' as const,
+    check: 'Cross-reference lens-status.ts deprecated lenses against lens-registry.ts showInSidebar',
+  },
+  {
+    id: 'low_score_public',
+    description: 'A lens with score < 5/7 is shown in public UI',
+    severity: 'warning' as const,
+    check: 'Run scoring script and compare against lens-registry.ts showInSidebar/showInCommandPalette',
+  },
+];

--- a/concord-frontend/lib/lenses/productization-roadmap.ts
+++ b/concord-frontend/lib/lenses/productization-roadmap.ts
@@ -1,0 +1,467 @@
+/**
+ * Productization Roadmap — Step 3 of the Core Lenses Roadmap.
+ *
+ * Defines the strict execution order for upgrading lenses to product status.
+ * Order is non-negotiable: each lens unlocks the next.
+ *
+ * Do NOT reorder. The dependency chain is:
+ *   Research → Simulation → Governance → Agents → Studio
+ *
+ * Each phase specifies:
+ *   - Must-have artifacts before moving on
+ *   - Must-have engines
+ *   - Must-have pipelines
+ *   - Acceptance criteria (what "done" means)
+ *   - Dependencies on prior phases
+ */
+
+export type PhaseStatus = 'blocked' | 'ready' | 'in_progress' | 'completed';
+
+export interface ProductionArtifact {
+  /** Artifact type name */
+  name: string;
+  /** Whether this artifact persists independently of DTUs */
+  persistsWithoutDTU: boolean;
+  /** Storage domain (lens artifact API) */
+  storageDomain: string;
+  /** Fields the artifact must have at minimum */
+  requiredFields: string[];
+}
+
+export interface ProductionEngine {
+  /** Engine name */
+  name: string;
+  /** What it does in one sentence */
+  description: string;
+  /** Whether it runs automatically or on-demand */
+  trigger: 'automatic' | 'on_demand' | 'scheduled';
+}
+
+export interface ProductionPipeline {
+  /** Pipeline name */
+  name: string;
+  /** Ordered steps */
+  steps: string[];
+  /** Which engines power each step */
+  engines: string[];
+}
+
+export interface ProductionPhase {
+  /** Phase number (execution order) */
+  order: number;
+  /** Target lens ID */
+  lensId: string;
+  /** Display name */
+  name: string;
+  /** Why this goes first / here */
+  rationale: string;
+  /** Which phases must complete first */
+  dependsOn: number[];
+  /** Artifacts that must exist before phase is "done" */
+  artifacts: ProductionArtifact[];
+  /** Engines that must be running */
+  engines: ProductionEngine[];
+  /** Pipelines that must be wired */
+  pipelines: ProductionPipeline[];
+  /** Acceptance criteria — every item must be true to mark complete */
+  acceptanceCriteria: string[];
+  /** Incumbent(s) this lens is designed to beat */
+  incumbents: string[];
+  /** Current status */
+  status: PhaseStatus;
+}
+
+/**
+ * The 5-phase productization roadmap.
+ * This is the minimum number of moves that yields maximum dominance.
+ */
+export const PRODUCTIZATION_PHASES: ProductionPhase[] = [
+  // ── PHASE 1: Research ─────────────────────────────────────────
+  {
+    order: 1,
+    lensId: 'paper',
+    name: 'Research',
+    rationale: 'Upgrades every other lens. Gives compounding intelligence. If Research is weak, everything else is cosmetic.',
+    dependsOn: [],
+    incumbents: ['Notion', 'Obsidian', 'Google Docs', 'Semantic Scholar'],
+    artifacts: [
+      {
+        name: 'ResearchProject',
+        persistsWithoutDTU: true,
+        storageDomain: 'paper',
+        requiredFields: ['id', 'title', 'description', 'status', 'claims', 'hypotheses', 'createdAt', 'updatedAt'],
+      },
+      {
+        name: 'Claim',
+        persistsWithoutDTU: true,
+        storageDomain: 'paper',
+        requiredFields: ['id', 'text', 'confidence', 'evidence', 'status', 'projectId'],
+      },
+      {
+        name: 'Hypothesis',
+        persistsWithoutDTU: true,
+        storageDomain: 'paper',
+        requiredFields: ['id', 'statement', 'status', 'evidence_for', 'evidence_against', 'projectId'],
+      },
+      {
+        name: 'Evidence',
+        persistsWithoutDTU: true,
+        storageDomain: 'paper',
+        requiredFields: ['id', 'type', 'source', 'content', 'confidence', 'claimIds'],
+      },
+      {
+        name: 'Experiment',
+        persistsWithoutDTU: true,
+        storageDomain: 'paper',
+        requiredFields: ['id', 'hypothesisId', 'method', 'status', 'results', 'conclusions'],
+      },
+      {
+        name: 'Synthesis',
+        persistsWithoutDTU: true,
+        storageDomain: 'paper',
+        requiredFields: ['id', 'projectId', 'claims', 'narrative', 'confidence', 'version'],
+      },
+    ],
+    engines: [
+      { name: 'claim-evidence-consistency', description: 'Validates that evidence actually supports linked claims', trigger: 'automatic' },
+      { name: 'hypothesis-mutation-retest', description: 'Mutates hypotheses when new evidence appears and re-evaluates', trigger: 'automatic' },
+      { name: 'contradiction-detection', description: 'Finds claims that conflict with each other across projects', trigger: 'automatic' },
+      { name: 'temporal-lineage-tracking', description: 'Tracks how knowledge evolves over time with full provenance', trigger: 'automatic' },
+    ],
+    pipelines: [
+      {
+        name: 'ingest-validate-synthesize',
+        steps: ['ingest', 'extract-claims', 'validate-evidence', 'detect-contradictions', 'synthesize'],
+        engines: ['claim-evidence-consistency', 'contradiction-detection'],
+      },
+      {
+        name: 'hypothesis-lifecycle',
+        steps: ['propose', 'design-experiment', 'run', 'evaluate', 'update-hypothesis'],
+        engines: ['hypothesis-mutation-retest', 'temporal-lineage-tracking'],
+      },
+    ],
+    acceptanceCriteria: [
+      'ResearchProject artifact persists in lens store with full CRUD',
+      'Claims are first-class objects linked to Evidence',
+      'Hypothesis lifecycle runs without manual intervention',
+      'Contradiction detection fires automatically on new evidence ingest',
+      'DTU exhaust is generated for every claim/evidence/hypothesis mutation',
+      'At least one pipeline is end-to-end functional',
+      'All merged modes (hypothesis, reflection, metacognition, etc.) are accessible within Research UI',
+    ],
+    status: 'ready',
+  },
+
+  // ── PHASE 2: Simulation ───────────────────────────────────────
+  {
+    order: 2,
+    lensId: 'sim',
+    name: 'Simulation',
+    rationale: 'Governance, science, and finance all depend on it. Turns ideas into testable outcomes.',
+    dependsOn: [1],
+    incumbents: ['Excel', '@Risk', 'MATLAB', 'Wolfram Alpha'],
+    artifacts: [
+      {
+        name: 'Scenario',
+        persistsWithoutDTU: true,
+        storageDomain: 'sim',
+        requiredFields: ['id', 'name', 'description', 'assumptionSetId', 'status', 'createdAt'],
+      },
+      {
+        name: 'AssumptionSet',
+        persistsWithoutDTU: true,
+        storageDomain: 'sim',
+        requiredFields: ['id', 'scenarioId', 'assumptions', 'version', 'locked'],
+      },
+      {
+        name: 'SimulationRun',
+        persistsWithoutDTU: true,
+        storageDomain: 'sim',
+        requiredFields: ['id', 'scenarioId', 'assumptionSetId', 'config', 'status', 'startedAt', 'completedAt'],
+      },
+      {
+        name: 'OutcomeDistribution',
+        persistsWithoutDTU: true,
+        storageDomain: 'sim',
+        requiredFields: ['id', 'runId', 'metric', 'distribution', 'percentiles', 'summary'],
+      },
+    ],
+    engines: [
+      { name: 'monte-carlo', description: 'Runs Monte Carlo simulations over assumption sets', trigger: 'on_demand' },
+      { name: 'sensitivity-analysis', description: 'Identifies which assumptions most affect outcomes', trigger: 'on_demand' },
+      { name: 'regime-detection', description: 'Detects phase transitions and non-linear regime changes', trigger: 'automatic' },
+    ],
+    pipelines: [
+      {
+        name: 'scenario-sim-summarize',
+        steps: ['define-scenario', 'set-assumptions', 'simulate', 'summarize-outcomes', 'archive'],
+        engines: ['monte-carlo', 'sensitivity-analysis'],
+      },
+      {
+        name: 'assumption-retest',
+        steps: ['load-assumptions', 'perturb', 're-simulate', 'compare-outcomes'],
+        engines: ['monte-carlo', 'regime-detection'],
+      },
+    ],
+    acceptanceCriteria: [
+      'Scenario artifact persists with full CRUD',
+      'AssumptionSet is versioned and lockable',
+      'Monte Carlo engine runs and produces OutcomeDistribution',
+      'Sensitivity analysis identifies top-3 influential assumptions',
+      'Results from Phase 1 Research feed into Simulation scenarios',
+      'DTU exhaust is generated for every simulation run',
+      'All merged science engines (math, physics, chem, bio, neuro, quantum) are callable',
+    ],
+    status: 'blocked',
+  },
+
+  // ── PHASE 3: Governance / City ────────────────────────────────
+  {
+    order: 3,
+    lensId: 'council',
+    name: 'Governance',
+    rationale: 'Real-world proof. Investors and cities understand this immediately. Policy becomes executable.',
+    dependsOn: [1, 2],
+    incumbents: ['PDFs', 'Spreadsheets', 'Civic portals', 'Decidim'],
+    artifacts: [
+      {
+        name: 'Proposal',
+        persistsWithoutDTU: true,
+        storageDomain: 'council',
+        requiredFields: ['id', 'title', 'body', 'author', 'status', 'budgetImpact', 'simulationId', 'createdAt'],
+      },
+      {
+        name: 'Vote',
+        persistsWithoutDTU: true,
+        storageDomain: 'council',
+        requiredFields: ['id', 'proposalId', 'voterId', 'choice', 'weight', 'rationale', 'timestamp'],
+      },
+      {
+        name: 'BudgetModel',
+        persistsWithoutDTU: true,
+        storageDomain: 'council',
+        requiredFields: ['id', 'projectId', 'lineItems', 'assumptions', 'simulationRunId', 'version'],
+      },
+      {
+        name: 'Project',
+        persistsWithoutDTU: true,
+        storageDomain: 'council',
+        requiredFields: ['id', 'proposalId', 'status', 'milestones', 'budget', 'team', 'auditTrailId'],
+      },
+      {
+        name: 'AuditTrail',
+        persistsWithoutDTU: true,
+        storageDomain: 'council',
+        requiredFields: ['id', 'entityType', 'entityId', 'action', 'actor', 'timestamp', 'details'],
+      },
+    ],
+    engines: [
+      { name: 'budget-monte-carlo', description: 'Monte Carlo simulation for budget projections using Phase 2 sim engine', trigger: 'on_demand' },
+      { name: 'fraud-feasibility-check', description: 'Flags proposals with unrealistic budgets or impossible timelines', trigger: 'automatic' },
+      { name: 'spillover-modeling', description: 'Models second-order effects of policy decisions', trigger: 'on_demand' },
+    ],
+    pipelines: [
+      {
+        name: 'proposal-to-execution',
+        steps: ['draft-proposal', 'simulate-budget', 'vote', 'execute', 'audit'],
+        engines: ['budget-monte-carlo', 'fraud-feasibility-check'],
+      },
+      {
+        name: 'policy-impact',
+        steps: ['define-policy', 'model-spillover', 'simulate', 'review', 'decide'],
+        engines: ['spillover-modeling', 'budget-monte-carlo'],
+      },
+    ],
+    acceptanceCriteria: [
+      'Proposal → Simulate → Vote → Execute → Audit pipeline is end-to-end functional',
+      'BudgetModel links to Simulation Phase 2 AssumptionSets',
+      'Votes are immutable and auditable',
+      'AuditTrail captures every state transition',
+      'DTU exhaust provides full transparency for every governance action',
+      'All merged modes (vote, ethics, alliance) are accessible within Governance UI',
+    ],
+    status: 'blocked',
+  },
+
+  // ── PHASE 4: Agents + Council ─────────────────────────────────
+  {
+    order: 4,
+    lensId: 'agents',
+    name: 'Agents',
+    rationale: 'Agents without governance are toys. Governance + agents = enterprise-grade AI.',
+    dependsOn: [1, 3],
+    incumbents: ['AutoGPT', 'CrewAI', 'LangChain Agents', 'Microsoft Copilot'],
+    artifacts: [
+      {
+        name: 'Agent',
+        persistsWithoutDTU: true,
+        storageDomain: 'agents',
+        requiredFields: ['id', 'name', 'role', 'capabilities', 'constraints', 'status', 'memoryId'],
+      },
+      {
+        name: 'Role',
+        persistsWithoutDTU: true,
+        storageDomain: 'agents',
+        requiredFields: ['id', 'name', 'permissions', 'constraints', 'safetyEnvelope'],
+      },
+      {
+        name: 'Task',
+        persistsWithoutDTU: true,
+        storageDomain: 'agents',
+        requiredFields: ['id', 'agentId', 'description', 'status', 'input', 'output', 'auditTrailId'],
+      },
+      {
+        name: 'Deliberation',
+        persistsWithoutDTU: true,
+        storageDomain: 'agents',
+        requiredFields: ['id', 'participants', 'topic', 'arguments', 'outcome', 'consensusScore'],
+      },
+      {
+        name: 'Decision',
+        persistsWithoutDTU: true,
+        storageDomain: 'agents',
+        requiredFields: ['id', 'deliberationId', 'choice', 'rationale', 'confidence', 'approvedBy'],
+      },
+    ],
+    engines: [
+      { name: 'multi-agent-arbitration', description: 'Resolves conflicts between agents with competing objectives', trigger: 'automatic' },
+      { name: 'role-based-constraints', description: 'Enforces role permissions and safety envelopes', trigger: 'automatic' },
+      { name: 'memory-reconciliation', description: 'Reconciles divergent agent memories after parallel execution', trigger: 'automatic' },
+      { name: 'safety-envelope-enforcement', description: 'Prevents agents from acting outside their safety bounds', trigger: 'automatic' },
+    ],
+    pipelines: [
+      {
+        name: 'task-lifecycle',
+        steps: ['assign', 'deliberate', 'decide', 'act', 'learn'],
+        engines: ['multi-agent-arbitration', 'role-based-constraints'],
+      },
+      {
+        name: 'safety-audit',
+        steps: ['monitor', 'detect-violation', 'halt', 'review', 'resume-or-terminate'],
+        engines: ['safety-envelope-enforcement', 'memory-reconciliation'],
+      },
+    ],
+    acceptanceCriteria: [
+      'Agents are governed by Phase 3 governance primitives',
+      'Multi-agent arbitration resolves conflicts with audit trail',
+      'Safety envelope prevents unauthorized actions',
+      'Memory reconciliation handles parallel agent execution',
+      'Every agent action generates DTU exhaust for auditability',
+      'Council deliberation produces persistent Decision artifacts',
+      'ML engine from merge is callable for model training/inference',
+    ],
+    status: 'blocked',
+  },
+
+  // ── PHASE 5: Studio (Creative) ────────────────────────────────
+  {
+    order: 5,
+    lensId: 'studio',
+    name: 'Studio',
+    rationale: 'User magnet. Proves Concord is not just thinking. Creative decisions become reusable knowledge.',
+    dependsOn: [1],
+    incumbents: ['Ableton', 'Figma', 'Adobe Creative Suite', 'Notion'],
+    artifacts: [
+      {
+        name: 'Project',
+        persistsWithoutDTU: true,
+        storageDomain: 'studio',
+        requiredFields: ['id', 'name', 'type', 'assets', 'status', 'version', 'createdAt'],
+      },
+      {
+        name: 'Track',
+        persistsWithoutDTU: true,
+        storageDomain: 'studio',
+        requiredFields: ['id', 'projectId', 'type', 'data', 'effects', 'version'],
+      },
+      {
+        name: 'Canvas',
+        persistsWithoutDTU: true,
+        storageDomain: 'studio',
+        requiredFields: ['id', 'projectId', 'layers', 'dimensions', 'exportFormats'],
+      },
+      {
+        name: 'Asset',
+        persistsWithoutDTU: true,
+        storageDomain: 'studio',
+        requiredFields: ['id', 'projectId', 'type', 'url', 'metadata', 'tags'],
+      },
+      {
+        name: 'Preset',
+        persistsWithoutDTU: true,
+        storageDomain: 'studio',
+        requiredFields: ['id', 'domain', 'name', 'config', 'isShared'],
+      },
+      {
+        name: 'Render',
+        persistsWithoutDTU: true,
+        storageDomain: 'studio',
+        requiredFields: ['id', 'projectId', 'format', 'status', 'outputUrl', 'createdAt'],
+      },
+    ],
+    engines: [
+      { name: 'audio-engine', description: 'Audio processing, mixing, mastering', trigger: 'on_demand' },
+      { name: 'visual-layout-engine', description: 'Layout computation, responsive design', trigger: 'on_demand' },
+      { name: 'text-generation-engine', description: 'Structured creative writing with style analysis', trigger: 'on_demand' },
+      { name: 'style-analysis', description: 'Extracts and compares stylistic patterns across projects', trigger: 'on_demand' },
+      { name: 'iteration-comparison', description: 'Compares versions of creative work with diff analysis', trigger: 'on_demand' },
+    ],
+    pipelines: [
+      {
+        name: 'create-refine-publish',
+        steps: ['create', 'refine', 'evaluate', 'render', 'publish'],
+        engines: ['audio-engine', 'visual-layout-engine', 'style-analysis'],
+      },
+      {
+        name: 'iteration-learning',
+        steps: ['create-version', 'compare-iterations', 'extract-patterns', 'update-presets'],
+        engines: ['iteration-comparison', 'style-analysis'],
+      },
+    ],
+    acceptanceCriteria: [
+      'Project artifact supports music, visual, and text types',
+      'At least one domain engine (audio, visual, or text) is functional',
+      'Presets are shareable across projects',
+      'Render pipeline produces exportable output',
+      'Creative decisions generate DTU exhaust for technique reuse',
+      'All merged modes (music, game, AR, fractal, voice) are accessible within Studio UI',
+      'Style analysis works across project types',
+    ],
+    status: 'blocked',
+  },
+];
+
+// ── Derived helpers ─────────────────────────────────────────────
+
+/** Get all phases in execution order. */
+export function getProductionPhases(): ProductionPhase[] {
+  return [...PRODUCTIZATION_PHASES].sort((a, b) => a.order - b.order);
+}
+
+/** Get the current phase (first non-completed in order). */
+export function getCurrentPhase(): ProductionPhase | undefined {
+  return getProductionPhases().find(p => p.status !== 'completed');
+}
+
+/** Get a phase by lens ID. */
+export function getPhaseByLens(lensId: string): ProductionPhase | undefined {
+  return PRODUCTIZATION_PHASES.find(p => p.lensId === lensId);
+}
+
+/** Check if all dependencies for a phase are met. */
+export function areDependenciesMet(phase: ProductionPhase): boolean {
+  return phase.dependsOn.every(depOrder => {
+    const dep = PRODUCTIZATION_PHASES.find(p => p.order === depOrder);
+    return dep?.status === 'completed';
+  });
+}
+
+/** Get the total artifact count across all phases. */
+export function getTotalArtifactCount(): number {
+  return PRODUCTIZATION_PHASES.reduce((sum, p) => sum + p.artifacts.length, 0);
+}
+
+/** Get the total engine count across all phases. */
+export function getTotalEngineCount(): number {
+  return PRODUCTIZATION_PHASES.reduce((sum, p) => sum + p.engines.length, 0);
+}

--- a/concord-frontend/package.json
+++ b/concord-frontend/package.json
@@ -12,7 +12,10 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "type-check": "tsc --noEmit",
-    "validate-routes": "npx tsx scripts/validate-routes.ts"
+    "validate-routes": "npx tsx scripts/validate-routes.ts",
+    "score-lenses": "npx tsx scripts/score-lenses.ts",
+    "validate-lens-quality": "npx tsx scripts/validate-lens-quality.ts",
+    "validate-lens-quality:strict": "npx tsx scripts/validate-lens-quality.ts --strict"
   },
   "dependencies": {
     "next": "^15.1.0",

--- a/concord-frontend/scripts/score-lenses.ts
+++ b/concord-frontend/scripts/score-lenses.ts
@@ -1,0 +1,221 @@
+#!/usr/bin/env npx tsx
+/**
+ * Lens Capability Scoring Script — Step 5 of the Core Lenses Roadmap.
+ *
+ * Scores each lens against the 7 Product Lens Gate capabilities:
+ *   1. Primary artifact
+ *   2. Persistence (uses real API, not MOCK/SEED)
+ *   3. Editor/workspace UI
+ *   4. Engine (server-side action)
+ *   5. Pipeline (multi-step chain)
+ *   6. Import/export
+ *   7. DTU exhaust
+ *
+ * Score < 5/7 → lens is flagged as not public-ready.
+ *
+ * Usage:
+ *   npx tsx scripts/score-lenses.ts
+ *   npx tsx scripts/score-lenses.ts --json       # Output as JSON
+ *   npx tsx scripts/score-lenses.ts --failing     # Only show failing lenses
+ */
+
+import { readdirSync, readFileSync, statSync, existsSync } from 'fs';
+import { join } from 'path';
+
+import { getAllLensIds } from '../lib/lens-registry';
+import { getLensManifest } from '../lib/lenses/manifest';
+import { getLensStatus, type LensStatusEntry } from '../lib/lenses/lens-status';
+import { GATE_PASS_THRESHOLD } from '../lib/lenses/product-lens-gate';
+
+// ── Configuration ───────────────────────────────────────────────
+
+const LENSES_DIR = join(__dirname, '..', 'app', 'lenses');
+const ROADMAP_PATH = join(__dirname, '..', 'lib', 'lenses', 'productization-roadmap.ts');
+
+const args = process.argv.slice(2);
+const jsonOutput = args.includes('--json');
+const failingOnly = args.includes('--failing');
+
+// ── Capability Checks ───────────────────────────────────────────
+
+interface CapabilityResult {
+  primary_artifact: boolean;
+  persistence: boolean;
+  editor_workspace: boolean;
+  engine: boolean;
+  pipeline: boolean;
+  import_export: boolean;
+  dtu_exhaust: boolean;
+}
+
+function readLensPageSource(lensId: string): string | null {
+  const pagePath = join(LENSES_DIR, lensId, 'page.tsx');
+  if (!existsSync(pagePath)) return null;
+  return readFileSync(pagePath, 'utf-8');
+}
+
+function checkCapabilities(lensId: string): CapabilityResult {
+  const manifest = getLensManifest(lensId);
+  const pageSource = readLensPageSource(lensId);
+
+  // 1. Primary artifact: manifest declares artifacts[]
+  const primary_artifact = !!(manifest && manifest.artifacts.length > 0);
+
+  // 2. Persistence: page uses useLensData/useArtifacts, not MOCK_/SEED_
+  let persistence = false;
+  if (pageSource) {
+    const usesHook = /useLensData|useArtifacts|useCreateArtifact/.test(pageSource);
+    const usesMock = /MOCK_|SEED_/.test(pageSource);
+    persistence = usesHook && !usesMock;
+  }
+
+  // 3. Editor/workspace: page has forms, editors, or interactive components
+  let editor_workspace = false;
+  if (pageSource) {
+    const hasEditor = /form|Form|editor|Editor|input|Input|textarea|Textarea|onSubmit|handleCreate|handleSave|ContentEditable|Tiptap|monaco/.test(pageSource);
+    const hasInteractive = /onClick.*create|onClick.*add|onClick.*save|Dialog|Modal|Sheet/.test(pageSource);
+    editor_workspace = hasEditor || hasInteractive;
+  }
+
+  // 4. Engine: manifest declares actions[] with at least one entry
+  const engine = !!(manifest && manifest.actions.length > 0);
+
+  // 5. Pipeline: referenced in productization roadmap
+  let pipeline = false;
+  if (existsSync(ROADMAP_PATH)) {
+    const roadmapSource = readFileSync(ROADMAP_PATH, 'utf-8');
+    pipeline = roadmapSource.includes(`lensId: '${lensId}'`) && roadmapSource.includes('pipelines:');
+  }
+
+  // 6. Import/export: manifest declares exports[]
+  const import_export = !!(manifest && manifest.exports.length > 0);
+
+  // 7. DTU exhaust: server-side _lensEmitDTU is called for this domain
+  // We check if the manifest has macros (which trigger DTU emission in the server)
+  const dtu_exhaust = !!(manifest && manifest.macros.create);
+
+  return {
+    primary_artifact,
+    persistence,
+    editor_workspace,
+    engine,
+    pipeline,
+    import_export,
+    dtu_exhaust,
+  };
+}
+
+// ── Scoring ─────────────────────────────────────────────────────
+
+interface LensScoreResult {
+  lensId: string;
+  status: string;
+  mergeTarget: string | null;
+  capabilities: CapabilityResult;
+  score: number;
+  maxScore: number;
+  passes: boolean;
+  publicReady: boolean;
+}
+
+function scoreLens(lensId: string): LensScoreResult {
+  const capabilities = checkCapabilities(lensId);
+  const score = Object.values(capabilities).filter(Boolean).length;
+  const statusEntry = getLensStatus(lensId);
+
+  return {
+    lensId,
+    status: statusEntry?.status ?? 'unknown',
+    mergeTarget: statusEntry?.mergeTarget ?? null,
+    capabilities,
+    score,
+    maxScore: 7,
+    passes: score >= GATE_PASS_THRESHOLD,
+    publicReady: score >= GATE_PASS_THRESHOLD,
+  };
+}
+
+// ── Main ────────────────────────────────────────────────────────
+
+function main() {
+  const allLensIds = getAllLensIds();
+  const results: LensScoreResult[] = allLensIds.map(id => scoreLens(id));
+
+  if (failingOnly) {
+    const failing = results.filter(r => !r.passes);
+    if (jsonOutput) {
+      console.log(JSON.stringify(failing, null, 2));
+    } else {
+      printResults(failing);
+    }
+    return;
+  }
+
+  if (jsonOutput) {
+    console.log(JSON.stringify(results, null, 2));
+    return;
+  }
+
+  printResults(results);
+}
+
+function printResults(results: LensScoreResult[]) {
+  // Group by status
+  const byStatus: Record<string, LensScoreResult[]> = {};
+  for (const r of results) {
+    const key = r.status;
+    if (!byStatus[key]) byStatus[key] = [];
+    byStatus[key].push(r);
+  }
+
+  console.log('\n  ═══════════════════════════════════════════════════════');
+  console.log('  LENS CAPABILITY SCORES');
+  console.log('  ═══════════════════════════════════════════════════════\n');
+
+  const capNames = ['artifact', 'persist', 'editor', 'engine', 'pipeline', 'export', 'dtu'];
+  const capKeys: (keyof CapabilityResult)[] = [
+    'primary_artifact', 'persistence', 'editor_workspace',
+    'engine', 'pipeline', 'import_export', 'dtu_exhaust',
+  ];
+
+  // Header
+  const header = '  ' + 'Lens'.padEnd(20) + 'Status'.padEnd(12) + capNames.map(n => n.padEnd(9)).join('') + 'Score'.padEnd(8) + 'Gate';
+  console.log(header);
+  console.log('  ' + '─'.repeat(header.length - 2));
+
+  const statusOrder = ['product', 'hybrid', 'viewer', 'system', 'deprecated', 'unknown'];
+
+  for (const status of statusOrder) {
+    const group = byStatus[status];
+    if (!group || group.length === 0) continue;
+
+    console.log(`\n  [${status.toUpperCase()}]`);
+
+    // Sort by score descending within group
+    group.sort((a, b) => b.score - a.score);
+
+    for (const r of group) {
+      const caps = capKeys.map(k => (r.capabilities[k] ? ' Y ' : ' - ').padEnd(9)).join('');
+      const scoreStr = `${r.score}/${r.maxScore}`.padEnd(8);
+      const gate = r.passes ? 'PASS' : 'FAIL';
+      const merge = r.mergeTarget ? ` → ${r.mergeTarget}` : '';
+      console.log(`  ${r.lensId.padEnd(20)}${r.status.padEnd(12)}${caps}${scoreStr}${gate}${merge}`);
+    }
+  }
+
+  // Summary
+  const passing = results.filter(r => r.passes).length;
+  const failing = results.filter(r => !r.passes).length;
+  const products = results.filter(r => r.status === 'product').length;
+  const deprecated = results.filter(r => r.status === 'deprecated').length;
+
+  console.log('\n  ─────────────────────────────────────────────────────');
+  console.log(`  Total:      ${results.length} lenses`);
+  console.log(`  Passing:    ${passing} (score >= ${GATE_PASS_THRESHOLD}/7)`);
+  console.log(`  Failing:    ${failing} (score < ${GATE_PASS_THRESHOLD}/7)`);
+  console.log(`  Product:    ${products}`);
+  console.log(`  Deprecated: ${deprecated} (scheduled for merge)`);
+  console.log('  ═══════════════════════════════════════════════════════\n');
+}
+
+main();

--- a/concord-frontend/scripts/validate-lens-quality.ts
+++ b/concord-frontend/scripts/validate-lens-quality.ts
@@ -1,0 +1,224 @@
+#!/usr/bin/env npx tsx
+/**
+ * Lens Quality Gate Validator — Step 4 of the Core Lenses Roadmap.
+ *
+ * Hard rules that should fail CI in production:
+ *
+ *   ERROR (build fails):
+ *     1. A product-status lens imports MOCK_* or SEED_* for display data
+ *     2. A product-status lens has no persisted artifact in manifest
+ *     3. A product-status lens has no create macro in manifest
+ *
+ *   WARNING (logged but does not fail):
+ *     4. A deprecated lens still has showInSidebar=true
+ *     5. A lens with score < 5/7 has showInSidebar=true or showInCommandPalette=true
+ *
+ * Usage:
+ *   npx tsx scripts/validate-lens-quality.ts
+ *   npx tsx scripts/validate-lens-quality.ts --strict   # Treat warnings as errors
+ *
+ * Add to CI pipeline to prevent regression.
+ */
+
+import { readdirSync, readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+import { LENS_REGISTRY } from '../lib/lens-registry';
+import { getLensManifest } from '../lib/lenses/manifest';
+import { LENS_STATUS_MAP, type LensStatusEntry } from '../lib/lenses/lens-status';
+
+// ── Configuration ───────────────────────────────────────────────
+
+const LENSES_DIR = join(__dirname, '..', 'app', 'lenses');
+const strict = process.argv.includes('--strict');
+
+interface Violation {
+  rule: string;
+  severity: 'error' | 'warning';
+  lensId: string;
+  message: string;
+}
+
+const violations: Violation[] = [];
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+function readLensPage(lensId: string): string | null {
+  const pagePath = join(LENSES_DIR, lensId, 'page.tsx');
+  if (!existsSync(pagePath)) return null;
+  return readFileSync(pagePath, 'utf-8');
+}
+
+function getStatusEntry(lensId: string): LensStatusEntry | undefined {
+  return LENS_STATUS_MAP.find(e => e.id === lensId);
+}
+
+function getRegistryEntry(lensId: string) {
+  return LENS_REGISTRY.find(e => e.id === lensId);
+}
+
+// ── Rule Checks ─────────────────────────────────────────────────
+
+function checkRule1_NoMockImportsInProducts() {
+  const productLenses = LENS_STATUS_MAP.filter(e => e.status === 'product');
+
+  for (const entry of productLenses) {
+    const pageSource = readLensPage(entry.id);
+    if (!pageSource) continue;
+
+    if (/MOCK_/.test(pageSource)) {
+      violations.push({
+        rule: 'no_mock_imports',
+        severity: 'error',
+        lensId: entry.id,
+        message: `Product lens "${entry.id}" imports MOCK_* constants. Replace with useLensData() or useArtifacts().`,
+      });
+    }
+
+    if (/SEED_/.test(pageSource)) {
+      // SEED_ is acceptable in useLensData({ seed: ... }) — check if it's standalone
+      const seedUsedStandalone = /(?<!seed:\s*)SEED_/.test(pageSource);
+      if (seedUsedStandalone) {
+        violations.push({
+          rule: 'no_mock_imports',
+          severity: 'error',
+          lensId: entry.id,
+          message: `Product lens "${entry.id}" uses SEED_* constants outside of useLensData seed option.`,
+        });
+      }
+    }
+  }
+}
+
+function checkRule2_ProductLensHasArtifact() {
+  const productLenses = LENS_STATUS_MAP.filter(e => e.status === 'product');
+
+  for (const entry of productLenses) {
+    const manifest = getLensManifest(entry.id);
+    if (!manifest || manifest.artifacts.length === 0) {
+      violations.push({
+        rule: 'no_artifact_no_product',
+        severity: 'error',
+        lensId: entry.id,
+        message: `Product lens "${entry.id}" has no artifacts in lens manifest. Add artifacts to LENS_MANIFESTS.`,
+      });
+    }
+  }
+}
+
+function checkRule3_ProductLensHasWriteMacro() {
+  const productLenses = LENS_STATUS_MAP.filter(e => e.status === 'product');
+
+  for (const entry of productLenses) {
+    const manifest = getLensManifest(entry.id);
+    if (!manifest) {
+      violations.push({
+        rule: 'no_write_macro',
+        severity: 'error',
+        lensId: entry.id,
+        message: `Product lens "${entry.id}" has no manifest entry at all. Add to LENS_MANIFESTS.`,
+      });
+      continue;
+    }
+    if (!manifest.macros.create) {
+      violations.push({
+        rule: 'no_write_macro',
+        severity: 'error',
+        lensId: entry.id,
+        message: `Product lens "${entry.id}" has no create macro in manifest. Lens must be writable.`,
+      });
+    }
+  }
+}
+
+function checkRule4_DeprecatedNotInSidebar() {
+  const deprecatedLenses = LENS_STATUS_MAP.filter(e => e.status === 'deprecated');
+
+  for (const entry of deprecatedLenses) {
+    const regEntry = getRegistryEntry(entry.id);
+    if (regEntry?.showInSidebar) {
+      violations.push({
+        rule: 'deprecated_in_sidebar',
+        severity: 'warning',
+        lensId: entry.id,
+        message: `Deprecated lens "${entry.id}" still has showInSidebar=true. Set to false (merges into "${entry.mergeTarget}").`,
+      });
+    }
+  }
+}
+
+function checkRule5_StatusMismatch() {
+  // Check that every lens in the registry has a status entry
+  for (const regEntry of LENS_REGISTRY) {
+    const statusEntry = getStatusEntry(regEntry.id);
+    if (!statusEntry) {
+      violations.push({
+        rule: 'missing_status',
+        severity: 'warning',
+        lensId: regEntry.id,
+        message: `Lens "${regEntry.id}" is in registry but has no entry in lens-status.ts. Add a status classification.`,
+      });
+    }
+  }
+
+  // Check that every status entry has a registry entry
+  for (const statusEntry of LENS_STATUS_MAP) {
+    const regEntry = getRegistryEntry(statusEntry.id);
+    if (!regEntry) {
+      violations.push({
+        rule: 'orphaned_status',
+        severity: 'warning',
+        lensId: statusEntry.id,
+        message: `Lens "${statusEntry.id}" is in lens-status.ts but has no entry in lens-registry.ts.`,
+      });
+    }
+  }
+}
+
+// ── Main ────────────────────────────────────────────────────────
+
+function main() {
+  console.log('\n  Lens Quality Gate Validation');
+  console.log('  ════════════════════════════\n');
+
+  checkRule1_NoMockImportsInProducts();
+  checkRule2_ProductLensHasArtifact();
+  checkRule3_ProductLensHasWriteMacro();
+  checkRule4_DeprecatedNotInSidebar();
+  checkRule5_StatusMismatch();
+
+  const errors = violations.filter(v => v.severity === 'error');
+  const warnings = violations.filter(v => v.severity === 'warning');
+
+  if (errors.length > 0) {
+    console.error('  ERRORS (build-blocking):\n');
+    for (const v of errors) {
+      console.error(`    [${v.rule}] ${v.lensId}: ${v.message}`);
+    }
+  }
+
+  if (warnings.length > 0) {
+    console.warn('\n  WARNINGS:\n');
+    for (const v of warnings) {
+      console.warn(`    [${v.rule}] ${v.lensId}: ${v.message}`);
+    }
+  }
+
+  if (errors.length === 0 && warnings.length === 0) {
+    console.log('  All checks passed.\n');
+  }
+
+  console.log(`\n  Summary: ${errors.length} errors, ${warnings.length} warnings\n`);
+
+  // Exit with error if there are errors, or if --strict and there are warnings
+  if (errors.length > 0) {
+    process.exit(1);
+  }
+  if (strict && warnings.length > 0) {
+    process.exit(1);
+  }
+
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
Implements the 6-step roadmap to consolidate ~97 lenses into ~18 world-class
products. This is the structural foundation that stops lens entropy and forces
product-level quality before any lens goes public.

Step 1 — lens-status.ts: Tags every lens as product/hybrid/viewer/system/deprecated.
Step 2 — lens-merge-map.ts: Defines 4 merge groups (Research, Simulation,
  Knowledge Graph, Collaboration) with concrete artifact/engine/pipeline specs.
Step 3 — productization-roadmap.ts: 5-phase execution order
  (Research → Simulation → Governance → Agents → Studio) with acceptance criteria.
Step 4 — validate-lens-quality.ts: CI script enforcing hard rules (no MOCK imports
  in product lenses, artifact + write macro required for product status).
Step 5 — score-lenses.ts: Scores each lens against 7 capabilities
  (artifact, persistence, editor, engine, pipeline, export, DTU exhaust).
Step 6 — product-lens-gate.ts: The non-negotiable rule — a lens must have a
  primary artifact that survives without DTUs.

Also adds lens quality gate step to CI pipeline and new npm scripts.

https://claude.ai/code/session_0121UdaWrnUq1G2tZnk62uxW