### PR TITLE
Fix frontend build blockers in household and logistics lenses

### DIFF
--- a/concord-frontend/app/lenses/household/page.tsx
+++ b/concord-frontend/app/lenses/household/page.tsx
@@ -16,7 +16,7 @@ import {
   CreditCard, PiggyBank, FileText, Stethoscope, Siren,
   Dog, Pill, Activity, MapPin, CircleDot, Zap,
   Sun, Snowflake, Leaf, CloudRain, ClipboardList,
-  ArrowUpDown, CircleCheck, Info, Beef, Coffee,
+  ArrowUpDown, CheckCircle2, Info, Beef, Coffee,
   Moon, Pizza, Salad, Soup, Cake, Apple,
 } from 'lucide-react';
 import { ErrorState } from '@/components/common/EmptyState';
@@ -422,7 +422,7 @@ export default function HouseholdLensPage() {
         <div className={ds.panel}>
           <h3 className={cn(ds.heading3, 'mb-3 flex items-center gap-2')}><CheckSquare className="w-5 h-5 text-red-400" /> Overdue Chores</h3>
           {overdueChores.length === 0 ? (
-            <p className={cn(ds.textMuted, 'flex items-center gap-2')}><CircleCheck className="w-4 h-4 text-green-400" /> All caught up!</p>
+            <p className={cn(ds.textMuted, 'flex items-center gap-2')}><CheckCircle2 className="w-4 h-4 text-green-400" /> All caught up!</p>
           ) : (
             <div className="space-y-2 max-h-48 overflow-y-auto">
               {overdueChores.map(ch => {
@@ -657,7 +657,7 @@ export default function HouseholdLensPage() {
                     <div className="flex items-center gap-3">
                       <span className={ds.badge('yellow-400')}><Star className="w-3 h-3" /> {stats.points} pts</span>
                       <span className={ds.badge('neon-blue')}><Clock className="w-3 h-3" /> {stats.hours.toFixed(1)}h</span>
-                      <span className={ds.badge('green-400')}><CircleCheck className="w-3 h-3" /> {stats.completed}</span>
+                      <span className={ds.badge('green-400')}><CheckCircle2 className="w-3 h-3" /> {stats.completed}</span>
                     </div>
                   </div>
                   <div className="flex gap-2">
@@ -696,7 +696,7 @@ export default function HouseholdLensPage() {
                         'w-5 h-5 rounded border-2 flex items-center justify-center transition-colors',
                         isComplete ? 'bg-green-400 border-green-400' : 'border-gray-500 hover:border-neon-cyan'
                       )}>
-                        {isComplete && <CircleCheck className="w-3 h-3 text-white" />}
+                        {isComplete && <CheckCircle2 className="w-3 h-3 text-white" />}
                       </button>
                       <h4 className={cn('text-sm font-medium text-white', isComplete && 'line-through')}>{item.title}</h4>
                     </div>
@@ -1081,7 +1081,7 @@ export default function HouseholdLensPage() {
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-medium text-white">{formatCurrency(d.amount)}</span>
                     <button className={cn(ds.btnGhost, ds.btnSmall)} onClick={() => toggleBillPaid(item)}>
-                      <CircleCheck className="w-4 h-4 text-green-400" />
+                      <CheckCircle2 className="w-4 h-4 text-green-400" />
                     </button>
                     <button className={cn(ds.btnGhost, ds.btnSmall)} onClick={() => openEdit(item)}><Edit3 className="w-3.5 h-3.5" /></button>
                   </div>

--- a/concord-frontend/app/lenses/logistics/page.tsx
+++ b/concord-frontend/app/lenses/logistics/page.tsx
@@ -262,6 +262,18 @@ export default function LogisticsLensPage() {
     : mode === 'routes' ? ROUTE_STATUSES
     : GENERAL_STATUSES;
 
+
+  const groupedShipments = useMemo(() => {
+    const map: Record<string, LensItem[]> = {};
+    for (const col of KANBAN_COLUMNS) map[col.key] = [];
+    map['exception'] = [];
+    for (const item of filtered) {
+      const st = item.meta?.status || 'booked';
+      if (map[st]) map[st].push(item);
+    }
+    return map;
+  }, [filtered]);
+
   // Editor helpers
   const resetForm = () => {
     setFormTitle(''); setFormStatus('active');
@@ -602,18 +614,7 @@ export default function LogisticsLensPage() {
 
   /** Shipment Tracking Board - Kanban */
   const renderShipmentsTab = () => {
-    const grouped = useMemo(() => {
-      const map: Record<string, LensItem[]> = {};
-      for (const col of KANBAN_COLUMNS) map[col.key] = [];
-      map['exception'] = [];
-      for (const item of filtered) {
-        const st = item.meta?.status || 'booked';
-        if (map[st]) map[st].push(item);
-      }
-      return map;
-    }, [filtered]);
-
-    const exceptionItems = grouped['exception'] || [];
+    const exceptionItems = groupedShipments['exception'] || [];
 
     return (
       <div className="space-y-4">
@@ -667,7 +668,7 @@ export default function LogisticsLensPage() {
           /* Kanban Board */
           <div className="flex gap-3 overflow-x-auto pb-4">
             {KANBAN_COLUMNS.map(col => {
-              const columnItems = grouped[col.key] || [];
+              const columnItems = groupedShipments[col.key] || [];
               return (
                 <div key={col.key} className="min-w-[260px] flex-shrink-0">
                   <div className={cn('flex items-center gap-2 px-3 py-2 rounded-t-lg', `bg-${col.color}/10 border border-${col.color}/30`)}>


### PR DESCRIPTION
### Motivation
- The Next.js production build was failing due to a missing export (`CircleCheck`) and an invalid hook usage inside a nested function, so the frontend needed fixes to unblock the build pipeline. 
- Make minimal, targeted changes to resolve the two build-blocking errors while keeping behavioral surface area unchanged.

### Description
- Replaced the unsupported `CircleCheck` usage with `CheckCircle2` from `lucide-react` and updated all JSX occurrences in `concord-frontend/app/lenses/household/page.tsx` to resolve the import/export mismatch. 
- Moved the shipment grouping `useMemo` out of the nested renderer and into the component scope as `groupedShipments`, and updated `concord-frontend/app/lenses/logistics/page.tsx` to consume that memoized value to satisfy React Hooks rules. 

### Testing
- Ran `npm run build` in `concord-frontend`, which advanced past the original `CircleCheck` and logistics hook errors but encountered an unrelated pre-existing type error in `app/lenses/creative/page.tsx` (build did not fully succeed due to that separate error). 
- Ran `npx eslint app/lenses/household/page.tsx app/lenses/logistics/page.tsx`, which produced no errors for the modified files (warnings only). 
- Started the dev server and executed an automated Playwright script to open `/lenses/household` and capture a screenshot, which completed successfully and confirmed the Household lens renders with the updated icon.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f89d72afc83269adf97d14919a14b)