### PR TITLE
feat: bridge Artistry marketplace to Economy ledger with citation royalties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 
+# Dependencies
+node_modules/
+
 # Server generated files
 server/node_modules/
 server/concord_state.json

--- a/server/economy/index.js
+++ b/server/economy/index.js
@@ -17,8 +17,9 @@ export function registerEconomyEndpoints(app, db) {
 export { getBalance, hasSufficientBalance } from "./balances.js";
 export { calculateFee, FEES, PLATFORM_ACCOUNT_ID } from "./fees.js";
 export { executeTransfer, executePurchase, executeMarketplacePurchase, executeReversal } from "./transfer.js";
-export { recordTransaction, getTransactions } from "./ledger.js";
+export { recordTransaction, recordTransactionBatch, getTransactions, generateTxId } from "./ledger.js";
 export { requestWithdrawal, processWithdrawal } from "./withdrawals.js";
 export { adminOnly, authRequired, requireAdmin, requireUser } from "./guards.js";
 export { economyAudit, auditCtx } from "./audit.js";
+export { validateAmount, validateBalance } from "./validators.js";
 export { STRIPE_ENABLED, createCheckoutSession, handleWebhook, createConnectOnboarding, getConnectStatus } from "./stripe.js";

--- a/server/economy/index.js
+++ b/server/economy/index.js
@@ -17,7 +17,7 @@ export function registerEconomyEndpoints(app, db) {
 export { getBalance, hasSufficientBalance } from "./balances.js";
 export { calculateFee, FEES, PLATFORM_ACCOUNT_ID } from "./fees.js";
 export { executeTransfer, executePurchase, executeMarketplacePurchase, executeReversal } from "./transfer.js";
-export { recordTransaction, recordTransactionBatch, getTransactions, generateTxId } from "./ledger.js";
+export { recordTransaction, recordTransactionBatch, getTransactions, generateTxId, checkRefIdProcessed } from "./ledger.js";
 export { requestWithdrawal, processWithdrawal } from "./withdrawals.js";
 export { adminOnly, authRequired, requireAdmin, requireUser } from "./guards.js";
 export { economyAudit, auditCtx } from "./audit.js";

--- a/server/economy/stripe.js
+++ b/server/economy/stripe.js
@@ -174,6 +174,11 @@ export async function handleWebhook(db, { rawBody, signature, requestId, ip }) {
             ip,
           });
 
+          if (!result.ok) {
+            console.error(`[Stripe Webhook] executePurchase failed for session ${session.id}:`, result.error, result.detail);
+            return { ok: false, error: "token_credit_failed", detail: result.error };
+          }
+
           economyAudit(db, {
             action: "token_purchase_completed",
             userId,

--- a/server/economy/stripe.js
+++ b/server/economy/stripe.js
@@ -161,7 +161,7 @@ export async function handleWebhook(db, { rawBody, signature, requestId, ip }) {
       if (purpose === "TOKEN_PURCHASE" && userId && tokens) {
         const tokenCount = parseInt(tokens, 10);
         if (tokenCount > 0) {
-          // Credit tokens through the ledger (atomic)
+          // Credit tokens through the ledger (atomic, idempotent via refId)
           const result = executePurchase(db, {
             userId,
             amount: tokenCount,
@@ -170,6 +170,7 @@ export async function handleWebhook(db, { rawBody, signature, requestId, ip }) {
               stripeSessionId: session.id,
               stripePaymentIntentId: session.payment_intent,
             },
+            refId: `stripe_checkout:${event.id}`,
             requestId,
             ip,
           });

--- a/server/migrations/004_ledger_idempotency.js
+++ b/server/migrations/004_ledger_idempotency.js
@@ -1,0 +1,26 @@
+// migrations/004_ledger_idempotency.js
+// Add ref_id column to economy_ledger for purchase idempotency.
+// All entries in a single settlement batch share the same ref_id.
+// A unique partial index prevents duplicate processing.
+
+export function up(db) {
+  db.exec(`
+    -- Add ref_id column for idempotency (nullable — legacy rows won't have one)
+    ALTER TABLE economy_ledger ADD COLUMN ref_id TEXT;
+
+    -- Unique partial index: only one settlement per ref_id
+    -- The "role = 'debit'" filter ensures only one constraint check per batch
+    -- (a batch has debit + credit + fee + royalties, all sharing the same ref_id,
+    --  but we only enforce uniqueness on the debit entry to avoid false conflicts)
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_ledger_ref_id_debit
+      ON economy_ledger(ref_id)
+      WHERE ref_id IS NOT NULL AND json_extract(metadata_json, '$.role') = 'debit';
+  `);
+}
+
+export function down(db) {
+  db.exec(`
+    DROP INDEX IF EXISTS idx_ledger_ref_id_debit;
+    -- SQLite doesn't support DROP COLUMN before 3.35.0, so we leave the column
+  `);
+}


### PR DESCRIPTION
Wire the Artistry marketplace purchase endpoint to settle atomically
through the Economy ledger instead of only doing in-memory entitlement
bookkeeping. This bridges the two previously disconnected systems.

Key changes:
- Artistry purchase now debits buyer, credits seller, takes platform
  fee (5%), and distributes citation royalties in a single atomic
  SQLite transaction via recordTransactionBatch
- Citation royalty system: cited work creators receive 30% of purchase
  price, decaying by 0.85x per usage, minimum 0.001% floor
- Citations resolved from Concord Global (DTU references + social
  layer) and Artistry Global (asset cross-references + remix lineage)
- Frontend marketplace checkout now calls POST /api/artistry/marketplace/purchase
  instead of only updating local state, with loading/error states and
  real platform fee display + balance check
- In-memory wallet ops (creditWallet/debitWallet) now bridge to
  economy_ledger so /api/economic/* transactions are visible to
  /api/economy/* queries
- Stripe webhook now validates executePurchase result before marking
  event as processed (prevents silent token credit failures)
- All Artistry listing endpoints wrapped in try-catch with input
  validation (ownerId required, price >= 0)
- Audit logging separated from settlement so non-critical audit
  failures don't mask successful transactions

https://claude.ai/code/session_01LH1cy2qH6UoEMvckgN5pmc