### PR TITLE
fix: resolve type errors in global page for unknown ReactNode values

### DIFF
--- a/concord-frontend/app/global/page.tsx
+++ b/concord-frontend/app/global/page.tsx
@@ -194,7 +194,7 @@ export default function GlobalPage() {
                   <span className="text-white font-medium truncate">
                     {(item.title as string) || (item.type as string) || (item.id as string)}
                   </span>
-                  {item.visibility && (
+                  {!!item.visibility && (
                     <span className={cn(
                       'text-xs px-2 py-0.5 rounded-full',
                       item.visibility === 'public' ? 'bg-neon-green/20 text-neon-green' :
@@ -205,7 +205,7 @@ export default function GlobalPage() {
                       {item.visibility as string}
                     </span>
                   )}
-                  {item.status && (
+                  {!!item.status && (
                     <span className={cn(
                       'text-xs px-2 py-0.5 rounded-full',
                       item.status === 'completed' ? 'bg-neon-green/20 text-neon-green' :
@@ -216,13 +216,13 @@ export default function GlobalPage() {
                       {item.status as string}
                     </span>
                   )}
-                  {item.tier && (
+                  {!!item.tier && (
                     <span className="text-xs text-gray-500">{item.tier as string}</span>
                   )}
                 </div>
                 <div className="text-xs text-gray-500 mt-0.5">
-                  {item.type && <span className="mr-3">Type: {item.type as string}</span>}
-                  {item.created_at && <span>Created: {new Date(item.created_at as string).toLocaleDateString()}</span>}
+                  {!!item.type && <span className="mr-3">Type: {item.type as string}</span>}
+                  {!!item.created_at && <span>Created: {new Date(item.created_at as string).toLocaleDateString()}</span>}
                 </div>
               </div>
 


### PR DESCRIPTION
Cast `item.visibility`, `item.status`, `item.tier`, `item.type`, and `item.created_at` to boolean with `!!` before using in JSX short-circuit expressions, preventing `unknown` from being treated as ReactNode.

https://claude.ai/code/session_01SGn8rikKqZea1ifYCh6B5h