### PR TITLE
feat: add purchase state machine, reconciliation engine, and support …

### DIFF
--- a/server/economy/index.js
+++ b/server/economy/index.js
@@ -23,3 +23,8 @@ export { adminOnly, authRequired, requireAdmin, requireUser } from "./guards.js"
 export { economyAudit, auditCtx } from "./audit.js";
 export { validateAmount, validateBalance } from "./validators.js";
 export { STRIPE_ENABLED, createCheckoutSession, handleWebhook, createConnectOnboarding, getConnectStatus } from "./stripe.js";
+export {
+  createPurchase, transitionPurchase, recordSettlement, getPurchase,
+  getPurchaseByRefId, getUserPurchases, findPurchasesByStatus, getPurchaseHistory, TRANSITIONS,
+} from "./purchases.js";
+export { runReconciliation, executeCorrection, getPurchaseReceipt, getReconciliationSummary } from "./reconciliation.js";

--- a/server/economy/purchases.js
+++ b/server/economy/purchases.js
@@ -1,0 +1,223 @@
+// economy/purchases.js
+// Purchase state machine — tracks every purchase through its lifecycle.
+// States: CREATED → PAYMENT_PENDING → PAID → SETTLED → FULFILLED → (terminal)
+// Terminal: FAILED, REFUNDED, CHARGEBACK, DISPUTED
+
+import { randomUUID } from "crypto";
+import { generateTxId } from "./ledger.js";
+
+function uid() {
+  return "pr_" + randomUUID().replace(/-/g, "").slice(0, 16);
+}
+
+function nowISO() {
+  return new Date().toISOString().replace("T", " ").replace("Z", "");
+}
+
+// Valid state transitions
+const TRANSITIONS = {
+  CREATED:          ["PAYMENT_PENDING", "PAID", "SETTLED", "FULFILLED", "FAILED"],
+  PAYMENT_PENDING:  ["PAID", "FAILED"],
+  PAID:             ["SETTLED", "FAILED", "REFUNDED", "CHARGEBACK"],
+  SETTLED:          ["FULFILLED", "FAILED", "REFUNDED", "CHARGEBACK"],
+  FULFILLED:        ["REFUNDED", "CHARGEBACK", "DISPUTED"],
+  FAILED:           ["CREATED"],  // allow retry
+  REFUNDED:         [],           // terminal
+  CHARGEBACK:       ["DISPUTED"], // can escalate
+  DISPUTED:         ["REFUNDED", "FULFILLED"], // can resolve either way
+};
+
+/**
+ * Create a new purchase record in CREATED state.
+ */
+export function createPurchase(db, {
+  purchaseId, buyerId, sellerId, listingId, listingType, licenseType,
+  amount, source = "artistry", stripeSessionId,
+}) {
+  const id = uid();
+  const now = nowISO();
+  const refId = `purchase:${purchaseId}`;
+
+  db.prepare(`
+    INSERT INTO purchases
+      (id, purchase_id, buyer_id, seller_id, listing_id, listing_type, license_type,
+       amount, source, status, ref_id, stripe_session_id, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'CREATED', ?, ?, ?, ?)
+  `).run(
+    id, purchaseId, buyerId, sellerId, listingId,
+    listingType || null, licenseType || null,
+    amount, source, refId, stripeSessionId || null, now, now,
+  );
+
+  recordTransition(db, purchaseId, null, "CREATED", "Purchase created", buyerId);
+
+  return { id, purchaseId, status: "CREATED", refId };
+}
+
+/**
+ * Transition a purchase to a new state. Enforces valid transitions.
+ */
+export function transitionPurchase(db, purchaseId, toStatus, { reason, actor, metadata, errorMessage } = {}) {
+  const purchase = getPurchase(db, purchaseId);
+  if (!purchase) return { ok: false, error: "purchase_not_found" };
+
+  const allowed = TRANSITIONS[purchase.status] || [];
+  if (!allowed.includes(toStatus)) {
+    return {
+      ok: false,
+      error: "invalid_transition",
+      detail: `Cannot transition from ${purchase.status} to ${toStatus}. Allowed: ${allowed.join(", ") || "none"}`,
+    };
+  }
+
+  const now = nowISO();
+  const updates = { status: toStatus, updated_at: now };
+
+  if (errorMessage !== undefined) updates.error_message = errorMessage;
+  if (toStatus === "FAILED") updates.retry_count = (purchase.retry_count || 0) + 1;
+  if (toStatus === "FAILED") updates.last_retry_at = now;
+  if (["REFUNDED", "CHARGEBACK", "DISPUTED"].includes(toStatus) && actor) {
+    updates.resolved_by = actor;
+    updates.resolved_at = now;
+  }
+
+  const setClauses = Object.keys(updates).map(k => `${k} = ?`).join(", ");
+  const values = Object.values(updates);
+
+  db.prepare(`UPDATE purchases SET ${setClauses} WHERE purchase_id = ?`).run(...values, purchaseId);
+
+  recordTransition(db, purchaseId, purchase.status, toStatus, reason, actor, metadata);
+
+  return { ok: true, purchaseId, from: purchase.status, to: toStatus };
+}
+
+/**
+ * Update settlement details on a purchase after successful ledger commit.
+ */
+export function recordSettlement(db, purchaseId, {
+  settlementBatchId, licenseId, marketplaceFee, sellerNet, totalRoyalties, royaltyDetails,
+}) {
+  const now = nowISO();
+  db.prepare(`
+    UPDATE purchases SET
+      settlement_batch_id = ?,
+      license_id = ?,
+      marketplace_fee = ?,
+      seller_net = ?,
+      total_royalties = ?,
+      royalty_details_json = ?,
+      updated_at = ?
+    WHERE purchase_id = ?
+  `).run(
+    settlementBatchId || null,
+    licenseId || null,
+    marketplaceFee ?? 0,
+    sellerNet ?? 0,
+    totalRoyalties ?? 0,
+    JSON.stringify(royaltyDetails || []),
+    now,
+    purchaseId,
+  );
+}
+
+/**
+ * Get a purchase by purchaseId.
+ */
+export function getPurchase(db, purchaseId) {
+  const row = db.prepare("SELECT * FROM purchases WHERE purchase_id = ?").get(purchaseId);
+  if (!row) return null;
+  return {
+    ...row,
+    royaltyDetails: safeJsonParse(row.royalty_details_json),
+  };
+}
+
+/**
+ * Get a purchase by ref_id (for reconciliation lookups).
+ */
+export function getPurchaseByRefId(db, refId) {
+  const row = db.prepare("SELECT * FROM purchases WHERE ref_id = ?").get(refId);
+  if (!row) return null;
+  return { ...row, royaltyDetails: safeJsonParse(row.royalty_details_json) };
+}
+
+/**
+ * Get purchases for a user (buyer or seller).
+ */
+export function getUserPurchases(db, userId, { role = "buyer", status, limit = 50, offset = 0 } = {}) {
+  const col = role === "seller" ? "seller_id" : "buyer_id";
+  let sql = `SELECT * FROM purchases WHERE ${col} = ?`;
+  const params = [userId];
+
+  if (status) {
+    sql += " AND status = ?";
+    params.push(status);
+  }
+
+  sql += " ORDER BY created_at DESC LIMIT ? OFFSET ?";
+  params.push(limit, offset);
+
+  const items = db.prepare(sql).all(...params).map(r => ({
+    ...r, royaltyDetails: safeJsonParse(r.royalty_details_json),
+  }));
+
+  const countSql = status
+    ? `SELECT COUNT(*) as c FROM purchases WHERE ${col} = ? AND status = ?`
+    : `SELECT COUNT(*) as c FROM purchases WHERE ${col} = ?`;
+  const countParams = status ? [userId, status] : [userId];
+  const total = db.prepare(countSql).get(...countParams)?.c || 0;
+
+  return { items, total, limit, offset };
+}
+
+/**
+ * Find purchases in a specific status (for reconciliation).
+ */
+export function findPurchasesByStatus(db, status, { limit = 100, olderThanMinutes } = {}) {
+  let sql = "SELECT * FROM purchases WHERE status = ?";
+  const params = [status];
+
+  if (olderThanMinutes) {
+    sql += " AND updated_at < datetime('now', ? || ' minutes')";
+    params.push(`-${olderThanMinutes}`);
+  }
+
+  sql += " ORDER BY created_at ASC LIMIT ?";
+  params.push(limit);
+
+  return db.prepare(sql).all(...params).map(r => ({
+    ...r, royaltyDetails: safeJsonParse(r.royalty_details_json),
+  }));
+}
+
+/**
+ * Get the full status history of a purchase.
+ */
+export function getPurchaseHistory(db, purchaseId) {
+  return db.prepare(
+    "SELECT * FROM purchase_status_history WHERE purchase_id = ? ORDER BY created_at ASC"
+  ).all(purchaseId).map(r => ({
+    ...r, metadata: safeJsonParse(r.metadata_json),
+  }));
+}
+
+/**
+ * Record a state transition in the history log.
+ */
+function recordTransition(db, purchaseId, fromStatus, toStatus, reason, actor, metadata) {
+  db.prepare(`
+    INSERT INTO purchase_status_history
+      (id, purchase_id, from_status, to_status, reason, actor, metadata_json, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    generateTxId(), purchaseId, fromStatus, toStatus,
+    reason || null, actor || null,
+    JSON.stringify(metadata || {}), nowISO(),
+  );
+}
+
+function safeJsonParse(str) {
+  try { return JSON.parse(str); } catch { return []; }
+}
+
+export { TRANSITIONS };

--- a/server/economy/reconciliation.js
+++ b/server/economy/reconciliation.js
@@ -1,0 +1,628 @@
+// economy/reconciliation.js
+// Reconciliation engine — scans for purchases in inconsistent states,
+// re-runs idempotent settlement/fulfillment steps, and logs corrective actions.
+// Never edits history; always creates counter-entries (REVERSAL, ADJUSTMENT, MAKE_GOOD).
+
+import { findPurchasesByStatus, transitionPurchase, getPurchase, recordSettlement } from "./purchases.js";
+import { checkRefIdProcessed, generateTxId, recordTransactionBatch } from "./ledger.js";
+import { getBalance } from "./balances.js";
+import { calculateFee, PLATFORM_ACCOUNT_ID } from "./fees.js";
+import { economyAudit } from "./audit.js";
+
+/**
+ * Run a full reconciliation sweep. Designed to be called by cron or admin endpoint.
+ *
+ * Checks:
+ *   1. CREATED purchases older than N minutes → mark FAILED if no payment
+ *   2. PAID purchases not SETTLED → re-attempt idempotent settlement
+ *   3. SETTLED purchases not FULFILLED → re-attempt fulfillment transition
+ *   4. Ledger entries with no matching purchase record → flag as orphans
+ *   5. Purchases with settlement_batch_id but ledger has no matching entries → flag mismatch
+ *
+ * @param {object} db — better-sqlite3 instance
+ * @param {object} [opts]
+ * @param {number} [opts.staleCreatedMinutes=30] — age threshold for stale CREATED
+ * @param {number} [opts.stalePaidMinutes=15] — age threshold for stuck PAID
+ * @param {number} [opts.staleSettledMinutes=15] — age threshold for stuck SETTLED
+ * @param {boolean} [opts.dryRun=false] — if true, don't make changes, only report
+ * @returns {{ ok: boolean, actions: object[], errors: object[], summary: object }}
+ */
+export function runReconciliation(db, {
+  staleCreatedMinutes = 30,
+  stalePaidMinutes = 15,
+  staleSettledMinutes = 15,
+  dryRun = false,
+} = {}) {
+  const actions = [];
+  const errors = [];
+
+  // 1. Stale CREATED → FAILED (abandoned carts)
+  try {
+    const staleCreated = findPurchasesByStatus(db, "CREATED", {
+      olderThanMinutes: staleCreatedMinutes,
+      limit: 200,
+    });
+
+    for (const purchase of staleCreated) {
+      if (dryRun) {
+        actions.push({ type: "would_expire", purchaseId: purchase.purchase_id, age: "stale_created" });
+        continue;
+      }
+
+      const result = transitionPurchase(db, purchase.purchase_id, "FAILED", {
+        reason: "reconciliation: stale CREATED purchase expired",
+        actor: "reconciliation_engine",
+        errorMessage: `Expired after ${staleCreatedMinutes} minutes in CREATED state`,
+      });
+
+      if (result.ok) {
+        actions.push({ type: "expired_stale_created", purchaseId: purchase.purchase_id });
+      } else {
+        errors.push({ type: "expire_failed", purchaseId: purchase.purchase_id, error: result.error });
+      }
+    }
+  } catch (err) {
+    errors.push({ type: "stale_created_scan_error", error: err.message });
+  }
+
+  // 2. Stuck PAID → re-attempt settlement
+  try {
+    const stuckPaid = findPurchasesByStatus(db, "PAID", {
+      olderThanMinutes: stalePaidMinutes,
+      limit: 100,
+    });
+
+    for (const purchase of stuckPaid) {
+      if (dryRun) {
+        actions.push({ type: "would_retry_settlement", purchaseId: purchase.purchase_id, age: "stuck_paid" });
+        continue;
+      }
+
+      const settled = attemptSettlement(db, purchase);
+      if (settled.ok) {
+        actions.push({ type: "retried_settlement", purchaseId: purchase.purchase_id, result: "settled" });
+      } else if (settled.already) {
+        actions.push({ type: "settlement_already_done", purchaseId: purchase.purchase_id });
+      } else {
+        errors.push({ type: "retry_settlement_failed", purchaseId: purchase.purchase_id, error: settled.error });
+      }
+    }
+  } catch (err) {
+    errors.push({ type: "stuck_paid_scan_error", error: err.message });
+  }
+
+  // 3. Stuck SETTLED → transition to FULFILLED
+  try {
+    const stuckSettled = findPurchasesByStatus(db, "SETTLED", {
+      olderThanMinutes: staleSettledMinutes,
+      limit: 100,
+    });
+
+    for (const purchase of stuckSettled) {
+      if (dryRun) {
+        actions.push({ type: "would_fulfill", purchaseId: purchase.purchase_id, age: "stuck_settled" });
+        continue;
+      }
+
+      // Check if entitlement (license) already exists — if so, just transition
+      const result = transitionPurchase(db, purchase.purchase_id, "FULFILLED", {
+        reason: "reconciliation: SETTLED purchase auto-fulfilled",
+        actor: "reconciliation_engine",
+      });
+
+      if (result.ok) {
+        actions.push({ type: "auto_fulfilled", purchaseId: purchase.purchase_id });
+      } else {
+        errors.push({ type: "auto_fulfill_failed", purchaseId: purchase.purchase_id, error: result.error });
+      }
+    }
+  } catch (err) {
+    errors.push({ type: "stuck_settled_scan_error", error: err.message });
+  }
+
+  // 4. Orphan detection — ledger entries tagged as MARKETPLACE_PURCHASE with no matching purchase record
+  try {
+    const orphans = detectOrphanLedgerEntries(db);
+    for (const orphan of orphans) {
+      actions.push({ type: "orphan_ledger_entry", txId: orphan.id, refId: orphan.ref_id, amount: orphan.amount });
+    }
+  } catch (err) {
+    errors.push({ type: "orphan_scan_error", error: err.message });
+  }
+
+  // 5. Settlement mismatch — purchases with settlement_batch_id but no ledger entries
+  try {
+    const mismatches = detectSettlementMismatches(db);
+    for (const m of mismatches) {
+      actions.push({ type: "settlement_mismatch", purchaseId: m.purchase_id, batchId: m.settlement_batch_id });
+    }
+  } catch (err) {
+    errors.push({ type: "mismatch_scan_error", error: err.message });
+  }
+
+  // Audit the reconciliation run
+  try {
+    economyAudit(db, {
+      action: "reconciliation_run",
+      userId: "system",
+      details: {
+        dryRun,
+        actionsCount: actions.length,
+        errorsCount: errors.length,
+        actions: actions.slice(0, 50), // cap logged details
+      },
+    });
+  } catch { /* non-critical */ }
+
+  return {
+    ok: errors.length === 0,
+    actions,
+    errors,
+    summary: {
+      totalActions: actions.length,
+      totalErrors: errors.length,
+      dryRun,
+      timestamp: new Date().toISOString(),
+    },
+  };
+}
+
+/**
+ * Attempt to settle a purchase that's stuck in PAID state.
+ * Uses the ref_id to check if ledger entries already exist (idempotent).
+ */
+function attemptSettlement(db, purchase) {
+  const refId = purchase.ref_id || `purchase:${purchase.purchase_id}`;
+
+  // Check if settlement already happened in the ledger
+  const existing = checkRefIdProcessed(db, refId);
+  if (existing.exists) {
+    // Ledger entries exist — just transition the state machine
+    const result = transitionPurchase(db, purchase.purchase_id, "SETTLED", {
+      reason: "reconciliation: ledger entries found, syncing state",
+      actor: "reconciliation_engine",
+    });
+    return result.ok ? { ok: true, already: true } : { ok: false, error: result.error };
+  }
+
+  // No ledger entries — this is unusual for a PAID purchase.
+  // Don't re-create settlement without the original context (prices, royalties).
+  // Mark as needing manual review by transitioning to FAILED.
+  const result = transitionPurchase(db, purchase.purchase_id, "FAILED", {
+    reason: "reconciliation: PAID but no ledger entries found — needs manual review",
+    actor: "reconciliation_engine",
+    errorMessage: "No settlement ledger entries found for PAID purchase",
+  });
+
+  return result.ok
+    ? { ok: false, error: "no_ledger_entries_flagged_for_review" }
+    : { ok: false, error: result.error };
+}
+
+/**
+ * Detect ledger entries for marketplace purchases that have no corresponding purchase record.
+ */
+function detectOrphanLedgerEntries(db) {
+  try {
+    return db.prepare(`
+      SELECT el.id, el.ref_id, el.amount, el.type, el.created_at
+      FROM economy_ledger el
+      WHERE el.type = 'MARKETPLACE_PURCHASE'
+        AND el.ref_id IS NOT NULL
+        AND el.ref_id LIKE 'purchase:%'
+        AND NOT EXISTS (
+          SELECT 1 FROM purchases p WHERE p.ref_id = el.ref_id
+        )
+      GROUP BY el.ref_id
+      ORDER BY el.created_at DESC
+      LIMIT 100
+    `).all();
+  } catch {
+    // purchases table may not exist yet
+    return [];
+  }
+}
+
+/**
+ * Detect purchases that claim to be settled but have no matching ledger entries.
+ */
+function detectSettlementMismatches(db) {
+  try {
+    return db.prepare(`
+      SELECT p.purchase_id, p.settlement_batch_id, p.status, p.amount
+      FROM purchases p
+      WHERE p.settlement_batch_id IS NOT NULL
+        AND p.status IN ('SETTLED', 'FULFILLED')
+        AND NOT EXISTS (
+          SELECT 1 FROM economy_ledger el
+          WHERE el.ref_id = p.ref_id AND el.status = 'complete'
+        )
+      LIMIT 100
+    `).all();
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Execute a corrective transaction. Never edits history — creates counter-entries.
+ *
+ * Correction types:
+ *   - REVERSAL: undo an entire settlement (swap from/to on all entries)
+ *   - ADJUSTMENT: add/remove tokens to fix an incorrect amount
+ *   - MAKE_GOOD: credit a user for a failed/disputed purchase
+ *
+ * @param {object} db
+ * @param {object} opts
+ * @param {'REVERSAL'|'ADJUSTMENT'|'MAKE_GOOD'} opts.correctionType
+ * @param {string} opts.purchaseId — the purchase to correct
+ * @param {string} opts.reason
+ * @param {string} opts.actor — who initiated the correction
+ * @param {number} [opts.adjustmentAmount] — for ADJUSTMENT type
+ * @param {string} [opts.adjustmentUserId] — for ADJUSTMENT: who gets credited/debited
+ * @returns {{ ok: boolean, entries?: object[], error?: string }}
+ */
+export function executeCorrection(db, {
+  correctionType,
+  purchaseId,
+  reason,
+  actor,
+  adjustmentAmount,
+  adjustmentUserId,
+}) {
+  const purchase = getPurchase(db, purchaseId);
+  if (!purchase) return { ok: false, error: "purchase_not_found" };
+
+  const correctionRefId = `correction:${correctionType.toLowerCase()}:${purchaseId}:${Date.now()}`;
+  const batchId = generateTxId();
+
+  // Check if this exact correction was already done
+  const existing = checkRefIdProcessed(db, correctionRefId);
+  if (existing.exists) return { ok: true, idempotent: true, entries: existing.entries };
+
+  if (correctionType === "REVERSAL") {
+    return executeReversalCorrection(db, purchase, { correctionRefId, batchId, reason, actor });
+  }
+
+  if (correctionType === "ADJUSTMENT") {
+    if (!adjustmentAmount || !adjustmentUserId) {
+      return { ok: false, error: "adjustment_requires_amount_and_user" };
+    }
+    return executeAdjustmentCorrection(db, purchase, {
+      correctionRefId, batchId, reason, actor, adjustmentAmount, adjustmentUserId,
+    });
+  }
+
+  if (correctionType === "MAKE_GOOD") {
+    return executeMakeGoodCorrection(db, purchase, { correctionRefId, batchId, reason, actor });
+  }
+
+  return { ok: false, error: "unknown_correction_type" };
+}
+
+/**
+ * Reverse an entire purchase settlement. Creates counter-entries for all original entries.
+ */
+function executeReversalCorrection(db, purchase, { correctionRefId, batchId, reason, actor }) {
+  const refId = purchase.ref_id || `purchase:${purchase.purchase_id}`;
+  const originalEntries = checkRefIdProcessed(db, refId);
+
+  if (!originalEntries.exists || !originalEntries.entries?.length) {
+    return { ok: false, error: "no_ledger_entries_to_reverse" };
+  }
+
+  // Build reversal entries — fetch full originals to get from/to
+  const originals = db.prepare(
+    "SELECT * FROM economy_ledger WHERE ref_id = ? AND status = 'complete'"
+  ).all(refId);
+
+  const reversalEntries = originals.map(orig => ({
+    id: generateTxId(),
+    type: "REVERSAL",
+    from: orig.to_user_id,
+    to: orig.from_user_id,
+    amount: orig.net,
+    fee: 0,
+    net: orig.net,
+    status: "complete",
+    refId: correctionRefId,
+    metadata: {
+      batchId,
+      role: "reversal",
+      originalTxId: orig.id,
+      originalType: orig.type,
+      purchaseId: purchase.purchase_id,
+      reason,
+      correctionType: "REVERSAL",
+    },
+  }));
+
+  const doReversal = db.transaction(() => {
+    const dupe = checkRefIdProcessed(db, correctionRefId);
+    if (dupe.exists) return { idempotent: true, entries: dupe.entries };
+
+    const results = recordTransactionBatch(db, reversalEntries);
+
+    // Mark originals as reversed
+    for (const orig of originals) {
+      db.prepare("UPDATE economy_ledger SET status = 'reversed' WHERE id = ?").run(orig.id);
+    }
+
+    return results;
+  });
+
+  try {
+    const results = doReversal();
+    if (results.idempotent) return { ok: true, idempotent: true, entries: results.entries };
+
+    // Transition purchase to REFUNDED
+    transitionPurchase(db, purchase.purchase_id, "REFUNDED", {
+      reason: `REVERSAL: ${reason}`,
+      actor,
+      metadata: { correctionRefId, batchId },
+    });
+
+    economyAudit(db, {
+      action: "correction_reversal",
+      userId: actor,
+      amount: purchase.amount,
+      txId: batchId,
+      details: { purchaseId: purchase.purchase_id, reason, entriesReversed: originals.length },
+    });
+
+    return { ok: true, batchId, entries: results, correctionType: "REVERSAL" };
+  } catch (err) {
+    if (err.message?.includes("UNIQUE constraint")) {
+      return { ok: true, idempotent: true };
+    }
+    return { ok: false, error: "reversal_failed", detail: err.message };
+  }
+}
+
+/**
+ * Create an adjustment entry to fix an incorrect amount on a purchase.
+ */
+function executeAdjustmentCorrection(db, purchase, { correctionRefId, batchId, reason, actor, adjustmentAmount, adjustmentUserId }) {
+  const isCredit = adjustmentAmount > 0;
+  const absAmount = Math.abs(adjustmentAmount);
+
+  const entry = {
+    id: generateTxId(),
+    type: "ADJUSTMENT",
+    from: isCredit ? null : adjustmentUserId,
+    to: isCredit ? adjustmentUserId : null,
+    amount: absAmount,
+    fee: 0,
+    net: absAmount,
+    status: "complete",
+    refId: correctionRefId,
+    metadata: {
+      batchId,
+      role: "adjustment",
+      purchaseId: purchase.purchase_id,
+      reason,
+      correctionType: "ADJUSTMENT",
+      direction: isCredit ? "credit" : "debit",
+    },
+  };
+
+  const doAdjustment = db.transaction(() => {
+    const dupe = checkRefIdProcessed(db, correctionRefId);
+    if (dupe.exists) return { idempotent: true, entries: dupe.entries };
+    return recordTransactionBatch(db, [entry]);
+  });
+
+  try {
+    const results = doAdjustment();
+    if (results.idempotent) return { ok: true, idempotent: true, entries: results.entries };
+
+    economyAudit(db, {
+      action: "correction_adjustment",
+      userId: actor,
+      amount: adjustmentAmount,
+      txId: batchId,
+      details: { purchaseId: purchase.purchase_id, adjustmentUserId, reason },
+    });
+
+    return { ok: true, batchId, entries: results, correctionType: "ADJUSTMENT" };
+  } catch (err) {
+    if (err.message?.includes("UNIQUE constraint")) {
+      return { ok: true, idempotent: true };
+    }
+    return { ok: false, error: "adjustment_failed", detail: err.message };
+  }
+}
+
+/**
+ * Credit the buyer for a failed/disputed purchase (make-good).
+ * Credits the original purchase amount back to the buyer.
+ */
+function executeMakeGoodCorrection(db, purchase, { correctionRefId, batchId, reason, actor }) {
+  const entry = {
+    id: generateTxId(),
+    type: "MAKE_GOOD",
+    from: null,
+    to: purchase.buyer_id,
+    amount: purchase.amount,
+    fee: 0,
+    net: purchase.amount,
+    status: "complete",
+    refId: correctionRefId,
+    metadata: {
+      batchId,
+      role: "make_good",
+      purchaseId: purchase.purchase_id,
+      reason,
+      correctionType: "MAKE_GOOD",
+    },
+  };
+
+  const doMakeGood = db.transaction(() => {
+    const dupe = checkRefIdProcessed(db, correctionRefId);
+    if (dupe.exists) return { idempotent: true, entries: dupe.entries };
+    return recordTransactionBatch(db, [entry]);
+  });
+
+  try {
+    const results = doMakeGood();
+    if (results.idempotent) return { ok: true, idempotent: true, entries: results.entries };
+
+    // Transition purchase to REFUNDED if currently in a disputable state
+    const disputableStates = ["FULFILLED", "DISPUTED", "CHARGEBACK"];
+    if (disputableStates.includes(purchase.status)) {
+      transitionPurchase(db, purchase.purchase_id, "REFUNDED", {
+        reason: `MAKE_GOOD: ${reason}`,
+        actor,
+        metadata: { correctionRefId, batchId },
+      });
+    }
+
+    economyAudit(db, {
+      action: "correction_make_good",
+      userId: actor,
+      amount: purchase.amount,
+      txId: batchId,
+      details: { purchaseId: purchase.purchase_id, buyerId: purchase.buyer_id, reason },
+    });
+
+    return { ok: true, batchId, entries: results, correctionType: "MAKE_GOOD" };
+  } catch (err) {
+    if (err.message?.includes("UNIQUE constraint")) {
+      return { ok: true, idempotent: true };
+    }
+    return { ok: false, error: "make_good_failed", detail: err.message };
+  }
+}
+
+/**
+ * Get a full receipt/breakdown for a purchase.
+ * Combines purchase record, ledger entries, and status history.
+ */
+export function getPurchaseReceipt(db, purchaseId) {
+  const purchase = getPurchase(db, purchaseId);
+  if (!purchase) return { ok: false, error: "purchase_not_found" };
+
+  const refId = purchase.ref_id || `purchase:${purchaseId}`;
+
+  // Get all ledger entries for this purchase
+  let ledgerEntries = [];
+  try {
+    ledgerEntries = db.prepare(
+      "SELECT * FROM economy_ledger WHERE ref_id = ? ORDER BY created_at ASC"
+    ).all(refId);
+  } catch { /* ref_id column may not exist */ }
+
+  // Get correction entries
+  let corrections = [];
+  try {
+    corrections = db.prepare(
+      "SELECT * FROM economy_ledger WHERE ref_id LIKE ? ORDER BY created_at ASC"
+    ).all(`correction:%:${purchaseId}:%`);
+  } catch { /* ignore */ }
+
+  // Get status history
+  let history = [];
+  try {
+    history = db.prepare(
+      "SELECT * FROM purchase_status_history WHERE purchase_id = ? ORDER BY created_at ASC"
+    ).all(purchaseId);
+  } catch { /* table may not exist */ }
+
+  // Build breakdown
+  const breakdown = {
+    grossAmount: purchase.amount,
+    marketplaceFee: purchase.marketplace_fee || 0,
+    totalRoyalties: purchase.total_royalties || 0,
+    sellerNet: purchase.seller_net || 0,
+    royaltyDetails: purchase.royaltyDetails || [],
+  };
+
+  return {
+    ok: true,
+    purchase: {
+      purchaseId: purchase.purchase_id,
+      status: purchase.status,
+      buyerId: purchase.buyer_id,
+      sellerId: purchase.seller_id,
+      listingId: purchase.listing_id,
+      listingType: purchase.listing_type,
+      licenseType: purchase.license_type,
+      amount: purchase.amount,
+      licenseId: purchase.license_id,
+      createdAt: purchase.created_at,
+      updatedAt: purchase.updated_at,
+    },
+    breakdown,
+    ledgerEntries: ledgerEntries.map(e => ({
+      id: e.id,
+      type: e.type,
+      from: e.from_user_id,
+      to: e.to_user_id,
+      amount: e.amount,
+      fee: e.fee,
+      net: e.net,
+      status: e.status,
+      createdAt: e.created_at,
+    })),
+    corrections: corrections.map(e => ({
+      id: e.id,
+      type: e.type,
+      from: e.from_user_id,
+      to: e.to_user_id,
+      amount: e.amount,
+      status: e.status,
+      createdAt: e.created_at,
+    })),
+    history: history.map(h => ({
+      fromStatus: h.from_status,
+      toStatus: h.to_status,
+      reason: h.reason,
+      actor: h.actor,
+      createdAt: h.created_at,
+    })),
+  };
+}
+
+/**
+ * Get a summary of purchases in each state (for admin dashboard).
+ */
+export function getReconciliationSummary(db) {
+  try {
+    const stateCounts = db.prepare(`
+      SELECT status, COUNT(*) as count, COALESCE(SUM(amount), 0) as total_amount
+      FROM purchases
+      GROUP BY status
+      ORDER BY status
+    `).all();
+
+    const recentFailures = db.prepare(`
+      SELECT purchase_id, buyer_id, seller_id, amount, error_message, retry_count, updated_at
+      FROM purchases
+      WHERE status = 'FAILED'
+      ORDER BY updated_at DESC
+      LIMIT 20
+    `).all();
+
+    const stuckPurchases = db.prepare(`
+      SELECT purchase_id, status, amount, updated_at
+      FROM purchases
+      WHERE status IN ('CREATED', 'PAYMENT_PENDING', 'PAID', 'SETTLED')
+        AND updated_at < datetime('now', '-15 minutes')
+      ORDER BY updated_at ASC
+      LIMIT 50
+    `).all();
+
+    return {
+      ok: true,
+      stateCounts: stateCounts.reduce((acc, r) => {
+        acc[r.status] = { count: r.count, totalAmount: Math.round(r.total_amount * 100) / 100 };
+        return acc;
+      }, {}),
+      recentFailures,
+      stuckPurchases,
+      timestamp: new Date().toISOString(),
+    };
+  } catch (err) {
+    return { ok: false, error: "summary_failed", detail: err.message };
+  }
+}

--- a/server/migrations/005_purchases_table.js
+++ b/server/migrations/005_purchases_table.js
@@ -1,0 +1,79 @@
+// migrations/005_purchases_table.js
+// Purchase state machine table — tracks every purchase through its lifecycle.
+// Enables reconciliation, dispute handling, and crash recovery.
+
+export function up(db) {
+  db.exec(`
+    -- Purchase lifecycle state machine.
+    -- Each purchase progresses through states; never deleted, only transitioned.
+    CREATE TABLE IF NOT EXISTS purchases (
+      id              TEXT PRIMARY KEY,
+      purchase_id     TEXT NOT NULL UNIQUE,
+      buyer_id        TEXT NOT NULL,
+      seller_id       TEXT NOT NULL,
+      listing_id      TEXT NOT NULL,
+      listing_type    TEXT,
+      license_type    TEXT,
+      amount          REAL NOT NULL CHECK(amount >= 0),
+      source          TEXT NOT NULL DEFAULT 'artistry',
+
+      status          TEXT NOT NULL DEFAULT 'CREATED' CHECK(status IN (
+        'CREATED','PAYMENT_PENDING','PAID','SETTLED','FULFILLED',
+        'FAILED','REFUNDED','CHARGEBACK','DISPUTED'
+      )),
+
+      -- Settlement references
+      settlement_batch_id TEXT,
+      ref_id              TEXT,
+      license_id          TEXT,
+      stripe_session_id   TEXT,
+      stripe_event_id     TEXT,
+
+      -- Fee/royalty breakdown (snapshot at time of settlement)
+      marketplace_fee     REAL DEFAULT 0,
+      seller_net          REAL DEFAULT 0,
+      total_royalties     REAL DEFAULT 0,
+      royalty_details_json TEXT DEFAULT '[]',
+
+      -- Lifecycle tracking
+      error_message     TEXT,
+      retry_count       INTEGER NOT NULL DEFAULT 0,
+      last_retry_at     TEXT,
+      resolved_by       TEXT,
+      resolved_at       TEXT,
+      resolution_notes  TEXT,
+
+      created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_purchases_buyer    ON purchases(buyer_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_purchases_seller   ON purchases(seller_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_purchases_status   ON purchases(status);
+    CREATE INDEX IF NOT EXISTS idx_purchases_listing  ON purchases(listing_id);
+    CREATE INDEX IF NOT EXISTS idx_purchases_ref      ON purchases(ref_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_purchases_purchase_id ON purchases(purchase_id);
+
+    -- Purchase status history — append-only log of every state transition.
+    CREATE TABLE IF NOT EXISTS purchase_status_history (
+      id          TEXT PRIMARY KEY,
+      purchase_id TEXT NOT NULL,
+      from_status TEXT,
+      to_status   TEXT NOT NULL,
+      reason      TEXT,
+      actor       TEXT,
+      metadata_json TEXT DEFAULT '{}',
+      created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (purchase_id) REFERENCES purchases(purchase_id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_psh_purchase ON purchase_status_history(purchase_id, created_at);
+  `);
+}
+
+export function down(db) {
+  db.exec(`
+    DROP TABLE IF EXISTS purchase_status_history;
+    DROP TABLE IF EXISTS purchases;
+  `);
+}


### PR DESCRIPTION
…surface

- Purchase state machine (CREATED → PAID → SETTLED → FULFILLED → terminal) with enforced transitions, retry tracking, and append-only history log
- Migration 005: purchases table + purchase_status_history table
- Reconciliation engine: scans for stuck purchases, expires stale CREATED, retries stuck PAID/SETTLED, detects orphan ledger entries and mismatches
- Correction patterns: REVERSAL (counter-entries), ADJUSTMENT, MAKE_GOOD — never edits history, always appends
- Support surface: receipt lookup with full breakdown, purchase history, admin refund/adjust/make-good/manual-transition endpoints
- Wired Artistry purchase handler to state machine: creates purchase record, transitions through PAID → SETTLED → FULFILLED on success, FAILED on error
- Admin reconciliation endpoints: run sweep, view summary, query by status

https://claude.ai/code/session_01LH1cy2qH6UoEMvckgN5pmc