### PR TITLE
Add auth middleware, PWA support, CSP headers, and production hardening

### DIFF
--- a/concord-frontend/app/manifest.json
+++ b/concord-frontend/app/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "Concord OS",
+  "name": "Concord Cognitive Engine",
   "short_name": "Concord",
-  "description": "Concord Cognitive Engine - 25 Lens Empire Platform",
+  "description": "Sovereign cognitive engine with 5 core workspaces: Chat, Board, Graph, Code, Studio",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#0a0a0f",
@@ -9,14 +9,14 @@
   "orientation": "portrait-primary",
   "icons": [
     {
-      "src": "/icons/icon-192x192.png",
+      "src": "/icons/icon-192x192.svg",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/svg+xml"
     },
     {
-      "src": "/icons/icon-512x512.png",
+      "src": "/icons/icon-512x512.svg",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/svg+xml"
     }
   ],
   "categories": ["productivity", "utilities", "education"]

--- a/concord-frontend/components/shell/AppShell.tsx
+++ b/concord-frontend/components/shell/AppShell.tsx
@@ -21,6 +21,13 @@ export function AppShell({ children }: AppShellProps) {
 
   useEffect(() => {
     setMounted(true);
+
+    // Register service worker for PWA support
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/sw.js').catch(() => {
+        // SW registration failed — offline caching won't work
+      });
+    }
   }, []);
 
   useEffect(() => {
@@ -39,7 +46,12 @@ export function AppShell({ children }: AppShellProps) {
   }, [commandPaletteOpen, setCommandPaletteOpen]);
 
   if (!mounted) {
-    return null;
+    // Minimal shell during hydration to prevent CLS flash
+    return (
+      <div className="flex h-screen overflow-hidden bg-lattice-void">
+        <div className="flex-1" />
+      </div>
+    );
   }
 
   // Full page mode: render children without shell chrome (for landing page, etc.)

--- a/concord-frontend/components/shell/Sidebar.tsx
+++ b/concord-frontend/components/shell/Sidebar.tsx
@@ -7,7 +7,7 @@
  * Hub link, and a collapsible Extensions section.
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, memo } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useUIStore } from '@/store/ui';
@@ -199,7 +199,7 @@ export function Sidebar() {
 }
 
 /** Core lens nav item with expandable absorbed sub-lenses */
-function CoreLensNavItem({
+const CoreLensNavItem = memo(function CoreLensNavItem({
   core,
   pathname,
   showLabel,
@@ -279,10 +279,10 @@ function CoreLensNavItem({
       )}
     </div>
   );
-}
+});
 
 /** Collapsible list of extension lenses */
-function ExtensionsList({ pathname }: { pathname: string }) {
+const ExtensionsList = memo(function ExtensionsList({ pathname }: { pathname: string }) {
   const extensions = getExtensionLenses();
 
   // Group by category for display, but keep it compact
@@ -327,4 +327,4 @@ function ExtensionsList({ pathname }: { pathname: string }) {
       </Link>
     </div>
   );
-}
+});

--- a/concord-frontend/middleware.ts
+++ b/concord-frontend/middleware.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+/**
+ * Auth middleware — enforces authentication at the routing layer.
+ *
+ * Checks for the presence of the session cookie (set by the backend on login).
+ * If missing on a protected route, redirects to /login.
+ * Public routes (login, register, landing, API, static assets) are allowed through.
+ */
+
+const PUBLIC_PATHS = new Set([
+  '/',
+  '/login',
+  '/register',
+  '/forgot-password',
+]);
+
+const PUBLIC_PREFIXES = [
+  '/api/',
+  '/_next/',
+  '/icons/',
+  '/manifest.json',
+  '/robots.txt',
+  '/favicon.ico',
+];
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Allow public paths through
+  if (PUBLIC_PATHS.has(pathname)) {
+    return NextResponse.next();
+  }
+
+  // Allow public prefixes through
+  if (PUBLIC_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
+    return NextResponse.next();
+  }
+
+  // Check for session cookie (httpOnly cookie set by backend on login)
+  // The backend sets either 'concord_session' or 'token' cookie
+  const hasSession =
+    request.cookies.has('concord_session') ||
+    request.cookies.has('token') ||
+    request.cookies.has('connect.sid');
+
+  if (!hasSession) {
+    const loginUrl = new URL('/login', request.url);
+    loginUrl.searchParams.set('from', pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all paths except static files and images.
+     * This ensures middleware runs on page navigations but not on
+     * static asset requests (which Next.js handles separately).
+     */
+    '/((?!_next/static|_next/image|favicon.ico|icons/).*)',
+  ],
+};

--- a/concord-frontend/next.config.js
+++ b/concord-frontend/next.config.js
@@ -6,7 +6,7 @@ const nextConfig = {
     domains: ['localhost', 'concord-os.org'],
     unoptimized: process.env.NODE_ENV === 'development',
   },
-  // PWA configuration
+  // Security + PWA headers
   async headers() {
     return [
       {
@@ -24,6 +24,34 @@ const nextConfig = {
             key: 'X-XSS-Protection',
             value: '1; mode=block',
           },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Content-Security-Policy',
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
+              "style-src 'self' 'unsafe-inline'",
+              `connect-src 'self' ${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5050'} ${process.env.NEXT_PUBLIC_SOCKET_URL || 'ws://localhost:5050'} ws: wss:`,
+              "img-src 'self' data: blob:",
+              "font-src 'self' data:",
+              "media-src 'self' blob:",
+              "worker-src 'self' blob:",
+              "frame-src 'none'",
+              "object-src 'none'",
+              "base-uri 'self'",
+            ].join('; '),
+          },
+        ],
+      },
+      {
+        // Allow service worker to control the entire scope
+        source: '/sw.js',
+        headers: [
+          { key: 'Service-Worker-Allowed', value: '/' },
+          { key: 'Cache-Control', value: 'no-cache' },
         ],
       },
     ];

--- a/concord-frontend/public/favicon.svg
+++ b/concord-frontend/public/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0a0e1a"/>
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#06b6d4"/>
+      <stop offset="100%" stop-color="#3b82f6"/>
+    </linearGradient>
+  </defs>
+  <path d="M10 16 L16 22 L22 16" fill="none" stroke="url(#g)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="16" cy="11" r="5" fill="none" stroke="url(#g)" stroke-width="2"/>
+</svg>

--- a/concord-frontend/public/icons/icon-192x192.svg
+++ b/concord-frontend/public/icons/icon-192x192.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="32" fill="#0a0e1a"/>
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#06b6d4"/>
+      <stop offset="100%" stop-color="#3b82f6"/>
+    </linearGradient>
+  </defs>
+  <circle cx="96" cy="76" r="28" fill="none" stroke="url(#g)" stroke-width="4"/>
+  <path d="M68 76 C68 60, 124 60, 124 76" fill="none" stroke="url(#g)" stroke-width="3" opacity="0.6"/>
+  <path d="M58 96 C58 70, 134 70, 134 96" fill="none" stroke="url(#g)" stroke-width="2" opacity="0.3"/>
+  <path d="M72 108 L96 130 L120 108" fill="none" stroke="url(#g)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="72" cy="108" r="4" fill="#06b6d4"/>
+  <circle cx="96" cy="130" r="4" fill="#8b5cf6"/>
+  <circle cx="120" cy="108" r="4" fill="#3b82f6"/>
+  <text x="96" y="160" text-anchor="middle" font-family="system-ui,sans-serif" font-size="16" font-weight="700" fill="white">CONCORD</text>
+</svg>

--- a/concord-frontend/public/icons/icon-512x512.svg
+++ b/concord-frontend/public/icons/icon-512x512.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="80" fill="#0a0e1a"/>
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#06b6d4"/>
+      <stop offset="100%" stop-color="#3b82f6"/>
+    </linearGradient>
+  </defs>
+  <circle cx="256" cy="196" r="72" fill="none" stroke="url(#g)" stroke-width="8"/>
+  <path d="M184 196 C184 152, 328 152, 328 196" fill="none" stroke="url(#g)" stroke-width="6" opacity="0.6"/>
+  <path d="M148 256 C148 180, 364 180, 364 256" fill="none" stroke="url(#g)" stroke-width="4" opacity="0.3"/>
+  <path d="M192 290 L256 350 L320 290" fill="none" stroke="url(#g)" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="192" cy="290" r="10" fill="#06b6d4"/>
+  <circle cx="256" cy="350" r="10" fill="#8b5cf6"/>
+  <circle cx="320" cy="290" r="10" fill="#3b82f6"/>
+  <text x="256" y="420" text-anchor="middle" font-family="system-ui,sans-serif" font-size="42" font-weight="700" fill="white">CONCORD</text>
+</svg>

--- a/concord-frontend/public/sw.js
+++ b/concord-frontend/public/sw.js
@@ -1,0 +1,97 @@
+/**
+ * Concord Service Worker — caches the app shell for offline support.
+ *
+ * Strategy:
+ * - App shell (HTML, CSS, JS): Cache-first with network update
+ * - API calls: Network-first with cache fallback
+ * - Static assets: Cache-first
+ */
+
+const CACHE_NAME = 'concord-v1';
+const SHELL_ASSETS = [
+  '/',
+  '/login',
+  '/hub',
+];
+
+// Install: pre-cache the app shell
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => {
+      return cache.addAll(SHELL_ASSETS).catch(() => {
+        // Some assets may fail during first install — that's OK
+        console.warn('[SW] Some shell assets failed to cache during install');
+      });
+    })
+  );
+  // Activate immediately without waiting for existing clients to close
+  self.skipWaiting();
+});
+
+// Activate: clean up old caches
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key !== CACHE_NAME)
+          .map((key) => caches.delete(key))
+      )
+    )
+  );
+  // Take control of all clients immediately
+  self.clients.claim();
+});
+
+// Fetch: network-first for API, cache-first for assets
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Skip non-GET requests
+  if (request.method !== 'GET') return;
+
+  // Skip WebSocket upgrades and chrome-extension requests
+  if (url.protocol === 'ws:' || url.protocol === 'wss:' || url.protocol === 'chrome-extension:') return;
+
+  // API calls: network-first
+  if (url.pathname.startsWith('/api/')) {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          // Cache successful GET responses for offline fallback
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+          }
+          return response;
+        })
+        .catch(() => {
+          return caches.match(request).then((cached) => {
+            return cached || new Response(JSON.stringify({ ok: false, error: 'Offline' }), {
+              status: 503,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          });
+        })
+    );
+    return;
+  }
+
+  // Static assets and pages: cache-first with network update
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      const networkFetch = fetch(request)
+        .then((response) => {
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+          }
+          return response;
+        })
+        .catch(() => cached);
+
+      return cached || networkFetch;
+    })
+  );
+});


### PR DESCRIPTION
- Auth middleware (middleware.ts): gate protected routes, redirect to /login?from=path
- Topbar: user menu dropdown with logout (clears session, disconnects socket)
- Login: redirect-after-login via ?from param, connect socket on success
- Providers: mount PermissionProvider, connect socket globally on auth
- AppShell: service worker registration, hydration flash fix
- PWA: service worker (cache-first assets, network-first API), SVG icons, manifest
- next.config.js: CSP header, Referrer-Policy, SW route headers
- Chat lens: mobile responsive sidebar with overlay/backdrop, full ARIA semantics
- Sidebar: React.memo on CoreLensNavItem and ExtensionsList

https://claude.ai/code/session_01Cdp2vBCtrKyG6UXYH2b2Y3