### PR TITLE
Harden server reliability and fix frontend crash bugs

### DIFF
--- a/concord-frontend/app/lenses/marketplace/page.tsx
+++ b/concord-frontend/app/lenses/marketplace/page.tsx
@@ -587,6 +587,11 @@ export default function MarketplaceLensPage() {
     setCheckoutLoading(false);
   }, [cart, checkoutLoading]);
 
+  // Clamp carousel index when featured items change
+  useEffect(() => {
+    setFeaturedIdx(i => (featuredItems.length === 0 ? 0 : Math.min(i, featuredItems.length - 1)));
+  }, [featuredItems.length]);
+
   // Featured carousel auto-advance
   useEffect(() => {
     if (featuredItems.length <= 1) return;
@@ -662,7 +667,7 @@ export default function MarketplaceLensPage() {
       {tab === 'browse' && (
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-6">
           {/* Hero / Featured Carousel */}
-          {featuredItems.length > 0 && (
+          {featuredItems.length > 0 && featuredItems[featuredIdx] && (
             <div className="relative panel p-0 overflow-hidden rounded-xl">
               <AnimatePresence mode="wait">
                 <motion.div key={featuredIdx} initial={{ opacity: 0, x: 40 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, x: -40 }} transition={{ duration: 0.35 }}


### PR DESCRIPTION
- Wrap all async route handlers to catch unhandled rejections (prevents 58+ routes from hanging on errors)
- Fix malformed /api/chat/stream: move chicken3/status and session/optin routes out of stream handler
- Add null guards for bcrypt/JWT in register and login (prevents unusable accounts and null cookies)
- Register missing macros: lattice:resonance, persona:speak, persona:animate
- Remove duplicate express.json() middleware (conflicting 2mb vs 10mb limits)
- Cap _PATTERN_HISTORY at 10k entries to prevent memory leak
- Fix marketplace carousel array bounds crash when featured items change
- Clamp carousel index on featured items length change

https://claude.ai/code/session_01WN5qcoyB2uzcQgMBStaWyJ