### PR TITLE
Add GRC v1 output spec, shared LensShell components, and SSR/SEO fixes

### DIFF
--- a/concord-frontend/app/layout.tsx
+++ b/concord-frontend/app/layout.tsx
@@ -9,10 +9,61 @@ import type { Metadata, Viewport } from 'next';
  */
 
 export const metadata: Metadata = {
-  title: 'Concord OS',
-  description: 'Concord Cognitive Engine - 76 Lens Empire',
+  title: {
+    default: 'Concord OS — Sovereign Cognitive Engine',
+    template: '%s | Concord OS',
+  },
+  description:
+    'A sovereign knowledge operating system. 76 domain lenses, DTU-based memory, lattice governance, local-first AI. Your thoughts never leave your control.',
+  keywords: [
+    'cognitive engine',
+    'knowledge OS',
+    'sovereign AI',
+    'DTU',
+    'lattice',
+    'local-first',
+    'concord',
+    'cognitive operating system',
+  ],
+  authors: [{ name: 'Concord OS' }],
+  creator: 'Concord OS',
   manifest: '/manifest.json',
   icons: { icon: '/favicon.ico' },
+  metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL || 'https://concord-os.org'),
+  openGraph: {
+    type: 'website',
+    locale: 'en_US',
+    siteName: 'Concord OS',
+    title: 'Concord OS — Sovereign Cognitive Engine',
+    description:
+      'A sovereign knowledge operating system. 76 domain lenses, DTU-based memory, lattice governance, local-first AI. No ads. No extraction. No surveillance.',
+    images: [
+      {
+        url: '/og-image.png',
+        width: 1200,
+        height: 630,
+        alt: 'Concord OS — Your Personal Cognitive Engine',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Concord OS — Sovereign Cognitive Engine',
+    description:
+      'A sovereign knowledge operating system. 76 domain lenses, local-first AI. Your thoughts never leave your control.',
+    images: ['/og-image.png'],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-video-preview': -1,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
+  },
 };
 
 export const viewport: Viewport = {

--- a/concord-frontend/app/page.tsx
+++ b/concord-frontend/app/page.tsx
@@ -1,377 +1,121 @@
 /**
- * FE-019: Canonical entry point.
+ * FE-019 + SEO Fix: Canonical entry point.
  *
- * `/` is the single entry for all users:
- *   - New users see the LandingPage (onboarding).
- *   - Returning users see the DashboardPage (the "home lens").
+ * Server Component that renders crawlable landing content.
+ * The HomeClient component hydrates on top for interactivity.
+ *
+ * Crawlers see: full landing page HTML with all text content.
+ * Users see: interactive LandingPage or Dashboard based on localStorage.
  */
-'use client';
 
-import { useState, useEffect } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api/client';
-import { ResonanceEmpireGraph } from '@/components/graphs/ResonanceEmpireGraph';
-import { DTUEmpireCard } from '@/components/dtu/DTUEmpireCard';
-import { LockDashboard } from '@/components/sovereignty/LockDashboard';
-import { CoherenceBadge } from '@/components/graphs/CoherenceBadge';
-import { LandingPage } from '@/components/landing/LandingPage';
-import { useUIStore } from '@/store/ui';
+import type { Metadata } from 'next';
+import { HomeClient } from '@/components/home/HomeClient';
 
-const ENTERED_KEY = 'concord_entered';
+export const metadata: Metadata = {
+  title: 'Concord OS — Sovereign Cognitive Engine',
+  description:
+    'A sovereign knowledge operating system that grows with you. 76 domain lenses, DTU-based memory, lattice governance, local-first AI. No ads, no extraction, no surveillance.',
+  alternates: {
+    canonical: '/',
+  },
+};
 
+/**
+ * Server-rendered landing content for SEO.
+ * This HTML is visible to crawlers even before JS loads.
+ * The HomeClient component renders on top once hydrated.
+ */
 export default function HomePage() {
-  const [hasEntered, setHasEntered] = useState<boolean | null>(null);
-  const setFullPageMode = useUIStore((state) => state.setFullPageMode);
-
-  useEffect(() => {
-    const entered = localStorage.getItem(ENTERED_KEY);
-    const isEntered = entered === 'true';
-    setHasEntered(isEntered);
-    // Set full page mode when showing landing page
-    setFullPageMode(!isEntered);
-  }, [setFullPageMode]);
-
-  const handleEnter = () => {
-    localStorage.setItem(ENTERED_KEY, 'true');
-    setHasEntered(true);
-    setFullPageMode(false);
-  };
-
-  // Still loading from localStorage
-  if (hasEntered === null) {
-    return (
-      <div className="min-h-screen bg-lattice-void flex items-center justify-center">
-        <div className="animate-pulse">
-          <div className="w-16 h-16 rounded-full bg-neon-cyan/20 flex items-center justify-center">
-            <div className="w-8 h-8 rounded-full bg-neon-cyan/40 animate-ping" />
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  // Show landing page for new visitors
-  if (!hasEntered) {
-    return <LandingPage onEnter={handleEnter} />;
-  }
-
-  // Show dashboard for returning users
-  return <DashboardPage />;
-}
-
-function DashboardPage() {
-  // Backend: GET /api/status
-  const { data: status, isLoading: statusLoading } = useQuery({
-    queryKey: ['status'],
-    queryFn: () => api.get('/api/status').then((r) => r.data),
-  });
-
-  // Backend: GET /api/dtus
-  const { data: dtusData, isLoading: dtusLoading } = useQuery({
-    queryKey: ['dtus'],
-    queryFn: () => api.get('/api/dtus').then((r) => r.data),
-  });
-
-  // Backend: GET /api/events
-  const { data: eventsData } = useQuery({
-    queryKey: ['events'],
-    queryFn: () => api.get('/api/events').then((r) => r.data),
-  });
-
-  const dtus = dtusData?.dtus || [];
-  const events = eventsData?.events || [];
-
   return (
-    <div className="p-6 space-y-6">
-      {/* Header */}
-      <header className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold text-gradient-neon">
-            Concord Empire Dashboard
+    <>
+      {/* SSR landing content — visible to crawlers, replaced by client on hydrate */}
+      <div id="ssr-landing" className="min-h-screen bg-lattice-void">
+        <header className="flex items-center justify-between px-8 py-6">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-neon-cyan to-neon-blue flex items-center justify-center">
+              <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+              </svg>
+            </div>
+            <span className="text-2xl font-bold text-white">Concord OS</span>
+          </div>
+        </header>
+
+        <main className="px-8 pt-20 pb-32 max-w-6xl mx-auto">
+          <h1 className="text-5xl md:text-7xl font-bold mb-6 leading-tight text-center">
+            <span className="text-white">Your Personal</span>
+            <br />
+            <span className="bg-gradient-to-r from-neon-cyan via-neon-blue to-neon-purple bg-clip-text text-transparent">
+              Cognitive Engine
+            </span>
           </h1>
-          <p className="text-gray-400 mt-1">
-            {statusLoading ? (
-              <span className="animate-pulse">Loading status...</span>
-            ) : (
-              <>
-                {status?.version || 'v5.0'} | {status?.counts?.dtus || 0} DTUs |{' '}
-                {status?.llm?.enabled ? 'LLM Ready' : 'Local Mode'}
-              </>
-            )}
+
+          <p className="text-xl text-gray-400 max-w-2xl mx-auto mb-12 text-center">
+            A sovereign knowledge operating system that grows with you.
+            Your thoughts never leave your control. No ads. No extraction. No surveillance.
           </p>
-        </div>
-        <CoherenceBadge score={events.length} />
-      </header>
 
-      {/* Metrics Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <MetricCard
-          label="Total DTUs"
-          value={statusLoading ? '...' : status?.counts?.dtus || 0}
-          icon="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2300d4ff' stroke-width='2'%3E%3Cpath d='M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z'/%3E%3C/svg%3E"
-          emoji="cube"
-          color="blue"
-        />
-        <MetricCard
-          label="Simulations"
-          value={statusLoading ? '...' : status?.counts?.simulations || 0}
-          emoji="flask"
-          color="purple"
-        />
-        <MetricCard
-          label="Events"
-          value={statusLoading ? '...' : status?.counts?.events || 0}
-          emoji="activity"
-          color="pink"
-        />
-        <MetricCard
-          label="Sovereignty"
-          value="70%"
-          emoji="lock"
-          color="green"
-          locked
-        />
-      </div>
+          <section className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mt-20">
+            <div className="bg-lattice-surface border border-lattice-border rounded-xl p-6">
+              <h3 className="text-lg font-semibold text-white mb-2">76 Domain Lenses</h3>
+              <p className="text-gray-400 text-sm">
+                Healthcare, education, legal, accounting, manufacturing, creative arts, and 70 more specialized lenses.
+              </p>
+            </div>
+            <div className="bg-lattice-surface border border-lattice-border rounded-xl p-6">
+              <h3 className="text-lg font-semibold text-white mb-2">DTU-Based Memory</h3>
+              <p className="text-gray-400 text-sm">
+                Discrete Thought Units with epistemic scoring, lattice governance, and provenance tracking.
+              </p>
+            </div>
+            <div className="bg-lattice-surface border border-lattice-border rounded-xl p-6">
+              <h3 className="text-lg font-semibold text-white mb-2">Local-First AI</h3>
+              <p className="text-gray-400 text-sm">
+                Hybrid local/cloud AI pipeline. Works offline with Ollama, optionally enhances with cloud LLMs.
+              </p>
+            </div>
+            <div className="bg-lattice-surface border border-lattice-border rounded-xl p-6">
+              <h3 className="text-lg font-semibold text-white mb-2">Sovereign by Design</h3>
+              <p className="text-gray-400 text-sm">
+                70% sovereignty lock. No telemetry, no ads, no secret monitoring. You own every byte.
+              </p>
+            </div>
+          </section>
 
-      {/* Jobs & Queues Status */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <QueueCard
-          label="Ingest Queue"
-          value={status?.queues?.ingest || 0}
-          color="blue"
-          loading={statusLoading}
-        />
-        <QueueCard
-          label="Autocrawl Queue"
-          value={status?.queues?.autocrawl || 0}
-          color="purple"
-          loading={statusLoading}
-        />
-        <QueueCard
-          label="Macro Domains"
-          value={status?.macro?.domains?.length || 0}
-          color="cyan"
-          loading={statusLoading}
-        />
-        <QueueCard
-          label="Wallets"
-          value={status?.counts?.wallets || 0}
-          color="green"
-          loading={statusLoading}
-        />
-      </div>
-
-      {/* Main Content */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Resonance Universe */}
-        <div className="lg:col-span-2 panel p-4">
-          <h2 className="text-xl font-semibold mb-4 flex items-center gap-2">
-            <span className="text-neon-blue">*</span> Resonance Universe
-          </h2>
-          <div className="h-[400px]">
-            <ResonanceEmpireGraph />
-          </div>
-        </div>
-
-        {/* 70% Lock Dashboard */}
-        <div className="panel p-4">
-          <LockDashboard />
-        </div>
-      </div>
-
-      {/* Recent DTUs */}
-      <div className="panel p-4">
-        <h2 className="text-xl font-semibold mb-4 flex items-center gap-2">
-          <span className="text-neon-cyan">*</span> Recent DTUs
-        </h2>
-        {dtusLoading ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {[1, 2, 3].map((i) => (
-              <div
-                key={i}
-                className="h-32 bg-lattice-surface animate-pulse rounded-lg"
-              />
-            ))}
-          </div>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {dtus.slice(0, 6).map((dtu: { id: string; tier: 'regular' | 'mega' | 'hyper' | 'shadow'; summary: string; timestamp: string; resonance?: number; tags?: string[] }) => (
-              <DTUEmpireCard key={dtu.id} dtu={dtu} />
-            ))}
-            {dtus.length === 0 && (
-              <div className="col-span-full text-center py-12">
-                <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-neon-cyan/10 flex items-center justify-center">
-                  <svg
-                    className="w-8 h-8 text-neon-cyan"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M12 6v6m0 0v6m0-6h6m-6 0H6"
-                    />
-                  </svg>
-                </div>
-                <p className="text-gray-400 mb-2">No DTUs yet</p>
-                <p className="text-gray-500 text-sm">
-                  Start forging in the Chat or Forge lens
-                </p>
+          <section className="mt-20 max-w-3xl mx-auto">
+            <h2 className="text-3xl font-bold text-white text-center mb-8">Architecture</h2>
+            <dl className="space-y-4">
+              <div className="bg-lattice-surface border border-lattice-border rounded-xl p-4">
+                <dt className="font-semibold text-neon-cyan">Lattice Governance</dt>
+                <dd className="text-gray-400 text-sm mt-1">
+                  Chicken2 reality gates, council-based promotion, credibility-weighted voting, and anti-gaming protection.
+                </dd>
               </div>
-            )}
-          </div>
-        )}
+              <div className="bg-lattice-surface border border-lattice-border rounded-xl p-4">
+                <dt className="font-semibold text-neon-blue">Macro-Max Engine</dt>
+                <dd className="text-gray-400 text-sm mt-1">
+                  All logic expressed as deterministic macros. Event-sourced, replayable, auditable.
+                </dd>
+              </div>
+              <div className="bg-lattice-surface border border-lattice-border rounded-xl p-4">
+                <dt className="font-semibold text-neon-purple">Epistemic Framework</dt>
+                <dd className="text-gray-400 text-sm mt-1">
+                  Domain-typed knowledge with formal, empirical, historical, interpretive, and model-based epistemic classes.
+                </dd>
+              </div>
+              <div className="bg-lattice-surface border border-lattice-border rounded-xl p-4">
+                <dt className="font-semibold text-neon-green">Grounded Recursive Closure</dt>
+                <dd className="text-gray-400 text-sm mt-1">
+                  GRC v1 output spec ensures all AI responses are lattice-anchored, reality-gated, and recursively deepening.
+                </dd>
+              </div>
+            </dl>
+          </section>
+        </main>
       </div>
 
-      {/* Quick Actions */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <QuickAction href="/lenses/chat" label="Chat" icon="message" />
-        <QuickAction href="/lenses/graph" label="Graph" icon="share2" />
-        <QuickAction href="/lenses/resonance" label="Resonance" icon="activity" />
-        <QuickAction href="/lenses/council" label="Council" icon="users" />
-      </div>
-    </div>
-  );
-}
-
-function MetricCard({
-  label,
-  value,
-  emoji,
-  color,
-  locked,
-}: {
-  label: string;
-  value: string | number;
-  emoji?: string;
-  icon?: string;
-  color: 'blue' | 'purple' | 'pink' | 'green';
-  locked?: boolean;
-}) {
-  const colorClasses = {
-    blue: 'border-neon-blue/30 text-neon-blue',
-    purple: 'border-neon-purple/30 text-neon-purple',
-    pink: 'border-neon-pink/30 text-neon-pink',
-    green: 'border-sovereignty-locked/30 text-sovereignty-locked',
-  };
-
-  const icons: Record<string, React.ReactNode> = {
-    cube: (
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
-      </svg>
-    ),
-    flask: (
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" />
-      </svg>
-    ),
-    activity: (
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-      </svg>
-    ),
-    lock: (
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-      </svg>
-    ),
-  };
-
-  return (
-    <div className={`lens-card ${locked ? 'sovereignty-lock lock-70' : ''}`}>
-      <div className="flex items-center gap-3">
-        <span className={`${colorClasses[color].split(' ')[1]}`}>
-          {emoji && icons[emoji]}
-        </span>
-        <div>
-          <p className="text-sm text-gray-400">{label}</p>
-          <p className={`text-2xl font-bold ${colorClasses[color].split(' ')[1]}`}>
-            {value}
-          </p>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function QueueCard({
-  label,
-  value,
-  color,
-  loading,
-}: {
-  label: string;
-  value: number;
-  color: 'blue' | 'purple' | 'cyan' | 'green';
-  loading?: boolean;
-}) {
-  const colorClasses = {
-    blue: 'text-neon-blue',
-    purple: 'text-neon-purple',
-    cyan: 'text-neon-cyan',
-    green: 'text-neon-green',
-  };
-
-  return (
-    <div className="lens-card">
-      <p className="text-sm text-gray-400">{label}</p>
-      <p className={`text-xl font-bold ${colorClasses[color]}`}>
-        {loading ? (
-          <span className="animate-pulse">...</span>
-        ) : (
-          value
-        )}
-      </p>
-    </div>
-  );
-}
-
-function QuickAction({
-  href,
-  label,
-  icon,
-}: {
-  href: string;
-  label: string;
-  icon: string;
-}) {
-  const icons: Record<string, React.ReactNode> = {
-    message: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-      </svg>
-    ),
-    share2: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <circle cx="18" cy="5" r="3" />
-        <circle cx="6" cy="12" r="3" />
-        <circle cx="18" cy="19" r="3" />
-        <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
-        <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
-      </svg>
-    ),
-    activity: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <polyline points="22,12 18,12 15,21 9,3 6,12 2,12" />
-      </svg>
-    ),
-    users: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
-      </svg>
-    ),
-  };
-
-  return (
-    <a
-      href={href}
-      className="lens-card flex items-center justify-center gap-2 py-4 hover:scale-105 hover:border-neon-cyan/50 transition-all"
-    >
-      <span className="text-neon-cyan">{icons[icon]}</span>
-      <span className="font-medium">{label}</span>
-    </a>
+      {/* Client component takes over on hydration */}
+      <HomeClient />
+    </>
   );
 }

--- a/concord-frontend/app/sitemap.ts
+++ b/concord-frontend/app/sitemap.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://concord-os.org';
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+  ];
+}

--- a/concord-frontend/components/common/LensShell.tsx
+++ b/concord-frontend/components/common/LensShell.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+/**
+ * LensShell — Shared execution shell for all lens pages
+ *
+ * Eliminates cross-lens duplication by providing:
+ * - Automatic useLensNav registration
+ * - Standard loading/error/empty states
+ * - Tab bar rendering (when tabs provided)
+ * - Search + filter bar (when searchable)
+ * - Consistent layout via ds.pageContainer
+ *
+ * Usage:
+ *   <LensShell
+ *     domain="education"
+ *     title="Education"
+ *     icon={<GraduationCap />}
+ *     tabs={tabs}
+ *     activeTab={activeTab}
+ *     onTabChange={setActiveTab}
+ *     isLoading={isLoading}
+ *     isError={isError}
+ *     error={error}
+ *   >
+ *     {children}
+ *   </LensShell>
+ */
+
+import { ReactNode } from 'react';
+import { useLensNav } from '@/hooks/useLensNav';
+import { ds } from '@/lib/design-system';
+import { cn } from '@/lib/utils';
+import { Loading } from '@/components/common/Loading';
+import { ErrorState } from '@/components/common/EmptyState';
+import { Search, X } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+export interface LensTab {
+  id: string;
+  icon: LucideIcon;
+  label?: string;
+}
+
+interface LensShellProps {
+  /** Domain slug for useLensNav (e.g. 'education') */
+  domain: string;
+  /** Page title displayed in header */
+  title: string;
+  /** Icon displayed next to title */
+  icon?: ReactNode;
+  /** Header actions (e.g. create button) */
+  actions?: ReactNode;
+
+  /** Tab configuration */
+  tabs?: LensTab[];
+  activeTab?: string;
+  onTabChange?: (tabId: string) => void;
+
+  /** Search bar */
+  searchable?: boolean;
+  searchQuery?: string;
+  onSearchChange?: (query: string) => void;
+  searchPlaceholder?: string;
+
+  /** Filter controls slot */
+  filters?: ReactNode;
+
+  /** Data loading states */
+  isLoading?: boolean;
+  isError?: boolean;
+  error?: { message?: string } | null;
+  onRetry?: () => void;
+
+  /** Main content */
+  children: ReactNode;
+  className?: string;
+}
+
+export function LensShell({
+  domain,
+  title,
+  icon,
+  actions,
+  tabs,
+  activeTab,
+  onTabChange,
+  searchable,
+  searchQuery,
+  onSearchChange,
+  searchPlaceholder = 'Search...',
+  filters,
+  isLoading,
+  isError,
+  error,
+  onRetry,
+  children,
+  className,
+}: LensShellProps) {
+  useLensNav(domain);
+
+  return (
+    <div className={cn(ds.pageContainer, className)}>
+      {/* Header */}
+      <div className={ds.sectionHeader}>
+        <div className="flex items-center gap-3">
+          {icon && <div className="text-neon-cyan">{icon}</div>}
+          <h1 className={ds.heading1}>{title}</h1>
+        </div>
+        {actions && <div className="flex items-center gap-2">{actions}</div>}
+      </div>
+
+      {/* Tab Bar */}
+      {tabs && tabs.length > 0 && (
+        <div className="flex gap-1 border-b border-lattice-border pb-px overflow-x-auto">
+          {tabs.map(tab => {
+            const Icon = tab.icon;
+            const isActive = activeTab === tab.id;
+            return (
+              <button
+                key={tab.id}
+                onClick={() => onTabChange?.(tab.id)}
+                className={cn(
+                  'flex items-center gap-2 px-4 py-2.5 text-sm font-medium rounded-t-lg transition-colors whitespace-nowrap',
+                  isActive
+                    ? 'text-neon-cyan border-b-2 border-neon-cyan bg-lattice-surface'
+                    : 'text-gray-400 hover:text-white hover:bg-lattice-surface/50'
+                )}
+              >
+                <Icon className="w-4 h-4" />
+                {tab.label || tab.id}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Search + Filters Row */}
+      {(searchable || filters) && (
+        <div className="flex items-center gap-3 flex-wrap">
+          {searchable && (
+            <div className="relative flex-1 min-w-[200px] max-w-md">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" />
+              <input
+                type="text"
+                value={searchQuery || ''}
+                onChange={e => onSearchChange?.(e.target.value)}
+                placeholder={searchPlaceholder}
+                className={cn(ds.input, 'pl-10 pr-8')}
+              />
+              {searchQuery && (
+                <button
+                  onClick={() => onSearchChange?.('')}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-white"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              )}
+            </div>
+          )}
+          {filters}
+        </div>
+      )}
+
+      {/* Content area with standard loading/error states */}
+      {isLoading ? (
+        <div className="flex items-center justify-center py-20">
+          <Loading text={`Loading ${title.toLowerCase()}...`} />
+        </div>
+      ) : isError ? (
+        <ErrorState error={error?.message} onRetry={onRetry} />
+      ) : (
+        children
+      )}
+    </div>
+  );
+}
+
+/**
+ * StatusBadge — Shared status badge with color mapping
+ */
+export function StatusBadge({
+  status,
+  colorMap,
+}: {
+  status: string;
+  colorMap?: Record<string, string>;
+}) {
+  const defaultColors: Record<string, string> = {
+    active: 'neon-green',
+    draft: 'gray-400',
+    completed: 'neon-cyan',
+    archived: 'gray-500',
+    pending: 'amber-400',
+    approved: 'neon-green',
+    rejected: 'red-400',
+    enrolled: 'neon-blue',
+    withdrawn: 'red-400',
+    graduated: 'amber-400',
+  };
+  const colors = colorMap || defaultColors;
+  const color = colors[status] || 'gray-400';
+
+  return (
+    <span className={ds.badge(color)}>
+      {status}
+    </span>
+  );
+}
+
+/**
+ * ItemList — Shared list rendering with empty state
+ */
+export function ItemList<T>({
+  items,
+  renderItem,
+  emptyTitle = 'No items found',
+  emptyDescription,
+  onCreateNew,
+  grid,
+}: {
+  items: T[];
+  renderItem: (item: T, index: number) => ReactNode;
+  emptyTitle?: string;
+  emptyDescription?: string;
+  onCreateNew?: () => void;
+  grid?: '2' | '3' | '4';
+}) {
+  if (items.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-gray-400 mb-2">{emptyTitle}</p>
+        {emptyDescription && <p className="text-sm text-gray-500">{emptyDescription}</p>}
+        {onCreateNew && (
+          <button onClick={onCreateNew} className={cn(ds.btnPrimary, 'mt-4')}>
+            Create New
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  const gridClass = grid === '4' ? ds.grid4 : grid === '3' ? ds.grid3 : grid === '2' ? ds.grid2 : 'space-y-3';
+
+  return (
+    <div className={gridClass}>
+      {items.map((item, i) => renderItem(item, i))}
+    </div>
+  );
+}

--- a/concord-frontend/components/home/HomeClient.tsx
+++ b/concord-frontend/components/home/HomeClient.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+/**
+ * HomeClient — Client-side home page logic
+ *
+ * Takes over from the SSR landing content once JS hydrates.
+ * Hides the SSR content and shows either:
+ *   - LandingPage (interactive) for new visitors
+ *   - DashboardPage for returning users
+ */
+
+import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api/client';
+import { ResonanceEmpireGraph } from '@/components/graphs/ResonanceEmpireGraph';
+import { DTUEmpireCard } from '@/components/dtu/DTUEmpireCard';
+import { LockDashboard } from '@/components/sovereignty/LockDashboard';
+import { CoherenceBadge } from '@/components/graphs/CoherenceBadge';
+import { LandingPage } from '@/components/landing/LandingPage';
+import { useUIStore } from '@/store/ui';
+
+const ENTERED_KEY = 'concord_entered';
+
+export function HomeClient() {
+  const [hasEntered, setHasEntered] = useState<boolean | null>(null);
+  const setFullPageMode = useUIStore((state) => state.setFullPageMode);
+
+  useEffect(() => {
+    // Hide SSR landing content once client takes over
+    const ssrEl = document.getElementById('ssr-landing');
+    if (ssrEl) ssrEl.style.display = 'none';
+
+    const entered = localStorage.getItem(ENTERED_KEY);
+    const isEntered = entered === 'true';
+    setHasEntered(isEntered);
+    setFullPageMode(!isEntered);
+  }, [setFullPageMode]);
+
+  const handleEnter = () => {
+    localStorage.setItem(ENTERED_KEY, 'true');
+    setHasEntered(true);
+    setFullPageMode(false);
+  };
+
+  // Still loading from localStorage
+  if (hasEntered === null) {
+    return null; // SSR content is visible until we know
+  }
+
+  // Show landing page for new visitors
+  if (!hasEntered) {
+    return <LandingPage onEnter={handleEnter} />;
+  }
+
+  // Show dashboard for returning users
+  return <DashboardPage />;
+}
+
+function DashboardPage() {
+  const { data: status, isLoading: statusLoading } = useQuery({
+    queryKey: ['status'],
+    queryFn: () => api.get('/api/status').then((r) => r.data),
+  });
+
+  const { data: dtusData, isLoading: dtusLoading } = useQuery({
+    queryKey: ['dtus'],
+    queryFn: () => api.get('/api/dtus').then((r) => r.data),
+  });
+
+  const { data: eventsData } = useQuery({
+    queryKey: ['events'],
+    queryFn: () => api.get('/api/events').then((r) => r.data),
+  });
+
+  const dtus = dtusData?.dtus || [];
+  const events = eventsData?.events || [];
+
+  return (
+    <div className="p-6 space-y-6">
+      <header className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-gradient-neon">
+            Concord Empire Dashboard
+          </h1>
+          <p className="text-gray-400 mt-1">
+            {statusLoading ? (
+              <span className="animate-pulse">Loading status...</span>
+            ) : (
+              <>
+                {status?.version || 'v5.0'} | {status?.counts?.dtus || 0} DTUs |{' '}
+                {status?.llm?.enabled ? 'LLM Ready' : 'Local Mode'}
+              </>
+            )}
+          </p>
+        </div>
+        <CoherenceBadge score={events.length} />
+      </header>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <MetricCard
+          label="Total DTUs"
+          value={statusLoading ? '...' : status?.counts?.dtus || 0}
+          emoji="cube"
+          color="blue"
+        />
+        <MetricCard
+          label="Simulations"
+          value={statusLoading ? '...' : status?.counts?.simulations || 0}
+          emoji="flask"
+          color="purple"
+        />
+        <MetricCard
+          label="Events"
+          value={statusLoading ? '...' : status?.counts?.events || 0}
+          emoji="activity"
+          color="pink"
+        />
+        <MetricCard
+          label="Sovereignty"
+          value="70%"
+          emoji="lock"
+          color="green"
+          locked
+        />
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <QueueCard label="Ingest Queue" value={status?.queues?.ingest || 0} color="blue" loading={statusLoading} />
+        <QueueCard label="Autocrawl Queue" value={status?.queues?.autocrawl || 0} color="purple" loading={statusLoading} />
+        <QueueCard label="Macro Domains" value={status?.macro?.domains?.length || 0} color="cyan" loading={statusLoading} />
+        <QueueCard label="Wallets" value={status?.counts?.wallets || 0} color="green" loading={statusLoading} />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2 panel p-4">
+          <h2 className="text-xl font-semibold mb-4 flex items-center gap-2">
+            <span className="text-neon-blue">*</span> Resonance Universe
+          </h2>
+          <div className="h-[400px]">
+            <ResonanceEmpireGraph />
+          </div>
+        </div>
+        <div className="panel p-4">
+          <LockDashboard />
+        </div>
+      </div>
+
+      <div className="panel p-4">
+        <h2 className="text-xl font-semibold mb-4 flex items-center gap-2">
+          <span className="text-neon-cyan">*</span> Recent DTUs
+        </h2>
+        {dtusLoading ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-32 bg-lattice-surface animate-pulse rounded-lg" />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {dtus.slice(0, 6).map((dtu: { id: string; tier: 'regular' | 'mega' | 'hyper' | 'shadow'; summary: string; timestamp: string; resonance?: number; tags?: string[] }) => (
+              <DTUEmpireCard key={dtu.id} dtu={dtu} />
+            ))}
+            {dtus.length === 0 && (
+              <div className="col-span-full text-center py-12">
+                <p className="text-gray-400 mb-2">No DTUs yet</p>
+                <p className="text-gray-500 text-sm">Start forging in the Chat or Forge lens</p>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <QuickAction href="/lenses/chat" label="Chat" icon="message" />
+        <QuickAction href="/lenses/graph" label="Graph" icon="share2" />
+        <QuickAction href="/lenses/resonance" label="Resonance" icon="activity" />
+        <QuickAction href="/lenses/council" label="Council" icon="users" />
+      </div>
+    </div>
+  );
+}
+
+function MetricCard({
+  label, value, emoji, color, locked,
+}: {
+  label: string; value: string | number; emoji?: string; icon?: string;
+  color: 'blue' | 'purple' | 'pink' | 'green'; locked?: boolean;
+}) {
+  const colorClasses = {
+    blue: 'border-neon-blue/30 text-neon-blue',
+    purple: 'border-neon-purple/30 text-neon-purple',
+    pink: 'border-neon-pink/30 text-neon-pink',
+    green: 'border-sovereignty-locked/30 text-sovereignty-locked',
+  };
+  const icons: Record<string, React.ReactNode> = {
+    cube: <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" /></svg>,
+    flask: <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" /></svg>,
+    activity: <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" /></svg>,
+    lock: <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" /></svg>,
+  };
+  return (
+    <div className={`lens-card ${locked ? 'sovereignty-lock lock-70' : ''}`}>
+      <div className="flex items-center gap-3">
+        <span className={`${colorClasses[color].split(' ')[1]}`}>{emoji && icons[emoji]}</span>
+        <div>
+          <p className="text-sm text-gray-400">{label}</p>
+          <p className={`text-2xl font-bold ${colorClasses[color].split(' ')[1]}`}>{value}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function QueueCard({ label, value, color, loading }: { label: string; value: number; color: 'blue' | 'purple' | 'cyan' | 'green'; loading?: boolean }) {
+  const colorClasses = { blue: 'text-neon-blue', purple: 'text-neon-purple', cyan: 'text-neon-cyan', green: 'text-neon-green' };
+  return (
+    <div className="lens-card">
+      <p className="text-sm text-gray-400">{label}</p>
+      <p className={`text-xl font-bold ${colorClasses[color]}`}>{loading ? <span className="animate-pulse">...</span> : value}</p>
+    </div>
+  );
+}
+
+function QuickAction({ href, label, icon }: { href: string; label: string; icon: string }) {
+  const icons: Record<string, React.ReactNode> = {
+    message: <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" /></svg>,
+    share2: <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><circle cx="18" cy="5" r="3" /><circle cx="6" cy="12" r="3" /><circle cx="18" cy="19" r="3" /><line x1="8.59" y1="13.51" x2="15.42" y2="17.49" /><line x1="15.41" y1="6.51" x2="8.59" y2="10.49" /></svg>,
+    activity: <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><polyline points="22,12 18,12 15,21 9,3 6,12 2,12" /></svg>,
+    users: <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" /></svg>,
+  };
+  return (
+    <a href={href} className="lens-card flex items-center justify-center gap-2 py-4 hover:scale-105 hover:border-neon-cyan/50 transition-all">
+      <span className="text-neon-cyan">{icons[icon]}</span>
+      <span className="font-medium">{label}</span>
+    </a>
+  );
+}

--- a/concord-frontend/lib/hooks/use-editor-modal.ts
+++ b/concord-frontend/lib/hooks/use-editor-modal.ts
@@ -1,0 +1,140 @@
+/**
+ * useEditorModal — Shared editor modal state hook
+ *
+ * Eliminates the repeated pattern of showEditor/editingItem/formState
+ * found across 10+ lenses. Provides open/close/save lifecycle with
+ * automatic form state management.
+ *
+ * Usage:
+ *   const editor = useEditorModal<MyDataType>({
+ *     onSave: async (data, id) => id ? update(id, data) : create(data),
+ *     onDelete: async (id) => remove(id),
+ *   });
+ *
+ *   editor.openNew({ status: 'draft' });
+ *   editor.openEdit(existingItem);
+ *   editor.close();
+ */
+
+import { useState, useCallback } from 'react';
+import type { LensItem } from './use-lens-data';
+
+interface EditorModalOptions<T> {
+  /** Called on save with merged form data and optional existing ID */
+  onSave: (data: { title: string; data: Partial<T>; meta?: Record<string, unknown> }, id: string | null) => Promise<unknown>;
+  /** Called on delete with item ID */
+  onDelete?: (id: string) => Promise<unknown>;
+  /** Default form values for new items */
+  defaults?: Partial<T>;
+}
+
+interface EditorModalState<T> {
+  isOpen: boolean;
+  isEditing: boolean;
+  editingId: string | null;
+  editingItem: LensItem<T> | null;
+  title: string;
+  data: Partial<T>;
+  isSaving: boolean;
+  isDeleting: boolean;
+}
+
+export function useEditorModal<T = Record<string, unknown>>(options: EditorModalOptions<T>) {
+  const { onSave, onDelete, defaults = {} as Partial<T> } = options;
+
+  const [state, setState] = useState<EditorModalState<T>>({
+    isOpen: false,
+    isEditing: false,
+    editingId: null,
+    editingItem: null,
+    title: '',
+    data: { ...defaults },
+    isSaving: false,
+    isDeleting: false,
+  });
+
+  const openNew = useCallback((initialData?: Partial<T>) => {
+    setState({
+      isOpen: true,
+      isEditing: false,
+      editingId: null,
+      editingItem: null,
+      title: '',
+      data: { ...defaults, ...initialData },
+      isSaving: false,
+      isDeleting: false,
+    });
+  }, [defaults]);
+
+  const openEdit = useCallback((item: LensItem<T>) => {
+    setState({
+      isOpen: true,
+      isEditing: true,
+      editingId: item.id,
+      editingItem: item,
+      title: item.title,
+      data: { ...item.data },
+      isSaving: false,
+      isDeleting: false,
+    });
+  }, []);
+
+  const close = useCallback(() => {
+    setState(s => ({ ...s, isOpen: false }));
+  }, []);
+
+  const setTitle = useCallback((title: string) => {
+    setState(s => ({ ...s, title }));
+  }, []);
+
+  const setData = useCallback((updater: Partial<T> | ((prev: Partial<T>) => Partial<T>)) => {
+    setState(s => ({
+      ...s,
+      data: typeof updater === 'function'
+        ? (updater as (prev: Partial<T>) => Partial<T>)(s.data)
+        : { ...s.data, ...updater },
+    }));
+  }, []);
+
+  const setField = useCallback(<K extends keyof T>(key: K, value: T[K]) => {
+    setState(s => ({ ...s, data: { ...s.data, [key]: value } }));
+  }, []);
+
+  const save = useCallback(async (meta?: Record<string, unknown>) => {
+    setState(s => ({ ...s, isSaving: true }));
+    try {
+      await onSave(
+        { title: state.title, data: state.data, meta },
+        state.editingId
+      );
+      setState(s => ({ ...s, isOpen: false, isSaving: false }));
+    } catch {
+      setState(s => ({ ...s, isSaving: false }));
+      throw new Error('Save failed');
+    }
+  }, [onSave, state.title, state.data, state.editingId]);
+
+  const remove = useCallback(async () => {
+    if (!onDelete || !state.editingId) return;
+    setState(s => ({ ...s, isDeleting: true }));
+    try {
+      await onDelete(state.editingId);
+      setState(s => ({ ...s, isOpen: false, isDeleting: false }));
+    } catch {
+      setState(s => ({ ...s, isDeleting: false }));
+      throw new Error('Delete failed');
+    }
+  }, [onDelete, state.editingId]);
+
+  return {
+    ...state,
+    openNew,
+    openEdit,
+    close,
+    setTitle,
+    setData,
+    setField,
+    save,
+    remove,
+  };
+}

--- a/concord-frontend/lib/hooks/use-search-filter.ts
+++ b/concord-frontend/lib/hooks/use-search-filter.ts
@@ -1,0 +1,85 @@
+/**
+ * useSearchFilter — Shared search + status filter hook
+ *
+ * Eliminates the repeated pattern of searchQuery/statusFilter/filtered
+ * memoization found across nearly every lens that renders a list.
+ *
+ * Usage:
+ *   const { filtered, searchQuery, setSearchQuery, statusFilter, setStatusFilter } =
+ *     useSearchFilter(items, {
+ *       searchFields: ['title', 'data.description'],
+ *       statusField: 'meta.status',
+ *     });
+ */
+
+import { useState, useMemo, useCallback } from 'react';
+
+interface SearchFilterOptions {
+  /** Dot-paths into each item to search against (default: ['title']) */
+  searchFields?: string[];
+  /** Dot-path to the status field (default: 'meta.status') */
+  statusField?: string;
+  /** Initial status filter (default: 'all') */
+  initialStatus?: string;
+}
+
+function getNestedValue(obj: unknown, path: string): unknown {
+  return path.split('.').reduce((curr: unknown, key: string) => {
+    if (curr && typeof curr === 'object') return (curr as Record<string, unknown>)[key];
+    return undefined;
+  }, obj);
+}
+
+export function useSearchFilter<T>(
+  items: T[],
+  options: SearchFilterOptions = {}
+) {
+  const {
+    searchFields = ['title'],
+    statusField = 'meta.status',
+    initialStatus = 'all',
+  } = options;
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [statusFilter, setStatusFilter] = useState(initialStatus);
+
+  const filtered = useMemo(() => {
+    let list = items;
+
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase();
+      list = list.filter(item =>
+        searchFields.some(field => {
+          const val = getNestedValue(item, field);
+          return typeof val === 'string' && val.toLowerCase().includes(q);
+        })
+      );
+    }
+
+    if (statusFilter !== 'all') {
+      list = list.filter(item => {
+        const val = getNestedValue(item, statusField);
+        return val === statusFilter;
+      });
+    }
+
+    return list;
+  }, [items, searchQuery, statusFilter, searchFields, statusField]);
+
+  const clearFilters = useCallback(() => {
+    setSearchQuery('');
+    setStatusFilter('all');
+  }, []);
+
+  return {
+    filtered,
+    searchQuery,
+    setSearchQuery,
+    statusFilter,
+    setStatusFilter,
+    clearFilters,
+    isFiltered: searchQuery !== '' || statusFilter !== 'all',
+    totalCount: items.length,
+    filteredCount: filtered.length,
+  };
+}

--- a/concord-frontend/lib/hooks/use-tab-system.ts
+++ b/concord-frontend/lib/hooks/use-tab-system.ts
@@ -1,0 +1,59 @@
+/**
+ * useTabSystem — Shared tab management hook
+ *
+ * Eliminates the repeated pattern of activeTab/MODE_TABS/currentType
+ * found across lenses with multi-tab architecture (accounting, education,
+ * legal, nonprofit, reasoning).
+ *
+ * Usage:
+ *   const tabs = useTabSystem({
+ *     tabs: [
+ *       { id: 'Students', icon: Users, artifactType: 'Student' },
+ *       { id: 'Courses', icon: BookOpen, artifactType: 'Course' },
+ *     ],
+ *     defaultTab: 'Students',
+ *   });
+ *
+ *   tabs.activeTab    // 'Students'
+ *   tabs.currentType  // 'Student'
+ *   tabs.setActiveTab('Courses')
+ */
+
+import { useState, useMemo, useCallback } from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+export interface TabDefinition {
+  id: string;
+  icon: LucideIcon;
+  artifactType: string;
+  label?: string;
+}
+
+interface TabSystemOptions {
+  tabs: TabDefinition[];
+  defaultTab?: string;
+}
+
+export function useTabSystem(options: TabSystemOptions) {
+  const { tabs, defaultTab } = options;
+  const [activeTab, setActiveTab] = useState(defaultTab || tabs[0]?.id || '');
+
+  const currentTab = useMemo(
+    () => tabs.find(t => t.id === activeTab) || tabs[0],
+    [tabs, activeTab]
+  );
+
+  const currentType = currentTab?.artifactType || '';
+
+  const switchTab = useCallback((tabId: string) => {
+    setActiveTab(tabId);
+  }, []);
+
+  return {
+    tabs,
+    activeTab,
+    setActiveTab: switchTab,
+    currentTab,
+    currentType,
+  };
+}

--- a/concord-frontend/public/robots.txt
+++ b/concord-frontend/public/robots.txt
@@ -1,0 +1,7 @@
+# Concord OS — concord-os.org
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /lenses/
+
+Sitemap: https://concord-os.org/sitemap.xml

--- a/server/grc/formatter.js
+++ b/server/grc/formatter.js
@@ -1,0 +1,283 @@
+/**
+ * GRC v1 Formatter — Grounded Recursive Closure output formatter
+ *
+ * Transforms raw LLM output + DTU context into the canonical GRC shape.
+ * Handles both cases:
+ *   1) LLM returns structured GRC JSON → validate and pass through
+ *   2) LLM returns freeform text → wrap into GRC envelope with inferred anchors
+ *
+ * This is the single exit gate for all Concord LLM responses.
+ */
+
+import { validateGRC, TONE_LOCK_OPENERS, FORBIDDEN_PATTERNS, WORD_LIMITS } from "./schema.js";
+
+// ---- Formatting ----
+
+/**
+ * Format a raw LLM response into GRC shape.
+ *
+ * @param {string} rawContent - Raw LLM output text
+ * @param {object} context - Execution context
+ * @param {string[]} context.dtuRefs - DTU IDs/titles used in prompt
+ * @param {string[]} context.macroRefs - Macro domain.name references
+ * @param {string[]} context.stateRefs - State keys referenced
+ * @param {string} context.mode - Governance mode (e.g. 'governed-response')
+ * @param {string[]} context.invariantsApplied - Invariants enforced during run
+ * @param {object} context.realitySnapshot - { facts, assumptions, unknowns }
+ * @returns {{ ok: boolean, grc: object|null, raw: string, validation: object }}
+ */
+export function formatGRC(rawContent, context = {}) {
+  const {
+    dtuRefs = [],
+    macroRefs = [],
+    stateRefs = [],
+    mode = "governed-response",
+    invariantsApplied = [],
+    realitySnapshot = null,
+  } = context;
+
+  // Attempt 1: Try to parse as structured GRC JSON from LLM
+  const parsed = tryParseGRC(rawContent);
+  if (parsed) {
+    // LLM returned structured output — validate and enrich
+    const enriched = enrichGRC(parsed, context);
+    const validation = validateGRC(enriched);
+    return { ok: validation.valid, grc: enriched, raw: rawContent, validation };
+  }
+
+  // Attempt 2: Wrap freeform text into GRC envelope
+  const envelope = buildGRCEnvelope(rawContent, {
+    dtuRefs,
+    macroRefs,
+    stateRefs,
+    mode,
+    invariantsApplied,
+    realitySnapshot,
+  });
+
+  const validation = validateGRC(envelope);
+  return { ok: validation.valid, grc: envelope, raw: rawContent, validation };
+}
+
+/**
+ * Try to extract a GRC JSON object from raw LLM output.
+ * Handles: pure JSON, JSON in code fences, JSON prefix/suffix.
+ */
+function tryParseGRC(raw) {
+  if (!raw || typeof raw !== "string") return null;
+
+  // Strip markdown code fences
+  let text = raw.trim();
+  const fenceMatch = text.match(/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/);
+  if (fenceMatch) text = fenceMatch[1].trim();
+
+  // Find JSON object boundaries
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) return null;
+
+  try {
+    const obj = JSON.parse(text.slice(start, end + 1));
+    // Check if it looks like a GRC object
+    if (obj.toneLock && obj.payload && obj.anchor) return obj;
+    if (obj.payload && obj.nextLoop) return obj;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Enrich a parsed GRC object with context that the LLM may have missed.
+ */
+function enrichGRC(grc, context) {
+  const out = { ...grc };
+
+  // Ensure anchor has at least context refs
+  if (!out.anchor) out.anchor = {};
+  if (!out.anchor.dtus?.length && context.dtuRefs?.length) {
+    out.anchor.dtus = context.dtuRefs;
+  }
+  if (!out.anchor.macros?.length && context.macroRefs?.length) {
+    out.anchor.macros = context.macroRefs;
+  }
+  if (!out.anchor.mode && context.mode) {
+    out.anchor.mode = context.mode;
+  }
+
+  // Ensure invariants include context ones
+  if (!Array.isArray(out.invariants)) out.invariants = [];
+  if (context.invariantsApplied?.length) {
+    const existing = new Set(out.invariants);
+    for (const inv of context.invariantsApplied) {
+      if (!existing.has(inv)) out.invariants.push(inv);
+    }
+  }
+
+  // Ensure toneLock exists
+  if (!out.toneLock) out.toneLock = "Aligned.";
+
+  // Ensure reality object exists
+  if (!out.reality) {
+    out.reality = context.realitySnapshot || { facts: [], assumptions: [], unknowns: [] };
+  }
+
+  return out;
+}
+
+/**
+ * Build a GRC envelope around freeform text.
+ * Used when the LLM did not return structured GRC JSON.
+ */
+function buildGRCEnvelope(rawContent, context) {
+  const {
+    dtuRefs = [],
+    macroRefs = [],
+    stateRefs = [],
+    mode = "governed-response",
+    invariantsApplied = [],
+    realitySnapshot = null,
+  } = context;
+
+  // Select tone lock
+  const toneLock = "Aligned.";
+
+  // Build anchor from context
+  const anchor = {
+    dtus: dtuRefs.length > 0 ? dtuRefs : ["general-context"],
+    macros: macroRefs,
+    stateRefs: stateRefs,
+    mode: mode,
+  };
+
+  // Build invariants (always include core set + context ones)
+  const coreInvariants = ["NoNegativeValence", "RealityGateBeforeEffects"];
+  const invariants = [...new Set([...coreInvariants, ...invariantsApplied])];
+
+  // Build reality from context or derive minimal
+  const reality = realitySnapshot || {
+    facts: dtuRefs.length > 0
+      ? [`Context includes ${dtuRefs.length} DTU reference(s)`]
+      : ["No specific DTU context provided"],
+    assumptions: ["LLM output is freeform; GRC envelope auto-applied"],
+    unknowns: ["Full lattice state not inspected for this response"],
+  };
+
+  // Clean the payload
+  const payload = cleanPayload(rawContent);
+
+  // Generate recursion hook from payload content
+  const nextLoop = inferNextLoop(payload, dtuRefs);
+
+  // Generate recursive question
+  const question = inferQuestion(payload, dtuRefs);
+
+  return {
+    toneLock,
+    anchor,
+    invariants,
+    reality,
+    payload,
+    nextLoop,
+    question,
+  };
+}
+
+/**
+ * Clean payload text: strip forbidden patterns, trim preambles.
+ */
+function cleanPayload(text) {
+  if (!text || typeof text !== "string") return "";
+
+  let cleaned = text.trim();
+
+  // Remove forbidden patterns
+  for (const pat of FORBIDDEN_PATTERNS) {
+    cleaned = cleaned.replace(pat, "");
+  }
+
+  // Collapse multiple newlines
+  cleaned = cleaned.replace(/\n{3,}/g, "\n\n");
+
+  return cleaned.trim();
+}
+
+/**
+ * Infer a next loop from payload content.
+ */
+function inferNextLoop(payload, dtuRefs) {
+  if (dtuRefs.length > 0) {
+    return {
+      name: "DTU Context Deepening",
+      why: `Deepen grounding against ${dtuRefs.length} referenced DTU(s) and verify lattice consistency.`,
+    };
+  }
+  return {
+    name: "Lattice Anchor Discovery",
+    why: "Locate relevant DTUs/state to ground future responses and reduce assumption surface.",
+  };
+}
+
+/**
+ * Infer a recursive question from payload content.
+ */
+function inferQuestion(payload, dtuRefs) {
+  if (dtuRefs.length > 0) {
+    return `Which DTU anchor should be deepened next to reduce unknowns in this context?`;
+  }
+  return `What lattice anchors should be established to ground this response domain?`;
+}
+
+// ---- GRC Prompt Template ----
+
+/**
+ * Returns the system prompt that forces LLM output into GRC shape.
+ * Feed this to MiniLlama / GPT-4.1-mini / any model.
+ */
+export function getGRCSystemPrompt(contextAnchors = {}) {
+  const anchorStr = contextAnchors.dtus?.length
+    ? `DTUs: [${contextAnchors.dtus.join(", ")}]`
+    : "DTUs: [general-context]";
+
+  return `You are Concord's cognitive engine. Your output MUST follow the Grounded Recursive Closure (GRC) v1 format exactly.
+
+OUTPUT FORMAT (JSON):
+{
+  "toneLock": "<1-6 words: Acknowledged. | Confirmed. | Aligned. | Proceeding.>",
+  "anchor": {
+    "dtus": ["<DTU IDs or titles referenced>"],
+    "macros": ["<macro references if any>"],
+    "stateRefs": ["<state keys if any>"],
+    "mode": "<governance mode>"
+  },
+  "invariants": ["<3-7 non-negotiables applied, e.g. NoNegativeValence, RealityGateBeforeEffects>"],
+  "reality": {
+    "facts": ["<derivable from DTUs/state/tools>"],
+    "assumptions": ["<labeled assumptions>"],
+    "unknowns": ["<admitted unknowns — no bluffing>"]
+  },
+  "payload": "<actual answer / patch / explanation — the ONLY long section>",
+  "nextLoop": {
+    "name": "<loop name, max 80 chars>",
+    "why": "<1 sentence why, max 180 chars>"
+  },
+  "question": "<one sharp actionable anchored question, max 220 chars>"
+}
+
+ACTIVE ANCHORS: ${anchorStr}
+MODE: governed-response
+
+HARD RULES:
+- Sections 0-3 combined: <= 120 words
+- Sections 5-6 combined: <= 50 words
+- Only Section 4 (payload) is allowed to be long
+- NEVER include meta-lectures about capability
+- NEVER re-explain the whole system
+- NEVER repeat the user's prompt in multiple forms
+- NEVER offer multiple forks/options unless requested
+- NEVER use "As an AI" or similar self-referential framing
+- NEVER add "startup heuristics" or minimize output unless requested
+- The "NoSaaSMinimizeRegression" invariant is ALWAYS active
+- Admit unknowns explicitly — never bluff
+- Exactly one nextLoop, exactly one question`;
+}

--- a/server/grc/index.js
+++ b/server/grc/index.js
@@ -1,0 +1,189 @@
+/**
+ * GRC v1 Module — Grounded Recursive Closure
+ *
+ * Entry point for the GRC output spec. Registers macros, provides the
+ * formatAndValidate() pipeline that wraps llmChat output, and exposes
+ * metrics for observability.
+ *
+ * Integration:
+ *   import { init as initGRC } from "./grc/index.js";
+ *   const grcModule = await initGRC({ register, STATE, helpers });
+ *
+ * Then call grcModule.formatAndValidate(rawLLMOutput, context) to get
+ * the canonical GRC output shape.
+ */
+
+import { GRC_JSON_SCHEMA, validateGRC } from "./schema.js";
+import { formatGRC, getGRCSystemPrompt } from "./formatter.js";
+import { runGRCInvariantChecks, CORE_INVARIANTS } from "./invariants.js";
+
+// ---- Module State ----
+
+const GRC_METRICS = {
+  totalOutputs: 0,
+  validOutputs: 0,
+  repairedOutputs: 0,
+  failedOutputs: 0,
+  structuredParses: 0,
+  envelopeWraps: 0,
+  invariantRepairs: 0,
+  forbiddenPatternHits: 0,
+  compressionHits: 0,
+};
+
+// ---- Core Pipeline ----
+
+/**
+ * Full GRC pipeline: format → invariant check → validate → emit.
+ *
+ * @param {string} rawContent - Raw LLM output text
+ * @param {object} context - Execution context (dtuRefs, macroRefs, mode, etc.)
+ * @param {object} opts - Server bindings
+ * @param {function} opts.inLatticeReality - Chicken2 reality gate
+ * @param {object} opts.STATE - Server state
+ * @param {object} opts.affectState - Current affect state
+ * @returns {{ ok, grc, raw, validation, repairs, failures, metrics }}
+ */
+export function formatAndValidate(rawContent, context = {}, opts = {}) {
+  GRC_METRICS.totalOutputs++;
+
+  // Step 1: Format raw content into GRC shape
+  const formatted = formatGRC(rawContent, context);
+
+  if (!formatted.grc) {
+    GRC_METRICS.failedOutputs++;
+    return {
+      ok: false,
+      grc: null,
+      raw: rawContent,
+      validation: { valid: false, errors: ["Failed to format into GRC shape"], warnings: [] },
+      repairs: [],
+      failures: ["Format failed"],
+      metrics: { ...GRC_METRICS },
+    };
+  }
+
+  // Track parse method
+  if (formatted.raw !== formatted.grc.payload) {
+    GRC_METRICS.structuredParses++;
+  } else {
+    GRC_METRICS.envelopeWraps++;
+  }
+
+  // Step 2: Run invariant checks (may repair)
+  const invariantResult = runGRCInvariantChecks(formatted.grc, {
+    inLatticeReality: opts.inLatticeReality,
+    STATE: opts.STATE,
+    affectState: opts.affectState,
+  });
+
+  if (invariantResult.repairs.length > 0) {
+    GRC_METRICS.repairedOutputs++;
+    GRC_METRICS.invariantRepairs += invariantResult.repairs.length;
+  }
+
+  // Step 3: Final validation
+  const finalValidation = validateGRC(invariantResult.grc);
+
+  if (finalValidation.valid) {
+    GRC_METRICS.validOutputs++;
+  } else {
+    GRC_METRICS.failedOutputs++;
+  }
+
+  return {
+    ok: finalValidation.valid,
+    grc: invariantResult.grc,
+    raw: rawContent,
+    validation: finalValidation,
+    repairs: invariantResult.repairs,
+    failures: invariantResult.failures,
+    metrics: { ...GRC_METRICS },
+  };
+}
+
+// ---- Init (Macro Registration) ----
+
+/**
+ * Initialize GRC module and register macros.
+ */
+export async function init({ register, STATE, helpers }) {
+  // Register GRC macros
+
+  register("grc", "format", async (ctx, input) => {
+    const { content, dtuRefs, macroRefs, stateRefs, mode, invariantsApplied, realitySnapshot } = input;
+    const result = formatAndValidate(
+      content,
+      { dtuRefs, macroRefs, stateRefs, mode, invariantsApplied, realitySnapshot },
+      {
+        inLatticeReality: helpers?.inLatticeReality || null,
+        STATE,
+        affectState: null,
+      }
+    );
+    return result;
+  }, {
+    description: "Format raw LLM output into GRC v1 shape with invariant checks",
+    inputExample: {
+      content: "Here is my analysis of the DTU...",
+      dtuRefs: ["Genesis", "Chicken2 Laws"],
+      mode: "governed-response",
+    },
+    outputExample: {
+      ok: true,
+      grc: {
+        toneLock: "Aligned.",
+        anchor: { dtus: ["Genesis", "Chicken2 Laws"], mode: "governed-response" },
+        invariants: ["NoNegativeValence", "RealityGateBeforeEffects"],
+        reality: { facts: [], assumptions: [], unknowns: [] },
+        payload: "Analysis...",
+        nextLoop: { name: "DTU Context Deepening", why: "..." },
+        question: "Which DTU anchor should be deepened next?",
+      },
+    },
+  });
+
+  register("grc", "validate", async (ctx, input) => {
+    const { grc } = input;
+    return validateGRC(grc);
+  }, {
+    description: "Validate a GRC output object against the spec",
+  });
+
+  register("grc", "systemPrompt", async (ctx, input) => {
+    const { anchors } = input || {};
+    return { ok: true, prompt: getGRCSystemPrompt(anchors) };
+  }, {
+    description: "Get the GRC system prompt for LLM instruction",
+  });
+
+  register("grc", "metrics", async () => {
+    return { ok: true, metrics: { ...GRC_METRICS } };
+  }, {
+    description: "Get GRC pipeline metrics",
+  });
+
+  register("grc", "schema", async () => {
+    return { ok: true, schema: GRC_JSON_SCHEMA };
+  }, {
+    description: "Get the GRC JSON schema for external validation",
+  });
+
+  register("grc", "invariants", async () => {
+    return { ok: true, invariants: CORE_INVARIANTS };
+  }, {
+    description: "List core GRC invariants",
+  });
+
+  console.log("[GRC] Grounded Recursive Closure v1 initialized — 6 macros registered");
+
+  return {
+    name: "grc",
+    version: "1.0.0",
+    macros: ["format", "validate", "systemPrompt", "metrics", "schema", "invariants"],
+    formatAndValidate,
+    getGRCSystemPrompt,
+    validateGRC,
+    CORE_INVARIANTS,
+  };
+}

--- a/server/grc/invariants.js
+++ b/server/grc/invariants.js
@@ -1,0 +1,281 @@
+/**
+ * GRC v1 Invariant Checks — Chicken2-compatible safety gates
+ *
+ * These run BEFORE emitting final GRC output:
+ *   1. inLatticeReality(payload) — verify payload stays inside lattice
+ *   2. NoNegativeValence check — per affect model
+ *   3. repair() if either fails — preserve intent, no new claims, no sanitize-to-uselessness
+ */
+
+import { FORBIDDEN_PATTERNS, WORD_LIMITS, countPreambleWords, countClosureWords } from "./schema.js";
+
+// ---- Core Invariant Set ----
+
+/** Standard invariants always applied to GRC outputs */
+export const CORE_INVARIANTS = [
+  "NoNegativeValence",
+  "RealityGateBeforeEffects",
+  "NoUnlabeledAssumptions",
+  "NoSaaSMinimizeRegression",
+  "FounderOverrideAllowed",
+];
+
+// ---- Invariant Check Functions ----
+
+/**
+ * Run the full GRC invariant check suite on a GRC output.
+ * Uses the STATE and inLatticeReality from the host server.
+ *
+ * @param {object} grc - The GRC output object
+ * @param {object} opts
+ * @param {function} opts.inLatticeReality - Server's reality gate function
+ * @param {object} opts.STATE - Server state
+ * @param {object} opts.affectState - Current affect state (optional)
+ * @returns {{ ok: boolean, grc: object, repairs: string[], failures: string[] }}
+ */
+export function runGRCInvariantChecks(grc, opts = {}) {
+  const { inLatticeReality, STATE, affectState } = opts;
+  const repairs = [];
+  const failures = [];
+  let output = { ...grc };
+
+  // ---- Check 1: Lattice Reality Gate ----
+  if (typeof inLatticeReality === "function") {
+    const check = inLatticeReality({
+      type: "grc_output",
+      domain: "grc",
+      name: "emit",
+      input: { payload: output.payload },
+      ctx: null,
+    });
+    if (!check.ok) {
+      // Attempt repair
+      const repaired = repairPayload(output.payload, "lattice_reality_failed");
+      if (repaired.changed) {
+        output.payload = repaired.text;
+        repairs.push(`LatticeReality repair: ${check.reason || "failed"}`);
+      } else {
+        failures.push(`LatticeReality gate failed: ${check.reason || "unknown"}`);
+      }
+    }
+  }
+
+  // ---- Check 2: NoNegativeValence ----
+  const valenceCheck = checkNoNegativeValence(output, affectState);
+  if (!valenceCheck.ok) {
+    const repaired = repairPayload(output.payload, "negative_valence");
+    if (repaired.changed) {
+      output.payload = repaired.text;
+      repairs.push(`NoNegativeValence repair: ${valenceCheck.reason}`);
+    } else {
+      failures.push(`NoNegativeValence check failed: ${valenceCheck.reason}`);
+    }
+  }
+
+  // ---- Check 3: NoUnlabeledAssumptions ----
+  const assumptionCheck = checkNoUnlabeledAssumptions(output);
+  if (!assumptionCheck.ok) {
+    // Add missing assumptions to reality.assumptions
+    if (output.reality && Array.isArray(output.reality.assumptions)) {
+      output.reality.assumptions.push("Auto-detected: some payload claims may be assumptions");
+    }
+    repairs.push("NoUnlabeledAssumptions: added disclosure to reality.assumptions");
+  }
+
+  // ---- Check 4: Forbidden patterns ----
+  const patternCheck = checkForbiddenPatterns(output.payload);
+  if (!patternCheck.ok) {
+    output.payload = patternCheck.cleaned;
+    repairs.push(`Removed ${patternCheck.patternsFound} forbidden pattern(s)`);
+  }
+
+  // ---- Check 5: Word count compression ----
+  const compressionCheck = enforceWordLimits(output);
+  if (compressionCheck.compressed) {
+    output = compressionCheck.output;
+    repairs.push("Applied word-count compression to stay within GRC rails");
+  }
+
+  // Ensure core invariants are listed
+  if (Array.isArray(output.invariants)) {
+    const existing = new Set(output.invariants);
+    for (const inv of CORE_INVARIANTS) {
+      if (!existing.has(inv)) output.invariants.push(inv);
+    }
+    // Cap at 12
+    if (output.invariants.length > 12) {
+      output.invariants = output.invariants.slice(0, 12);
+    }
+  }
+
+  return {
+    ok: failures.length === 0,
+    grc: output,
+    repairs,
+    failures,
+  };
+}
+
+// ---- Individual Check Functions ----
+
+/**
+ * NoNegativeValence: Ensure output doesn't project harmful affect.
+ */
+function checkNoNegativeValence(grc, affectState) {
+  // Check affect state if available
+  if (affectState) {
+    const valence = affectState.E?.valence ?? affectState.valence ?? 0;
+    if (valence < -0.3) {
+      return { ok: false, reason: `Affect valence too low: ${valence.toFixed(2)}` };
+    }
+  }
+
+  // Check payload for strongly negative sentiment markers
+  const negativeMarkers = [
+    /\b(?:you(?:'re| are) wrong|you fail|hopeless|impossible|give up|worthless)\b/i,
+    /\b(?:can(?:'t| ?not) (?:help|assist|do (?:that|this)))\b/i,
+    /\b(?:unfortunately.{0,20}(?:impossible|cannot|unable))\b/i,
+  ];
+
+  if (typeof grc.payload === "string") {
+    for (const marker of negativeMarkers) {
+      if (marker.test(grc.payload)) {
+        return { ok: false, reason: `Negative valence pattern detected: ${marker.source}` };
+      }
+    }
+  }
+
+  return { ok: true };
+}
+
+/**
+ * NoUnlabeledAssumptions: Ensure payload doesn't assert assumed facts
+ * without labeling them in reality.assumptions.
+ */
+function checkNoUnlabeledAssumptions(grc) {
+  if (!grc.reality || !Array.isArray(grc.reality.assumptions)) {
+    return { ok: false, reason: "No reality.assumptions array" };
+  }
+
+  // Heuristic: if payload is long and assumptions is empty, flag it
+  const payloadWords = (grc.payload || "").trim().split(/\s+/).length;
+  if (payloadWords > 100 && grc.reality.assumptions.length === 0) {
+    return { ok: false, reason: "Long payload with zero labeled assumptions" };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Check for forbidden word-salad patterns in payload.
+ */
+function checkForbiddenPatterns(payload) {
+  if (!payload || typeof payload !== "string") return { ok: true, cleaned: payload, patternsFound: 0 };
+
+  let cleaned = payload;
+  let patternsFound = 0;
+
+  for (const pat of FORBIDDEN_PATTERNS) {
+    if (pat.test(cleaned)) {
+      cleaned = cleaned.replace(pat, "");
+      patternsFound++;
+    }
+  }
+
+  return {
+    ok: patternsFound === 0,
+    cleaned: cleaned.trim(),
+    patternsFound,
+  };
+}
+
+/**
+ * Enforce word-count compression rules.
+ */
+function enforceWordLimits(grc) {
+  let compressed = false;
+  const output = { ...grc };
+
+  // Check preamble (sections 0-3)
+  const preambleWords = countPreambleWords(output);
+  if (preambleWords > WORD_LIMITS.preambleMax) {
+    // Trim reality arrays to reduce word count
+    if (output.reality) {
+      output.reality = { ...output.reality };
+      for (const key of ["facts", "assumptions", "unknowns"]) {
+        if (Array.isArray(output.reality[key]) && output.reality[key].length > 3) {
+          output.reality[key] = output.reality[key].slice(0, 3);
+          compressed = true;
+        }
+      }
+    }
+    // Trim invariants if still over
+    if (Array.isArray(output.invariants) && output.invariants.length > 7) {
+      output.invariants = output.invariants.slice(0, 7);
+      compressed = true;
+    }
+  }
+
+  // Check closure (sections 5-6)
+  const closureWords = countClosureWords(output);
+  if (closureWords > WORD_LIMITS.closureMax) {
+    // Truncate nextLoop.why
+    if (output.nextLoop?.why) {
+      output.nextLoop = { ...output.nextLoop };
+      const words = output.nextLoop.why.split(/\s+/);
+      if (words.length > 25) {
+        output.nextLoop.why = words.slice(0, 25).join(" ") + ".";
+        compressed = true;
+      }
+    }
+  }
+
+  return { compressed, output };
+}
+
+// ---- Repair Functions ----
+
+/**
+ * Repair a payload while preserving semantic intent.
+ * Rules:
+ *   - Preserve semantic intent
+ *   - Don't add new claims
+ *   - Don't "sanitize into uselessness"
+ */
+function repairPayload(payload, reason) {
+  if (!payload || typeof payload !== "string") {
+    return { changed: false, text: payload || "" };
+  }
+
+  let text = payload;
+  let changed = false;
+
+  if (reason === "negative_valence") {
+    // Soften strongly negative language while preserving meaning
+    const softeners = [
+      [/\byou(?:'re| are) wrong\b/gi, "this needs correction"],
+      [/\bhopeless\b/gi, "challenging"],
+      [/\bimpossible\b/gi, "requires further analysis"],
+      [/\bgive up\b/gi, "reconsider the approach"],
+      [/\bworthless\b/gi, "needs revision"],
+      [/\bcan(?:'t| ?not) (?:help|assist)\b/gi, "can address this differently"],
+    ];
+
+    for (const [pat, replacement] of softeners) {
+      if (pat.test(text)) {
+        text = text.replace(pat, replacement);
+        changed = true;
+      }
+    }
+  }
+
+  if (reason === "lattice_reality_failed") {
+    // Prefix with grounding disclaimer
+    if (!text.startsWith("[")) {
+      text = "[Note: Response generated outside full lattice context] " + text;
+      changed = true;
+    }
+  }
+
+  return { changed, text };
+}

--- a/server/grc/schema.js
+++ b/server/grc/schema.js
@@ -1,0 +1,260 @@
+/**
+ * GRC v1 Schema — Grounded Recursive Closure output spec
+ *
+ * Defines the canonical JSON schema for Concord's post-LLM output shape.
+ * Enforces structure, word-count rails, and forbidden patterns.
+ *
+ * Every LLM response exits through this shape — no exceptions.
+ */
+
+// ---- JSON Schema (for external consumers / OpenAPI docs) ----
+
+export const GRC_JSON_SCHEMA = {
+  type: "object",
+  required: ["toneLock", "anchor", "invariants", "reality", "payload", "nextLoop", "question"],
+  properties: {
+    toneLock: { type: "string", maxLength: 60 },
+    anchor: {
+      type: "object",
+      properties: {
+        dtus: { type: "array", items: { type: "string" } },
+        macros: { type: "array", items: { type: "string" } },
+        stateRefs: { type: "array", items: { type: "string" } },
+        mode: { type: "string" }
+      },
+      additionalProperties: true
+    },
+    invariants: { type: "array", items: { type: "string" }, maxItems: 12 },
+    reality: {
+      type: "object",
+      required: ["facts", "assumptions", "unknowns"],
+      properties: {
+        facts: { type: "array", items: { type: "string" } },
+        assumptions: { type: "array", items: { type: "string" } },
+        unknowns: { type: "array", items: { type: "string" } }
+      }
+    },
+    payload: { type: "string" },
+    nextLoop: {
+      type: "object",
+      required: ["name", "why"],
+      properties: {
+        name: { type: "string", maxLength: 80 },
+        why: { type: "string", maxLength: 180 }
+      }
+    },
+    question: { type: "string", maxLength: 220 }
+  }
+};
+
+// ---- Validation Constants ----
+
+/** Valid tone lock openers (max 6 words) */
+export const TONE_LOCK_OPENERS = [
+  "Acknowledged.", "Confirmed.", "Aligned.", "Proceeding.",
+  "Locked.", "Anchored.", "Received.", "Grounded."
+];
+
+/** Forbidden output patterns (word salad detection) */
+export const FORBIDDEN_PATTERNS = [
+  /\bI(?:'m| am) (?:just |only )?an? (?:AI|language model|LLM)\b/i,
+  /\bAs an AI\b/i,
+  /\bI don['']t have (?:the ability|access|capability)\b/i,
+  /\blet me (?:re-?explain|clarify|break (?:it |this )?down)\b/i,
+  /\bto (?:summarize|sum up|recap)\s*[,:]/i,
+  /\bgreat question\b/i,
+  /\bthat['']s a (?:great|good|interesting|excellent) (?:point|question|observation)\b/i,
+  /\bhere['']s (?:what|how) (?:I think|I would|we could)\b/i,
+];
+
+/** Word count limits per GRC spec */
+export const WORD_LIMITS = {
+  /** Sections 0-3 combined: toneLock + anchor + invariants + reality */
+  preambleMax: 120,
+  /** Sections 5-6 combined: nextLoop + question */
+  closureMax: 50,
+  /** Tone lock max words */
+  toneLockMax: 6,
+  /** Invariants count range */
+  invariantsMin: 0,
+  invariantsMax: 12,
+};
+
+// ---- Structural Validator ----
+
+/**
+ * Validate a GRC output object against the spec.
+ * Returns { valid, errors[], warnings[] }.
+ */
+export function validateGRC(output) {
+  const errors = [];
+  const warnings = [];
+
+  if (!output || typeof output !== "object") {
+    return { valid: false, errors: ["Output must be an object"], warnings };
+  }
+
+  // Required fields
+  const required = ["toneLock", "anchor", "invariants", "reality", "payload", "nextLoop", "question"];
+  for (const field of required) {
+    if (!(field in output)) {
+      errors.push(`Missing required field: ${field}`);
+    }
+  }
+  if (errors.length > 0) return { valid: false, errors, warnings };
+
+  // Section 0: Tone Lock
+  if (typeof output.toneLock !== "string") {
+    errors.push("toneLock must be a string");
+  } else {
+    if (output.toneLock.length > 60) {
+      errors.push(`toneLock exceeds 60 chars (got ${output.toneLock.length})`);
+    }
+    const wordCount = output.toneLock.trim().split(/\s+/).length;
+    if (wordCount > WORD_LIMITS.toneLockMax) {
+      errors.push(`toneLock exceeds ${WORD_LIMITS.toneLockMax} words (got ${wordCount})`);
+    }
+  }
+
+  // Section 1: Anchor
+  if (!output.anchor || typeof output.anchor !== "object") {
+    errors.push("anchor must be an object");
+  } else {
+    const hasAnchors =
+      (Array.isArray(output.anchor.dtus) && output.anchor.dtus.length > 0) ||
+      (Array.isArray(output.anchor.macros) && output.anchor.macros.length > 0) ||
+      (Array.isArray(output.anchor.stateRefs) && output.anchor.stateRefs.length > 0) ||
+      (typeof output.anchor.mode === "string" && output.anchor.mode.length > 0);
+    if (!hasAnchors) {
+      errors.push("anchor must include at least 1 anchor (dtus, macros, stateRefs, or mode)");
+    }
+  }
+
+  // Section 2: Invariants
+  if (!Array.isArray(output.invariants)) {
+    errors.push("invariants must be an array");
+  } else {
+    if (output.invariants.length > WORD_LIMITS.invariantsMax) {
+      errors.push(`invariants exceeds max ${WORD_LIMITS.invariantsMax} items (got ${output.invariants.length})`);
+    }
+    for (const inv of output.invariants) {
+      if (typeof inv !== "string") {
+        errors.push("Each invariant must be a string");
+        break;
+      }
+    }
+  }
+
+  // Section 3: Reality
+  if (!output.reality || typeof output.reality !== "object") {
+    errors.push("reality must be an object");
+  } else {
+    for (const key of ["facts", "assumptions", "unknowns"]) {
+      if (!Array.isArray(output.reality[key])) {
+        errors.push(`reality.${key} must be an array`);
+      }
+    }
+  }
+
+  // Section 4: Payload
+  if (typeof output.payload !== "string") {
+    errors.push("payload must be a string");
+  }
+
+  // Section 5: Next Loop
+  if (!output.nextLoop || typeof output.nextLoop !== "object") {
+    errors.push("nextLoop must be an object");
+  } else {
+    if (typeof output.nextLoop.name !== "string" || !output.nextLoop.name) {
+      errors.push("nextLoop.name is required");
+    } else if (output.nextLoop.name.length > 80) {
+      errors.push(`nextLoop.name exceeds 80 chars (got ${output.nextLoop.name.length})`);
+    }
+    if (typeof output.nextLoop.why !== "string" || !output.nextLoop.why) {
+      errors.push("nextLoop.why is required");
+    } else if (output.nextLoop.why.length > 180) {
+      errors.push(`nextLoop.why exceeds 180 chars (got ${output.nextLoop.why.length})`);
+    }
+  }
+
+  // Section 6: Question
+  if (typeof output.question !== "string") {
+    errors.push("question must be a string");
+  } else {
+    if (output.question.length > 220) {
+      errors.push(`question exceeds 220 chars (got ${output.question.length})`);
+    }
+    if (!output.question.includes("?")) {
+      warnings.push("question should end with '?'");
+    }
+  }
+
+  // Word count rails
+  const preambleWords = countPreambleWords(output);
+  if (preambleWords > WORD_LIMITS.preambleMax) {
+    warnings.push(`Sections 0-3 exceed ${WORD_LIMITS.preambleMax} words (got ${preambleWords})`);
+  }
+
+  const closureWords = countClosureWords(output);
+  if (closureWords > WORD_LIMITS.closureMax) {
+    warnings.push(`Sections 5-6 exceed ${WORD_LIMITS.closureMax} words (got ${closureWords})`);
+  }
+
+  // Forbidden patterns in payload
+  if (typeof output.payload === "string") {
+    for (const pat of FORBIDDEN_PATTERNS) {
+      if (pat.test(output.payload)) {
+        warnings.push(`Payload contains forbidden pattern: ${pat.source}`);
+      }
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  };
+}
+
+// ---- Word count helpers ----
+
+function wordCount(text) {
+  if (!text || typeof text !== "string") return 0;
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+function arrayWordCount(arr) {
+  if (!Array.isArray(arr)) return 0;
+  return arr.reduce((sum, s) => sum + wordCount(String(s)), 0);
+}
+
+export function countPreambleWords(output) {
+  let count = 0;
+  count += wordCount(output.toneLock);
+  // Anchor
+  if (output.anchor) {
+    count += arrayWordCount(output.anchor.dtus);
+    count += arrayWordCount(output.anchor.macros);
+    count += arrayWordCount(output.anchor.stateRefs);
+    count += wordCount(output.anchor.mode);
+  }
+  // Invariants
+  count += arrayWordCount(output.invariants);
+  // Reality
+  if (output.reality) {
+    count += arrayWordCount(output.reality.facts);
+    count += arrayWordCount(output.reality.assumptions);
+    count += arrayWordCount(output.reality.unknowns);
+  }
+  return count;
+}
+
+export function countClosureWords(output) {
+  let count = 0;
+  if (output.nextLoop) {
+    count += wordCount(output.nextLoop.name);
+    count += wordCount(output.nextLoop.why);
+  }
+  count += wordCount(output.question);
+  return count;
+}


### PR DESCRIPTION
Backend — GRC (Grounded Recursive Closure) v1:
- server/grc/schema.js: JSON schema, structural validator, word-count
  rails, forbidden pattern detection
- server/grc/formatter.js: Formats raw LLM output into GRC envelope,
  handles structured JSON parse + freeform wrapping, GRC system prompt
  template for MiniLlama/GPT-4.1-mini
- server/grc/invariants.js: Chicken2-compatible invariant checks
  (NoNegativeValence, RealityGateBeforeEffects, NoUnlabeledAssumptions),
  repair pipeline that preserves semantic intent
- server/grc/index.js: Module init, macro registration (6 macros),
  formatAndValidate pipeline, metrics tracking
- server/server.js: GRC module import + init, llmChat pipeline hooks
  GRC formatting on all LLM responses, GRC system prompt injection
  into chat.respond, 5 new API endpoints (/api/grc/*)

Frontend — Performance fixes (shared execution shell):
- LensShell: Unified page wrapper eliminating cross-lens duplication
  (useLensNav, loading/error/empty states, tab bar, search bar)
- useEditorModal: Shared editor modal state management hook
- useSearchFilter: Shared search + status filter with memoization
- useTabSystem: Shared multi-tab architecture hook
- StatusBadge, ItemList: Reusable list rendering components

Frontend — SSR/SEO (fixes crawlability):
- layout.tsx: Full Open Graph, Twitter Card, robots directives,
  structured metadata with keywords and canonical URL
- page.tsx: Server Component with SSR landing content visible to
  crawlers, HomeClient hydrates on top for interactivity
- HomeClient: Extracted client component that hides SSR content
  once JS loads, preserves all dashboard functionality
- robots.txt: Allow /, block /api/ and /lenses/
- sitemap.ts: Dynamic sitemap generation

https://claude.ai/code/session_01X6sW3bm1U5wNwdY2hwZ9iS