### PR TITLE
Wire up remaining disconnected frontend features to backend APIs

### DIFF
--- a/concord-frontend/app/lenses/attention/page.tsx
+++ b/concord-frontend/app/lenses/attention/page.tsx
@@ -55,6 +55,9 @@ export default function AttentionLensPage() {
       queryClient.invalidateQueries({ queryKey: ['attention-status'] });
       setNewDesc('');
     },
+    onError: (err) => {
+      console.error('Failed to create thread:', err instanceof Error ? err.message : err);
+    },
   });
 
   const completeThread = useMutation({
@@ -62,6 +65,9 @@ export default function AttentionLensPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['attention-threads'] });
       queryClient.invalidateQueries({ queryKey: ['attention-status'] });
+    },
+    onError: (err) => {
+      console.error('Failed to complete thread:', err instanceof Error ? err.message : err);
     },
   });
 

--- a/concord-frontend/app/lenses/billing/page.tsx
+++ b/concord-frontend/app/lenses/billing/page.tsx
@@ -17,7 +17,7 @@ interface TokenPackage {
 }
 
 export default function BillingPage() {
-  const _queryClient = useQueryClient();
+  const queryClient = useQueryClient();
   const [selectedPackage, setSelectedPackage] = useState<string | null>(null);
 
   // Get economic config
@@ -45,6 +45,8 @@ export default function BillingPage() {
     onSuccess: (data) => {
       if (data.url) {
         window.location.href = data.url;
+      } else {
+        queryClient.invalidateQueries({ queryKey: ['wallet'] });
       }
     },
     onError: (err) => {
@@ -62,6 +64,9 @@ export default function BillingPage() {
     onSuccess: (data) => {
       if (data.url) {
         window.location.href = data.url;
+      } else {
+        queryClient.invalidateQueries({ queryKey: ['wallet'] });
+        queryClient.invalidateQueries({ queryKey: ['economic-config'] });
       }
     },
     onError: (err) => {
@@ -69,7 +74,7 @@ export default function BillingPage() {
     },
   });
 
-  const _tiers = config?.tiers || {};
+  const tiers = config?.tiers || {};
   const tokenPackages = config?.tokenPackages || [];
 
 

--- a/concord-frontend/components/search/GlobalSearch.tsx
+++ b/concord-frontend/components/search/GlobalSearch.tsx
@@ -45,6 +45,9 @@ export function GlobalSearch({ isOpen, onClose, onSelect }: GlobalSearchProps) {
   const [scope, setScope] = useState<SearchScope>('all');
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
   const [showFilters, setShowFilters] = useState(false);
+  const [filterTier, setFilterTier] = useState('');
+  const [filterDate, setFilterDate] = useState('');
+  const [filterSort, setFilterSort] = useState('relevance');
 
   const inputRef = useRef<HTMLInputElement>(null);
   const resultsRef = useRef<HTMLDivElement>(null);
@@ -79,9 +82,11 @@ export function GlobalSearch({ isOpen, onClose, onSelect }: GlobalSearchProps) {
     const searchTimeout = setTimeout(async () => {
       setLoading(true);
       try {
-        const res = await api.get('/api/global/search', {
-          params: { q: query, scope, limit: 20 }
-        });
+        const params: Record<string, string | number> = { q: query, scope, limit: 20 };
+        if (filterTier) params.tier = filterTier;
+        if (filterDate) params.dateRange = filterDate;
+        if (filterSort && filterSort !== 'relevance') params.sort = filterSort;
+        const res = await api.get('/api/global/search', { params });
         const data = res.data;
         if (data.ok && Array.isArray(data.results)) {
           setResults(data.results);
@@ -97,7 +102,7 @@ export function GlobalSearch({ isOpen, onClose, onSelect }: GlobalSearchProps) {
     }, 300);
 
     return () => clearTimeout(searchTimeout);
-  }, [query, scope]);
+  }, [query, scope, filterTier, filterDate, filterSort]);
 
   const handleSelect = useCallback((result: SearchResult) => {
     // Save to recent searches
@@ -258,7 +263,7 @@ export function GlobalSearch({ isOpen, onClose, onSelect }: GlobalSearchProps) {
                     <div className="p-4 grid grid-cols-3 gap-4">
                       <div>
                         <label className="text-xs text-gray-500 block mb-1">Tier</label>
-                        <select className="w-full bg-lattice-surface border border-lattice-border rounded px-2 py-1.5 text-sm text-white">
+                        <select value={filterTier} onChange={(e) => setFilterTier(e.target.value)} className="w-full bg-lattice-surface border border-lattice-border rounded px-2 py-1.5 text-sm text-white">
                           <option value="">All tiers</option>
                           <option value="regular">Regular</option>
                           <option value="mega">Mega</option>
@@ -267,7 +272,7 @@ export function GlobalSearch({ isOpen, onClose, onSelect }: GlobalSearchProps) {
                       </div>
                       <div>
                         <label className="text-xs text-gray-500 block mb-1">Date range</label>
-                        <select className="w-full bg-lattice-surface border border-lattice-border rounded px-2 py-1.5 text-sm text-white">
+                        <select value={filterDate} onChange={(e) => setFilterDate(e.target.value)} className="w-full bg-lattice-surface border border-lattice-border rounded px-2 py-1.5 text-sm text-white">
                           <option value="">Any time</option>
                           <option value="today">Today</option>
                           <option value="week">This week</option>
@@ -276,7 +281,7 @@ export function GlobalSearch({ isOpen, onClose, onSelect }: GlobalSearchProps) {
                       </div>
                       <div>
                         <label className="text-xs text-gray-500 block mb-1">Sort by</label>
-                        <select className="w-full bg-lattice-surface border border-lattice-border rounded px-2 py-1.5 text-sm text-white">
+                        <select value={filterSort} onChange={(e) => setFilterSort(e.target.value)} className="w-full bg-lattice-surface border border-lattice-border rounded px-2 py-1.5 text-sm text-white">
                           <option value="relevance">Relevance</option>
                           <option value="recent">Most recent</option>
                           <option value="resonance">Resonance</option>


### PR DESCRIPTION
Game lens:
- Replace hardcoded empty quests/achievements arrays with useQuery calls to /api/game/challenges and /api/game/achievements endpoints
- Use optimistic UI pattern (local overrides) for quest accept/complete and achievement unlock so state persists through API refetches
- Fix achievement count display to use effectiveAchievements

Search:
- Add state management for tier/date/sort filter controls in GlobalSearch
- Wire filter values into API params (tier, dateRange, sort)
- Add onChange handlers to all three filter select elements

Attention lens:
- Add onError handlers to createThread and completeThread mutations

Backend:
- Add GET /api/economic/config returning TIERS and TOKEN_PACKAGES (billing page was calling this with no endpoint)
- Add GET /api/economic/wallet/:odId returning balance, tier, usage (billing page wallet display was calling this with no endpoint)
- Add GET /api/artistry/marketplace/art returning filtered artwork assets (art lens marketplace tab was calling this with no endpoint)

https://claude.ai/code/session_01Cdp2vBCtrKyG6UXYH2b2Y3