### PR TITLE
Integrate frontend-backend: wire all placeholder UI to real API logic

### DIFF
--- a/concord-frontend/app/lenses/billing/page.tsx
+++ b/concord-frontend/app/lenses/billing/page.tsx
@@ -147,8 +147,8 @@ export default function BillingPage() {
               '100 tokens/month',
             ]}
             current={wallet?.tier === 'free'}
-            onSelect={() => {}}
-            disabled={true}
+            onSelect={() => subscribeMutation.mutate('free')}
+            disabled={wallet?.tier === 'free'}
           />
 
           {/* Pro Tier */}

--- a/concord-frontend/app/lenses/council/page.tsx
+++ b/concord-frontend/app/lenses/council/page.tsx
@@ -515,6 +515,9 @@ export default function CouncilLensPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['dtus'] });
     },
+    onError: (err) => {
+      console.error('Debate failed:', err instanceof Error ? err.message : err);
+    },
   });
 
   const { isError, error, refetch, items: _proposalArtifacts, create: _createProposal } = useLensData('council', 'proposal', { noSeed: true });

--- a/concord-frontend/app/lenses/database/page.tsx
+++ b/concord-frontend/app/lenses/database/page.tsx
@@ -394,10 +394,16 @@ export default function DatabaseLensPage() {
   const migrateMutation = useMutation({
     mutationFn: () => api.post('/api/db/migrate', {}),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['db-tables'] }),
+    onError: (err) => {
+      console.error('Migration failed:', err instanceof Error ? err.message : err);
+    },
   });
 
   const syncMutation = useMutation({
     mutationFn: () => api.post('/api/db/sync', { batchSize: 100 }),
+    onError: (err) => {
+      console.error('Sync failed:', err instanceof Error ? err.message : err);
+    },
   });
 
   const executeQuery = useMutation({

--- a/concord-frontend/app/lenses/timeline/page.tsx
+++ b/concord-frontend/app/lenses/timeline/page.tsx
@@ -88,6 +88,8 @@ export default function TimelineLensPage() {
 
   const [_newPost, setNewPost] = useState('');
   const [showReactions, setShowReactions] = useState<string | null>(null);
+  const [showPostModal, setShowPostModal] = useState(false);
+  const [postContent, setPostContent] = useState('');
 
   const { data: posts, isLoading, isError: isError, error: error, refetch: refetch,} = useQuery({
     queryKey: ['timeline-posts'],
@@ -137,13 +139,23 @@ export default function TimelineLensPage() {
     ] as Story[]),
   });
 
-  const _postMutation = useMutation({
+  const postMutation = useMutation({
     mutationFn: (content: string) => api.post('/api/dtus', { content, tags: ['timeline'] }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['timeline-posts'] });
       setNewPost('');
+      setPostContent('');
+      setShowPostModal(false);
+    },
+    onError: (err) => {
+      console.error('Failed to create post:', err instanceof Error ? err.message : err);
     },
   });
+
+  const handleCreatePost = () => {
+    if (!postContent.trim() || postMutation.isPending) return;
+    postMutation.mutate(postContent.trim());
+  };
 
   const formatTime = (dateStr: string) => {
     const date = new Date(dateStr);
@@ -274,9 +286,9 @@ export default function TimelineLensPage() {
               <div className="w-10 h-10 rounded-full bg-gradient-to-br from-blue-500 to-purple-500 flex-shrink-0" />
               <button
                 className="flex-1 px-4 py-2.5 bg-[#3a3b3c] rounded-full text-left text-gray-400 hover:bg-[#4a4b4c] transition-colors"
-                onClick={() => {}}
+                onClick={() => setShowPostModal(true)}
               >
-                What's on your mind?
+                What&apos;s on your mind?
               </button>
             </div>
             <div className="flex items-center justify-between mt-3 pt-3 border-t border-gray-700">
@@ -487,6 +499,63 @@ export default function TimelineLensPage() {
           </div>
         </aside>
       </div>
+
+      {/* Create Post Modal */}
+      <AnimatePresence>
+        {showPostModal && (
+          <motion.div
+            initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+            onClick={() => setShowPostModal(false)}
+          >
+            <motion.div
+              initial={{ scale: 0.95, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.95, opacity: 0 }}
+              className="bg-[#242526] border border-gray-700 rounded-xl w-full max-w-lg p-6 space-y-4"
+              onClick={e => e.stopPropagation()}
+            >
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-bold text-white">Create Post</h3>
+                <button onClick={() => setShowPostModal(false)} className="text-gray-400 hover:text-white">
+                  <MoreHorizontal className="w-5 h-5" />
+                </button>
+              </div>
+              <div className="flex gap-3 items-start">
+                <div className="w-10 h-10 rounded-full bg-gradient-to-br from-blue-500 to-purple-500 flex-shrink-0" />
+                <textarea
+                  value={postContent}
+                  onChange={e => setPostContent(e.target.value)}
+                  placeholder="What's on your mind?"
+                  rows={4}
+                  autoFocus
+                  className="flex-1 bg-transparent text-white placeholder-gray-500 outline-none resize-none text-lg"
+                />
+              </div>
+              <div className="flex items-center justify-between pt-3 border-t border-gray-700">
+                <div className="flex items-center gap-2">
+                  <button className="p-2 rounded-lg hover:bg-[#3a3b3c] text-green-500 transition-colors">
+                    <ImageIcon className="w-5 h-5" />
+                  </button>
+                  <button className="p-2 rounded-lg hover:bg-[#3a3b3c] text-yellow-500 transition-colors">
+                    <Smile className="w-5 h-5" />
+                  </button>
+                </div>
+                <button
+                  onClick={handleCreatePost}
+                  disabled={!postContent.trim() || postMutation.isPending}
+                  className={cn(
+                    'px-6 py-2 rounded-lg font-medium text-sm transition-colors',
+                    postContent.trim() && !postMutation.isPending
+                      ? 'bg-blue-600 text-white hover:bg-blue-700'
+                      : 'bg-gray-700 text-gray-500 cursor-not-allowed'
+                  )}
+                >
+                  {postMutation.isPending ? 'Posting...' : 'Post'}
+                </button>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }


### PR DESCRIPTION
- Chat: add error handling on sendMutation, implement regenerate button
  with full re-send of last user message and response replacement
- Voice: fix empty Blob in saveMutation (now passes actual audio data),
  wire skip forward/back buttons to navigate between takes, add onError
- Marketplace: wire Publish Listing form with controlled inputs, form
  state, API submission to /api/marketplace/submit, error display, and
  loading states; invalidates queries on success
- Council: add onError handler to debateMutation
- Database: add onError handlers to migrateMutation and syncMutation
- Timeline: wire "What's on your mind?" button to open post creation
  modal with textarea, submit handler calling /api/dtus, loading state
- Billing: make Free tier dynamically disabled only when already on
  free tier instead of unconditionally hardcoded disabled
- Game: connect profile/leaderboard to backend API with useQuery,
  replace all INITIAL_PROFILE references with live profile data,
  replace INITIAL_XP_HISTORY with API xpHistory, add onError to
  completeQuestMutation

https://claude.ai/code/session_01Cdp2vBCtrKyG6UXYH2b2Y3