### PR TITLE
Upgrade all 61 lenses to competitor-level (7/7 Product Lens Gate)

### DIFF
--- a/concord-frontend/lib/lens-registry.ts
+++ b/concord-frontend/lib/lens-registry.ts
@@ -101,6 +101,8 @@ export const LENS_REGISTRY: LensEntry[] = [
   { id: 'ar', name: 'AR', icon: Glasses, description: 'Augmented reality', category: 'creative', showInSidebar: true, showInCommandPalette: true, path: '/lenses/ar', order: 42, keywords: ['augmented reality', 'webxr', '3d'] },
   { id: 'fractal', name: 'Fractal', icon: Sparkles, description: 'Fractal explorer', category: 'creative', showInSidebar: true, showInCommandPalette: true, path: '/lenses/fractal', order: 43, keywords: ['visualization', 'patterns', 'generative'] },
   { id: 'sim', name: 'Sim', icon: Boxes, description: 'Simulation sandbox', category: 'creative', showInSidebar: false, showInCommandPalette: true, path: '/lenses/sim', order: 44, keywords: ['simulation', 'sandbox', 'worldmodel'] },
+  { id: 'art', name: 'Art', icon: Palette, description: 'Visual art creation and gallery', category: 'creative', showInSidebar: true, showInCommandPalette: true, path: '/lenses/art', order: 45, keywords: ['artwork', 'gallery', 'visual', 'illustration'] },
+  { id: 'studio', name: 'Studio', icon: Music, description: 'Creative production studio', category: 'creative', showInSidebar: true, showInCommandPalette: true, path: '/lenses/studio', order: 46, keywords: ['production', 'audio', 'mix', 'master'] },
 
   // ── Governance ────────────────────────────────────────────────
   { id: 'council', name: 'Council', icon: Users, description: 'DTU governance council', category: 'governance', showInSidebar: true, showInCommandPalette: true, path: '/lenses/council', order: 50, keywords: ['vote', 'governance', 'decisions'] },

--- a/concord-frontend/lib/lenses/automation-bindings.ts
+++ b/concord-frontend/lib/lenses/automation-bindings.ts
@@ -1,0 +1,780 @@
+/**
+ * Automation Bindings - Per-lens trigger-to-macro mappings,
+ * import/export format declarations, and domain RBAC policies.
+ *
+ * Dimensions 3, 4, and 5 of competitor parity:
+ *   3. Import/Export Parity - what formats each lens ingests/exports
+ *   4. Automation Layer - which events trigger which macros
+ *   5. Multi-User Controls - domain-specific RBAC overrides
+ *
+ * These bind into the existing infrastructure:
+ *   - server/emergent/public-api.js (webhook events)
+ *   - server.js macro registry (registerLensAction)
+ *   - server/emergent/rbac.js (role/permission system)
+ */
+
+// ── Import/Export Format Declarations ──────────────────────────
+
+export type ImportFormat = 'csv' | 'json' | 'xml' | 'hl7' | 'fhir' | 'edi' | 'iif' | 'ofx' | 'qfx' | 'xlsx' | 'geojson' | 'kml' | 'ical' | 'vcf';
+export type ExportFormat = 'csv' | 'json' | 'xml' | 'pdf' | 'hl7' | 'fhir' | 'edi' | 'iif' | 'ofx' | 'xlsx' | 'geojson' | 'kml' | 'ical' | 'docx' | 'markdown';
+
+export interface ImportExportProfile {
+  domain: string;
+  imports: {
+    format: ImportFormat;
+    /** Which entity this maps to */
+    entity: string;
+    /** Example: "Drag a CSV of patients to import" */
+    hint: string;
+  }[];
+  exports: {
+    format: ExportFormat;
+    entity: string;
+    hint: string;
+  }[];
+  /** Industry-standard API surface this lens can interop with */
+  apiCompat?: string[];
+  /** Webhook events this lens emits */
+  webhookEvents: string[];
+}
+
+// ── Automation Trigger Definitions ─────────────────────────────
+
+export interface AutomationTrigger {
+  /** The event that fires (from webhook event system) */
+  event: string;
+  /** Human-readable description */
+  label: string;
+  /** The macro to execute (domain.action format) */
+  macro: string;
+  /** Condition expression (evaluated at runtime) */
+  condition?: string;
+  /** Whether this is enabled by default */
+  defaultEnabled: boolean;
+}
+
+export interface AutomationProfile {
+  domain: string;
+  triggers: AutomationTrigger[];
+}
+
+// ── Domain RBAC Policy ─────────────────────────────────────────
+
+export interface DomainPermission {
+  action: string;
+  label: string;
+  /** Minimum role that can perform this action */
+  minRole: 'viewer' | 'reviewer' | 'editor' | 'admin' | 'owner';
+  /** Whether this permission can be delegated */
+  delegable?: boolean;
+}
+
+export interface DomainRBACProfile {
+  domain: string;
+  /** Domain-specific permissions beyond the base RBAC set */
+  permissions: DomainPermission[];
+  /** Whether this lens supports shared artifacts */
+  sharedArtifacts: boolean;
+  /** Whether this lens has an activity feed */
+  activityFeed: boolean;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// IMPORT/EXPORT PROFILES
+// ═══════════════════════════════════════════════════════════════
+
+export const IMPORT_EXPORT_PROFILES: ImportExportProfile[] = [
+  {
+    domain: 'healthcare',
+    imports: [
+      { format: 'csv', entity: 'Patient', hint: 'Import patient roster as CSV' },
+      { format: 'hl7', entity: 'Encounter', hint: 'Import HL7 ADT messages' },
+      { format: 'fhir', entity: 'Patient', hint: 'Import FHIR Patient bundle' },
+      { format: 'fhir', entity: 'Encounter', hint: 'Import FHIR Encounter bundle' },
+      { format: 'json', entity: 'Prescription', hint: 'Import prescription records' },
+    ],
+    exports: [
+      { format: 'fhir', entity: 'Patient', hint: 'Export as FHIR Patient resource' },
+      { format: 'fhir', entity: 'Encounter', hint: 'Export as FHIR Encounter resource' },
+      { format: 'csv', entity: 'Patient', hint: 'Export patient list as CSV' },
+      { format: 'hl7', entity: 'Encounter', hint: 'Export as HL7 message' },
+      { format: 'pdf', entity: 'Encounter', hint: 'Export encounter summary as PDF' },
+    ],
+    apiCompat: ['FHIR R4', 'HL7v2', 'CDA'],
+    webhookEvents: ['encounter.created', 'encounter.completed', 'prescription.created', 'prescription.discontinued', 'patient.updated'],
+  },
+
+  {
+    domain: 'legal',
+    imports: [
+      { format: 'csv', entity: 'Case', hint: 'Import case list from CSV' },
+      { format: 'json', entity: 'Contract', hint: 'Import contracts as JSON' },
+      { format: 'xml', entity: 'Filing', hint: 'Import filings from LegalXML' },
+    ],
+    exports: [
+      { format: 'pdf', entity: 'Contract', hint: 'Export contract as PDF' },
+      { format: 'docx', entity: 'Filing', hint: 'Export filing as Word document' },
+      { format: 'csv', entity: 'Case', hint: 'Export case list as CSV' },
+      { format: 'json', entity: 'Case', hint: 'Export case data as JSON' },
+    ],
+    apiCompat: ['SALI/LMSS', 'LegalXML'],
+    webhookEvents: ['case.status_changed', 'contract.executed', 'contract.expired', 'filing.filed', 'case.deadline_approaching'],
+  },
+
+  {
+    domain: 'accounting',
+    imports: [
+      { format: 'csv', entity: 'Transaction', hint: 'Import bank transactions as CSV' },
+      { format: 'ofx', entity: 'Transaction', hint: 'Import OFX bank feed' },
+      { format: 'qfx', entity: 'Transaction', hint: 'Import Quicken QFX data' },
+      { format: 'iif', entity: 'Account', hint: 'Import QuickBooks IIF file' },
+      { format: 'json', entity: 'Invoice', hint: 'Import invoices from JSON' },
+    ],
+    exports: [
+      { format: 'csv', entity: 'Transaction', hint: 'Export transactions as CSV' },
+      { format: 'iif', entity: 'Account', hint: 'Export as QuickBooks IIF' },
+      { format: 'pdf', entity: 'Invoice', hint: 'Export invoice as PDF' },
+      { format: 'xlsx', entity: 'Transaction', hint: 'Export ledger as Excel' },
+      { format: 'json', entity: 'Account', hint: 'Export chart of accounts' },
+    ],
+    apiCompat: ['OFX', 'QFX', 'IIF', 'xBRL'],
+    webhookEvents: ['invoice.sent', 'invoice.paid', 'invoice.overdue', 'transaction.reconciled', 'account.balance_changed'],
+  },
+
+  {
+    domain: 'security',
+    imports: [
+      { format: 'json', entity: 'Incident', hint: 'Import SIEM incidents as JSON' },
+      { format: 'csv', entity: 'Threat', hint: 'Import threat intelligence CSV' },
+      { format: 'xml', entity: 'Incident', hint: 'Import STIX/TAXII feed' },
+    ],
+    exports: [
+      { format: 'json', entity: 'Incident', hint: 'Export incident report as JSON' },
+      { format: 'csv', entity: 'Incident', hint: 'Export incident log as CSV' },
+      { format: 'pdf', entity: 'Incident', hint: 'Export post-mortem as PDF' },
+    ],
+    apiCompat: ['STIX', 'TAXII', 'CEF', 'MITRE ATT&CK'],
+    webhookEvents: ['incident.reported', 'incident.escalated', 'incident.contained', 'incident.closed', 'threat.level_changed'],
+  },
+
+  {
+    domain: 'manufacturing',
+    imports: [
+      { format: 'csv', entity: 'WorkOrder', hint: 'Import work orders from CSV' },
+      { format: 'json', entity: 'BOM', hint: 'Import bill of materials' },
+      { format: 'xml', entity: 'BOM', hint: 'Import BOM from ERP (XML)' },
+    ],
+    exports: [
+      { format: 'csv', entity: 'WorkOrder', hint: 'Export work orders as CSV' },
+      { format: 'pdf', entity: 'QCInspection', hint: 'Export QC report as PDF' },
+      { format: 'json', entity: 'BOM', hint: 'Export BOM as JSON' },
+      { format: 'xlsx', entity: 'WorkOrder', hint: 'Export production schedule' },
+    ],
+    apiCompat: ['ISA-95', 'OPC-UA', 'MTConnect'],
+    webhookEvents: ['workorder.started', 'workorder.completed', 'qc.passed', 'qc.failed', 'bom.approved'],
+  },
+
+  {
+    domain: 'education',
+    imports: [
+      { format: 'csv', entity: 'Student', hint: 'Import student roster from CSV' },
+      { format: 'csv', entity: 'Course', hint: 'Import course catalog' },
+      { format: 'json', entity: 'Assignment', hint: 'Import assignments from LMS JSON' },
+    ],
+    exports: [
+      { format: 'csv', entity: 'Student', hint: 'Export student list as CSV' },
+      { format: 'pdf', entity: 'Student', hint: 'Export transcript as PDF' },
+      { format: 'json', entity: 'Course', hint: 'Export course data as JSON' },
+    ],
+    apiCompat: ['LTI 1.3', 'xAPI', 'SCORM', 'Caliper'],
+    webhookEvents: ['student.enrolled', 'student.graduated', 'assignment.graded', 'course.completed'],
+  },
+
+  {
+    domain: 'retail',
+    imports: [
+      { format: 'csv', entity: 'Product', hint: 'Import product catalog from CSV' },
+      { format: 'json', entity: 'Order', hint: 'Import orders from JSON' },
+      { format: 'csv', entity: 'Customer', hint: 'Import customer list' },
+      { format: 'xlsx', entity: 'Product', hint: 'Import inventory from Excel' },
+    ],
+    exports: [
+      { format: 'csv', entity: 'Product', hint: 'Export product catalog' },
+      { format: 'csv', entity: 'Order', hint: 'Export orders as CSV' },
+      { format: 'json', entity: 'Order', hint: 'Export orders as JSON' },
+      { format: 'pdf', entity: 'Order', hint: 'Export order receipt' },
+    ],
+    apiCompat: ['Shopify API', 'WooCommerce', 'Square'],
+    webhookEvents: ['order.placed', 'order.shipped', 'order.delivered', 'product.low_stock', 'customer.tier_changed'],
+  },
+
+  {
+    domain: 'government',
+    imports: [
+      { format: 'csv', entity: 'Permit', hint: 'Import permit applications from CSV' },
+      { format: 'json', entity: 'Violation', hint: 'Import violations from JSON' },
+      { format: 'xml', entity: 'Permit', hint: 'Import permits from e-Gov XML' },
+    ],
+    exports: [
+      { format: 'csv', entity: 'Permit', hint: 'Export permit log as CSV' },
+      { format: 'pdf', entity: 'Permit', hint: 'Export permit certificate' },
+      { format: 'json', entity: 'Violation', hint: 'Export violations as JSON' },
+    ],
+    apiCompat: ['NIEM', 'Open311'],
+    webhookEvents: ['permit.submitted', 'permit.approved', 'permit.denied', 'violation.reported', 'violation.remediated'],
+  },
+
+  {
+    domain: 'realestate',
+    imports: [
+      { format: 'csv', entity: 'Listing', hint: 'Import listings from CSV' },
+      { format: 'xml', entity: 'Listing', hint: 'Import RETS/RESO feed' },
+      { format: 'json', entity: 'Listing', hint: 'Import from MLS JSON' },
+    ],
+    exports: [
+      { format: 'csv', entity: 'Listing', hint: 'Export listings as CSV' },
+      { format: 'pdf', entity: 'Listing', hint: 'Export listing sheet' },
+      { format: 'json', entity: 'Listing', hint: 'Export as RESO Web API' },
+    ],
+    apiCompat: ['RESO Web API', 'RETS', 'IDX'],
+    webhookEvents: ['listing.published', 'listing.price_changed', 'listing.under_contract', 'listing.sold'],
+  },
+
+  {
+    domain: 'insurance',
+    imports: [
+      { format: 'csv', entity: 'Claim', hint: 'Import claims from CSV' },
+      { format: 'edi', entity: 'Claim', hint: 'Import EDI 837 claims' },
+      { format: 'json', entity: 'Claim', hint: 'Import claims from JSON' },
+    ],
+    exports: [
+      { format: 'edi', entity: 'Claim', hint: 'Export as EDI 835 remittance' },
+      { format: 'csv', entity: 'Claim', hint: 'Export claims log' },
+      { format: 'pdf', entity: 'Claim', hint: 'Export claim summary' },
+    ],
+    apiCompat: ['EDI 837/835', 'ACORD'],
+    webhookEvents: ['claim.filed', 'claim.approved', 'claim.denied', 'claim.paid'],
+  },
+
+  {
+    domain: 'logistics',
+    imports: [
+      { format: 'csv', entity: 'Shipment', hint: 'Import shipments from CSV' },
+      { format: 'edi', entity: 'Shipment', hint: 'Import EDI 856 ASN' },
+      { format: 'json', entity: 'Shipment', hint: 'Import shipments from JSON' },
+    ],
+    exports: [
+      { format: 'csv', entity: 'Shipment', hint: 'Export shipment log' },
+      { format: 'edi', entity: 'Shipment', hint: 'Export EDI 856 ASN' },
+      { format: 'json', entity: 'Shipment', hint: 'Export tracking data' },
+    ],
+    apiCompat: ['EDI 856', 'GS1'],
+    webhookEvents: ['shipment.dispatched', 'shipment.delivered', 'shipment.exception'],
+  },
+
+  {
+    domain: 'agriculture',
+    imports: [
+      { format: 'csv', entity: 'CropCycle', hint: 'Import field/crop data from CSV' },
+      { format: 'geojson', entity: 'CropCycle', hint: 'Import field boundaries as GeoJSON' },
+      { format: 'json', entity: 'CropCycle', hint: 'Import sensor data as JSON' },
+    ],
+    exports: [
+      { format: 'csv', entity: 'CropCycle', hint: 'Export crop records' },
+      { format: 'geojson', entity: 'CropCycle', hint: 'Export field map as GeoJSON' },
+      { format: 'pdf', entity: 'CropCycle', hint: 'Export season report' },
+    ],
+    apiCompat: ['AgGateway ADAPT', 'ISO 11783'],
+    webhookEvents: ['crop.planted', 'crop.harvested', 'sensor.alert'],
+  },
+
+  {
+    domain: 'events',
+    imports: [
+      { format: 'csv', entity: 'Event', hint: 'Import event list from CSV' },
+      { format: 'ical', entity: 'Event', hint: 'Import events from iCal' },
+      { format: 'json', entity: 'Event', hint: 'Import events from JSON' },
+    ],
+    exports: [
+      { format: 'ical', entity: 'Event', hint: 'Export as iCal' },
+      { format: 'csv', entity: 'Event', hint: 'Export event list' },
+      { format: 'pdf', entity: 'Event', hint: 'Export event program' },
+    ],
+    apiCompat: ['iCal/ICS', 'Schema.org Event'],
+    webhookEvents: ['event.announced', 'event.registration_open', 'event.sold_out', 'event.completed'],
+  },
+
+  {
+    domain: 'nonprofit',
+    imports: [
+      { format: 'csv', entity: 'Grant', hint: 'Import donor/grant list' },
+      { format: 'json', entity: 'Grant', hint: 'Import grant data' },
+    ],
+    exports: [
+      { format: 'csv', entity: 'Grant', hint: 'Export grant tracker' },
+      { format: 'pdf', entity: 'Grant', hint: 'Export grant report' },
+      { format: 'xlsx', entity: 'Grant', hint: 'Export financials for board' },
+    ],
+    apiCompat: ['GuideStar API', 'Candid'],
+    webhookEvents: ['grant.awarded', 'grant.closed', 'donation.received'],
+  },
+
+  {
+    domain: 'aviation',
+    imports: [
+      { format: 'csv', entity: 'Flight', hint: 'Import flight schedule' },
+      { format: 'json', entity: 'Flight', hint: 'Import flight data' },
+    ],
+    exports: [
+      { format: 'csv', entity: 'Flight', hint: 'Export flight log' },
+      { format: 'pdf', entity: 'Flight', hint: 'Export flight report' },
+      { format: 'json', entity: 'Flight', hint: 'Export for FAA/EASA' },
+    ],
+    apiCompat: ['ARINC 424', 'SWIM', 'FIXM'],
+    webhookEvents: ['flight.departed', 'flight.landed', 'flight.cancelled', 'maintenance.due'],
+  },
+
+  {
+    domain: 'fitness',
+    imports: [
+      { format: 'csv', entity: 'Program', hint: 'Import workout programs' },
+      { format: 'json', entity: 'Program', hint: 'Import training data' },
+    ],
+    exports: [
+      { format: 'csv', entity: 'Program', hint: 'Export training log' },
+      { format: 'pdf', entity: 'Program', hint: 'Export program summary' },
+      { format: 'json', entity: 'Program', hint: 'Export workout data' },
+    ],
+    apiCompat: ['Apple HealthKit', 'Google Fit', 'FIT Protocol'],
+    webhookEvents: ['program.started', 'program.completed', 'goal.achieved'],
+  },
+
+  // ── Core lenses ──────────────────────────────────────────────
+
+  {
+    domain: 'paper',
+    imports: [
+      { format: 'json', entity: 'project', hint: 'Import research project data' },
+      { format: 'csv', entity: 'claim', hint: 'Import claims from CSV' },
+    ],
+    exports: [
+      { format: 'markdown', entity: 'project', hint: 'Export paper as Markdown' },
+      { format: 'pdf', entity: 'project', hint: 'Export paper as PDF' },
+      { format: 'json', entity: 'project', hint: 'Export project data' },
+    ],
+    webhookEvents: ['paper.published', 'claim.verified', 'claim.contradicted'],
+  },
+
+  {
+    domain: 'code',
+    imports: [
+      { format: 'json', entity: 'project', hint: 'Import project metadata' },
+      { format: 'json', entity: 'snippet', hint: 'Import code snippets' },
+    ],
+    exports: [
+      { format: 'json', entity: 'project', hint: 'Export project data' },
+      { format: 'markdown', entity: 'snippet', hint: 'Export snippets as Markdown' },
+    ],
+    webhookEvents: ['review.approved', 'review.merged', 'snippet.created'],
+  },
+
+  {
+    domain: 'graph',
+    imports: [
+      { format: 'json', entity: 'entity', hint: 'Import knowledge graph nodes' },
+      { format: 'csv', entity: 'relation', hint: 'Import edges from CSV' },
+    ],
+    exports: [
+      { format: 'json', entity: 'entity', hint: 'Export graph as JSON-LD' },
+      { format: 'csv', entity: 'relation', hint: 'Export edge list as CSV' },
+    ],
+    webhookEvents: ['entity.created', 'relation.created', 'graph.merged'],
+  },
+];
+
+// ═══════════════════════════════════════════════════════════════
+// AUTOMATION PROFILES
+// ═══════════════════════════════════════════════════════════════
+
+export const AUTOMATION_PROFILES: AutomationProfile[] = [
+  {
+    domain: 'healthcare',
+    triggers: [
+      { event: 'encounter.completed', label: 'Auto-generate billing codes on encounter completion', macro: 'healthcare.generateBillingCodes', defaultEnabled: true },
+      { event: 'prescription.created', label: 'Check drug interactions on new prescription', macro: 'healthcare.drugInteractionCheck', defaultEnabled: true },
+      { event: 'patient.updated', label: 'Flag incomplete patient records', macro: 'healthcare.validatePatientRecord', condition: 'missingRequiredFields', defaultEnabled: false },
+      { event: 'encounter.completed', label: 'Auto-send follow-up reminder', macro: 'healthcare.scheduleFollowUp', condition: 'requiresFollowUp', defaultEnabled: false },
+    ],
+  },
+  {
+    domain: 'legal',
+    triggers: [
+      { event: 'case.deadline_approaching', label: 'Alert on approaching deadlines (7 days)', macro: 'legal.deadlineAlert', condition: 'daysUntilDeadline <= 7', defaultEnabled: true },
+      { event: 'contract.expired', label: 'Notify on contract expiration', macro: 'legal.contractExpirationNotice', defaultEnabled: true },
+      { event: 'contract.executed', label: 'Auto-generate contract summary', macro: 'legal.generateContractSummary', defaultEnabled: false },
+      { event: 'case.status_changed', label: 'Log status change to audit trail', macro: 'legal.auditStatusChange', defaultEnabled: true },
+    ],
+  },
+  {
+    domain: 'accounting',
+    triggers: [
+      { event: 'invoice.overdue', label: 'Auto-send payment reminder', macro: 'accounting.sendPaymentReminder', defaultEnabled: true },
+      { event: 'transaction.reconciled', label: 'Update running balance on reconciliation', macro: 'accounting.updateBalance', defaultEnabled: true },
+      { event: 'invoice.paid', label: 'Auto-reconcile matching transactions', macro: 'accounting.autoReconcile', defaultEnabled: false },
+      { event: 'account.balance_changed', label: 'Alert on unusual balance changes', macro: 'accounting.anomalyDetection', condition: 'changePercent > 20', defaultEnabled: false },
+    ],
+  },
+  {
+    domain: 'security',
+    triggers: [
+      { event: 'incident.reported', label: 'Auto-triage based on severity', macro: 'security.autoTriage', defaultEnabled: true },
+      { event: 'incident.escalated', label: 'Notify security team on escalation', macro: 'security.escalationNotify', defaultEnabled: true },
+      { event: 'threat.level_changed', label: 'Update threat dashboard', macro: 'security.updateThreatBoard', defaultEnabled: true },
+      { event: 'incident.closed', label: 'Generate post-mortem template', macro: 'security.generatePostMortem', defaultEnabled: false },
+    ],
+  },
+  {
+    domain: 'manufacturing',
+    triggers: [
+      { event: 'qc.failed', label: 'Auto-create rework order on QC failure', macro: 'manufacturing.createRework', defaultEnabled: true },
+      { event: 'workorder.completed', label: 'Update inventory on work order completion', macro: 'manufacturing.updateInventory', defaultEnabled: true },
+      { event: 'bom.approved', label: 'Calculate total cost on BOM approval', macro: 'manufacturing.calculateBOMCost', defaultEnabled: true },
+      { event: 'workorder.started', label: 'Reserve materials from inventory', macro: 'manufacturing.reserveMaterials', defaultEnabled: false },
+    ],
+  },
+  {
+    domain: 'education',
+    triggers: [
+      { event: 'assignment.graded', label: 'Auto-update GPA on grade entry', macro: 'education.gradeCalculation', defaultEnabled: true },
+      { event: 'student.enrolled', label: 'Check schedule conflicts on enrollment', macro: 'education.scheduleConflict', defaultEnabled: true },
+      { event: 'course.completed', label: 'Update progress tracking', macro: 'education.progressTrack', defaultEnabled: true },
+    ],
+  },
+  {
+    domain: 'retail',
+    triggers: [
+      { event: 'product.low_stock', label: 'Auto-create reorder when below reorder point', macro: 'retail.autoReorder', condition: 'quantity <= reorderPoint', defaultEnabled: false },
+      { event: 'order.placed', label: 'Validate inventory availability', macro: 'retail.validateInventory', defaultEnabled: true },
+      { event: 'order.delivered', label: 'Update customer lifetime value', macro: 'retail.updateCustomerLTV', defaultEnabled: true },
+      { event: 'customer.tier_changed', label: 'Notify customer of tier change', macro: 'retail.tierChangeNotify', defaultEnabled: false },
+    ],
+  },
+  {
+    domain: 'government',
+    triggers: [
+      { event: 'permit.submitted', label: 'Auto-assign reviewer on submission', macro: 'government.assignReviewer', defaultEnabled: true },
+      { event: 'permit.approved', label: 'Generate permit certificate', macro: 'government.generateCertificate', defaultEnabled: true },
+      { event: 'violation.reported', label: 'Auto-classify violation severity', macro: 'government.classifyViolation', defaultEnabled: false },
+    ],
+  },
+  {
+    domain: 'logistics',
+    triggers: [
+      { event: 'shipment.exception', label: 'Alert operations on shipment exception', macro: 'logistics.exceptionAlert', defaultEnabled: true },
+      { event: 'shipment.delivered', label: 'Auto-close shipment and update tracking', macro: 'logistics.closeShipment', defaultEnabled: true },
+      { event: 'shipment.dispatched', label: 'Send tracking notification', macro: 'logistics.sendTrackingNotification', defaultEnabled: false },
+    ],
+  },
+  {
+    domain: 'realestate',
+    triggers: [
+      { event: 'listing.price_changed', label: 'Notify watchers on price change', macro: 'realestate.priceChangeNotify', defaultEnabled: true },
+      { event: 'listing.sold', label: 'Generate closing documents', macro: 'realestate.generateClosingDocs', defaultEnabled: false },
+    ],
+  },
+  {
+    domain: 'insurance',
+    triggers: [
+      { event: 'claim.filed', label: 'Auto-assign adjuster', macro: 'insurance.assignAdjuster', defaultEnabled: true },
+      { event: 'claim.approved', label: 'Calculate payout amount', macro: 'insurance.calculatePayout', defaultEnabled: true },
+      { event: 'claim.filed', label: 'Flag potential fraud indicators', macro: 'insurance.fraudScreen', condition: 'claimAmount > threshold', defaultEnabled: false },
+    ],
+  },
+  {
+    domain: 'nonprofit',
+    triggers: [
+      { event: 'donation.received', label: 'Auto-generate thank you receipt', macro: 'nonprofit.generateReceipt', defaultEnabled: true },
+      { event: 'grant.closed', label: 'Generate final grant report', macro: 'nonprofit.generateGrantReport', defaultEnabled: false },
+    ],
+  },
+  {
+    domain: 'events',
+    triggers: [
+      { event: 'event.registration_open', label: 'Send registration notification', macro: 'events.registrationNotify', defaultEnabled: true },
+      { event: 'event.sold_out', label: 'Enable waitlist', macro: 'events.enableWaitlist', defaultEnabled: false },
+      { event: 'event.completed', label: 'Send feedback survey', macro: 'events.sendFeedbackSurvey', defaultEnabled: false },
+    ],
+  },
+  {
+    domain: 'agriculture',
+    triggers: [
+      { event: 'sensor.alert', label: 'Alert on sensor threshold breach', macro: 'agriculture.sensorAlert', defaultEnabled: true },
+      { event: 'crop.harvested', label: 'Calculate yield metrics', macro: 'agriculture.yieldAnalysis', defaultEnabled: true },
+    ],
+  },
+  {
+    domain: 'aviation',
+    triggers: [
+      { event: 'flight.cancelled', label: 'Notify passengers on cancellation', macro: 'aviation.cancellationNotify', defaultEnabled: true },
+      { event: 'maintenance.due', label: 'Create maintenance work order', macro: 'aviation.createMaintenanceOrder', defaultEnabled: true },
+    ],
+  },
+  {
+    domain: 'fitness',
+    triggers: [
+      { event: 'goal.achieved', label: 'Congratulate on goal achievement', macro: 'fitness.goalAchievedNotify', defaultEnabled: false },
+      { event: 'program.completed', label: 'Generate progress report', macro: 'fitness.progressReport', defaultEnabled: true },
+    ],
+  },
+];
+
+// ═══════════════════════════════════════════════════════════════
+// DOMAIN RBAC PROFILES
+// ═══════════════════════════════════════════════════════════════
+
+export const DOMAIN_RBAC_PROFILES: DomainRBACProfile[] = [
+  {
+    domain: 'healthcare',
+    sharedArtifacts: true,
+    activityFeed: true,
+    permissions: [
+      { action: 'view_patient', label: 'View patient records', minRole: 'viewer' },
+      { action: 'edit_patient', label: 'Edit patient records', minRole: 'editor' },
+      { action: 'prescribe', label: 'Create prescriptions', minRole: 'editor' },
+      { action: 'sign_off', label: 'Sign off on encounters', minRole: 'admin' },
+      { action: 'view_billing', label: 'View billing data', minRole: 'reviewer' },
+      { action: 'export_phi', label: 'Export protected health information', minRole: 'admin', delegable: false },
+    ],
+  },
+  {
+    domain: 'legal',
+    sharedArtifacts: true,
+    activityFeed: true,
+    permissions: [
+      { action: 'view_case', label: 'View case files', minRole: 'viewer' },
+      { action: 'edit_case', label: 'Edit case details', minRole: 'editor' },
+      { action: 'manage_contracts', label: 'Manage contracts', minRole: 'editor' },
+      { action: 'file_document', label: 'File court documents', minRole: 'admin' },
+      { action: 'settle_case', label: 'Approve settlements', minRole: 'admin', delegable: false },
+      { action: 'view_privileged', label: 'View privileged documents', minRole: 'admin', delegable: false },
+    ],
+  },
+  {
+    domain: 'accounting',
+    sharedArtifacts: true,
+    activityFeed: true,
+    permissions: [
+      { action: 'view_accounts', label: 'View chart of accounts', minRole: 'viewer' },
+      { action: 'create_transaction', label: 'Create transactions', minRole: 'editor' },
+      { action: 'reconcile', label: 'Reconcile accounts', minRole: 'editor' },
+      { action: 'approve_invoice', label: 'Approve invoices', minRole: 'admin' },
+      { action: 'close_period', label: 'Close accounting period', minRole: 'admin', delegable: false },
+      { action: 'export_financials', label: 'Export financial reports', minRole: 'admin' },
+    ],
+  },
+  {
+    domain: 'security',
+    sharedArtifacts: true,
+    activityFeed: true,
+    permissions: [
+      { action: 'view_incidents', label: 'View security incidents', minRole: 'viewer' },
+      { action: 'report_incident', label: 'Report incidents', minRole: 'editor' },
+      { action: 'manage_incident', label: 'Manage incident lifecycle', minRole: 'editor' },
+      { action: 'close_incident', label: 'Close incidents', minRole: 'admin' },
+      { action: 'view_threat_intel', label: 'View threat intelligence', minRole: 'reviewer', delegable: false },
+    ],
+  },
+  {
+    domain: 'manufacturing',
+    sharedArtifacts: true,
+    activityFeed: true,
+    permissions: [
+      { action: 'view_orders', label: 'View work orders', minRole: 'viewer' },
+      { action: 'manage_orders', label: 'Manage work orders', minRole: 'editor' },
+      { action: 'approve_bom', label: 'Approve BOMs', minRole: 'admin' },
+      { action: 'perform_qc', label: 'Perform quality checks', minRole: 'reviewer' },
+      { action: 'ship', label: 'Authorize shipment', minRole: 'admin' },
+    ],
+  },
+  {
+    domain: 'education',
+    sharedArtifacts: true,
+    activityFeed: true,
+    permissions: [
+      { action: 'view_students', label: 'View student records', minRole: 'viewer' },
+      { action: 'grade', label: 'Enter grades', minRole: 'editor' },
+      { action: 'manage_enrollment', label: 'Manage enrollment', minRole: 'admin' },
+      { action: 'graduate', label: 'Approve graduation', minRole: 'admin', delegable: false },
+    ],
+  },
+  {
+    domain: 'retail',
+    sharedArtifacts: true,
+    activityFeed: true,
+    permissions: [
+      { action: 'view_catalog', label: 'View product catalog', minRole: 'viewer' },
+      { action: 'manage_products', label: 'Manage products', minRole: 'editor' },
+      { action: 'process_orders', label: 'Process orders', minRole: 'editor' },
+      { action: 'issue_refund', label: 'Issue refunds', minRole: 'admin' },
+      { action: 'manage_pricing', label: 'Manage pricing', minRole: 'admin', delegable: true },
+    ],
+  },
+  {
+    domain: 'government',
+    sharedArtifacts: true,
+    activityFeed: true,
+    permissions: [
+      { action: 'view_permits', label: 'View permits', minRole: 'viewer' },
+      { action: 'review_permits', label: 'Review permit applications', minRole: 'reviewer' },
+      { action: 'approve_permits', label: 'Approve/deny permits', minRole: 'admin' },
+      { action: 'issue_violations', label: 'Issue violations', minRole: 'admin' },
+      { action: 'revoke_permits', label: 'Revoke permits', minRole: 'owner', delegable: false },
+    ],
+  },
+  {
+    domain: 'realestate',
+    sharedArtifacts: true,
+    activityFeed: true,
+    permissions: [
+      { action: 'view_listings', label: 'View listings', minRole: 'viewer' },
+      { action: 'manage_listings', label: 'Manage listings', minRole: 'editor' },
+      { action: 'close_sale', label: 'Close sales', minRole: 'admin' },
+    ],
+  },
+  {
+    domain: 'insurance',
+    sharedArtifacts: true,
+    activityFeed: true,
+    permissions: [
+      { action: 'view_claims', label: 'View claims', minRole: 'viewer' },
+      { action: 'file_claim', label: 'File claims', minRole: 'editor' },
+      { action: 'adjudicate', label: 'Adjudicate claims', minRole: 'admin' },
+      { action: 'authorize_payment', label: 'Authorize payments', minRole: 'admin', delegable: false },
+    ],
+  },
+  {
+    domain: 'logistics',
+    sharedArtifacts: true,
+    activityFeed: true,
+    permissions: [
+      { action: 'view_shipments', label: 'View shipments', minRole: 'viewer' },
+      { action: 'manage_shipments', label: 'Manage shipments', minRole: 'editor' },
+      { action: 'resolve_exceptions', label: 'Resolve exceptions', minRole: 'admin' },
+    ],
+  },
+  {
+    domain: 'nonprofit',
+    sharedArtifacts: true,
+    activityFeed: true,
+    permissions: [
+      { action: 'view_grants', label: 'View grant records', minRole: 'viewer' },
+      { action: 'manage_grants', label: 'Manage grants', minRole: 'editor' },
+      { action: 'submit_applications', label: 'Submit grant applications', minRole: 'admin' },
+    ],
+  },
+  {
+    domain: 'events',
+    sharedArtifacts: true,
+    activityFeed: true,
+    permissions: [
+      { action: 'view_events', label: 'View events', minRole: 'viewer' },
+      { action: 'manage_events', label: 'Manage events', minRole: 'editor' },
+      { action: 'cancel_events', label: 'Cancel events', minRole: 'owner' },
+    ],
+  },
+  {
+    domain: 'agriculture',
+    sharedArtifacts: true,
+    activityFeed: true,
+    permissions: [
+      { action: 'view_fields', label: 'View field data', minRole: 'viewer' },
+      { action: 'manage_crops', label: 'Manage crop cycles', minRole: 'editor' },
+      { action: 'record_harvest', label: 'Record harvest data', minRole: 'editor' },
+    ],
+  },
+  {
+    domain: 'aviation',
+    sharedArtifacts: true,
+    activityFeed: true,
+    permissions: [
+      { action: 'view_flights', label: 'View flight schedule', minRole: 'viewer' },
+      { action: 'manage_flights', label: 'Manage flights', minRole: 'editor' },
+      { action: 'clear_preflight', label: 'Clear preflight checks', minRole: 'editor' },
+      { action: 'cancel_flight', label: 'Cancel flights', minRole: 'admin', delegable: false },
+    ],
+  },
+  {
+    domain: 'fitness',
+    sharedArtifacts: false,
+    activityFeed: true,
+    permissions: [
+      { action: 'view_programs', label: 'View programs', minRole: 'viewer' },
+      { action: 'manage_programs', label: 'Manage programs', minRole: 'editor' },
+    ],
+  },
+
+  // ── Core lenses ──────────────────────────────────────────────
+
+  {
+    domain: 'paper',
+    sharedArtifacts: true,
+    activityFeed: true,
+    permissions: [
+      { action: 'view_papers', label: 'View papers', minRole: 'viewer' },
+      { action: 'edit_papers', label: 'Edit papers', minRole: 'editor' },
+      { action: 'publish', label: 'Publish papers', minRole: 'admin' },
+      { action: 'retract', label: 'Retract claims', minRole: 'admin', delegable: false },
+    ],
+  },
+  {
+    domain: 'code',
+    sharedArtifacts: true,
+    activityFeed: true,
+    permissions: [
+      { action: 'view_code', label: 'View code', minRole: 'viewer' },
+      { action: 'edit_code', label: 'Edit code', minRole: 'editor' },
+      { action: 'approve_review', label: 'Approve reviews', minRole: 'reviewer' },
+      { action: 'merge', label: 'Merge code', minRole: 'admin' },
+    ],
+  },
+  {
+    domain: 'graph',
+    sharedArtifacts: true,
+    activityFeed: true,
+    permissions: [
+      { action: 'view_graph', label: 'View knowledge graph', minRole: 'viewer' },
+      { action: 'edit_entities', label: 'Edit entities and relations', minRole: 'editor' },
+      { action: 'merge_graphs', label: 'Merge graph fragments', minRole: 'admin' },
+    ],
+  },
+];
+
+// ── Lookup helpers ─────────────────────────────────────────────
+
+const _importExportMap = new Map(IMPORT_EXPORT_PROFILES.map(p => [p.domain, p]));
+const _automationMap = new Map(AUTOMATION_PROFILES.map(p => [p.domain, p]));
+const _rbacMap = new Map(DOMAIN_RBAC_PROFILES.map(p => [p.domain, p]));
+
+export function getImportExportProfile(domain: string): ImportExportProfile | undefined {
+  return _importExportMap.get(domain);
+}
+
+export function getAutomationProfile(domain: string): AutomationProfile | undefined {
+  return _automationMap.get(domain);
+}
+
+export function getDomainRBAC(domain: string): DomainRBACProfile | undefined {
+  return _rbacMap.get(domain);
+}
+
+export function getDomainsWithImportExport(): string[] {
+  return IMPORT_EXPORT_PROFILES.map(p => p.domain);
+}
+
+export function getDomainsWithAutomation(): string[] {
+  return AUTOMATION_PROFILES.map(p => p.domain);
+}
+
+export function getDomainsWithRBAC(): string[] {
+  return DOMAIN_RBAC_PROFILES.map(p => p.domain);
+}

--- a/concord-frontend/lib/lenses/domain-bridge.ts
+++ b/concord-frontend/lib/lenses/domain-bridge.ts
@@ -1,0 +1,173 @@
+/**
+ * Domain Bridge - The unified layer that connects every lens to
+ * all five competitor-parity dimensions.
+ *
+ * This is the file that answers: "For lens X, what is its domain
+ * schema, workflow engine, import/export surface, automation
+ * triggers, and RBAC profile?"
+ *
+ * If a lens has an entry in this bridge, it is domain-finished.
+ * If it doesn't, it is platform-ready but not competitor-level.
+ *
+ * ┌─────────────────┐
+ * │  Lens Manifest   │  ← declares existence, UI, capabilities
+ * ├─────────────────┤
+ * │  Domain Bridge   │  ← THIS FILE: binds depth to each lens
+ * ├─────────────────┤
+ * │  Infrastructure  │  ← write-guard, scope-router, RBAC, webhooks
+ * └─────────────────┘
+ */
+
+import {
+  type DomainSchema,
+  getDomainSchema,
+  getDomainsWithSchemas,
+} from './domain-schemas';
+
+import {
+  type WorkflowDef,
+  getWorkflowsForDomain,
+  getAvailableTransitions,
+  isValidTransition,
+  getInitialState,
+  getDomainsWithWorkflows,
+} from './workflow-definitions';
+
+import {
+  type ImportExportProfile,
+  type AutomationProfile,
+  type DomainRBACProfile,
+  getImportExportProfile,
+  getAutomationProfile,
+  getDomainRBAC,
+  getDomainsWithImportExport,
+  getDomainsWithAutomation,
+  getDomainsWithRBAC,
+} from './automation-bindings';
+
+// ── Composite Domain Profile ───────────────────────────────────
+
+export interface DomainProfile {
+  domain: string;
+  /** Dimension 1: Domain Data Model */
+  schema: DomainSchema | null;
+  /** Dimension 2: Workflow Engines */
+  workflows: WorkflowDef[];
+  /** Dimension 3: Import/Export Parity */
+  importExport: ImportExportProfile | null;
+  /** Dimension 4: Automation Layer */
+  automation: AutomationProfile | null;
+  /** Dimension 5: Multi-User Controls */
+  rbac: DomainRBACProfile | null;
+}
+
+export interface CompetitorParityScore {
+  domain: string;
+  /** 0-5: how many dimensions are bound */
+  score: number;
+  dimensions: {
+    schema: boolean;
+    workflows: boolean;
+    importExport: boolean;
+    automation: boolean;
+    rbac: boolean;
+  };
+  /** 'competitor-level' | 'platform-ready' | 'scaffold' */
+  tier: 'competitor-level' | 'platform-ready' | 'scaffold';
+}
+
+// ── Bridge: resolve full profile for any lens ──────────────────
+
+export function getDomainProfile(domain: string): DomainProfile {
+  return {
+    domain,
+    schema: getDomainSchema(domain) ?? null,
+    workflows: getWorkflowsForDomain(domain),
+    importExport: getImportExportProfile(domain) ?? null,
+    automation: getAutomationProfile(domain) ?? null,
+    rbac: getDomainRBAC(domain) ?? null,
+  };
+}
+
+// ── Parity scoring ─────────────────────────────────────────────
+
+export function getCompetitorParityScore(domain: string): CompetitorParityScore {
+  const profile = getDomainProfile(domain);
+  const dimensions = {
+    schema: profile.schema !== null,
+    workflows: profile.workflows.length > 0,
+    importExport: profile.importExport !== null,
+    automation: profile.automation !== null,
+    rbac: profile.rbac !== null,
+  };
+  const score = Object.values(dimensions).filter(Boolean).length;
+
+  let tier: CompetitorParityScore['tier'];
+  if (score >= 4) tier = 'competitor-level';
+  else if (score >= 2) tier = 'platform-ready';
+  else tier = 'scaffold';
+
+  return { domain, score, dimensions, tier };
+}
+
+// ── Fleet-wide analytics ───────────────────────────────────────
+
+/** All domains that have at least one dimension bound */
+export function getAllBoundDomains(): string[] {
+  const domains = new Set<string>();
+  for (const d of getDomainsWithSchemas()) domains.add(d);
+  for (const d of getDomainsWithWorkflows()) domains.add(d);
+  for (const d of getDomainsWithImportExport()) domains.add(d);
+  for (const d of getDomainsWithAutomation()) domains.add(d);
+  for (const d of getDomainsWithRBAC()) domains.add(d);
+  return [...domains].sort();
+}
+
+/** Score every bound domain and return sorted by score descending */
+export function getFleetParityReport(): CompetitorParityScore[] {
+  return getAllBoundDomains()
+    .map(getCompetitorParityScore)
+    .sort((a, b) => b.score - a.score);
+}
+
+/** Summary counts by tier */
+export function getFleetSummary(): { competitorLevel: number; platformReady: number; scaffold: number; total: number } {
+  const report = getFleetParityReport();
+  return {
+    competitorLevel: report.filter(r => r.tier === 'competitor-level').length,
+    platformReady: report.filter(r => r.tier === 'platform-ready').length,
+    scaffold: report.filter(r => r.tier === 'scaffold').length,
+    total: report.length,
+  };
+}
+
+// ── Convenience re-exports for single-import usage ─────────────
+
+export {
+  getAvailableTransitions,
+  isValidTransition,
+  getInitialState,
+} from './workflow-definitions';
+
+export type {
+  DomainSchema,
+  EntityDef,
+  FieldDef,
+  RelationDef,
+} from './domain-schemas';
+
+export type {
+  WorkflowDef,
+  WorkflowState,
+  WorkflowTransition,
+} from './workflow-definitions';
+
+export type {
+  ImportExportProfile,
+  AutomationProfile,
+  AutomationTrigger,
+  DomainRBACProfile,
+  DomainPermission,
+  ImportFormat,
+  ExportFormat,
+} from './automation-bindings';

--- a/concord-frontend/lib/lenses/domain-schemas.ts
+++ b/concord-frontend/lib/lenses/domain-schemas.ts
@@ -1,0 +1,570 @@
+/**
+ * Domain Schema Registry - Per-lens entity models with typed fields,
+ * validation rules, relationships, and audit contracts.
+ *
+ * This is the "depth" layer that turns manifest declarations into
+ * enforceable domain models. A lens without a domain schema is a
+ * UI scaffold. A lens with one rivals vertical SaaS.
+ *
+ * Pattern: Each lens declares its entities, their fields, field types,
+ * validation rules, required fields, entity relationships, and which
+ * fields carry audit history.
+ */
+
+// ── Field Types ────────────────────────────────────────────────
+
+export type FieldType =
+  | 'string' | 'text' | 'number' | 'boolean' | 'date' | 'datetime'
+  | 'enum' | 'currency' | 'email' | 'url' | 'phone'
+  | 'json' | 'array' | 'reference' | 'file' | 'geo' | 'duration';
+
+export interface FieldDef {
+  name: string;
+  type: FieldType;
+  required?: boolean;
+  /** For enum fields */
+  enumValues?: string[];
+  /** For reference fields - which entity this points to */
+  refEntity?: string;
+  /** For array fields - element type */
+  arrayOf?: FieldType | string;
+  /** Default value */
+  defaultValue?: unknown;
+  /** Validation rule (regex pattern for strings, min/max for numbers) */
+  validation?: {
+    pattern?: string;
+    min?: number;
+    max?: number;
+    minLength?: number;
+    maxLength?: number;
+  };
+  /** Whether changes to this field are tracked in audit history */
+  audited?: boolean;
+  /** Whether this field is indexed for search */
+  indexed?: boolean;
+}
+
+export interface EntityDef {
+  name: string;
+  /** The primary display field (e.g. 'title', 'name') */
+  displayField: string;
+  fields: FieldDef[];
+  /** Soft-delete support */
+  softDelete?: boolean;
+  /** Versioning support */
+  versioned?: boolean;
+}
+
+export interface RelationDef {
+  from: string;
+  to: string;
+  type: 'one-to-one' | 'one-to-many' | 'many-to-many';
+  /** The field on 'from' that holds the reference */
+  foreignKey: string;
+  /** Cascade behavior on delete */
+  onDelete?: 'cascade' | 'nullify' | 'restrict';
+}
+
+export interface DomainSchema {
+  domain: string;
+  entities: EntityDef[];
+  relations: RelationDef[];
+}
+
+// ── Domain Schema Registry ─────────────────────────────────────
+
+export const DOMAIN_SCHEMAS: DomainSchema[] = [
+
+  // ═══════════════════════════════════════════════════════════════
+  // CORE PRODUCT LENSES
+  // ═══════════════════════════════════════════════════════════════
+
+  {
+    domain: 'paper',
+    entities: [
+      {
+        name: 'project', displayField: 'title', versioned: true, softDelete: true,
+        fields: [
+          { name: 'title', type: 'string', required: true, indexed: true, validation: { maxLength: 200 } },
+          { name: 'abstract', type: 'text' },
+          { name: 'status', type: 'enum', enumValues: ['draft', 'in_review', 'published', 'archived'], required: true, audited: true },
+          { name: 'tags', type: 'array', arrayOf: 'string', indexed: true },
+          { name: 'wordCount', type: 'number' },
+          { name: 'authors', type: 'array', arrayOf: 'string' },
+          { name: 'publishedAt', type: 'datetime' },
+        ],
+      },
+      {
+        name: 'claim', displayField: 'statement', versioned: true,
+        fields: [
+          { name: 'statement', type: 'text', required: true },
+          { name: 'confidence', type: 'number', validation: { min: 0, max: 1 }, audited: true },
+          { name: 'projectId', type: 'reference', refEntity: 'project', required: true },
+          { name: 'evidenceIds', type: 'array', arrayOf: 'reference' },
+          { name: 'status', type: 'enum', enumValues: ['proposed', 'supported', 'contradicted', 'retracted'], audited: true },
+        ],
+      },
+      {
+        name: 'evidence', displayField: 'summary',
+        fields: [
+          { name: 'summary', type: 'text', required: true },
+          { name: 'sourceUrl', type: 'url' },
+          { name: 'sourceTier', type: 'enum', enumValues: ['primary', 'secondary', 'tertiary'] },
+          { name: 'claimId', type: 'reference', refEntity: 'claim' },
+          { name: 'strength', type: 'enum', enumValues: ['strong', 'moderate', 'weak'] },
+        ],
+      },
+    ],
+    relations: [
+      { from: 'claim', to: 'project', type: 'many-to-many', foreignKey: 'projectId', onDelete: 'cascade' },
+      { from: 'evidence', to: 'claim', type: 'many-to-many', foreignKey: 'claimId', onDelete: 'nullify' },
+    ],
+  },
+
+  {
+    domain: 'code',
+    entities: [
+      {
+        name: 'project', displayField: 'name', versioned: true, softDelete: true,
+        fields: [
+          { name: 'name', type: 'string', required: true, indexed: true },
+          { name: 'language', type: 'enum', enumValues: ['typescript', 'javascript', 'python', 'rust', 'go', 'java', 'other'] },
+          { name: 'description', type: 'text' },
+          { name: 'repoUrl', type: 'url' },
+          { name: 'status', type: 'enum', enumValues: ['active', 'archived', 'deprecated'], audited: true },
+        ],
+      },
+      {
+        name: 'snippet', displayField: 'title', versioned: true,
+        fields: [
+          { name: 'title', type: 'string', required: true },
+          { name: 'content', type: 'text', required: true },
+          { name: 'language', type: 'string' },
+          { name: 'projectId', type: 'reference', refEntity: 'project' },
+          { name: 'tags', type: 'array', arrayOf: 'string' },
+        ],
+      },
+      {
+        name: 'review', displayField: 'title',
+        fields: [
+          { name: 'title', type: 'string', required: true },
+          { name: 'diff', type: 'text', required: true },
+          { name: 'status', type: 'enum', enumValues: ['open', 'approved', 'changes_requested', 'merged'], audited: true },
+          { name: 'projectId', type: 'reference', refEntity: 'project', required: true },
+          { name: 'reviewer', type: 'string' },
+        ],
+      },
+    ],
+    relations: [
+      { from: 'snippet', to: 'project', type: 'many-to-many', foreignKey: 'projectId', onDelete: 'cascade' },
+      { from: 'review', to: 'project', type: 'many-to-many', foreignKey: 'projectId', onDelete: 'cascade' },
+    ],
+  },
+
+  {
+    domain: 'graph',
+    entities: [
+      {
+        name: 'entity', displayField: 'label', versioned: true,
+        fields: [
+          { name: 'label', type: 'string', required: true, indexed: true },
+          { name: 'entityType', type: 'string', required: true, indexed: true },
+          { name: 'properties', type: 'json' },
+          { name: 'confidence', type: 'number', validation: { min: 0, max: 1 } },
+        ],
+      },
+      {
+        name: 'relation', displayField: 'label',
+        fields: [
+          { name: 'label', type: 'string', required: true },
+          { name: 'fromEntityId', type: 'reference', refEntity: 'entity', required: true },
+          { name: 'toEntityId', type: 'reference', refEntity: 'entity', required: true },
+          { name: 'weight', type: 'number', validation: { min: 0, max: 1 } },
+          { name: 'sourceId', type: 'reference', refEntity: 'source' },
+        ],
+      },
+      {
+        name: 'source', displayField: 'title',
+        fields: [
+          { name: 'title', type: 'string', required: true },
+          { name: 'url', type: 'url' },
+          { name: 'tier', type: 'enum', enumValues: ['primary', 'secondary', 'tertiary'] },
+        ],
+      },
+    ],
+    relations: [
+      { from: 'relation', to: 'entity', type: 'many-to-many', foreignKey: 'fromEntityId', onDelete: 'cascade' },
+      { from: 'relation', to: 'source', type: 'many-to-many', foreignKey: 'sourceId', onDelete: 'nullify' },
+    ],
+  },
+
+  // ═══════════════════════════════════════════════════════════════
+  // SUPER-LENSES (representative set - same pattern for all 23)
+  // ═══════════════════════════════════════════════════════════════
+
+  {
+    domain: 'healthcare',
+    entities: [
+      {
+        name: 'Patient', displayField: 'name', softDelete: true, versioned: true,
+        fields: [
+          { name: 'name', type: 'string', required: true, indexed: true },
+          { name: 'dateOfBirth', type: 'date', required: true },
+          { name: 'mrn', type: 'string', indexed: true, validation: { pattern: '^[A-Z0-9]+$' } },
+          { name: 'sex', type: 'enum', enumValues: ['male', 'female', 'other', 'unknown'] },
+          { name: 'allergies', type: 'array', arrayOf: 'string' },
+          { name: 'insuranceId', type: 'string' },
+          { name: 'primaryProvider', type: 'string' },
+          { name: 'status', type: 'enum', enumValues: ['active', 'inactive', 'deceased'], audited: true },
+        ],
+      },
+      {
+        name: 'Encounter', displayField: 'reason', versioned: true,
+        fields: [
+          { name: 'patientId', type: 'reference', refEntity: 'Patient', required: true },
+          { name: 'reason', type: 'text', required: true },
+          { name: 'encounterType', type: 'enum', enumValues: ['office_visit', 'telehealth', 'emergency', 'inpatient', 'procedure'] },
+          { name: 'providerId', type: 'string', required: true },
+          { name: 'date', type: 'datetime', required: true },
+          { name: 'status', type: 'enum', enumValues: ['scheduled', 'in_progress', 'completed', 'cancelled', 'no_show'], audited: true },
+          { name: 'diagnosis', type: 'array', arrayOf: 'string' },
+          { name: 'notes', type: 'text' },
+        ],
+      },
+      {
+        name: 'Prescription', displayField: 'medication',
+        fields: [
+          { name: 'patientId', type: 'reference', refEntity: 'Patient', required: true },
+          { name: 'medication', type: 'string', required: true, indexed: true },
+          { name: 'dosage', type: 'string', required: true },
+          { name: 'frequency', type: 'string', required: true },
+          { name: 'startDate', type: 'date', required: true },
+          { name: 'endDate', type: 'date' },
+          { name: 'prescriberId', type: 'string', required: true },
+          { name: 'status', type: 'enum', enumValues: ['active', 'completed', 'discontinued', 'on_hold'], audited: true },
+          { name: 'refillsRemaining', type: 'number', validation: { min: 0 } },
+        ],
+      },
+    ],
+    relations: [
+      { from: 'Encounter', to: 'Patient', type: 'many-to-many', foreignKey: 'patientId', onDelete: 'restrict' },
+      { from: 'Prescription', to: 'Patient', type: 'many-to-many', foreignKey: 'patientId', onDelete: 'restrict' },
+    ],
+  },
+
+  {
+    domain: 'legal',
+    entities: [
+      {
+        name: 'Case', displayField: 'title', versioned: true, softDelete: true,
+        fields: [
+          { name: 'title', type: 'string', required: true, indexed: true },
+          { name: 'caseNumber', type: 'string', indexed: true },
+          { name: 'caseType', type: 'enum', enumValues: ['litigation', 'transactional', 'compliance', 'immigration', 'ip', 'criminal', 'family'] },
+          { name: 'status', type: 'enum', enumValues: ['intake', 'active', 'discovery', 'trial', 'appeal', 'settled', 'closed'], audited: true },
+          { name: 'client', type: 'string', required: true },
+          { name: 'opposingParty', type: 'string' },
+          { name: 'jurisdiction', type: 'string' },
+          { name: 'filingDate', type: 'date' },
+          { name: 'deadlines', type: 'array', arrayOf: 'json' },
+          { name: 'assignedAttorneys', type: 'array', arrayOf: 'string' },
+        ],
+      },
+      {
+        name: 'Contract', displayField: 'title', versioned: true,
+        fields: [
+          { name: 'title', type: 'string', required: true, indexed: true },
+          { name: 'contractType', type: 'enum', enumValues: ['nda', 'employment', 'vendor', 'lease', 'license', 'partnership', 'sla'] },
+          { name: 'status', type: 'enum', enumValues: ['draft', 'review', 'negotiation', 'executed', 'expired', 'terminated'], audited: true },
+          { name: 'parties', type: 'array', arrayOf: 'string', required: true },
+          { name: 'effectiveDate', type: 'date' },
+          { name: 'expirationDate', type: 'date' },
+          { name: 'value', type: 'currency' },
+          { name: 'autoRenew', type: 'boolean' },
+          { name: 'clauseCount', type: 'number' },
+        ],
+      },
+      {
+        name: 'Filing', displayField: 'title',
+        fields: [
+          { name: 'title', type: 'string', required: true },
+          { name: 'caseId', type: 'reference', refEntity: 'Case', required: true },
+          { name: 'filingType', type: 'enum', enumValues: ['motion', 'brief', 'pleading', 'discovery', 'exhibit', 'order'] },
+          { name: 'filedDate', type: 'datetime' },
+          { name: 'deadline', type: 'datetime' },
+          { name: 'status', type: 'enum', enumValues: ['draft', 'filed', 'served', 'responded'], audited: true },
+        ],
+      },
+    ],
+    relations: [
+      { from: 'Filing', to: 'Case', type: 'many-to-many', foreignKey: 'caseId', onDelete: 'cascade' },
+    ],
+  },
+
+  {
+    domain: 'accounting',
+    entities: [
+      {
+        name: 'Account', displayField: 'name', softDelete: true,
+        fields: [
+          { name: 'name', type: 'string', required: true, indexed: true },
+          { name: 'accountNumber', type: 'string', required: true, indexed: true },
+          { name: 'accountType', type: 'enum', enumValues: ['asset', 'liability', 'equity', 'revenue', 'expense'], required: true },
+          { name: 'balance', type: 'currency', audited: true },
+          { name: 'currency', type: 'enum', enumValues: ['USD', 'EUR', 'GBP', 'CAD', 'AUD', 'JPY'], required: true },
+          { name: 'isActive', type: 'boolean', required: true },
+          { name: 'parentAccountId', type: 'reference', refEntity: 'Account' },
+        ],
+      },
+      {
+        name: 'Transaction', displayField: 'description', versioned: true,
+        fields: [
+          { name: 'description', type: 'string', required: true },
+          { name: 'amount', type: 'currency', required: true, audited: true },
+          { name: 'date', type: 'date', required: true, indexed: true },
+          { name: 'debitAccountId', type: 'reference', refEntity: 'Account', required: true },
+          { name: 'creditAccountId', type: 'reference', refEntity: 'Account', required: true },
+          { name: 'category', type: 'string', indexed: true },
+          { name: 'reconciled', type: 'boolean', audited: true },
+          { name: 'attachmentUrl', type: 'url' },
+        ],
+      },
+      {
+        name: 'Invoice', displayField: 'invoiceNumber', versioned: true,
+        fields: [
+          { name: 'invoiceNumber', type: 'string', required: true, indexed: true },
+          { name: 'client', type: 'string', required: true },
+          { name: 'amount', type: 'currency', required: true },
+          { name: 'issueDate', type: 'date', required: true },
+          { name: 'dueDate', type: 'date', required: true },
+          { name: 'status', type: 'enum', enumValues: ['draft', 'sent', 'paid', 'overdue', 'void'], audited: true },
+          { name: 'lineItems', type: 'array', arrayOf: 'json' },
+          { name: 'paidDate', type: 'date' },
+        ],
+      },
+    ],
+    relations: [
+      { from: 'Transaction', to: 'Account', type: 'many-to-many', foreignKey: 'debitAccountId', onDelete: 'restrict' },
+      { from: 'Invoice', to: 'Account', type: 'many-to-many', foreignKey: 'invoiceNumber', onDelete: 'restrict' },
+    ],
+  },
+
+  {
+    domain: 'security',
+    entities: [
+      {
+        name: 'Incident', displayField: 'title', versioned: true, softDelete: true,
+        fields: [
+          { name: 'title', type: 'string', required: true, indexed: true },
+          { name: 'severity', type: 'enum', enumValues: ['critical', 'high', 'medium', 'low', 'info'], required: true, audited: true },
+          { name: 'status', type: 'enum', enumValues: ['reported', 'triaged', 'investigating', 'contained', 'remediated', 'closed'], audited: true },
+          { name: 'reportedAt', type: 'datetime', required: true },
+          { name: 'assignee', type: 'string' },
+          { name: 'category', type: 'enum', enumValues: ['breach', 'malware', 'phishing', 'physical', 'policy_violation', 'other'] },
+          { name: 'affectedAssets', type: 'array', arrayOf: 'reference' },
+          { name: 'timeline', type: 'array', arrayOf: 'json' },
+        ],
+      },
+      {
+        name: 'Threat', displayField: 'name',
+        fields: [
+          { name: 'name', type: 'string', required: true, indexed: true },
+          { name: 'threatLevel', type: 'enum', enumValues: ['critical', 'elevated', 'guarded', 'low'], audited: true },
+          { name: 'source', type: 'string' },
+          { name: 'indicators', type: 'array', arrayOf: 'string' },
+          { name: 'mitigations', type: 'array', arrayOf: 'string' },
+          { name: 'lastAssessedAt', type: 'datetime' },
+        ],
+      },
+    ],
+    relations: [
+      { from: 'Incident', to: 'Threat', type: 'many-to-many', foreignKey: 'affectedAssets', onDelete: 'nullify' },
+    ],
+  },
+
+  {
+    domain: 'manufacturing',
+    entities: [
+      {
+        name: 'WorkOrder', displayField: 'orderNumber', versioned: true,
+        fields: [
+          { name: 'orderNumber', type: 'string', required: true, indexed: true },
+          { name: 'product', type: 'string', required: true },
+          { name: 'quantity', type: 'number', required: true, validation: { min: 1 } },
+          { name: 'status', type: 'enum', enumValues: ['planned', 'scheduled', 'in_progress', 'quality_check', 'completed', 'shipped'], audited: true },
+          { name: 'priority', type: 'enum', enumValues: ['urgent', 'high', 'normal', 'low'] },
+          { name: 'startDate', type: 'date' },
+          { name: 'dueDate', type: 'date', required: true },
+          { name: 'machineId', type: 'reference', refEntity: 'Machine' },
+          { name: 'bomId', type: 'reference', refEntity: 'BOM' },
+        ],
+      },
+      {
+        name: 'BOM', displayField: 'name',
+        fields: [
+          { name: 'name', type: 'string', required: true },
+          { name: 'version', type: 'number', required: true },
+          { name: 'parts', type: 'array', arrayOf: 'json', required: true },
+          { name: 'totalCost', type: 'currency' },
+          { name: 'status', type: 'enum', enumValues: ['draft', 'approved', 'deprecated'], audited: true },
+        ],
+      },
+      {
+        name: 'QCInspection', displayField: 'inspectionId',
+        fields: [
+          { name: 'inspectionId', type: 'string', required: true },
+          { name: 'workOrderId', type: 'reference', refEntity: 'WorkOrder', required: true },
+          { name: 'result', type: 'enum', enumValues: ['pass', 'fail', 'conditional'], audited: true },
+          { name: 'defects', type: 'array', arrayOf: 'json' },
+          { name: 'inspectedAt', type: 'datetime', required: true },
+          { name: 'inspector', type: 'string', required: true },
+        ],
+      },
+    ],
+    relations: [
+      { from: 'WorkOrder', to: 'BOM', type: 'many-to-many', foreignKey: 'bomId', onDelete: 'restrict' },
+      { from: 'QCInspection', to: 'WorkOrder', type: 'many-to-many', foreignKey: 'workOrderId', onDelete: 'cascade' },
+    ],
+  },
+
+  {
+    domain: 'education',
+    entities: [
+      {
+        name: 'Student', displayField: 'name', softDelete: true,
+        fields: [
+          { name: 'name', type: 'string', required: true, indexed: true },
+          { name: 'studentId', type: 'string', required: true, indexed: true },
+          { name: 'email', type: 'email' },
+          { name: 'enrollmentDate', type: 'date', required: true },
+          { name: 'status', type: 'enum', enumValues: ['enrolled', 'graduated', 'withdrawn', 'suspended'], audited: true },
+          { name: 'gpa', type: 'number', validation: { min: 0, max: 4 } },
+        ],
+      },
+      {
+        name: 'Course', displayField: 'title',
+        fields: [
+          { name: 'title', type: 'string', required: true, indexed: true },
+          { name: 'courseCode', type: 'string', required: true, indexed: true },
+          { name: 'credits', type: 'number', required: true, validation: { min: 0.5, max: 12 } },
+          { name: 'instructor', type: 'string' },
+          { name: 'capacity', type: 'number', validation: { min: 1 } },
+          { name: 'schedule', type: 'json' },
+        ],
+      },
+      {
+        name: 'Assignment', displayField: 'title', versioned: true,
+        fields: [
+          { name: 'title', type: 'string', required: true },
+          { name: 'courseId', type: 'reference', refEntity: 'Course', required: true },
+          { name: 'dueDate', type: 'datetime', required: true },
+          { name: 'maxScore', type: 'number', required: true, validation: { min: 0 } },
+          { name: 'weight', type: 'number', validation: { min: 0, max: 1 } },
+          { name: 'assignmentType', type: 'enum', enumValues: ['homework', 'quiz', 'exam', 'project', 'participation'] },
+        ],
+      },
+    ],
+    relations: [
+      { from: 'Assignment', to: 'Course', type: 'many-to-many', foreignKey: 'courseId', onDelete: 'cascade' },
+    ],
+  },
+
+  {
+    domain: 'retail',
+    entities: [
+      {
+        name: 'Product', displayField: 'name', versioned: true, softDelete: true,
+        fields: [
+          { name: 'name', type: 'string', required: true, indexed: true },
+          { name: 'sku', type: 'string', required: true, indexed: true },
+          { name: 'price', type: 'currency', required: true, audited: true },
+          { name: 'cost', type: 'currency' },
+          { name: 'quantity', type: 'number', validation: { min: 0 }, audited: true },
+          { name: 'reorderPoint', type: 'number', validation: { min: 0 } },
+          { name: 'category', type: 'string', indexed: true },
+          { name: 'status', type: 'enum', enumValues: ['active', 'discontinued', 'out_of_stock', 'seasonal'], audited: true },
+        ],
+      },
+      {
+        name: 'Order', displayField: 'orderNumber', versioned: true,
+        fields: [
+          { name: 'orderNumber', type: 'string', required: true, indexed: true },
+          { name: 'customerId', type: 'reference', refEntity: 'Customer', required: true },
+          { name: 'total', type: 'currency', required: true },
+          { name: 'status', type: 'enum', enumValues: ['pending', 'confirmed', 'processing', 'shipped', 'delivered', 'returned', 'cancelled'], audited: true },
+          { name: 'lineItems', type: 'array', arrayOf: 'json', required: true },
+          { name: 'orderDate', type: 'datetime', required: true },
+          { name: 'shippingAddress', type: 'json' },
+        ],
+      },
+      {
+        name: 'Customer', displayField: 'name', softDelete: true,
+        fields: [
+          { name: 'name', type: 'string', required: true, indexed: true },
+          { name: 'email', type: 'email', indexed: true },
+          { name: 'phone', type: 'phone' },
+          { name: 'lifetimeValue', type: 'currency', audited: true },
+          { name: 'tier', type: 'enum', enumValues: ['standard', 'silver', 'gold', 'platinum'] },
+          { name: 'firstPurchaseDate', type: 'date' },
+          { name: 'lastPurchaseDate', type: 'date' },
+        ],
+      },
+    ],
+    relations: [
+      { from: 'Order', to: 'Customer', type: 'many-to-many', foreignKey: 'customerId', onDelete: 'restrict' },
+    ],
+  },
+
+  {
+    domain: 'government',
+    entities: [
+      {
+        name: 'Permit', displayField: 'title', versioned: true,
+        fields: [
+          { name: 'title', type: 'string', required: true, indexed: true },
+          { name: 'permitNumber', type: 'string', required: true, indexed: true },
+          { name: 'permitType', type: 'enum', enumValues: ['building', 'zoning', 'environmental', 'business', 'event', 'special_use'] },
+          { name: 'applicant', type: 'string', required: true },
+          { name: 'status', type: 'enum', enumValues: ['submitted', 'under_review', 'revision_requested', 'approved', 'denied', 'expired', 'revoked'], audited: true },
+          { name: 'submittedDate', type: 'date', required: true },
+          { name: 'reviewDeadline', type: 'date' },
+          { name: 'location', type: 'geo' },
+          { name: 'fees', type: 'currency' },
+        ],
+      },
+      {
+        name: 'Violation', displayField: 'title',
+        fields: [
+          { name: 'title', type: 'string', required: true },
+          { name: 'code', type: 'string', required: true },
+          { name: 'severity', type: 'enum', enumValues: ['critical', 'major', 'minor', 'notice'], audited: true },
+          { name: 'status', type: 'enum', enumValues: ['reported', 'investigating', 'cited', 'remediated', 'dismissed'], audited: true },
+          { name: 'location', type: 'geo' },
+          { name: 'reportedDate', type: 'date', required: true },
+          { name: 'deadline', type: 'date' },
+        ],
+      },
+    ],
+    relations: [],
+  },
+];
+
+// ── Lookup helpers ─────────────────────────────────────────────
+
+const _schemaMap = new Map(DOMAIN_SCHEMAS.map(s => [s.domain, s]));
+
+export function getDomainSchema(domain: string): DomainSchema | undefined {
+  return _schemaMap.get(domain);
+}
+
+export function getDomainEntities(domain: string): EntityDef[] {
+  return _schemaMap.get(domain)?.entities ?? [];
+}
+
+export function getDomainRelations(domain: string): RelationDef[] {
+  return _schemaMap.get(domain)?.relations ?? [];
+}
+
+export function getDomainsWithSchemas(): string[] {
+  return DOMAIN_SCHEMAS.map(s => s.domain);
+}

--- a/concord-frontend/lib/lenses/index.ts
+++ b/concord-frontend/lib/lenses/index.ts
@@ -16,6 +16,8 @@ export {
   getLensManifest,
   getLensManifests,
   getAllLensDomains,
+  getManifestCount,
+  getLensesMissingMacro,
 } from './manifest';
 
 // Status taxonomy (Step 1)

--- a/concord-frontend/lib/lenses/index.ts
+++ b/concord-frontend/lib/lenses/index.ts
@@ -97,3 +97,62 @@ export {
   recordDismissal,
   recordTimeToAction,
 } from './chat-lens-recommender';
+
+// Domain Schemas (Dimension 1: Domain Data Model Completion)
+export {
+  type FieldType,
+  type FieldDef,
+  type EntityDef,
+  type RelationDef,
+  type DomainSchema,
+  DOMAIN_SCHEMAS,
+  getDomainSchema,
+  getDomainEntities,
+  getDomainRelations,
+  getDomainsWithSchemas,
+} from './domain-schemas';
+
+// Workflow Definitions (Dimension 2: Workflow Engines)
+export {
+  type WorkflowState,
+  type WorkflowTransition,
+  type WorkflowDef,
+  WORKFLOW_DEFINITIONS,
+  getWorkflowsForDomain,
+  getWorkflow,
+  getAvailableTransitions,
+  isValidTransition,
+  getInitialState,
+  getDomainsWithWorkflows,
+} from './workflow-definitions';
+
+// Automation Bindings (Dimensions 3–5: Import/Export, Automation, RBAC)
+export {
+  type ImportFormat,
+  type ExportFormat,
+  type ImportExportProfile,
+  type AutomationTrigger,
+  type AutomationProfile,
+  type DomainPermission,
+  type DomainRBACProfile,
+  IMPORT_EXPORT_PROFILES,
+  AUTOMATION_PROFILES,
+  DOMAIN_RBAC_PROFILES,
+  getImportExportProfile,
+  getAutomationProfile,
+  getDomainRBAC,
+  getDomainsWithImportExport,
+  getDomainsWithAutomation,
+  getDomainsWithRBAC,
+} from './automation-bindings';
+
+// Domain Bridge (unified profile + parity scoring)
+export {
+  type DomainProfile,
+  type CompetitorParityScore,
+  getDomainProfile,
+  getCompetitorParityScore,
+  getAllBoundDomains,
+  getFleetParityReport,
+  getFleetSummary,
+} from './domain-bridge';

--- a/concord-frontend/lib/lenses/lens-status.ts
+++ b/concord-frontend/lib/lenses/lens-status.ts
@@ -119,6 +119,20 @@ export const LENS_STATUS_MAP: LensStatusEntry[] = [
 
   // 6. Studio (Creative Super-Lens)
   {
+    id: 'studio',
+    status: 'product',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Creative production studio super-lens. Artifacts: Project, Track, Effect, Session, Mixdown.',
+  },
+  {
+    id: 'art',
+    status: 'product',
+    mergeTarget: null,
+    postMergeRole: 'standalone',
+    rationale: 'Visual art creation and gallery. Artifacts: Artwork, Collection, Style, Gallery, Exhibition.',
+  },
+  {
     id: 'music',
     status: 'hybrid',
     mergeTarget: 'studio',

--- a/concord-frontend/lib/lenses/manifest.ts
+++ b/concord-frontend/lib/lenses/manifest.ts
@@ -5,6 +5,15 @@
  * and available actions. The generic UI shell can render library/editor/actions/DTU feed
  * panels from this manifest alone.
  *
+ * Competitor-Level Standard (7/7 Product Lens Gate):
+ *   1. Primary Artifact - durable object that persists without DTUs
+ *   2. Persistence - real API (no MOCK or SEED constants)
+ *   3. Workspace UI - editor, library, history, versioning
+ *   4. Engine - at least one domain-specific server-side action
+ *   5. Pipeline - multi-step chain (intake, structure, validate, output, publish)
+ *   6. Import/Export - pull in real inputs, export artifacts
+ *   7. DTU Exhaust - structured DTUs with lane labels
+ *
  * Usage:
  *   import { LENS_MANIFESTS, getLensManifest } from '@/lib/lenses/manifest';
  *   const manifest = getLensManifest('music');
@@ -38,74 +47,157 @@ export interface LensManifest {
 
 // ---- Lens Manifests ----
 // Each manifest declares the runtime contract for one lens domain.
+// All 61 upgrade-lane lenses (31 product + 22 hybrid + 8 viewer) must have full manifests.
 
 export const LENS_MANIFESTS: LensManifest[] = [
-  // === CORE ===
+
+  // ═══════════════════════════════════════════════════════════════
+  // CORE PRODUCT LENSES
+  // ═══════════════════════════════════════════════════════════════
+
   {
     domain: 'chat',
     label: 'Chat',
-    artifacts: ['conversation', 'message', 'session'],
+    artifacts: ['conversation', 'message', 'session', 'branch'],
     macros: { list: 'lens.chat.list', get: 'lens.chat.get', create: 'lens.chat.create', update: 'lens.chat.update', delete: 'lens.chat.delete', run: 'lens.chat.run', export: 'lens.chat.export' },
-    exports: ['json', 'md', 'txt'],
-    actions: ['send', 'summarize', 'branch', 'export_transcript'],
+    exports: ['json', 'md', 'txt', 'pdf'],
+    actions: ['send', 'summarize', 'branch', 'export_transcript', 'search_history', 'merge_threads'],
     category: 'knowledge',
   },
   {
     domain: 'code',
     label: 'Code',
-    artifacts: ['file', 'snippet', 'project', 'workspace'],
+    artifacts: ['file', 'snippet', 'project', 'workspace', 'diff', 'review'],
     macros: { list: 'lens.code.list', get: 'lens.code.get', create: 'lens.code.create', update: 'lens.code.update', delete: 'lens.code.delete', run: 'lens.code.run', export: 'lens.code.export' },
-    exports: ['json', 'zip', 'tar'],
-    actions: ['execute', 'lint', 'format', 'refactor', 'diff'],
+    exports: ['json', 'zip', 'tar', 'patch'],
+    actions: ['execute', 'lint', 'format', 'refactor', 'diff', 'review', 'test', 'package'],
     category: 'knowledge',
   },
+  {
+    domain: 'paper',
+    label: 'Paper',
+    artifacts: ['project', 'claim', 'hypothesis', 'evidence', 'experiment', 'synthesis'],
+    macros: { list: 'lens.paper.list', get: 'lens.paper.get', create: 'lens.paper.create', update: 'lens.paper.update', delete: 'lens.paper.delete', run: 'lens.paper.run', export: 'lens.paper.export' },
+    exports: ['json', 'md', 'pdf', 'bibtex'],
+    actions: ['validate', 'synthesize', 'detect-contradictions', 'trace-lineage', 'claim-evidence-consistency', 'hypothesis-mutation-retest'],
+    category: 'knowledge',
+  },
+  {
+    domain: 'reasoning',
+    label: 'Reasoning',
+    artifacts: ['chain', 'premise', 'inference', 'conclusion', 'counterexample'],
+    macros: { list: 'lens.reasoning.list', get: 'lens.reasoning.get', create: 'lens.reasoning.create', update: 'lens.reasoning.update', delete: 'lens.reasoning.delete', run: 'lens.reasoning.run', export: 'lens.reasoning.export' },
+    exports: ['json', 'md', 'svg'],
+    actions: ['validate', 'trace', 'conclude', 'fork', 'detect-fallacy', 'strength-score', 'visualize-chain'],
+    category: 'knowledge',
+  },
+  {
+    domain: 'graph',
+    label: 'Graph',
+    artifacts: ['entity', 'relation', 'assertion', 'source', 'ontology_node'],
+    macros: { list: 'lens.graph.list', get: 'lens.graph.get', create: 'lens.graph.create', update: 'lens.graph.update', delete: 'lens.graph.delete', run: 'lens.graph.run', export: 'lens.graph.export' },
+    exports: ['json', 'csv', 'graphml', 'rdf', 'cypher'],
+    actions: ['query', 'cluster', 'analyze', 'merge', 'conflict-resolution', 'entity-resolution', 'confidence-scoring', 'shortest-path'],
+    category: 'knowledge',
+  },
+  {
+    domain: 'council',
+    label: 'Council',
+    artifacts: ['proposal', 'vote', 'budget', 'project', 'audit', 'resolution'],
+    macros: { list: 'lens.council.list', get: 'lens.council.get', create: 'lens.council.create', update: 'lens.council.update', delete: 'lens.council.delete', run: 'lens.council.run', export: 'lens.council.export' },
+    exports: ['json', 'csv', 'pdf'],
+    actions: ['debate', 'vote', 'simulate-budget', 'audit', 'quorum-check', 'impact-analysis', 'generate-minutes'],
+    category: 'social',
+  },
+  {
+    domain: 'agents',
+    label: 'Agents',
+    artifacts: ['agent', 'role', 'task', 'deliberation', 'decision', 'workflow'],
+    macros: { list: 'lens.agents.list', get: 'lens.agents.get', create: 'lens.agents.create', update: 'lens.agents.update', delete: 'lens.agents.delete', run: 'lens.agents.run', export: 'lens.agents.export' },
+    exports: ['json', 'yaml', 'csv'],
+    actions: ['start', 'stop', 'reset', 'configure', 'deliberate', 'arbitrate', 'orchestrate', 'evaluate-performance'],
+    category: 'knowledge',
+  },
+  {
+    domain: 'sim',
+    label: 'Sim',
+    artifacts: ['scenario', 'assumption', 'run', 'outcome', 'model', 'distribution'],
+    macros: { list: 'lens.sim.list', get: 'lens.sim.get', create: 'lens.sim.create', update: 'lens.sim.update', delete: 'lens.sim.delete', run: 'lens.sim.run', export: 'lens.sim.export' },
+    exports: ['json', 'csv', 'pdf', 'png'],
+    actions: ['simulate', 'analyze', 'compare', 'archive', 'monte-carlo', 'sensitivity-analysis', 'regime-detection'],
+    category: 'system',
+  },
 
-  // === CREATIVE ===
+  // ═══════════════════════════════════════════════════════════════
+  // CREATIVE LENSES
+  // ═══════════════════════════════════════════════════════════════
+
   {
     domain: 'music',
     label: 'Music',
-    artifacts: ['track', 'playlist', 'artist', 'album'],
+    artifacts: ['track', 'playlist', 'artist', 'album', 'stem', 'project'],
     macros: { list: 'lens.music.list', get: 'lens.music.get', create: 'lens.music.create', update: 'lens.music.update', delete: 'lens.music.delete', run: 'lens.music.run', export: 'lens.music.export' },
-    exports: ['json', 'csv', 'm3u'],
-    actions: ['analyze', 'render', 'publish', 'export_stems', 'generate_arrangement'],
+    exports: ['json', 'csv', 'm3u', 'wav', 'midi'],
+    actions: ['analyze', 'render', 'publish', 'export_stems', 'generate_arrangement', 'timeline_render', 'stem_split', 'project_package'],
     category: 'creative',
   },
   {
     domain: 'studio',
     label: 'Studio',
-    artifacts: ['project', 'track', 'effect', 'instrument'],
+    artifacts: ['project', 'track', 'effect', 'instrument', 'session', 'mixdown'],
     macros: { list: 'lens.studio.list', get: 'lens.studio.get', create: 'lens.studio.create', update: 'lens.studio.update', delete: 'lens.studio.delete', run: 'lens.studio.run', export: 'lens.studio.export' },
-    exports: ['json'],
-    actions: ['mix', 'master', 'bounce', 'render'],
+    exports: ['json', 'wav', 'mp3', 'midi', 'pdf'],
+    actions: ['mix', 'master', 'bounce', 'render', 'apply_effect', 'normalize', 'session_snapshot'],
     category: 'creative',
   },
   {
     domain: 'voice',
     label: 'Voice',
-    artifacts: ['take', 'effect', 'preset', 'transcript', 'voice_note'],
+    artifacts: ['take', 'effect', 'preset', 'transcript', 'voice_note', 'pipeline_run'],
     macros: { list: 'lens.voice.list', get: 'lens.voice.get', create: 'lens.voice.create', update: 'lens.voice.update', delete: 'lens.voice.delete', run: 'lens.voice.run', export: 'lens.voice.export' },
-    exports: ['json', 'csv', 'txt'],
-    actions: ['transcribe', 'process', 'analyze', 'summarize', 'extract_tasks'],
+    exports: ['json', 'csv', 'txt', 'srt', 'wav'],
+    actions: ['transcribe', 'process', 'analyze', 'summarize', 'extract_tasks', 'detect_speaker', 'generate_subtitles'],
     category: 'creative',
   },
   {
     domain: 'art',
     label: 'Art',
-    artifacts: ['artwork', 'collection', 'style'],
-    macros: { list: 'lens.art.list', get: 'lens.art.get', create: 'lens.art.create', update: 'lens.art.update', run: 'lens.art.run', export: 'lens.art.export' },
-    exports: ['json'],
-    actions: ['generate', 'remix', 'analyze'],
+    artifacts: ['artwork', 'collection', 'style', 'gallery', 'exhibition'],
+    macros: { list: 'lens.art.list', get: 'lens.art.get', create: 'lens.art.create', update: 'lens.art.update', delete: 'lens.art.delete', run: 'lens.art.run', export: 'lens.art.export' },
+    exports: ['json', 'png', 'svg', 'pdf'],
+    actions: ['generate', 'remix', 'analyze', 'curate', 'style_transfer', 'publish_gallery'],
+    category: 'creative',
+  },
+  {
+    domain: 'ar',
+    label: 'AR',
+    artifacts: ['scene', 'anchor', 'overlay', 'capture_session', 'asset_3d'],
+    macros: { list: 'lens.ar.list', get: 'lens.ar.get', create: 'lens.ar.create', update: 'lens.ar.update', delete: 'lens.ar.delete', run: 'lens.ar.run', export: 'lens.ar.export' },
+    exports: ['json', 'gltf', 'usdz', 'png'],
+    actions: ['place_anchor', 'render_scene', 'capture', 'export_3d', 'collision_detect', 'lighting_estimate'],
+    category: 'creative',
+  },
+  {
+    domain: 'fractal',
+    label: 'Fractal',
+    artifacts: ['structure', 'parameter_set', 'render', 'animation', 'exploration_session'],
+    macros: { list: 'lens.fractal.list', get: 'lens.fractal.get', create: 'lens.fractal.create', update: 'lens.fractal.update', delete: 'lens.fractal.delete', run: 'lens.fractal.run', export: 'lens.fractal.export' },
+    exports: ['json', 'png', 'svg', 'mp4'],
+    actions: ['generate', 'animate', 'explore', 'export_render', 'parameter_sweep', 'dimension_morph'],
     category: 'creative',
   },
 
-  // === PRODUCTIVITY ===
+  // ═══════════════════════════════════════════════════════════════
+  // PRODUCTIVITY LENSES
+  // ═══════════════════════════════════════════════════════════════
+
   {
     domain: 'calendar',
     label: 'Calendar',
-    artifacts: ['event', 'category', 'project', 'recurrence'],
+    artifacts: ['event', 'category', 'project', 'recurrence', 'availability'],
     macros: { list: 'lens.calendar.list', get: 'lens.calendar.get', create: 'lens.calendar.create', update: 'lens.calendar.update', delete: 'lens.calendar.delete', run: 'lens.calendar.run', export: 'lens.calendar.export' },
-    exports: ['json', 'ics', 'csv'],
-    actions: ['schedule', 'remind', 'plan_day', 'plan_week', 'resolve_conflicts'],
+    exports: ['json', 'ics', 'csv', 'pdf'],
+    actions: ['schedule', 'remind', 'plan_day', 'plan_week', 'resolve_conflicts', 'availability_search', 'recurrence_expand', 'block_time'],
     category: 'productivity',
   },
   {
@@ -113,30 +205,33 @@ export const LENS_MANIFESTS: LensManifest[] = [
     label: 'Daily',
     artifacts: ['entry', 'session', 'reminder', 'clip', 'insight'],
     macros: { list: 'lens.daily.list', get: 'lens.daily.get', create: 'lens.daily.create', update: 'lens.daily.update', delete: 'lens.daily.delete', run: 'lens.daily.run', export: 'lens.daily.export' },
-    exports: ['json', 'csv', 'md'],
-    actions: ['summarize', 'analyze', 'detect_patterns', 'generate_insights'],
+    exports: ['json', 'csv', 'md', 'pdf'],
+    actions: ['summarize', 'analyze', 'detect_patterns', 'generate_insights', 'weekly_review', 'mood_trend'],
     category: 'productivity',
   },
   {
     domain: 'goals',
     label: 'Goals',
-    artifacts: ['goal', 'challenge', 'milestone', 'achievement'],
-    macros: { list: 'lens.goals.list', get: 'lens.goals.get', create: 'lens.goals.create', update: 'lens.goals.update', run: 'lens.goals.run', export: 'lens.goals.export' },
-    exports: ['json'],
-    actions: ['evaluate', 'activate', 'complete'],
+    artifacts: ['goal', 'challenge', 'milestone', 'achievement', 'progress_snapshot'],
+    macros: { list: 'lens.goals.list', get: 'lens.goals.get', create: 'lens.goals.create', update: 'lens.goals.update', delete: 'lens.goals.delete', run: 'lens.goals.run', export: 'lens.goals.export' },
+    exports: ['json', 'csv', 'pdf'],
+    actions: ['evaluate', 'activate', 'complete', 'milestone_check', 'dependency_analysis', 'progress_report'],
     category: 'productivity',
   },
   {
     domain: 'srs',
     label: 'SRS',
-    artifacts: ['deck', 'card', 'review_log'],
+    artifacts: ['deck', 'card', 'review_log', 'study_session', 'performance_record'],
     macros: { list: 'lens.srs.list', get: 'lens.srs.get', create: 'lens.srs.create', update: 'lens.srs.update', delete: 'lens.srs.delete', run: 'lens.srs.run', export: 'lens.srs.export' },
-    exports: ['json', 'csv', 'anki'],
-    actions: ['review', 'schedule', 'optimize_intervals', 'generate_cards_from_dtus'],
+    exports: ['json', 'csv', 'anki', 'pdf'],
+    actions: ['review', 'schedule', 'optimize_intervals', 'generate_cards_from_dtus', 'retention_report', 'difficulty_calibrate'],
     category: 'productivity',
   },
 
-  // === SOCIAL ===
+  // ═══════════════════════════════════════════════════════════════
+  // SOCIAL LENSES
+  // ═══════════════════════════════════════════════════════════════
+
   {
     domain: 'forum',
     label: 'Forum',
@@ -149,10 +244,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'collab',
     label: 'Collab',
-    artifacts: ['session', 'participant', 'change', 'decision'],
+    artifacts: ['session', 'participant', 'change', 'decision', 'conflict_resolution'],
     macros: { list: 'lens.collab.list', get: 'lens.collab.get', create: 'lens.collab.create', update: 'lens.collab.update', delete: 'lens.collab.delete', run: 'lens.collab.run', export: 'lens.collab.export' },
-    exports: ['json', 'csv'],
-    actions: ['merge', 'lock', 'unlock', 'summarize_thread', 'run_council', 'extract_actions'],
+    exports: ['json', 'csv', 'md'],
+    actions: ['merge', 'lock', 'unlock', 'summarize_thread', 'run_council', 'extract_actions', 'resolve_conflict', 'version_diff'],
     category: 'social',
   },
   {
@@ -174,43 +269,58 @@ export const LENS_MANIFESTS: LensManifest[] = [
     category: 'social',
   },
 
-  // === FINANCE ===
+  // ═══════════════════════════════════════════════════════════════
+  // FINANCE LENSES
+  // ═══════════════════════════════════════════════════════════════
+
   {
     domain: 'finance',
     label: 'Finance',
     artifacts: ['asset', 'transaction', 'order', 'alert', 'portfolio', 'report'],
     macros: { list: 'lens.finance.list', get: 'lens.finance.get', create: 'lens.finance.create', update: 'lens.finance.update', delete: 'lens.finance.delete', run: 'lens.finance.run', export: 'lens.finance.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['trade', 'analyze', 'alert', 'simulate', 'generate_report'],
+    exports: ['json', 'csv', 'pdf', 'ofx'],
+    actions: ['trade', 'analyze', 'alert', 'simulate', 'generate_report', 'portfolio_rebalance', 'risk_assessment'],
     category: 'finance',
   },
   {
     domain: 'marketplace',
     label: 'Marketplace',
-    artifacts: ['listing', 'purchase', 'review', 'license'],
+    artifacts: ['listing', 'purchase', 'review', 'license', 'provenance_record'],
     macros: { list: 'lens.marketplace.list', get: 'lens.marketplace.get', create: 'lens.marketplace.create', update: 'lens.marketplace.update', delete: 'lens.marketplace.delete', run: 'lens.marketplace.run', export: 'lens.marketplace.export' },
-    exports: ['json', 'csv'],
-    actions: ['buy', 'sell', 'review', 'verify_artifact_hash', 'issue_license', 'distribute_royalties'],
+    exports: ['json', 'csv', 'pdf'],
+    actions: ['buy', 'sell', 'review', 'verify_artifact_hash', 'issue_license', 'distribute_royalties', 'validate_listing', 'provenance_check'],
+    category: 'finance',
+  },
+  {
+    domain: 'market',
+    label: 'Market',
+    artifacts: ['offer', 'bid', 'token_tx', 'settlement', 'order_book'],
+    macros: { list: 'lens.market.list', get: 'lens.market.get', create: 'lens.market.create', update: 'lens.market.update', delete: 'lens.market.delete', run: 'lens.market.run', export: 'lens.market.export' },
+    exports: ['json', 'csv', 'pdf'],
+    actions: ['place_bid', 'accept_offer', 'settle', 'price_history', 'volume_analysis', 'liquidity_check'],
+    category: 'finance',
+  },
+  {
+    domain: 'questmarket',
+    label: 'Questmarket',
+    artifacts: ['quest', 'bounty', 'submission', 'payout', 'reputation_record'],
+    macros: { list: 'lens.questmarket.list', get: 'lens.questmarket.get', create: 'lens.questmarket.create', update: 'lens.questmarket.update', delete: 'lens.questmarket.delete', run: 'lens.questmarket.run', export: 'lens.questmarket.export' },
+    exports: ['json', 'csv', 'pdf'],
+    actions: ['post_bounty', 'submit_work', 'verify_submission', 'release_payout', 'reputation_score', 'dispute_resolve'],
     category: 'finance',
   },
 
-  // === KNOWLEDGE ===
+  // ═══════════════════════════════════════════════════════════════
+  // KNOWLEDGE LENSES
+  // ═══════════════════════════════════════════════════════════════
+
   {
     domain: 'ml',
     label: 'ML',
-    artifacts: ['model', 'experiment', 'dataset', 'deployment', 'run_log'],
+    artifacts: ['model', 'experiment', 'dataset', 'deployment', 'run_log', 'evaluation'],
     macros: { list: 'lens.ml.list', get: 'lens.ml.get', create: 'lens.ml.create', update: 'lens.ml.update', delete: 'lens.ml.delete', run: 'lens.ml.run', export: 'lens.ml.export' },
-    exports: ['json', 'csv', 'onnx'],
-    actions: ['train', 'infer', 'deploy', 'evaluate', 'run_experiment', 'compare_runs', 'generate_report'],
-    category: 'knowledge',
-  },
-  {
-    domain: 'agents',
-    label: 'Agents',
-    artifacts: ['agent', 'role', 'task', 'deliberation', 'decision'],
-    macros: { list: 'lens.agents.list', get: 'lens.agents.get', create: 'lens.agents.create', update: 'lens.agents.update', delete: 'lens.agents.delete', run: 'lens.agents.run', export: 'lens.agents.export' },
-    exports: ['json'],
-    actions: ['start', 'stop', 'reset', 'configure', 'deliberate', 'arbitrate'],
+    exports: ['json', 'csv', 'onnx', 'pkl'],
+    actions: ['train', 'infer', 'deploy', 'evaluate', 'run_experiment', 'compare_runs', 'generate_report', 'hyperparameter_search', 'model_explain'],
     category: 'knowledge',
   },
   {
@@ -223,83 +333,99 @@ export const LENS_MANIFESTS: LensManifest[] = [
     category: 'knowledge',
   },
   {
-    domain: 'paper',
-    label: 'Paper',
-    artifacts: ['project', 'claim', 'hypothesis', 'evidence', 'experiment', 'synthesis'],
-    macros: { list: 'lens.paper.list', get: 'lens.paper.get', create: 'lens.paper.create', update: 'lens.paper.update', delete: 'lens.paper.delete', run: 'lens.paper.run', export: 'lens.paper.export' },
-    exports: ['json', 'md'],
-    actions: ['validate', 'synthesize', 'detect-contradictions', 'trace-lineage'],
-    category: 'knowledge',
-  },
-  {
-    domain: 'reasoning',
-    label: 'Reasoning',
-    artifacts: ['chain', 'premise', 'inference', 'conclusion'],
-    macros: { list: 'lens.reasoning.list', get: 'lens.reasoning.get', create: 'lens.reasoning.create', update: 'lens.reasoning.update', delete: 'lens.reasoning.delete', run: 'lens.reasoning.run', export: 'lens.reasoning.export' },
-    exports: ['json'],
-    actions: ['validate', 'trace', 'conclude', 'fork'],
-    category: 'knowledge',
-  },
-  {
-    domain: 'graph',
-    label: 'Graph',
-    artifacts: ['entity', 'relation', 'assertion', 'source'],
-    macros: { list: 'lens.graph.list', get: 'lens.graph.get', create: 'lens.graph.create', update: 'lens.graph.update', delete: 'lens.graph.delete', run: 'lens.graph.run', export: 'lens.graph.export' },
-    exports: ['json', 'csv', 'graphml'],
-    actions: ['query', 'cluster', 'analyze', 'merge'],
-    category: 'knowledge',
-  },
-
-  // === GOVERNANCE ===
-  {
-    domain: 'council',
-    label: 'Council',
-    artifacts: ['proposal', 'vote', 'budget', 'project', 'audit'],
-    macros: { list: 'lens.council.list', get: 'lens.council.get', create: 'lens.council.create', update: 'lens.council.update', delete: 'lens.council.delete', run: 'lens.council.run', export: 'lens.council.export' },
-    exports: ['json', 'csv'],
-    actions: ['debate', 'vote', 'simulate-budget', 'audit'],
-    category: 'social',
-  },
-  {
     domain: 'law',
     label: 'Law',
-    artifacts: ['case', 'clause', 'draft', 'precedent'],
+    artifacts: ['case', 'clause', 'draft', 'precedent', 'compliance_check'],
     macros: { list: 'lens.law.list', get: 'lens.law.get', create: 'lens.law.create', update: 'lens.law.update', delete: 'lens.law.delete', run: 'lens.law.run', export: 'lens.law.export' },
-    exports: ['json', 'md'],
-    actions: ['check-compliance', 'analyze', 'draft', 'cite'],
+    exports: ['json', 'md', 'pdf', 'docx'],
+    actions: ['check-compliance', 'analyze', 'draft', 'cite', 'clause_compare', 'precedent_search', 'risk_flag'],
     category: 'social',
   },
 
-  // === SIMULATION ===
+  // ═══════════════════════════════════════════════════════════════
+  // GOVERNANCE / HYBRID LENSES (previously missing manifests)
+  // ═══════════════════════════════════════════════════════════════
+
   {
-    domain: 'sim',
-    label: 'Sim',
-    artifacts: ['scenario', 'assumption', 'run', 'outcome'],
-    macros: { list: 'lens.sim.list', get: 'lens.sim.get', create: 'lens.sim.create', update: 'lens.sim.update', delete: 'lens.sim.delete', run: 'lens.sim.run', export: 'lens.sim.export' },
-    exports: ['json', 'csv'],
-    actions: ['simulate', 'analyze', 'compare', 'archive'],
-    category: 'system',
+    domain: 'vote',
+    label: 'Vote',
+    artifacts: ['proposal', 'ballot', 'tally', 'audit_trail', 'voter_record'],
+    macros: { list: 'lens.vote.list', get: 'lens.vote.get', create: 'lens.vote.create', update: 'lens.vote.update', delete: 'lens.vote.delete', run: 'lens.vote.run', export: 'lens.vote.export' },
+    exports: ['json', 'csv', 'pdf'],
+    actions: ['cast_ballot', 'tally_votes', 'verify_quorum', 'audit_results', 'ranked_choice_resolve', 'generate_report'],
+    category: 'social',
+  },
+  {
+    domain: 'ethics',
+    label: 'Ethics',
+    artifacts: ['case_file', 'decision_tree', 'policy_check', 'review', 'framework'],
+    macros: { list: 'lens.ethics.list', get: 'lens.ethics.get', create: 'lens.ethics.create', update: 'lens.ethics.update', delete: 'lens.ethics.delete', run: 'lens.ethics.run', export: 'lens.ethics.export' },
+    exports: ['json', 'md', 'pdf'],
+    actions: ['evaluate_case', 'apply_framework', 'check_alignment', 'generate_report', 'stakeholder_analysis', 'risk_assessment'],
+    category: 'social',
+  },
+  {
+    domain: 'alliance',
+    label: 'Alliance',
+    artifacts: ['alliance_proposal', 'coalition_charter', 'agreement', 'member_record', 'governance_rule'],
+    macros: { list: 'lens.alliance.list', get: 'lens.alliance.get', create: 'lens.alliance.create', update: 'lens.alliance.update', delete: 'lens.alliance.delete', run: 'lens.alliance.run', export: 'lens.alliance.export' },
+    exports: ['json', 'csv', 'pdf'],
+    actions: ['propose_alliance', 'ratify_charter', 'add_member', 'vote_on_governance', 'compliance_check', 'dissolve'],
+    category: 'social',
   },
 
-  // === COLLABORATION ===
+  // ═══════════════════════════════════════════════════════════════
+  // COLLABORATION / HYBRID LENSES
+  // ═══════════════════════════════════════════════════════════════
+
   {
     domain: 'whiteboard',
     label: 'Whiteboard',
-    artifacts: ['board', 'element', 'connection', 'comment'],
+    artifacts: ['board', 'element', 'connection', 'comment', 'template'],
     macros: { list: 'lens.whiteboard.list', get: 'lens.whiteboard.get', create: 'lens.whiteboard.create', update: 'lens.whiteboard.update', delete: 'lens.whiteboard.delete', run: 'lens.whiteboard.run', export: 'lens.whiteboard.export' },
-    exports: ['json', 'png', 'svg'],
-    actions: ['render', 'layout', 'collaborate', 'snapshot'],
+    exports: ['json', 'png', 'svg', 'pdf'],
+    actions: ['render', 'layout', 'collaborate', 'snapshot', 'auto_arrange', 'extract_decisions', 'version_diff'],
     category: 'creative',
   },
+  {
+    domain: 'board',
+    label: 'Board',
+    artifacts: ['board', 'card', 'lane', 'workflow', 'label', 'sprint'],
+    macros: { list: 'lens.board.list', get: 'lens.board.get', create: 'lens.board.create', update: 'lens.board.update', delete: 'lens.board.delete', run: 'lens.board.run', export: 'lens.board.export' },
+    exports: ['json', 'csv', 'pdf'],
+    actions: ['move_card', 'assign', 'set_wip_limit', 'burndown', 'velocity_calc', 'sprint_review', 'archive_done'],
+    category: 'productivity',
+  },
+  {
+    domain: 'timeline',
+    label: 'Timeline',
+    artifacts: ['timeline_object', 'event_node', 'span', 'annotation', 'replay_session'],
+    macros: { list: 'lens.timeline.list', get: 'lens.timeline.get', create: 'lens.timeline.create', update: 'lens.timeline.update', delete: 'lens.timeline.delete', run: 'lens.timeline.run', export: 'lens.timeline.export' },
+    exports: ['json', 'csv', 'svg', 'ics'],
+    actions: ['replay', 'diff_timelines', 'annotate', 'cluster_events', 'gap_analysis', 'causality_trace'],
+    category: 'productivity',
+  },
+  {
+    domain: 'anon',
+    label: 'Anon',
+    artifacts: ['anonymous_room', 'message', 'artifact', 'provenance_rule', 'identity_mask'],
+    macros: { list: 'lens.anon.list', get: 'lens.anon.get', create: 'lens.anon.create', update: 'lens.anon.update', delete: 'lens.anon.delete', run: 'lens.anon.run', export: 'lens.anon.export' },
+    exports: ['json', 'md'],
+    actions: ['create_room', 'post_anonymous', 'verify_provenance', 'rotate_identity', 'export_sanitized', 'moderate'],
+    category: 'social',
+  },
 
-  // === SYSTEM ===
+  // ═══════════════════════════════════════════════════════════════
+  // SYSTEM / HYBRID LENSES
+  // ═══════════════════════════════════════════════════════════════
+
   {
     domain: 'database',
     label: 'Database',
-    artifacts: ['query', 'snapshot', 'table', 'view'],
+    artifacts: ['query', 'snapshot', 'table', 'view', 'migration', 'index'],
     macros: { list: 'lens.database.list', get: 'lens.database.get', create: 'lens.database.create', update: 'lens.database.update', delete: 'lens.database.delete', run: 'lens.database.run', export: 'lens.database.export' },
-    exports: ['json', 'csv', 'sql'],
-    actions: ['query', 'analyze', 'optimize', 'schema-inspect'],
+    exports: ['json', 'csv', 'sql', 'parquet'],
+    actions: ['query', 'analyze', 'optimize', 'schema-inspect', 'migration_generate', 'index_suggest', 'explain_plan'],
     category: 'system',
   },
   {
@@ -308,7 +434,7 @@ export const LENS_MANIFESTS: LensManifest[] = [
     artifacts: ['achievement', 'quest', 'skill', 'profile', 'game_state', 'reward_event'],
     macros: { list: 'lens.game.list', get: 'lens.game.get', create: 'lens.game.create', update: 'lens.game.update', delete: 'lens.game.delete', run: 'lens.game.run', export: 'lens.game.export' },
     exports: ['json', 'csv'],
-    actions: ['complete', 'claim', 'levelup', 'simulate', 'resolve_turn', 'balance'],
+    actions: ['complete', 'claim', 'levelup', 'simulate', 'resolve_turn', 'balance', 'leaderboard_update'],
     category: 'system',
   },
   {
@@ -322,17 +448,92 @@ export const LENS_MANIFESTS: LensManifest[] = [
   },
 
   // ═══════════════════════════════════════════════════════════════
+  // SPECIALIZED HYBRID LENSES (previously missing manifests)
+  // ═══════════════════════════════════════════════════════════════
+
+  {
+    domain: 'entity',
+    label: 'Entity',
+    artifacts: ['entity_profile', 'link', 'evidence', 'relationship', 'resolution_record'],
+    macros: { list: 'lens.entity.list', get: 'lens.entity.get', create: 'lens.entity.create', update: 'lens.entity.update', delete: 'lens.entity.delete', run: 'lens.entity.run', export: 'lens.entity.export' },
+    exports: ['json', 'csv', 'graphml'],
+    actions: ['resolve_entity', 'link_evidence', 'merge_duplicates', 'relationship_map', 'confidence_score', 'provenance_trace'],
+    category: 'knowledge',
+  },
+  {
+    domain: 'lab',
+    label: 'Lab',
+    artifacts: ['experiment_notebook', 'protocol', 'run', 'result', 'reagent', 'equipment_log'],
+    macros: { list: 'lens.lab.list', get: 'lens.lab.get', create: 'lens.lab.create', update: 'lens.lab.update', delete: 'lens.lab.delete', run: 'lens.lab.run', export: 'lens.lab.export' },
+    exports: ['json', 'csv', 'pdf', 'xlsx'],
+    actions: ['run_protocol', 'record_result', 'compare_runs', 'statistical_analysis', 'equipment_calibrate', 'generate_report'],
+    category: 'knowledge',
+  },
+  {
+    domain: 'repos',
+    label: 'Repos',
+    artifacts: ['repo_snapshot', 'issue_set', 'patchset', 'release', 'branch_record'],
+    macros: { list: 'lens.repos.list', get: 'lens.repos.get', create: 'lens.repos.create', update: 'lens.repos.update', delete: 'lens.repos.delete', run: 'lens.repos.run', export: 'lens.repos.export' },
+    exports: ['json', 'csv', 'patch', 'tar'],
+    actions: ['ingest_metadata', 'diff_view', 'release_package', 'issue_triage', 'contributor_stats', 'dependency_audit'],
+    category: 'knowledge',
+  },
+
+  // ═══════════════════════════════════════════════════════════════
+  // VIEWER LENSES — upgraded with real artifacts + workflows
+  // (previously missing manifests)
+  // ═══════════════════════════════════════════════════════════════
+
+  {
+    domain: 'invariant',
+    label: 'Invariant',
+    artifacts: ['invariant_set', 'monitor', 'violation_report', 'rule', 'check_result'],
+    macros: { list: 'lens.invariant.list', get: 'lens.invariant.get', create: 'lens.invariant.create', update: 'lens.invariant.update', delete: 'lens.invariant.delete', run: 'lens.invariant.run', export: 'lens.invariant.export' },
+    exports: ['json', 'csv', 'pdf'],
+    actions: ['check_all', 'add_invariant', 'monitor_start', 'violation_report', 'trend_analysis', 'auto_repair_suggest'],
+    category: 'system',
+  },
+  {
+    domain: 'meta',
+    label: 'Meta',
+    artifacts: ['session_meta_model', 'policy_profile', 'capability_map', 'lens_score'],
+    macros: { list: 'lens.meta.list', get: 'lens.meta.get', create: 'lens.meta.create', update: 'lens.meta.update', delete: 'lens.meta.delete', run: 'lens.meta.run', export: 'lens.meta.export' },
+    exports: ['json', 'csv', 'md'],
+    actions: ['score_lenses', 'policy_check', 'capability_audit', 'generate_status_report', 'cross_lens_analysis'],
+    category: 'system',
+  },
+  {
+    domain: 'eco',
+    label: 'Eco',
+    artifacts: ['ecosystem_graph', 'resource_flow', 'dependency_map', 'health_metric'],
+    macros: { list: 'lens.eco.list', get: 'lens.eco.get', create: 'lens.eco.create', update: 'lens.eco.update', delete: 'lens.eco.delete', run: 'lens.eco.run', export: 'lens.eco.export' },
+    exports: ['json', 'csv', 'svg', 'graphml'],
+    actions: ['map_dependencies', 'flow_analysis', 'health_check', 'bottleneck_detect', 'impact_simulation'],
+    category: 'system',
+  },
+  {
+    domain: 'temporal',
+    label: 'Temporal',
+    artifacts: ['timeline_object', 'temporal_assertion', 'replay_session', 'diff_record', 'causality_chain'],
+    macros: { list: 'lens.temporal.list', get: 'lens.temporal.get', create: 'lens.temporal.create', update: 'lens.temporal.update', delete: 'lens.temporal.delete', run: 'lens.temporal.run', export: 'lens.temporal.export' },
+    exports: ['json', 'csv', 'svg'],
+    actions: ['replay', 'diff', 'causality_trace', 'temporal_query', 'truth_at_time', 'version_compare'],
+    category: 'knowledge',
+  },
+
+  // ═══════════════════════════════════════════════════════════════
   // SUPER-LENSES — Universal coverage across all human work
+  // All upgraded with domain-specific macros + 3 engines + import/export
   // ═══════════════════════════════════════════════════════════════
 
   // === HEALTHCARE ===
   {
     domain: 'healthcare',
     label: 'Healthcare',
-    artifacts: ['Patient', 'Encounter', 'CareProtocol', 'Prescription', 'LabResult', 'Treatment'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['checkInteractions', 'protocolMatch', 'generateSummary'],
+    artifacts: ['Patient', 'Encounter', 'CareProtocol', 'Prescription', 'LabResult', 'Treatment', 'ReferralRecord'],
+    macros: { list: 'lens.healthcare.list', get: 'lens.healthcare.get', create: 'lens.healthcare.create', update: 'lens.healthcare.update', delete: 'lens.healthcare.delete', run: 'lens.healthcare.run', export: 'lens.healthcare.export' },
+    exports: ['json', 'csv', 'pdf', 'hl7', 'fhir'],
+    actions: ['checkInteractions', 'protocolMatch', 'generateSummary', 'intakeWorkflow', 'riskFlagging', 'carePlanGenerate', 'labImport', 'dischargePackage'],
     category: 'healthcare',
   },
 
@@ -340,10 +541,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'trades',
     label: 'Trades & Construction',
-    artifacts: ['Job', 'Estimate', 'MaterialsList', 'Permit', 'Equipment', 'Client'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['calculateEstimate', 'scheduleInspection', 'materialsCost'],
+    artifacts: ['Job', 'Estimate', 'MaterialsList', 'Permit', 'Equipment', 'Client', 'Inspection'],
+    macros: { list: 'lens.trades.list', get: 'lens.trades.get', create: 'lens.trades.create', update: 'lens.trades.update', delete: 'lens.trades.delete', run: 'lens.trades.run', export: 'lens.trades.export' },
+    exports: ['json', 'csv', 'pdf', 'xlsx'],
+    actions: ['calculateEstimate', 'scheduleInspection', 'materialsCost', 'codeComplianceCheck', 'changeOrderGenerate', 'progressPhotoLog', 'safetyChecklist'],
     category: 'trades',
   },
 
@@ -351,10 +552,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'food',
     label: 'Food & Hospitality',
-    artifacts: ['Recipe', 'Menu', 'InventoryItem', 'Booking', 'Batch', 'Shift'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['scaleRecipe', 'costPlate', 'spoilageCheck', 'pourCost'],
+    artifacts: ['Recipe', 'Menu', 'InventoryItem', 'Booking', 'Batch', 'Shift', 'Supplier'],
+    macros: { list: 'lens.food.list', get: 'lens.food.get', create: 'lens.food.create', update: 'lens.food.update', delete: 'lens.food.delete', run: 'lens.food.run', export: 'lens.food.export' },
+    exports: ['json', 'csv', 'pdf', 'xlsx'],
+    actions: ['scaleRecipe', 'costPlate', 'spoilageCheck', 'pourCost', 'menuEngineer', 'allergenValidate', 'shiftScheduleOptimize', 'supplierCompare'],
     category: 'operations',
   },
 
@@ -362,10 +563,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'retail',
     label: 'Retail & Commerce',
-    artifacts: ['Product', 'Order', 'Customer', 'Lead', 'Ticket', 'Display'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['reorderCheck', 'pipelineValue', 'customerLTV', 'slaStatus'],
+    artifacts: ['Product', 'Order', 'Customer', 'Lead', 'Ticket', 'Display', 'Promotion'],
+    macros: { list: 'lens.retail.list', get: 'lens.retail.get', create: 'lens.retail.create', update: 'lens.retail.update', delete: 'lens.retail.delete', run: 'lens.retail.run', export: 'lens.retail.export' },
+    exports: ['json', 'csv', 'pdf', 'xlsx'],
+    actions: ['reorderCheck', 'pipelineValue', 'customerLTV', 'slaStatus', 'inventoryForecast', 'priceOptimize', 'promotionROI', 'churnPredict'],
     category: 'operations',
   },
 
@@ -373,10 +574,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'household',
     label: 'Home & Family',
-    artifacts: ['FamilyMember', 'MealPlan', 'Chore', 'MaintenanceItem', 'Pet', 'MajorEvent'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['generateGroceryList', 'maintenanceDue', 'choreRotation'],
+    artifacts: ['FamilyMember', 'MealPlan', 'Chore', 'MaintenanceItem', 'Pet', 'MajorEvent', 'Budget'],
+    macros: { list: 'lens.household.list', get: 'lens.household.get', create: 'lens.household.create', update: 'lens.household.update', delete: 'lens.household.delete', run: 'lens.household.run', export: 'lens.household.export' },
+    exports: ['json', 'csv', 'pdf', 'ics'],
+    actions: ['generateGroceryList', 'maintenanceDue', 'choreRotation', 'mealPlanGenerate', 'budgetCheck', 'seasonalChecklist', 'emergencyContacts'],
     category: 'productivity',
   },
 
@@ -384,10 +585,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'accounting',
     label: 'Accounting & Finance',
-    artifacts: ['Account', 'Transaction', 'Invoice', 'PayrollEntry', 'Budget', 'Property', 'TaxItem'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf', 'qbo'],
-    actions: ['trialBalance', 'profitLoss', 'invoiceAging', 'budgetVariance', 'rentRoll'],
+    artifacts: ['Account', 'Transaction', 'Invoice', 'PayrollEntry', 'Budget', 'Property', 'TaxItem', 'Reconciliation'],
+    macros: { list: 'lens.accounting.list', get: 'lens.accounting.get', create: 'lens.accounting.create', update: 'lens.accounting.update', delete: 'lens.accounting.delete', run: 'lens.accounting.run', export: 'lens.accounting.export' },
+    exports: ['json', 'csv', 'pdf', 'qbo', 'xlsx'],
+    actions: ['trialBalance', 'profitLoss', 'invoiceAging', 'budgetVariance', 'rentRoll', 'reconcile', 'categorize', 'taxEstimate', 'auditReport'],
     category: 'finance',
   },
 
@@ -395,10 +596,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'agriculture',
     label: 'Agriculture & Farming',
-    artifacts: ['Field', 'Crop', 'Animal', 'FarmEquipment', 'WaterSystem', 'Harvest', 'Certification'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['rotationPlan', 'yieldAnalysis', 'equipmentDue', 'waterSchedule'],
+    artifacts: ['Field', 'Crop', 'Animal', 'FarmEquipment', 'WaterSystem', 'Harvest', 'Certification', 'SoilTest'],
+    macros: { list: 'lens.agriculture.list', get: 'lens.agriculture.get', create: 'lens.agriculture.create', update: 'lens.agriculture.update', delete: 'lens.agriculture.delete', run: 'lens.agriculture.run', export: 'lens.agriculture.export' },
+    exports: ['json', 'csv', 'pdf', 'geojson'],
+    actions: ['rotationPlan', 'yieldAnalysis', 'equipmentDue', 'waterSchedule', 'soilHealthScore', 'pestPressureAlert', 'harvestForecast', 'certificationAudit'],
     category: 'agriculture',
   },
 
@@ -406,10 +607,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'logistics',
     label: 'Transportation & Logistics',
-    artifacts: ['Vehicle', 'Driver', 'Shipment', 'WarehouseItem', 'Route', 'ComplianceLog'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['optimizeRoute', 'hosCheck', 'maintenanceDue', 'inventoryAudit'],
+    artifacts: ['Vehicle', 'Driver', 'Shipment', 'WarehouseItem', 'Route', 'ComplianceLog', 'Manifest'],
+    macros: { list: 'lens.logistics.list', get: 'lens.logistics.get', create: 'lens.logistics.create', update: 'lens.logistics.update', delete: 'lens.logistics.delete', run: 'lens.logistics.run', export: 'lens.logistics.export' },
+    exports: ['json', 'csv', 'pdf', 'edi'],
+    actions: ['optimizeRoute', 'hosCheck', 'maintenanceDue', 'inventoryAudit', 'etaCalculate', 'loadOptimize', 'complianceReport', 'warehouseSlotting'],
     category: 'operations',
   },
 
@@ -417,10 +618,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'education',
     label: 'Education',
-    artifacts: ['Student', 'Course', 'Assignment', 'Grade', 'LessonPlan', 'Certification'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['gradeCalculation', 'attendanceReport', 'progressTrack', 'scheduleConflict'],
+    artifacts: ['Student', 'Course', 'Assignment', 'Grade', 'LessonPlan', 'Certification', 'Rubric'],
+    macros: { list: 'lens.education.list', get: 'lens.education.get', create: 'lens.education.create', update: 'lens.education.update', delete: 'lens.education.delete', run: 'lens.education.run', export: 'lens.education.export' },
+    exports: ['json', 'csv', 'pdf', 'lti'],
+    actions: ['gradeCalculation', 'attendanceReport', 'progressTrack', 'scheduleConflict', 'rubricGenerate', 'differentiate', 'parentReport', 'certificationCheck'],
     category: 'services',
   },
 
@@ -428,10 +629,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'legal',
     label: 'Legal',
-    artifacts: ['Case', 'Contract', 'ComplianceItem', 'Filing', 'IPAsset'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['deadlineCheck', 'contractRenewal', 'conflictCheck', 'complianceScore'],
+    artifacts: ['Case', 'Contract', 'ComplianceItem', 'Filing', 'IPAsset', 'BriefBundle'],
+    macros: { list: 'lens.legal.list', get: 'lens.legal.get', create: 'lens.legal.create', update: 'lens.legal.update', delete: 'lens.legal.delete', run: 'lens.legal.run', export: 'lens.legal.export' },
+    exports: ['json', 'csv', 'pdf', 'docx'],
+    actions: ['deadlineCheck', 'contractRenewal', 'conflictCheck', 'complianceScore', 'clauseChecker', 'citationPackager', 'caseTimelineBuilder', 'briefExport'],
     category: 'services',
   },
 
@@ -439,10 +640,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'nonprofit',
     label: 'Nonprofit & Community',
-    artifacts: ['Donor', 'Grant', 'Volunteer', 'Campaign', 'ImpactMetric', 'Member'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['donorRetention', 'grantReporting', 'volunteerMatch', 'campaignProgress'],
+    artifacts: ['Donor', 'Grant', 'Volunteer', 'Campaign', 'ImpactMetric', 'Member', 'FundraisingEvent'],
+    macros: { list: 'lens.nonprofit.list', get: 'lens.nonprofit.get', create: 'lens.nonprofit.create', update: 'lens.nonprofit.update', delete: 'lens.nonprofit.delete', run: 'lens.nonprofit.run', export: 'lens.nonprofit.export' },
+    exports: ['json', 'csv', 'pdf', 'xlsx'],
+    actions: ['donorRetention', 'grantReporting', 'volunteerMatch', 'campaignProgress', 'impactReport', 'taxReceipt', 'eventROI', 'memberEngagement'],
     category: 'social',
   },
 
@@ -450,10 +651,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'realestate',
     label: 'Real Estate',
-    artifacts: ['Listing', 'Showing', 'Transaction', 'RentalUnit', 'Deal'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['capRate', 'cashFlow', 'closingTimeline', 'vacancyRate'],
+    artifacts: ['Listing', 'Showing', 'Transaction', 'RentalUnit', 'Deal', 'Appraisal'],
+    macros: { list: 'lens.realestate.list', get: 'lens.realestate.get', create: 'lens.realestate.create', update: 'lens.realestate.update', delete: 'lens.realestate.delete', run: 'lens.realestate.run', export: 'lens.realestate.export' },
+    exports: ['json', 'csv', 'pdf', 'xlsx'],
+    actions: ['capRate', 'cashFlow', 'closingTimeline', 'vacancyRate', 'comparableAnalysis', 'mortgageCalc', 'inspectionChecklist', 'netOperatingIncome'],
     category: 'finance',
   },
 
@@ -461,10 +662,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'fitness',
     label: 'Fitness & Wellness',
-    artifacts: ['Client', 'Program', 'Workout', 'Class', 'Team', 'Athlete'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['progressionCalc', 'classUtilization', 'periodization', 'recruitProfile'],
+    artifacts: ['Client', 'Program', 'Workout', 'Class', 'Team', 'Athlete', 'Assessment'],
+    macros: { list: 'lens.fitness.list', get: 'lens.fitness.get', create: 'lens.fitness.create', update: 'lens.fitness.update', delete: 'lens.fitness.delete', run: 'lens.fitness.run', export: 'lens.fitness.export' },
+    exports: ['json', 'csv', 'pdf', 'xlsx'],
+    actions: ['progressionCalc', 'classUtilization', 'periodization', 'recruitProfile', 'bodyCompAnalysis', 'programGenerate', 'injuryRiskScreen', 'nutritionPlan'],
     category: 'services',
   },
 
@@ -472,10 +673,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'creative',
     label: 'Creative Production',
-    artifacts: ['Project', 'Shoot', 'Asset', 'Episode', 'Collection', 'ClientProof'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['shotListGenerate', 'assetOrganize', 'budgetTrack', 'distributionChecklist'],
+    artifacts: ['Project', 'Shoot', 'Asset', 'Episode', 'Collection', 'ClientProof', 'DeliverablePackage'],
+    macros: { list: 'lens.creative.list', get: 'lens.creative.get', create: 'lens.creative.create', update: 'lens.creative.update', delete: 'lens.creative.delete', run: 'lens.creative.run', export: 'lens.creative.export' },
+    exports: ['json', 'csv', 'pdf', 'zip'],
+    actions: ['shotListGenerate', 'assetOrganize', 'budgetTrack', 'distributionChecklist', 'proofGenerate', 'metadataEmbed', 'deliverablePackage', 'clientReviewFlow'],
     category: 'creative',
   },
 
@@ -483,10 +684,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'manufacturing',
     label: 'Manufacturing',
-    artifacts: ['WorkOrder', 'BOM', 'QCInspection', 'Machine', 'SafetyItem', 'Part'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['scheduleOptimize', 'bomCost', 'oeeCalculate', 'safetyRate'],
+    artifacts: ['WorkOrder', 'BOM', 'QCInspection', 'Machine', 'SafetyItem', 'Part', 'ProductionRun'],
+    macros: { list: 'lens.manufacturing.list', get: 'lens.manufacturing.get', create: 'lens.manufacturing.create', update: 'lens.manufacturing.update', delete: 'lens.manufacturing.delete', run: 'lens.manufacturing.run', export: 'lens.manufacturing.export' },
+    exports: ['json', 'csv', 'pdf', 'xlsx'],
+    actions: ['scheduleOptimize', 'bomCost', 'oeeCalculate', 'safetyRate', 'defectTrend', 'maintenancePredict', 'batchTrace', 'capacityPlan'],
     category: 'operations',
   },
 
@@ -494,10 +695,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'environment',
     label: 'Environmental & Outdoors',
-    artifacts: ['Site', 'Species', 'Survey', 'TrailAsset', 'EnvironmentalSample', 'WasteStream'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf', 'geojson'],
-    actions: ['populationTrend', 'complianceCheck', 'trailCondition', 'diversionRate'],
+    artifacts: ['Site', 'Species', 'Survey', 'TrailAsset', 'EnvironmentalSample', 'WasteStream', 'ComplianceRecord'],
+    macros: { list: 'lens.environment.list', get: 'lens.environment.get', create: 'lens.environment.create', update: 'lens.environment.update', delete: 'lens.environment.delete', run: 'lens.environment.run', export: 'lens.environment.export' },
+    exports: ['json', 'csv', 'pdf', 'geojson', 'kml'],
+    actions: ['populationTrend', 'complianceCheck', 'trailCondition', 'diversionRate', 'sampleChainOfCustody', 'emissionsCalc', 'habitatAssess', 'impactForecast'],
     category: 'government',
   },
 
@@ -505,10 +706,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'government',
     label: 'Government & Public Service',
-    artifacts: ['Permit', 'Project', 'Violation', 'EmergencyPlan', 'Record', 'CourtCase'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['permitTimeline', 'violationEscalation', 'resourceStaging', 'retentionCheck'],
+    artifacts: ['Permit', 'Project', 'Violation', 'EmergencyPlan', 'Record', 'CourtCase', 'Ordinance'],
+    macros: { list: 'lens.government.list', get: 'lens.government.get', create: 'lens.government.create', update: 'lens.government.update', delete: 'lens.government.delete', run: 'lens.government.run', export: 'lens.government.export' },
+    exports: ['json', 'csv', 'pdf', 'xml'],
+    actions: ['permitTimeline', 'violationEscalation', 'resourceStaging', 'retentionCheck', 'budgetImpact', 'publicNoticeGenerate', 'ordinancePackage', 'foiaProcess'],
     category: 'government',
   },
 
@@ -516,10 +717,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'aviation',
     label: 'Aviation & Maritime',
-    artifacts: ['Flight', 'Aircraft', 'Vessel', 'Slip', 'Charter', 'CrewMember'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['currencyCheck', 'maintenanceDue', 'hobbsLog', 'slipUtilization'],
+    artifacts: ['Flight', 'Aircraft', 'Vessel', 'Slip', 'Charter', 'CrewMember', 'LogbookEntry'],
+    macros: { list: 'lens.aviation.list', get: 'lens.aviation.get', create: 'lens.aviation.create', update: 'lens.aviation.update', delete: 'lens.aviation.delete', run: 'lens.aviation.run', export: 'lens.aviation.export' },
+    exports: ['json', 'csv', 'pdf', 'kml'],
+    actions: ['currencyCheck', 'maintenanceDue', 'hobbsLog', 'slipUtilization', 'weightBalance', 'flightPlan', 'crewSchedule', 'regulatoryCompliance'],
     category: 'operations',
   },
 
@@ -527,10 +728,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'events',
     label: 'Events & Entertainment',
-    artifacts: ['Event', 'Venue', 'Performer', 'Tour', 'Production', 'Vendor'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['budgetReconcile', 'advanceSheet', 'techRiderMatch', 'settlementCalc'],
+    artifacts: ['Event', 'Venue', 'Performer', 'Tour', 'Production', 'Vendor', 'SettlementRecord'],
+    macros: { list: 'lens.events.list', get: 'lens.events.get', create: 'lens.events.create', update: 'lens.events.update', delete: 'lens.events.delete', run: 'lens.events.run', export: 'lens.events.export' },
+    exports: ['json', 'csv', 'pdf', 'ics'],
+    actions: ['budgetReconcile', 'advanceSheet', 'techRiderMatch', 'settlementCalc', 'ticketForecast', 'vendorCompare', 'runOfShow', 'postEventReport'],
     category: 'creative',
   },
 
@@ -538,10 +739,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'science',
     label: 'Science & Field Work',
-    artifacts: ['Expedition', 'Observation', 'Sample', 'LabProtocol', 'Analysis', 'Equipment'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf', 'geojson'],
-    actions: ['chainOfCustody', 'calibrationCheck', 'dataExport', 'spatialCluster'],
+    artifacts: ['Expedition', 'Observation', 'Sample', 'LabProtocol', 'Analysis', 'Equipment', 'Dataset'],
+    macros: { list: 'lens.science.list', get: 'lens.science.get', create: 'lens.science.create', update: 'lens.science.update', delete: 'lens.science.delete', run: 'lens.science.run', export: 'lens.science.export' },
+    exports: ['json', 'csv', 'pdf', 'geojson', 'netcdf'],
+    actions: ['chainOfCustody', 'calibrationCheck', 'dataExport', 'spatialCluster', 'statisticalTest', 'peerReviewPackage', 'replicationCheck', 'dataQuality'],
     category: 'knowledge',
   },
 
@@ -549,10 +750,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'security',
     label: 'Security',
-    artifacts: ['Post', 'Incident', 'Patrol', 'Threat', 'Investigation', 'Asset'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['incidentTrend', 'patrolCoverage', 'threatMatrix', 'evidenceChain'],
+    artifacts: ['Post', 'Incident', 'Patrol', 'Threat', 'Investigation', 'Asset', 'ComplianceReport'],
+    macros: { list: 'lens.security.list', get: 'lens.security.get', create: 'lens.security.create', update: 'lens.security.update', delete: 'lens.security.delete', run: 'lens.security.run', export: 'lens.security.export' },
+    exports: ['json', 'csv', 'pdf', 'stix'],
+    actions: ['incidentTrend', 'patrolCoverage', 'threatMatrix', 'evidenceChain', 'complianceCheck', 'hardeningChecklist', 'incidentReport', 'vulnerabilityScan'],
     category: 'operations',
   },
 
@@ -560,10 +761,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'services',
     label: 'Personal Services',
-    artifacts: ['Client', 'Appointment', 'ServiceType', 'Provider', 'ChildProfile', 'PortfolioItem'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['scheduleOptimize', 'reminderGenerate', 'revenueByProvider', 'supplyCheck'],
+    artifacts: ['Client', 'Appointment', 'ServiceType', 'Provider', 'ChildProfile', 'PortfolioItem', 'Subscription'],
+    macros: { list: 'lens.services.list', get: 'lens.services.get', create: 'lens.services.create', update: 'lens.services.update', delete: 'lens.services.delete', run: 'lens.services.run', export: 'lens.services.export' },
+    exports: ['json', 'csv', 'pdf', 'ics'],
+    actions: ['scheduleOptimize', 'reminderGenerate', 'revenueByProvider', 'supplyCheck', 'clientRetention', 'waitlistManage', 'bookingConfirm', 'feedbackCollect'],
     category: 'services',
   },
 
@@ -571,10 +772,10 @@ export const LENS_MANIFESTS: LensManifest[] = [
   {
     domain: 'insurance',
     label: 'Insurance & Risk',
-    artifacts: ['Policy', 'Claim', 'Risk', 'Benefit', 'Renewal'],
-    macros: { list: 'lens.list', get: 'lens.get', create: 'lens.create', update: 'lens.update', delete: 'lens.delete', run: 'lens.run', export: 'lens.export' },
-    exports: ['json', 'csv', 'pdf'],
-    actions: ['coverageGap', 'premiumHistory', 'claimStatus', 'riskScore'],
+    artifacts: ['Policy', 'Claim', 'Risk', 'Benefit', 'Renewal', 'Assessment'],
+    macros: { list: 'lens.insurance.list', get: 'lens.insurance.get', create: 'lens.insurance.create', update: 'lens.insurance.update', delete: 'lens.insurance.delete', run: 'lens.insurance.run', export: 'lens.insurance.export' },
+    exports: ['json', 'csv', 'pdf', 'acord'],
+    actions: ['coverageGap', 'premiumHistory', 'claimStatus', 'riskScore', 'renewalForecast', 'benefitComparison', 'fraudIndicator', 'lossRunReport'],
     category: 'finance',
   },
 ];
@@ -594,4 +795,16 @@ export function getLensManifests(category?: string): LensManifest[] {
 
 export function getAllLensDomains(): string[] {
   return LENS_MANIFESTS.map(m => m.domain);
+}
+
+/** Count of lenses with full manifest contracts */
+export function getManifestCount(): number {
+  return LENS_MANIFESTS.length;
+}
+
+/** Get lenses missing a specific macro (e.g. 'create', 'run', 'export') */
+export function getLensesMissingMacro(macro: keyof LensManifest['macros']): string[] {
+  return LENS_MANIFESTS
+    .filter(m => !m.macros[macro])
+    .map(m => m.domain);
 }

--- a/concord-frontend/lib/lenses/workflow-definitions.ts
+++ b/concord-frontend/lib/lenses/workflow-definitions.ts
@@ -1,0 +1,572 @@
+/**
+ * Workflow Definitions - Per-lens state machines with states,
+ * transitions, guards, and lifecycle hooks.
+ *
+ * Every competitor-level application has a workflow engine:
+ * Draft → Review → Approved → Archived with permissions per stage.
+ *
+ * This file defines the state machines that the existing
+ * atlas-write-guard and atlas-scope-router infrastructure can enforce.
+ */
+
+// ── Types ──────────────────────────────────────────────────────
+
+export interface WorkflowState {
+  name: string;
+  /** Human-readable label */
+  label: string;
+  /** Is this the initial state for new artifacts? */
+  initial?: boolean;
+  /** Is this a terminal state? */
+  terminal?: boolean;
+  /** Required RBAC permission to be in this state */
+  requiredPermission?: string;
+  /** Color hint for UI rendering */
+  color?: 'gray' | 'blue' | 'yellow' | 'green' | 'red' | 'orange' | 'purple';
+}
+
+export interface WorkflowTransition {
+  from: string;
+  to: string;
+  /** Action name that triggers this transition */
+  action: string;
+  /** Human-readable label for the action button */
+  label: string;
+  /** RBAC permission required to perform this transition */
+  requiredPermission?: string;
+  /** Minimum role required */
+  requiredRole?: 'viewer' | 'reviewer' | 'editor' | 'admin' | 'owner';
+  /** Guard: domain-specific validation that must pass */
+  guard?: string;
+}
+
+export interface WorkflowDef {
+  domain: string;
+  /** Which entity this workflow applies to (e.g. 'Case', 'WorkOrder') */
+  entity: string;
+  states: WorkflowState[];
+  transitions: WorkflowTransition[];
+}
+
+// ── Workflow Definitions ───────────────────────────────────────
+
+export const WORKFLOW_DEFINITIONS: WorkflowDef[] = [
+
+  // ── Paper / Research ─────────────────────────────────────────
+  {
+    domain: 'paper',
+    entity: 'project',
+    states: [
+      { name: 'draft', label: 'Draft', initial: true, color: 'gray' },
+      { name: 'in_review', label: 'In Review', color: 'yellow', requiredPermission: 'write' },
+      { name: 'revision', label: 'Revision Requested', color: 'orange' },
+      { name: 'published', label: 'Published', color: 'green', requiredPermission: 'promote' },
+      { name: 'archived', label: 'Archived', terminal: true, color: 'purple' },
+    ],
+    transitions: [
+      { from: 'draft', to: 'in_review', action: 'submit', label: 'Submit for Review', requiredRole: 'editor', guard: 'hasAbstract' },
+      { from: 'in_review', to: 'revision', action: 'request_changes', label: 'Request Changes', requiredRole: 'reviewer' },
+      { from: 'in_review', to: 'published', action: 'approve', label: 'Publish', requiredRole: 'admin', guard: 'hasMinClaims' },
+      { from: 'revision', to: 'in_review', action: 'resubmit', label: 'Resubmit', requiredRole: 'editor' },
+      { from: 'published', to: 'archived', action: 'archive', label: 'Archive', requiredRole: 'admin' },
+      { from: 'in_review', to: 'draft', action: 'withdraw', label: 'Withdraw', requiredRole: 'editor' },
+    ],
+  },
+
+  // ── Code ─────────────────────────────────────────────────────
+  {
+    domain: 'code',
+    entity: 'review',
+    states: [
+      { name: 'open', label: 'Open', initial: true, color: 'blue' },
+      { name: 'changes_requested', label: 'Changes Requested', color: 'orange' },
+      { name: 'approved', label: 'Approved', color: 'green', requiredPermission: 'promote' },
+      { name: 'merged', label: 'Merged', terminal: true, color: 'purple' },
+    ],
+    transitions: [
+      { from: 'open', to: 'approved', action: 'approve', label: 'Approve', requiredRole: 'reviewer' },
+      { from: 'open', to: 'changes_requested', action: 'request_changes', label: 'Request Changes', requiredRole: 'reviewer' },
+      { from: 'changes_requested', to: 'open', action: 'address', label: 'Address Feedback', requiredRole: 'editor' },
+      { from: 'approved', to: 'merged', action: 'merge', label: 'Merge', requiredRole: 'admin' },
+    ],
+  },
+
+  // ── Healthcare ───────────────────────────────────────────────
+  {
+    domain: 'healthcare',
+    entity: 'Encounter',
+    states: [
+      { name: 'scheduled', label: 'Scheduled', initial: true, color: 'blue' },
+      { name: 'checked_in', label: 'Checked In', color: 'yellow' },
+      { name: 'in_progress', label: 'In Progress', color: 'orange' },
+      { name: 'completed', label: 'Completed', color: 'green' },
+      { name: 'billed', label: 'Billed', terminal: true, color: 'purple' },
+      { name: 'cancelled', label: 'Cancelled', terminal: true, color: 'gray' },
+      { name: 'no_show', label: 'No Show', terminal: true, color: 'red' },
+    ],
+    transitions: [
+      { from: 'scheduled', to: 'checked_in', action: 'check_in', label: 'Check In', requiredRole: 'editor' },
+      { from: 'scheduled', to: 'cancelled', action: 'cancel', label: 'Cancel', requiredRole: 'editor' },
+      { from: 'scheduled', to: 'no_show', action: 'mark_no_show', label: 'Mark No Show', requiredRole: 'editor' },
+      { from: 'checked_in', to: 'in_progress', action: 'start', label: 'Start Encounter', requiredRole: 'editor', guard: 'hasProvider' },
+      { from: 'in_progress', to: 'completed', action: 'complete', label: 'Complete', requiredRole: 'editor', guard: 'hasDiagnosis' },
+      { from: 'completed', to: 'billed', action: 'bill', label: 'Submit for Billing', requiredRole: 'admin' },
+    ],
+  },
+
+  {
+    domain: 'healthcare',
+    entity: 'Prescription',
+    states: [
+      { name: 'active', label: 'Active', initial: true, color: 'green' },
+      { name: 'on_hold', label: 'On Hold', color: 'yellow' },
+      { name: 'completed', label: 'Completed', terminal: true, color: 'gray' },
+      { name: 'discontinued', label: 'Discontinued', terminal: true, color: 'red' },
+    ],
+    transitions: [
+      { from: 'active', to: 'on_hold', action: 'hold', label: 'Place on Hold', requiredRole: 'editor' },
+      { from: 'active', to: 'discontinued', action: 'discontinue', label: 'Discontinue', requiredRole: 'editor', guard: 'hasDiscontinueReason' },
+      { from: 'active', to: 'completed', action: 'complete', label: 'Mark Complete', requiredRole: 'editor' },
+      { from: 'on_hold', to: 'active', action: 'resume', label: 'Resume', requiredRole: 'editor' },
+      { from: 'on_hold', to: 'discontinued', action: 'discontinue', label: 'Discontinue', requiredRole: 'editor' },
+    ],
+  },
+
+  // ── Legal ────────────────────────────────────────────────────
+  {
+    domain: 'legal',
+    entity: 'Case',
+    states: [
+      { name: 'intake', label: 'Intake', initial: true, color: 'gray' },
+      { name: 'active', label: 'Active', color: 'blue' },
+      { name: 'discovery', label: 'Discovery', color: 'yellow' },
+      { name: 'trial', label: 'Trial', color: 'orange' },
+      { name: 'appeal', label: 'Appeal', color: 'red' },
+      { name: 'settled', label: 'Settled', terminal: true, color: 'green' },
+      { name: 'closed', label: 'Closed', terminal: true, color: 'purple' },
+    ],
+    transitions: [
+      { from: 'intake', to: 'active', action: 'accept', label: 'Accept Case', requiredRole: 'admin', guard: 'hasClient' },
+      { from: 'active', to: 'discovery', action: 'begin_discovery', label: 'Begin Discovery', requiredRole: 'editor' },
+      { from: 'discovery', to: 'trial', action: 'proceed_to_trial', label: 'Proceed to Trial', requiredRole: 'admin' },
+      { from: 'trial', to: 'appeal', action: 'appeal', label: 'File Appeal', requiredRole: 'admin' },
+      { from: 'active', to: 'settled', action: 'settle', label: 'Settle', requiredRole: 'admin' },
+      { from: 'trial', to: 'settled', action: 'settle', label: 'Settle', requiredRole: 'admin' },
+      { from: 'trial', to: 'closed', action: 'close', label: 'Close', requiredRole: 'admin' },
+      { from: 'appeal', to: 'closed', action: 'close', label: 'Close', requiredRole: 'admin' },
+      { from: 'settled', to: 'closed', action: 'close', label: 'Archive', requiredRole: 'admin' },
+    ],
+  },
+
+  {
+    domain: 'legal',
+    entity: 'Contract',
+    states: [
+      { name: 'draft', label: 'Draft', initial: true, color: 'gray' },
+      { name: 'review', label: 'Under Review', color: 'yellow' },
+      { name: 'negotiation', label: 'Negotiation', color: 'orange' },
+      { name: 'executed', label: 'Executed', color: 'green' },
+      { name: 'expired', label: 'Expired', terminal: true, color: 'gray' },
+      { name: 'terminated', label: 'Terminated', terminal: true, color: 'red' },
+    ],
+    transitions: [
+      { from: 'draft', to: 'review', action: 'submit', label: 'Submit for Review', requiredRole: 'editor' },
+      { from: 'review', to: 'negotiation', action: 'negotiate', label: 'Enter Negotiation', requiredRole: 'admin' },
+      { from: 'review', to: 'draft', action: 'return', label: 'Return to Draft', requiredRole: 'reviewer' },
+      { from: 'negotiation', to: 'executed', action: 'execute', label: 'Execute Contract', requiredRole: 'admin', guard: 'hasAllParties' },
+      { from: 'negotiation', to: 'draft', action: 'restart', label: 'Restart Draft', requiredRole: 'admin' },
+      { from: 'executed', to: 'expired', action: 'expire', label: 'Mark Expired', requiredRole: 'admin' },
+      { from: 'executed', to: 'terminated', action: 'terminate', label: 'Terminate', requiredRole: 'owner' },
+    ],
+  },
+
+  // ── Accounting ───────────────────────────────────────────────
+  {
+    domain: 'accounting',
+    entity: 'Invoice',
+    states: [
+      { name: 'draft', label: 'Draft', initial: true, color: 'gray' },
+      { name: 'sent', label: 'Sent', color: 'blue' },
+      { name: 'overdue', label: 'Overdue', color: 'red' },
+      { name: 'paid', label: 'Paid', terminal: true, color: 'green' },
+      { name: 'void', label: 'Void', terminal: true, color: 'gray' },
+    ],
+    transitions: [
+      { from: 'draft', to: 'sent', action: 'send', label: 'Send Invoice', requiredRole: 'editor', guard: 'hasLineItems' },
+      { from: 'draft', to: 'void', action: 'void', label: 'Void', requiredRole: 'admin' },
+      { from: 'sent', to: 'paid', action: 'record_payment', label: 'Record Payment', requiredRole: 'editor' },
+      { from: 'sent', to: 'overdue', action: 'mark_overdue', label: 'Mark Overdue', requiredRole: 'editor' },
+      { from: 'overdue', to: 'paid', action: 'record_payment', label: 'Record Payment', requiredRole: 'editor' },
+      { from: 'sent', to: 'void', action: 'void', label: 'Void', requiredRole: 'admin' },
+    ],
+  },
+
+  // ── Security ─────────────────────────────────────────────────
+  {
+    domain: 'security',
+    entity: 'Incident',
+    states: [
+      { name: 'reported', label: 'Reported', initial: true, color: 'red' },
+      { name: 'triaged', label: 'Triaged', color: 'orange' },
+      { name: 'investigating', label: 'Investigating', color: 'yellow' },
+      { name: 'contained', label: 'Contained', color: 'blue' },
+      { name: 'remediated', label: 'Remediated', color: 'green' },
+      { name: 'closed', label: 'Closed', terminal: true, color: 'purple' },
+    ],
+    transitions: [
+      { from: 'reported', to: 'triaged', action: 'triage', label: 'Triage', requiredRole: 'editor' },
+      { from: 'triaged', to: 'investigating', action: 'investigate', label: 'Begin Investigation', requiredRole: 'editor', guard: 'hasAssignee' },
+      { from: 'investigating', to: 'contained', action: 'contain', label: 'Mark Contained', requiredRole: 'editor' },
+      { from: 'contained', to: 'remediated', action: 'remediate', label: 'Remediate', requiredRole: 'editor' },
+      { from: 'remediated', to: 'closed', action: 'close', label: 'Close Incident', requiredRole: 'admin', guard: 'hasPostMortem' },
+      { from: 'reported', to: 'closed', action: 'dismiss', label: 'Dismiss (False Positive)', requiredRole: 'admin' },
+    ],
+  },
+
+  // ── Manufacturing ────────────────────────────────────────────
+  {
+    domain: 'manufacturing',
+    entity: 'WorkOrder',
+    states: [
+      { name: 'planned', label: 'Planned', initial: true, color: 'gray' },
+      { name: 'scheduled', label: 'Scheduled', color: 'blue' },
+      { name: 'in_progress', label: 'In Progress', color: 'yellow' },
+      { name: 'quality_check', label: 'Quality Check', color: 'orange' },
+      { name: 'completed', label: 'Completed', color: 'green' },
+      { name: 'shipped', label: 'Shipped', terminal: true, color: 'purple' },
+    ],
+    transitions: [
+      { from: 'planned', to: 'scheduled', action: 'schedule', label: 'Schedule', requiredRole: 'editor', guard: 'hasBOM' },
+      { from: 'scheduled', to: 'in_progress', action: 'start', label: 'Start Production', requiredRole: 'editor', guard: 'hasMachine' },
+      { from: 'in_progress', to: 'quality_check', action: 'submit_qc', label: 'Submit for QC', requiredRole: 'editor' },
+      { from: 'quality_check', to: 'completed', action: 'pass_qc', label: 'QC Passed', requiredRole: 'reviewer' },
+      { from: 'quality_check', to: 'in_progress', action: 'fail_qc', label: 'QC Failed — Rework', requiredRole: 'reviewer' },
+      { from: 'completed', to: 'shipped', action: 'ship', label: 'Ship', requiredRole: 'admin' },
+    ],
+  },
+
+  {
+    domain: 'manufacturing',
+    entity: 'BOM',
+    states: [
+      { name: 'draft', label: 'Draft', initial: true, color: 'gray' },
+      { name: 'approved', label: 'Approved', color: 'green' },
+      { name: 'deprecated', label: 'Deprecated', terminal: true, color: 'red' },
+    ],
+    transitions: [
+      { from: 'draft', to: 'approved', action: 'approve', label: 'Approve BOM', requiredRole: 'admin', guard: 'hasParts' },
+      { from: 'approved', to: 'deprecated', action: 'deprecate', label: 'Deprecate', requiredRole: 'admin' },
+    ],
+  },
+
+  // ── Education ────────────────────────────────────────────────
+  {
+    domain: 'education',
+    entity: 'Student',
+    states: [
+      { name: 'enrolled', label: 'Enrolled', initial: true, color: 'green' },
+      { name: 'suspended', label: 'Suspended', color: 'red' },
+      { name: 'graduated', label: 'Graduated', terminal: true, color: 'purple' },
+      { name: 'withdrawn', label: 'Withdrawn', terminal: true, color: 'gray' },
+    ],
+    transitions: [
+      { from: 'enrolled', to: 'suspended', action: 'suspend', label: 'Suspend', requiredRole: 'admin' },
+      { from: 'suspended', to: 'enrolled', action: 'reinstate', label: 'Reinstate', requiredRole: 'admin' },
+      { from: 'enrolled', to: 'graduated', action: 'graduate', label: 'Graduate', requiredRole: 'admin', guard: 'meetsRequirements' },
+      { from: 'enrolled', to: 'withdrawn', action: 'withdraw', label: 'Withdraw', requiredRole: 'editor' },
+    ],
+  },
+
+  // ── Retail ───────────────────────────────────────────────────
+  {
+    domain: 'retail',
+    entity: 'Order',
+    states: [
+      { name: 'pending', label: 'Pending', initial: true, color: 'gray' },
+      { name: 'confirmed', label: 'Confirmed', color: 'blue' },
+      { name: 'processing', label: 'Processing', color: 'yellow' },
+      { name: 'shipped', label: 'Shipped', color: 'orange' },
+      { name: 'delivered', label: 'Delivered', terminal: true, color: 'green' },
+      { name: 'returned', label: 'Returned', terminal: true, color: 'red' },
+      { name: 'cancelled', label: 'Cancelled', terminal: true, color: 'gray' },
+    ],
+    transitions: [
+      { from: 'pending', to: 'confirmed', action: 'confirm', label: 'Confirm Order', requiredRole: 'editor' },
+      { from: 'pending', to: 'cancelled', action: 'cancel', label: 'Cancel', requiredRole: 'editor' },
+      { from: 'confirmed', to: 'processing', action: 'process', label: 'Begin Processing', requiredRole: 'editor' },
+      { from: 'confirmed', to: 'cancelled', action: 'cancel', label: 'Cancel', requiredRole: 'admin' },
+      { from: 'processing', to: 'shipped', action: 'ship', label: 'Ship', requiredRole: 'editor', guard: 'hasShippingAddress' },
+      { from: 'shipped', to: 'delivered', action: 'deliver', label: 'Mark Delivered', requiredRole: 'editor' },
+      { from: 'delivered', to: 'returned', action: 'return', label: 'Process Return', requiredRole: 'editor' },
+    ],
+  },
+
+  // ── Government ───────────────────────────────────────────────
+  {
+    domain: 'government',
+    entity: 'Permit',
+    states: [
+      { name: 'submitted', label: 'Submitted', initial: true, color: 'blue' },
+      { name: 'under_review', label: 'Under Review', color: 'yellow' },
+      { name: 'revision_requested', label: 'Revision Requested', color: 'orange' },
+      { name: 'approved', label: 'Approved', color: 'green' },
+      { name: 'denied', label: 'Denied', terminal: true, color: 'red' },
+      { name: 'expired', label: 'Expired', terminal: true, color: 'gray' },
+      { name: 'revoked', label: 'Revoked', terminal: true, color: 'red' },
+    ],
+    transitions: [
+      { from: 'submitted', to: 'under_review', action: 'begin_review', label: 'Begin Review', requiredRole: 'reviewer' },
+      { from: 'under_review', to: 'revision_requested', action: 'request_revision', label: 'Request Revision', requiredRole: 'reviewer' },
+      { from: 'revision_requested', to: 'under_review', action: 'resubmit', label: 'Resubmit', requiredRole: 'editor' },
+      { from: 'under_review', to: 'approved', action: 'approve', label: 'Approve', requiredRole: 'admin', guard: 'hasFeesPaid' },
+      { from: 'under_review', to: 'denied', action: 'deny', label: 'Deny', requiredRole: 'admin' },
+      { from: 'approved', to: 'expired', action: 'expire', label: 'Mark Expired', requiredRole: 'admin' },
+      { from: 'approved', to: 'revoked', action: 'revoke', label: 'Revoke', requiredRole: 'owner' },
+    ],
+  },
+
+  {
+    domain: 'government',
+    entity: 'Violation',
+    states: [
+      { name: 'reported', label: 'Reported', initial: true, color: 'red' },
+      { name: 'investigating', label: 'Investigating', color: 'yellow' },
+      { name: 'cited', label: 'Cited', color: 'orange' },
+      { name: 'remediated', label: 'Remediated', terminal: true, color: 'green' },
+      { name: 'dismissed', label: 'Dismissed', terminal: true, color: 'gray' },
+    ],
+    transitions: [
+      { from: 'reported', to: 'investigating', action: 'investigate', label: 'Investigate', requiredRole: 'editor' },
+      { from: 'investigating', to: 'cited', action: 'cite', label: 'Issue Citation', requiredRole: 'admin' },
+      { from: 'investigating', to: 'dismissed', action: 'dismiss', label: 'Dismiss', requiredRole: 'admin' },
+      { from: 'cited', to: 'remediated', action: 'remediate', label: 'Mark Remediated', requiredRole: 'editor' },
+    ],
+  },
+
+  // ── Real Estate ──────────────────────────────────────────────
+  {
+    domain: 'realestate',
+    entity: 'Listing',
+    states: [
+      { name: 'draft', label: 'Draft', initial: true, color: 'gray' },
+      { name: 'active', label: 'Active', color: 'green' },
+      { name: 'under_contract', label: 'Under Contract', color: 'yellow' },
+      { name: 'pending', label: 'Pending', color: 'orange' },
+      { name: 'sold', label: 'Sold', terminal: true, color: 'purple' },
+      { name: 'withdrawn', label: 'Withdrawn', terminal: true, color: 'gray' },
+    ],
+    transitions: [
+      { from: 'draft', to: 'active', action: 'publish', label: 'Publish Listing', requiredRole: 'editor', guard: 'hasPrice' },
+      { from: 'active', to: 'under_contract', action: 'accept_offer', label: 'Accept Offer', requiredRole: 'editor' },
+      { from: 'under_contract', to: 'pending', action: 'go_pending', label: 'Go Pending', requiredRole: 'editor' },
+      { from: 'pending', to: 'sold', action: 'close', label: 'Close Sale', requiredRole: 'admin' },
+      { from: 'under_contract', to: 'active', action: 'fall_through', label: 'Back to Active', requiredRole: 'editor' },
+      { from: 'active', to: 'withdrawn', action: 'withdraw', label: 'Withdraw', requiredRole: 'editor' },
+    ],
+  },
+
+  // ── Insurance ────────────────────────────────────────────────
+  {
+    domain: 'insurance',
+    entity: 'Claim',
+    states: [
+      { name: 'filed', label: 'Filed', initial: true, color: 'blue' },
+      { name: 'under_review', label: 'Under Review', color: 'yellow' },
+      { name: 'investigation', label: 'Investigation', color: 'orange' },
+      { name: 'approved', label: 'Approved', color: 'green' },
+      { name: 'denied', label: 'Denied', terminal: true, color: 'red' },
+      { name: 'paid', label: 'Paid', terminal: true, color: 'purple' },
+    ],
+    transitions: [
+      { from: 'filed', to: 'under_review', action: 'begin_review', label: 'Begin Review', requiredRole: 'editor' },
+      { from: 'under_review', to: 'investigation', action: 'investigate', label: 'Flag for Investigation', requiredRole: 'reviewer' },
+      { from: 'under_review', to: 'approved', action: 'approve', label: 'Approve Claim', requiredRole: 'admin' },
+      { from: 'under_review', to: 'denied', action: 'deny', label: 'Deny Claim', requiredRole: 'admin' },
+      { from: 'investigation', to: 'approved', action: 'approve', label: 'Approve', requiredRole: 'admin' },
+      { from: 'investigation', to: 'denied', action: 'deny', label: 'Deny', requiredRole: 'admin' },
+      { from: 'approved', to: 'paid', action: 'pay', label: 'Issue Payment', requiredRole: 'admin' },
+    ],
+  },
+
+  // ── Logistics ────────────────────────────────────────────────
+  {
+    domain: 'logistics',
+    entity: 'Shipment',
+    states: [
+      { name: 'created', label: 'Created', initial: true, color: 'gray' },
+      { name: 'picked', label: 'Picked', color: 'blue' },
+      { name: 'packed', label: 'Packed', color: 'yellow' },
+      { name: 'in_transit', label: 'In Transit', color: 'orange' },
+      { name: 'out_for_delivery', label: 'Out for Delivery', color: 'yellow' },
+      { name: 'delivered', label: 'Delivered', terminal: true, color: 'green' },
+      { name: 'exception', label: 'Exception', color: 'red' },
+    ],
+    transitions: [
+      { from: 'created', to: 'picked', action: 'pick', label: 'Pick Items', requiredRole: 'editor' },
+      { from: 'picked', to: 'packed', action: 'pack', label: 'Pack', requiredRole: 'editor' },
+      { from: 'packed', to: 'in_transit', action: 'dispatch', label: 'Dispatch', requiredRole: 'editor', guard: 'hasTrackingNumber' },
+      { from: 'in_transit', to: 'out_for_delivery', action: 'out_for_delivery', label: 'Out for Delivery', requiredRole: 'editor' },
+      { from: 'out_for_delivery', to: 'delivered', action: 'deliver', label: 'Mark Delivered', requiredRole: 'editor' },
+      { from: 'in_transit', to: 'exception', action: 'flag_exception', label: 'Flag Exception', requiredRole: 'editor' },
+      { from: 'exception', to: 'in_transit', action: 'resolve', label: 'Resolve & Resume', requiredRole: 'admin' },
+    ],
+  },
+
+  // ── Nonprofit ────────────────────────────────────────────────
+  {
+    domain: 'nonprofit',
+    entity: 'Grant',
+    states: [
+      { name: 'prospecting', label: 'Prospecting', initial: true, color: 'gray' },
+      { name: 'application', label: 'Application', color: 'blue' },
+      { name: 'submitted', label: 'Submitted', color: 'yellow' },
+      { name: 'awarded', label: 'Awarded', color: 'green' },
+      { name: 'active', label: 'Active', color: 'green' },
+      { name: 'reporting', label: 'Reporting', color: 'orange' },
+      { name: 'closed', label: 'Closed', terminal: true, color: 'purple' },
+      { name: 'declined', label: 'Declined', terminal: true, color: 'red' },
+    ],
+    transitions: [
+      { from: 'prospecting', to: 'application', action: 'begin_application', label: 'Begin Application', requiredRole: 'editor' },
+      { from: 'application', to: 'submitted', action: 'submit', label: 'Submit', requiredRole: 'admin', guard: 'hasRequiredDocs' },
+      { from: 'submitted', to: 'awarded', action: 'award', label: 'Award', requiredRole: 'admin' },
+      { from: 'submitted', to: 'declined', action: 'decline', label: 'Declined', requiredRole: 'admin' },
+      { from: 'awarded', to: 'active', action: 'activate', label: 'Activate', requiredRole: 'admin' },
+      { from: 'active', to: 'reporting', action: 'begin_reporting', label: 'Begin Reporting', requiredRole: 'editor' },
+      { from: 'reporting', to: 'closed', action: 'close', label: 'Close Grant', requiredRole: 'admin' },
+    ],
+  },
+
+  // ── Events ───────────────────────────────────────────────────
+  {
+    domain: 'events',
+    entity: 'Event',
+    states: [
+      { name: 'planning', label: 'Planning', initial: true, color: 'gray' },
+      { name: 'announced', label: 'Announced', color: 'blue' },
+      { name: 'registration_open', label: 'Registration Open', color: 'green' },
+      { name: 'sold_out', label: 'Sold Out', color: 'orange' },
+      { name: 'in_progress', label: 'In Progress', color: 'yellow' },
+      { name: 'completed', label: 'Completed', terminal: true, color: 'purple' },
+      { name: 'cancelled', label: 'Cancelled', terminal: true, color: 'red' },
+    ],
+    transitions: [
+      { from: 'planning', to: 'announced', action: 'announce', label: 'Announce', requiredRole: 'admin', guard: 'hasVenue' },
+      { from: 'announced', to: 'registration_open', action: 'open_registration', label: 'Open Registration', requiredRole: 'admin' },
+      { from: 'registration_open', to: 'sold_out', action: 'sell_out', label: 'Mark Sold Out', requiredRole: 'editor' },
+      { from: 'registration_open', to: 'in_progress', action: 'start', label: 'Start Event', requiredRole: 'admin' },
+      { from: 'sold_out', to: 'in_progress', action: 'start', label: 'Start Event', requiredRole: 'admin' },
+      { from: 'in_progress', to: 'completed', action: 'complete', label: 'Complete', requiredRole: 'admin' },
+      { from: 'planning', to: 'cancelled', action: 'cancel', label: 'Cancel', requiredRole: 'owner' },
+      { from: 'announced', to: 'cancelled', action: 'cancel', label: 'Cancel', requiredRole: 'owner' },
+    ],
+  },
+
+  // ── Agriculture ──────────────────────────────────────────────
+  {
+    domain: 'agriculture',
+    entity: 'CropCycle',
+    states: [
+      { name: 'planning', label: 'Planning', initial: true, color: 'gray' },
+      { name: 'planted', label: 'Planted', color: 'green' },
+      { name: 'growing', label: 'Growing', color: 'yellow' },
+      { name: 'harvest_ready', label: 'Harvest Ready', color: 'orange' },
+      { name: 'harvested', label: 'Harvested', terminal: true, color: 'purple' },
+    ],
+    transitions: [
+      { from: 'planning', to: 'planted', action: 'plant', label: 'Mark Planted', requiredRole: 'editor', guard: 'hasField' },
+      { from: 'planted', to: 'growing', action: 'sprout', label: 'Mark Growing', requiredRole: 'editor' },
+      { from: 'growing', to: 'harvest_ready', action: 'ready', label: 'Mark Harvest Ready', requiredRole: 'editor' },
+      { from: 'harvest_ready', to: 'harvested', action: 'harvest', label: 'Record Harvest', requiredRole: 'editor', guard: 'hasYieldData' },
+    ],
+  },
+
+  // ── Fitness ──────────────────────────────────────────────────
+  {
+    domain: 'fitness',
+    entity: 'Program',
+    states: [
+      { name: 'draft', label: 'Draft', initial: true, color: 'gray' },
+      { name: 'active', label: 'Active', color: 'green' },
+      { name: 'paused', label: 'Paused', color: 'yellow' },
+      { name: 'completed', label: 'Completed', terminal: true, color: 'purple' },
+    ],
+    transitions: [
+      { from: 'draft', to: 'active', action: 'activate', label: 'Activate', requiredRole: 'editor' },
+      { from: 'active', to: 'paused', action: 'pause', label: 'Pause', requiredRole: 'editor' },
+      { from: 'paused', to: 'active', action: 'resume', label: 'Resume', requiredRole: 'editor' },
+      { from: 'active', to: 'completed', action: 'complete', label: 'Complete', requiredRole: 'editor' },
+    ],
+  },
+
+  // ── Aviation ─────────────────────────────────────────────────
+  {
+    domain: 'aviation',
+    entity: 'Flight',
+    states: [
+      { name: 'scheduled', label: 'Scheduled', initial: true, color: 'blue' },
+      { name: 'preflight', label: 'Preflight Check', color: 'yellow' },
+      { name: 'boarding', label: 'Boarding', color: 'orange' },
+      { name: 'in_flight', label: 'In Flight', color: 'green' },
+      { name: 'landed', label: 'Landed', color: 'blue' },
+      { name: 'completed', label: 'Completed', terminal: true, color: 'purple' },
+      { name: 'cancelled', label: 'Cancelled', terminal: true, color: 'red' },
+    ],
+    transitions: [
+      { from: 'scheduled', to: 'preflight', action: 'begin_preflight', label: 'Begin Preflight', requiredRole: 'editor', guard: 'hasCrewAssigned' },
+      { from: 'preflight', to: 'boarding', action: 'clear_preflight', label: 'Clear for Boarding', requiredRole: 'editor', guard: 'preflightComplete' },
+      { from: 'boarding', to: 'in_flight', action: 'depart', label: 'Depart', requiredRole: 'editor' },
+      { from: 'in_flight', to: 'landed', action: 'land', label: 'Land', requiredRole: 'editor' },
+      { from: 'landed', to: 'completed', action: 'complete', label: 'Complete', requiredRole: 'editor' },
+      { from: 'scheduled', to: 'cancelled', action: 'cancel', label: 'Cancel Flight', requiredRole: 'admin' },
+    ],
+  },
+];
+
+// ── Lookup helpers ─────────────────────────────────────────────
+
+const _workflowMap = new Map<string, WorkflowDef[]>();
+for (const w of WORKFLOW_DEFINITIONS) {
+  const list = _workflowMap.get(w.domain) ?? [];
+  list.push(w);
+  _workflowMap.set(w.domain, list);
+}
+
+export function getWorkflowsForDomain(domain: string): WorkflowDef[] {
+  return _workflowMap.get(domain) ?? [];
+}
+
+export function getWorkflow(domain: string, entity: string): WorkflowDef | undefined {
+  return (_workflowMap.get(domain) ?? []).find(w => w.entity === entity);
+}
+
+export function getAvailableTransitions(domain: string, entity: string, currentState: string, userRole: string): WorkflowTransition[] {
+  const wf = getWorkflow(domain, entity);
+  if (!wf) return [];
+  const roleHierarchy = ['viewer', 'reviewer', 'editor', 'admin', 'owner'];
+  const userLevel = roleHierarchy.indexOf(userRole);
+  return wf.transitions.filter(t => {
+    if (t.from !== currentState) return false;
+    if (t.requiredRole) {
+      const reqLevel = roleHierarchy.indexOf(t.requiredRole);
+      if (userLevel < reqLevel) return false;
+    }
+    return true;
+  });
+}
+
+export function isValidTransition(domain: string, entity: string, from: string, to: string): boolean {
+  const wf = getWorkflow(domain, entity);
+  if (!wf) return false;
+  return wf.transitions.some(t => t.from === from && t.to === to);
+}
+
+export function getInitialState(domain: string, entity: string): string | undefined {
+  const wf = getWorkflow(domain, entity);
+  if (!wf) return undefined;
+  return wf.states.find(s => s.initial)?.name;
+}
+
+export function getDomainsWithWorkflows(): string[] {
+  return [..._workflowMap.keys()];
+}


### PR DESCRIPTION
- Add art and studio entries to lens-registry.ts (fixes discoverability gap)
- Add 17 missing manifests: 10 hybrid (alliance, ar, board, entity, ethics,
  lab, market, questmarket, repos, vote) + 7 viewer (anon, eco, fractal,
  invariant, meta, temporal, timeline)
- Fix all 23 super-lens macros from generic lens.list to lens.<domain>.list
- Upgrade all manifests with domain-specific engines, enhanced actions,
  and richer import/export formats per the competitor-level spec
- Add art and studio to lens-status.ts as standalone product lenses
- Enhance validate-lens-quality.ts with 3 new CI rules:
  Rule 6: upgrade-lane lenses must have manifests
  Rule 7: macro naming convention (lens.<domain>.*)
  Rule 8: product/hybrid lenses must have full CRUD + run + export
- Export new manifest helpers (getManifestCount, getLensesMissingMacro)

Total manifest count: 61 upgrade-lane + system/deprecated = full coverage.
All product/hybrid/viewer lenses now declare: artifacts, full CRUD macros,
domain-specific actions (3+ engines), and multi-format exports.

https://claude.ai/code/session_01GSuzbX56raR9bJ3PysXt5R