### PR TITLE
fix: remove duplicate routes, dead useQuery calls, and fix productiza…

### DIFF
--- a/concord-frontend/app/lenses/agents/page.tsx
+++ b/concord-frontend/app/lenses/agents/page.tsx
@@ -2,7 +2,6 @@
 
 import { useLensNav } from '@/hooks/useLensNav';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useLensData } from '@/lib/hooks/use-lens-data';
 import { apiHelpers } from '@/lib/api/client';
 import { useState, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -176,9 +175,6 @@ export default function AgentsLensPage() {
   useLensNav('agents');
 
   const queryClient = useQueryClient();
-  const { items: _agentItems } = useLensData('agents', 'agent', {
-    seed: INITIAL_AGENTS.map(a => ({ title: a.name, data: a as unknown as Record<string, unknown> })),
-  });
   const [_view, setView] = useState<ViewMode>('dashboard');
   const [selectedAgent, setSelectedAgent] = useState<Agent | null>(null);
   const [showCreate, setShowCreate] = useState(false);

--- a/concord-frontend/app/lenses/ar/page.tsx
+++ b/concord-frontend/app/lenses/ar/page.tsx
@@ -12,11 +12,6 @@ export default function ARLensPage() {
   const [arEnabled, setArEnabled] = useState(false);
   const [selectedLayer, setSelectedLayer] = useState<string | null>(null);
 
-  const { data: _arStatus } = useQuery({
-    queryKey: ['ar-status'],
-    queryFn: () => api.get('/api/ar/status').then((r) => r.data),
-  });
-
   const { data: arLayers } = useQuery({
     queryKey: ['ar-layers'],
     queryFn: () => api.get('/api/ar/layers').then((r) => r.data),

--- a/concord-frontend/app/lenses/collab/page.tsx
+++ b/concord-frontend/app/lenses/collab/page.tsx
@@ -350,21 +350,6 @@ export default function CollabLensPage() {
   const [activeSession, setActiveSession] = useState<CollabSession | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
 
-  // Queries -- fall back to demo data
-  const { data: _sessionsData } = useQuery({
-    queryKey: ['artistry-collab-sessions'],
-    queryFn: () => api.get('/api/artistry/collab/sessions').then(r => r.data),
-    refetchInterval: 8000,
-    retry: 1,
-  });
-
-  const { data: _collabData } = useQuery({
-    queryKey: ['collab-sessions'],
-    queryFn: () => api.get('/api/collab/sessions').then(r => r.data),
-    refetchInterval: 8000,
-    retry: 1,
-  });
-
   const sessions: CollabSession[] = INITIAL_SESSIONS;
   const onlineCount = sessions.reduce((n, s) => n + s.participants.filter(p => p.online).length, 0);
 

--- a/concord-frontend/app/lenses/daily/page.tsx
+++ b/concord-frontend/app/lenses/daily/page.tsx
@@ -5,7 +5,6 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useLensData } from '@/lib/hooks/use-lens-data';
 import { apiHelpers } from '@/lib/api/client';
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { DailyNotes as _DailyNotes } from '@/components/daily/DailyNotes';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   Bell, Plus, Sparkles, CheckCircle2, Clock, Play, Square, RotateCcw,
@@ -153,15 +152,6 @@ export default function DailyLensPage() {
   const { data: dailyData } = useQuery({
     queryKey: ['daily-notes'],
     queryFn: () => apiHelpers.daily.list().then((r) => r.data),
-  });
-  const { data: _currentData } = useQuery({
-    queryKey: ['daily-current'],
-    queryFn: () => apiHelpers.daily.get().then((r) => r.data),
-  });
-  const { data: _dueReminders } = useQuery({
-    queryKey: ['reminders-due'],
-    queryFn: () => apiHelpers.daily.dueReminders().then((r) => r.data),
-    refetchInterval: 60000,
   });
   const generateDigest = useMutation({
     mutationFn: () => apiHelpers.daily.digest(),

--- a/concord-frontend/app/lenses/game/page.tsx
+++ b/concord-frontend/app/lenses/game/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useMemo } from 'react';
 import { useLensNav } from '@/hooks/useLensNav';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useLensData } from '@/lib/hooks/use-lens-data';
 import { api } from '@/lib/api/client';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -264,18 +264,6 @@ export default function GameLensPage() {
   });
 
   // API queries -- fall back to demo data when backend is unavailable
-  const { data: _profileData } = useQuery({
-    queryKey: ['game-profile'],
-    queryFn: () => api.get('/api/game/profile').then((r) => r.data),
-    retry: false,
-  });
-
-  const { data: _serverAchievements } = useQuery({
-    queryKey: ['game-achievements'],
-    queryFn: () => api.get('/api/game/achievements').then((r) => r.data),
-    retry: false,
-  });
-
   const completeQuestMutation = useMutation({
     mutationFn: (questId: string) => api.post(`/api/game/quests/${questId}/complete`),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['game-profile'] }),

--- a/concord-frontend/app/lenses/goals/page.tsx
+++ b/concord-frontend/app/lenses/goals/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useLensNav } from '@/hooks/useLensNav';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useLensData } from '@/lib/hooks/use-lens-data';
 import { apiHelpers } from '@/lib/api/client';
 import { useState, useMemo } from 'react';
@@ -296,17 +296,6 @@ export default function GoalsLensPage() {
   const [achievements] = useState<Achievement[]>(SEED_ACHIEVEMENTS);
 
   // API integration (preserves original backend connectivity)
-  const { data: _goalsData } = useQuery({
-    queryKey: ['goals'],
-    queryFn: () => apiHelpers.goals.list().then((r) => r.data),
-    refetchInterval: 10000,
-  });
-
-  const { data: _statusData } = useQuery({
-    queryKey: ['goals-status'],
-    queryFn: () => apiHelpers.goals.status().then((r) => r.data),
-  });
-
   const createGoalMutation = useMutation({
     mutationFn: () =>
       apiHelpers.goals.create({

--- a/concord-frontend/app/lenses/marketplace/page.tsx
+++ b/concord-frontend/app/lenses/marketplace/page.tsx
@@ -428,11 +428,6 @@ export default function MarketplaceLensPage() {
   });
 
   // Queries (with demo fallback)
-  const { data: _browseData } = useQuery({
-    queryKey: ['marketplace-browse', search, category],
-    queryFn: () => api.get(`/api/marketplace/browse?search=${search}&category=${category}`).then(r => r.data).catch(() => null),
-  });
-
   const { data: beatsData } = useQuery({
     queryKey: ['artistry-beats'],
     queryFn: () => api.get('/api/artistry/marketplace/beats').then(r => r.data).catch(() => null),

--- a/concord-frontend/app/lenses/ml/page.tsx
+++ b/concord-frontend/app/lenses/ml/page.tsx
@@ -264,16 +264,6 @@ export default function MLLensPage() {
   const [playgroundModel, setPlaygroundModel] = useState<string>('');
 
   // Queries
-  const { data: _modelsData } = useQuery({
-    queryKey: ['ml-models'],
-    queryFn: () => api.get('/api/ml/models').then(r => r.data),
-  });
-
-  const { data: _experimentsData } = useQuery({
-    queryKey: ['ml-experiments'],
-    queryFn: () => api.get('/api/ml/experiments').then(r => r.data),
-  });
-
   const { data: metricsData } = useQuery({
     queryKey: ['ml-metrics'],
     queryFn: () => api.get('/api/ml/metrics').then(r => r.data),

--- a/concord-frontend/app/lenses/physics/page.tsx
+++ b/concord-frontend/app/lenses/physics/page.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import { useLensNav } from '@/hooks/useLensNav';
-import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api/client';
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
@@ -271,12 +269,6 @@ export default function PhysicsLensPage() {
     totalEnergy: 0,
     momentum: { x: 0, y: 0 },
     fps: 60
-  });
-
-  // Sync with backend
-  const { data: _backendSim } = useQuery({
-    queryKey: ['physics-sim'],
-    queryFn: () => api.get('/api/physics/simulation').then((r) => r.data).catch(() => null),
   });
 
   // Helper functions

--- a/concord-frontend/app/lenses/thread/page.tsx
+++ b/concord-frontend/app/lenses/thread/page.tsx
@@ -3,7 +3,6 @@
 import { useState, useMemo, useCallback } from 'react';
 import { useLensNav } from '@/hooks/useLensNav';
 import { useQuery } from '@tanstack/react-query';
-import { useLensData } from '@/lib/hooks/use-lens-data';
 import { api } from '@/lib/api/client';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
@@ -157,12 +156,6 @@ export default function ThreadLensPage() {
   const [expandedNodes, setExpandedNodes] = useState<Set<string>>(new Set(['msg-1', 'msg-2']));
   const [viewMode, setViewMode] = useState<ViewMode>('tree');
   const [searchQuery, setSearchQuery] = useState('');
-  const [_showArchived, _setShowArchived] = useState(false);
-
-  const { items: _threadItems, create: _createThread } = useLensData('thread', 'thread', {
-    seed: INITIAL_THREADS.map(t => ({ title: t.name, data: t as unknown as Record<string, unknown> })),
-  });
-
   const { data: sessions } = useQuery({
     queryKey: ['sessions'],
     queryFn: () => api.get('/api/state/latest').then((r) => r.data),

--- a/concord-frontend/lib/lenses/productization-roadmap.ts
+++ b/concord-frontend/lib/lenses/productization-roadmap.ts
@@ -715,7 +715,6 @@ export const PRODUCTIZATION_PHASES: ProductionPhase[] = [
     ],
     status: 'blocked',
   },
-];
 
   // ── PHASE 11: Calendar ───────────────────────────────────────────
   {


### PR DESCRIPTION
…tion-roadmap TS errors

Backend (server.js):
- Remove 6 duplicate route registrations (auth/me, plugins GET/POST, personas GET/POST, webhooks GET) that were unreachable dead code
- Rename dead voice/transcribe duplicate to /transcribe-raw to preserve raw audio upload capability
- Replace admin/audit stub with real implementation proxying to AuditDB
- Add comments documenting which routes are already registered above

Frontend (10 lens pages):
- Remove 18 dead useQuery/useLensData calls that fired API requests but stored results in unused underscore-prefixed variables (ml, physics, daily, goals, game, collab, thread, agents, marketplace, ar)
- Clean up unused imports (useLensData, useQuery, api client) where no longer needed

Fix productization-roadmap.ts:
- Remove premature ]; on line 718 that closed the PRODUCTIZATION_PHASES array after only 10 of 24 phases, causing all subsequent phases to produce TS parse errors

https://claude.ai/code/session_01TdKt8s7dM1HD4dRLgaH3UW