### PR TITLE
Harden production readiness: fix 30+ audit findings across security, resilience, and ops

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,13 +66,10 @@ LLM_ENABLED=true
 # SECURITY (CRITICAL - Must configure for production)
 # ============================================
 
-# REQUIRED: JWT secret for token signing (generate with: openssl rand -hex 64)
-# WARNING: If not set, tokens will be invalidated on server restart!
-JWT_SECRET=
+# NOTE: JWT_SECRET and ADMIN_PASSWORD are defined at the top of this file (lines 9, 12).
+# Do NOT set them again here — duplicate definitions cause confusion.
 
-# REQUIRED: Admin password for initial admin account (minimum 12 characters)
-# WARNING: Server will not create admin account without this!
-ADMIN_PASSWORD=
+# (JWT_SECRET and ADMIN_PASSWORD — see REQUIRED section at the top)
 
 # Enable authentication (defaults to true in production)
 AUTH_ENABLED=true
@@ -174,8 +171,13 @@ FRONTEND_URL=https://yourdomain.com
 # MIN_WITHDRAW_TOKENS=20
 # MAX_WITHDRAW_TOKENS_PER_DAY=5000
 
-# Founder secret for admin economy operations (optional, ops backdoor)
-# FOUNDER_SECRET=your_strong_secret_here
+# Founder secret for emergency admin economy operations (optional).
+# SECURITY: When set, allows bypassing normal approval flow for critical economy fixes
+# (e.g., reversing erroneous transactions, emergency balance corrections).
+# All operations gated by this secret are audit-logged with the caller's IP and timestamp.
+# Generate with: openssl rand -hex 32
+# WARNING: Treat this like a root password. Rotate after every use.
+# FOUNDER_SECRET=
 
 # ============================================
 # MONITORING (Required for docker-compose)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,8 +135,8 @@ jobs:
             NPM_CONFIG_FETCH_RETRIES=5
             NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=20000
             NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000
-            CI_SKIP_TYPECHECK=1
-            CI_SKIP_LINT_IN_BUILD=1
+            CI_SKIP_TYPECHECK=0
+            CI_SKIP_LINT_IN_BUILD=0
 
   smoke-test:
     name: Smoke Test (Everything Real)

--- a/concord-frontend/lib/realtime/socket.ts
+++ b/concord-frontend/lib/realtime/socket.ts
@@ -75,12 +75,20 @@ export function getSocket(): Socket {
 }
 
 // Reconnect with fresh credentials (call after login)
+// Debounced to prevent reconnect storms from rapid network flaps
+let _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+const RECONNECT_DEBOUNCE_MS = 2000;
+
 export function reconnectSocket(): void {
-  if (socket) {
-    socket.disconnect();
-    socket.auth = getAuthCredentials();
-    socket.connect();
-  }
+  if (_reconnectTimer) clearTimeout(_reconnectTimer);
+  _reconnectTimer = setTimeout(() => {
+    _reconnectTimer = null;
+    if (socket) {
+      socket.disconnect();
+      socket.auth = getAuthCredentials();
+      socket.connect();
+    }
+  }, RECONNECT_DEBOUNCE_MS);
 }
 
 export function connectSocket(): void {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,11 @@ services:
       dockerfile: Dockerfile
     container_name: concord-backend
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    read_only: false  # Data dir needs writes; consider tmpfs for /tmp
+    tmpfs:
+      - /tmp:noexec,nosuid,size=100M
     environment:
       - NODE_ENV=production
       - PORT=5050
@@ -91,6 +96,8 @@ services:
     image: nginx:alpine
     container_name: concord-nginx
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
     ports:
       - "80:80"
       - "443:443"

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -44,10 +44,10 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' wss: ws:; frame-ancestors 'self'; base-uri 'self'; form-action 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' wss: ws:; frame-ancestors 'self'; base-uri 'self'; form-action 'self';" always;
 
-    # Max upload size
-    client_max_body_size 100M;
+    # Max upload size — aligned with backend Express limit (10mb JSON + overhead)
+    client_max_body_size 25M;
 
     # API proxy
     location /api/ {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -42,8 +42,8 @@ http {
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
 
     # Content Security Policy - prevents XSS, injection attacks
-    # Adjust script-src and style-src based on your needs (e.g., add CDN domains)
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' wss: ws:; frame-ancestors 'self'; base-uri 'self'; form-action 'self';" always;
+    # NOTE: unsafe-eval removed for production security. unsafe-inline kept for Next.js hydration.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' wss: ws:; frame-ancestors 'self'; base-uri 'self'; form-action 'self';" always;
 
     # Rate limiting
     limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,6 @@
 # Backend Dockerfile (glibc-based for onnxruntime compatibility)
-FROM node:20-bookworm-slim
+# Pin to Node 20 LTS for reproducibility
+FROM node:20-bookworm-slim AS base
 
 # Install build tools for native modules (better-sqlite3) and runtime deps
 RUN apt-get update && apt-get install -y \
@@ -39,6 +40,6 @@ USER concord
 EXPOSE 5050
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-  CMD curl -f http://localhost:5050/api/status || exit 1
+  CMD curl -f http://localhost:5050/health || exit 1
 
 CMD ["node", "server.js"]

--- a/server/economy/stripe.js
+++ b/server/economy/stripe.js
@@ -140,6 +140,12 @@ export async function handleWebhook(db, { rawBody, signature, requestId, ip }) {
   const stripeClient = await getStripe();
   if (!stripeClient) return { ok: false, error: "stripe_not_configured" };
 
+  // Guard: webhook secret must be configured for signature verification to work
+  if (!STRIPE_WEBHOOK_SECRET) {
+    console.error("[Stripe Webhook] STRIPE_WEBHOOK_SECRET is not configured — rejecting webhook");
+    return { ok: false, error: "webhook_secret_not_configured" };
+  }
+
   let event;
   try {
     event = stripeClient.webhooks.constructEvent(rawBody, signature, STRIPE_WEBHOOK_SECRET);


### PR DESCRIPTION
CRITICAL fixes:
- Reject CORS requests in production when ALLOWED_ORIGINS is not configured
- Remove 'unsafe-eval' from CSP in Nginx and Helmet (XSS protection)
- Fix graceful shutdown timeout capped at 1s (was Math.min, now uses full timeout)
- Crash on unhandled rejection in production (prevents corrupted state)
- Remove duplicate SIGINT handler that referenced potentially-null server
- Crash on startup if security deps (jwt, bcrypt, helmet, rate-limit) fail in production
- Guard Stripe webhook endpoint when STRIPE_WEBHOOK_SECRET is not configured

HIGH fixes:
- Add CircuitBreaker class for external service calls (Ollama, OpenAI, Stripe)
- Wire circuit breaker into Ollama vision call with 60s AbortSignal timeout
- Replace 40+ silent empty catch blocks with structured warn/error logging
- Add overlap guard to auto-promotion scheduler (prevents concurrent runs)
- Fix N+1 query in studio project load (batch fetch clips/effects with IN clause)
- Add size caps to marketplace abuse Maps (50k seller, 100k trade entries)
- Add exponential backoff retry (3x) for 502/503/504 in frontend API client
- Debounce WebSocket reconnect (2s) to prevent reconnect storms

MEDIUM fixes:
- Health endpoint now checks database connectivity and memory pressure
- Readiness endpoint verifies database is queryable
- Redact API key from stdout in production (writes to secure file instead)
- Fix floating-point drift in economy balances (integer cents arithmetic)
- Document FOUNDER_SECRET with security guidance, remove "ops backdoor" label
- Deduplicate JWT_SECRET/ADMIN_PASSWORD in .env.example
- Reduce Nginx client_max_body_size from 100M to 25M (aligned with backend)
- Enable TypeScript and lint checks in CI Docker builds (was skipped)
- Add no-new-privileges and tmpfs security options to Docker containers
- Backend Dockerfile healthcheck now hits /health instead of /api/status

https://claude.ai/code/session_01KhdsBcSxnM6dS4t3FYt851