### PR TITLE
Harden for public deployment — 7 security/production fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -167,6 +167,22 @@ STRIPE_PRICE_TEAMS=price_your_teams_price_id
 FRONTEND_URL=https://yourdomain.com
 
 # ============================================
+# MONITORING (Required for docker-compose)
+# ============================================
+
+# Grafana admin credentials (no defaults — must set explicitly)
+GRAFANA_USER=admin
+GRAFANA_PASSWORD=
+
+# ============================================
+# UNSAFE SURFACES (defaults to disabled)
+# ============================================
+
+# Terminal/sandbox command execution — disabled by default.
+# Only enable for development or isolated/air-gapped deployments.
+# ENABLE_TERMINAL_EXEC=false
+
+# ============================================
 # DEVELOPMENT ONLY
 # ============================================
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,12 +24,14 @@ services:
       # Optional features
       - EMBEDDINGS_ENABLED=${EMBEDDINGS_ENABLED:-true}
       - FEDERATION_ENABLED=${FEDERATION_ENABLED:-false}
+      # Unsafe surfaces — disabled by default in production
+      - ENABLE_TERMINAL_EXEC=${ENABLE_TERMINAL_EXEC:-false}
     volumes:
       - concord-data:/data
     networks:
       - concord-network
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:5050/ready && curl -f http://localhost:5050/api/status | grep -q '\"database\":{\"type\":\"sqlite\"'"]
+      test: ["CMD-SHELL", "curl -f http://localhost:5050/ready && curl -f http://localhost:5050/api/status | grep -q '\"ok\":true'"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -149,15 +151,16 @@ services:
     container_name: concord-grafana
     restart: unless-stopped
     environment:
-      - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-admin}
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-concord}
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:?GRAFANA_USER must be set in .env}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:?GRAFANA_PASSWORD must be set in .env}
       - GF_USERS_ALLOW_SIGN_UP=false
     volumes:
       - grafana-data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
       - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    # Bind Grafana to localhost only — access via SSH tunnel or VPN in production
     ports:
-      - "3001:3000"
+      - "127.0.0.1:3001:3000"
     networks:
       - concord-network
     depends_on:

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -38,8 +38,13 @@ server {
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers off;
 
-    # HSTS - Enforce HTTPS for 1 year, include subdomains
+    # Security headers (must repeat in server block — add_header does not inherit across contexts)
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' wss: ws:; frame-ancestors 'self'; base-uri 'self'; form-action 'self';" always;
 
     # Max upload size
     client_max_body_size 100M;
@@ -92,13 +97,16 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
 
-        # Cache static assets
+        # Cache static assets (re-include security headers — add_header in nested block overrides parent)
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
             proxy_pass http://frontend;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             expires 1y;
             add_header Cache-Control "public, immutable";
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header X-Frame-Options "SAMEORIGIN" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         }
     }
 

--- a/server/scripts/convert-dtus-to-packs.js
+++ b/server/scripts/convert-dtus-to-packs.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * convert-dtus-to-packs.js
+ *
+ * Converts the monolithic dtus.js export into chunked JSONL packs with a
+ * SHA-256 manifest.  Once generated, the server loads from packs (lazy,
+ * streaming) instead of importing the full 3.9 MB JS module at startup.
+ *
+ * Usage:
+ *   node server/scripts/convert-dtus-to-packs.js [--out <dir>] [--chunk-size <n>]
+ *
+ * Defaults:
+ *   --out        DATA_DIR/dtu-packs  (or ./data/dtu-packs)
+ *   --chunk-size 200                 (DTUs per JSONL file)
+ */
+
+import fs from "fs";
+import path from "path";
+import crypto from "crypto";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Parse CLI args
+const args = process.argv.slice(2);
+function getArg(flag, fallback) {
+  const idx = args.indexOf(flag);
+  return idx !== -1 && args[idx + 1] ? args[idx + 1] : fallback;
+}
+
+const DATA_DIR = process.env.DATA_DIR || path.join(__dirname, "..", "data");
+const OUT_DIR = getArg("--out", path.join(DATA_DIR, "dtu-packs"));
+const CHUNK_SIZE = Number(getArg("--chunk-size", "200"));
+
+async function main() {
+  console.log("[convert-dtus-to-packs] Loading dtus.js...");
+  const mod = await import("../dtus.js");
+  const dtus = mod?.DTUS ?? mod?.dtus ?? mod?.default ?? [];
+  if (!Array.isArray(dtus) || dtus.length === 0) {
+    console.error("[convert-dtus-to-packs] No DTUs found in dtus.js");
+    process.exit(1);
+  }
+  console.log(`[convert-dtus-to-packs] Found ${dtus.length} DTUs`);
+
+  // Create output directory
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+
+  const chunks = [];
+  for (let i = 0; i < dtus.length; i += CHUNK_SIZE) {
+    const slice = dtus.slice(i, i + CHUNK_SIZE);
+    const chunkIndex = Math.floor(i / CHUNK_SIZE);
+    const fileName = `chunk-${String(chunkIndex).padStart(4, "0")}.jsonl`;
+    const filePath = path.join(OUT_DIR, fileName);
+
+    const content = slice.map(d => JSON.stringify(d)).join("\n") + "\n";
+    const sha256 = crypto.createHash("sha256").update(content).digest("hex");
+
+    fs.writeFileSync(filePath, content, "utf-8");
+    chunks.push({ file: fileName, count: slice.length, sha256 });
+    console.log(`  wrote ${fileName} (${slice.length} DTUs, ${(content.length / 1024).toFixed(1)} KB)`);
+  }
+
+  const manifest = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    totalDtus: dtus.length,
+    chunkSize: CHUNK_SIZE,
+    chunks
+  };
+
+  const manifestPath = path.join(OUT_DIR, "manifest.json");
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2), "utf-8");
+
+  const totalSizeKB = chunks.reduce((acc, c) => {
+    const p = path.join(OUT_DIR, c.file);
+    return acc + fs.statSync(p).size;
+  }, 0) / 1024;
+
+  console.log(`\n[convert-dtus-to-packs] Done!`);
+  console.log(`  ${chunks.length} chunks, ${dtus.length} DTUs, ${totalSizeKB.toFixed(0)} KB total`);
+  console.log(`  Manifest: ${manifestPath}`);
+  console.log(`\nThe server will now load from packs instead of dtus.js on next restart.`);
+}
+
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
P0.1: Hard-disable terminal/sandbox exec in production
      - Gate behind ENABLE_TERMINAL_EXEC env var (default false)
      - Defense-in-depth: macro, sandbox fn, and compose all check the flag

P0.2: Remove Grafana default credentials
      - Require explicit GRAFANA_USER / GRAFANA_PASSWORD via :? syntax
      - Bind Grafana port to 127.0.0.1 only

P0.3: Add security headers to nginx edge
      - CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy
      - Propagated into static asset sub-location (add_header override fix)

P1.1: Relax backend healthcheck
      - Match "ok":true instead of sqlite-specific string
      - Accepts both sqlite and JSON persistence backends

P1.2: Add dtus.js → JSONL pack conversion script
      - server/scripts/convert-dtus-to-packs.js generates chunked JSONL
      - Seed loader warns when falling back to monolithic import
      - Server already prefers packs when manifest.json exists

P2.1: Add centralized CAPS (capabilities) registry
      - Single frozen object gating sqlite, jwt, openai, ollama, exec, etc.
      - Exposed on /api/status for operator visibility

P2.2: Document unsafe surfaces in SECURITY.md
      - Table of gated surfaces with env vars and risk levels
      - Runtime verification instructions via /api/status
      - Pre-deployment hardening checklist

https://claude.ai/code/session_01SaZnm3KzEDpAU4LTvDyKLy