### PR TITLE
fix: restore frontend interactivity and upgrade dashboard UX

### DIFF
--- a/concord-frontend/app/hub/page.tsx
+++ b/concord-frontend/app/hub/page.tsx
@@ -1,257 +1,330 @@
 'use client';
 
 /**
- * Lens Hub — Redesigned for Core 5 + Extensions model.
+ * Lens Explorer — Full ecosystem view of all 106+ lenses.
  *
- * Shows the 5 core lenses as hero cards with their absorbed sub-lenses,
- * then a collapsible Extensions section for everything else.
- * Search works across all lenses for discoverability via Cmd+K.
+ * Designed to feel like opening a city, not picking from a menu.
+ * Searchable, categorized grid showing the SCALE of what's available.
  */
 
 import { useState, useMemo } from 'react';
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import {
   CORE_LENSES,
-  getAbsorbedLenses,
-  getExtensionLenses,
-  type LensEntry,
-  type CoreLensConfig,
+  LENS_REGISTRY,
   LENS_CATEGORIES,
+  getAbsorbedLenses,
+  type LensEntry,
   type LensCategory,
+  type CoreLensConfig,
 } from '@/lib/lens-registry';
 import { cn } from '@/lib/utils';
-import { ds } from '@/lib/design-system';
-import { Search, X, ChevronDown, Puzzle, ArrowRight } from 'lucide-react';
+import {
+  Search, X, ArrowRight, Sparkles, Grid3X3, LayoutGrid,
+} from 'lucide-react';
 
-const EXTENSION_CATEGORIES: LensCategory[] = [
-  'core', 'system', 'governance', 'science', 'ai', 'specialized', 'superlens',
+/** Display order for categories in the explorer */
+const CATEGORY_ORDER: LensCategory[] = [
+  'core', 'knowledge', 'creative', 'ai', 'science', 'governance', 'system', 'specialized', 'superlens',
 ];
 
+/** Friendly descriptions for each category */
+const CATEGORY_DESCRIPTIONS: Partial<Record<LensCategory, string>> = {
+  core: 'Primary workspaces — your daily tools',
+  knowledge: 'Capture, organize, and retrieve knowledge',
+  creative: 'Art, music, games, and generative tools',
+  ai: 'Machine learning, reasoning, and cognitive engines',
+  science: 'Biology, chemistry, physics, and mathematics',
+  governance: 'Voting, markets, ethics, and community',
+  system: 'Administration, queues, audit, and debugging',
+  specialized: 'Domain-specific tools and utilities',
+  superlens: 'Full industry solutions — healthcare to aviation',
+};
+
 export default function LensHubPage() {
-  const router = useRouter();
   const [search, setSearch] = useState('');
-  const [extensionsOpen, setExtensionsOpen] = useState(false);
+  const [viewMode, setViewMode] = useState<'grid' | 'compact'>('grid');
 
-  const extensions = useMemo(() => getExtensionLenses(), []);
+  // All lenses (except hub/global which are meta)
+  const allLenses = useMemo(() =>
+    LENS_REGISTRY.filter(l => l.id !== 'hub' && l.id !== 'global'),
+  []);
 
-  const filteredExtensions = useMemo(() => {
-    if (!search) return extensions;
+  // Filtered lenses based on search
+  const filteredLenses = useMemo(() => {
+    if (!search) return allLenses;
     const q = search.toLowerCase();
-    return extensions.filter(
-      (l) =>
+    return allLenses.filter(
+      l =>
         l.name.toLowerCase().includes(q) ||
         l.description.toLowerCase().includes(q) ||
         l.id.toLowerCase().includes(q) ||
-        (l.keywords || []).some((k) => k.toLowerCase().includes(q))
+        (l.keywords || []).some(k => k.toLowerCase().includes(q)) ||
+        l.category.toLowerCase().includes(q)
     );
-  }, [search, extensions]);
+  }, [search, allLenses]);
 
-  const extensionsByCategory = useMemo(() => {
+  // Group filtered lenses by category
+  const grouped = useMemo(() => {
     const map = new Map<LensCategory, LensEntry[]>();
-    for (const lens of filteredExtensions) {
+    for (const lens of filteredLenses) {
       const list = map.get(lens.category) || [];
       list.push(lens);
       map.set(lens.category, list);
     }
     return map;
-  }, [filteredExtensions]);
+  }, [filteredLenses]);
 
-  // When searching, also filter core lenses
-  const filteredCores = useMemo(() => {
-    if (!search) return CORE_LENSES;
-    const q = search.toLowerCase();
-    return CORE_LENSES.filter(
-      (c) =>
-        c.name.toLowerCase().includes(q) ||
-        c.description.toLowerCase().includes(q) ||
-        c.id.toLowerCase().includes(q)
-    );
-  }, [search]);
-
-  const totalExtensions = extensions.length;
+  // Stats
+  const totalCount = allLenses.length;
+  const filteredCount = filteredLenses.length;
+  const categoryCount = grouped.size;
 
   return (
-    <div className={cn(ds.pageContainer, 'max-w-6xl mx-auto')}>
-      {/* Header */}
-      <div className="text-center mb-2">
-        <h1 className="text-3xl font-bold text-white mb-2">Concord</h1>
-        <p className="text-gray-400 max-w-lg mx-auto">
-          Five workspaces. Everything connected. Pick one and start.
-        </p>
-      </div>
-
-      {/* Core 5 Lenses — Hero Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {filteredCores.map((core) => (
-          <CoreLensCard key={core.id} core={core} router={router} />
-        ))}
-      </div>
-
-      {/* Divider */}
-      <div className="flex items-center gap-4 pt-4">
-        <div className="flex-1 border-t border-lattice-border" />
-        <button
-          onClick={() => setExtensionsOpen(!extensionsOpen)}
-          className="flex items-center gap-2 px-4 py-2 text-sm text-gray-400 hover:text-white transition-colors rounded-lg hover:bg-lattice-surface"
-          aria-expanded={extensionsOpen}
-          aria-controls="extensions-panel"
-        >
-          <Puzzle className="w-4 h-4" />
-          <span>Extensions</span>
-          <span className="text-xs text-gray-500">({totalExtensions})</span>
-          <ChevronDown className={cn('w-4 h-4 transition-transform', extensionsOpen && 'rotate-180')} />
-        </button>
-        <div className="flex-1 border-t border-lattice-border" />
-      </div>
-
-      {/* Extensions Panel */}
-      {extensionsOpen && (
-        <div id="extensions-panel" className="space-y-6">
-          <p className="text-sm text-gray-500 text-center">
-            Specialized lenses you can enable as your needs grow.
-            Always reachable via <kbd className="px-1.5 py-0.5 bg-lattice-surface border border-lattice-border rounded text-xs text-gray-300">Cmd+K</kbd>
-          </p>
-
-          {/* Extension Search */}
-          <div className="relative max-w-md mx-auto">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" />
-            <input
-              type="text"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search extensions..."
-              className={cn(ds.input, 'pl-10 pr-8')}
-              aria-label="Search extensions"
-            />
-            {search && (
-              <button
-                onClick={() => setSearch('')}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-white"
-                aria-label="Clear search"
-              >
-                <X className="w-4 h-4" />
-              </button>
-            )}
+    <div className="min-h-[calc(100vh-4rem)] bg-lattice-void">
+      {/* Hero Header */}
+      <div className="border-b border-lattice-border bg-gradient-to-b from-lattice-surface/80 to-lattice-void">
+        <div className="max-w-7xl mx-auto px-4 lg:px-6 py-8 lg:py-12">
+          <div className="flex items-start justify-between gap-6">
+            <div>
+              <h1 className="text-3xl lg:text-4xl font-bold text-white mb-2">
+                Lens Explorer
+              </h1>
+              <p className="text-gray-400 max-w-2xl text-sm lg:text-base">
+                {totalCount} lenses across {Object.keys(LENS_CATEGORIES).length} domains.
+                Every lens is a specialized workspace — from AI reasoning to healthcare management.
+              </p>
+            </div>
+            <div className="hidden md:flex items-center gap-2 text-xs text-gray-500">
+              <span className="px-2 py-1 rounded bg-neon-cyan/10 text-neon-cyan font-mono">{totalCount}</span>
+              <span>lenses</span>
+            </div>
           </div>
 
-          {/* Extensions by Category */}
-          {filteredExtensions.length === 0 ? (
-            <div className="text-center py-8">
-              <p className="text-gray-400">No extensions match &ldquo;{search}&rdquo;</p>
+          {/* Search + View Toggle */}
+          <div className="mt-6 flex items-center gap-3">
+            <div className="relative flex-1 max-w-xl">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" />
+              <input
+                type="text"
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                placeholder="Search lenses by name, category, or keyword..."
+                className="w-full pl-10 pr-10 py-3 bg-lattice-deep border border-lattice-border rounded-xl text-white placeholder-gray-500 focus:outline-none focus:border-neon-cyan/50 focus:ring-1 focus:ring-neon-cyan/20 transition-all text-sm"
+                aria-label="Search lenses"
+              />
+              {search && (
+                <button
+                  onClick={() => setSearch('')}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-white transition-colors"
+                  aria-label="Clear search"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              )}
             </div>
-          ) : (
-            <div className="space-y-6">
-              {EXTENSION_CATEGORIES.map((category) => {
-                const lenses = extensionsByCategory.get(category);
-                if (!lenses || lenses.length === 0) return null;
+            <div className="flex items-center bg-lattice-deep border border-lattice-border rounded-lg overflow-hidden">
+              <button
+                onClick={() => setViewMode('grid')}
+                className={cn('p-2.5 transition-colors', viewMode === 'grid' ? 'bg-lattice-elevated text-white' : 'text-gray-500 hover:text-gray-300')}
+                aria-label="Grid view"
+              >
+                <LayoutGrid className="w-4 h-4" />
+              </button>
+              <button
+                onClick={() => setViewMode('compact')}
+                className={cn('p-2.5 transition-colors', viewMode === 'compact' ? 'bg-lattice-elevated text-white' : 'text-gray-500 hover:text-gray-300')}
+                aria-label="Compact view"
+              >
+                <Grid3X3 className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
 
-                return (
-                  <div key={category}>
-                    <h3 className={cn(
-                      'text-xs font-semibold uppercase tracking-wider mb-2',
-                      LENS_CATEGORIES[category]?.color || 'text-gray-500'
-                    )}>
-                      {LENS_CATEGORIES[category]?.label || category} ({lenses.length})
-                    </h3>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-2">
-                      {lenses
-                        .sort((a, b) => a.order - b.order)
-                        .map((lens) => {
-                          const Icon = lens.icon;
-                          return (
-                            <button
-                              key={lens.id}
-                              onClick={() => router.push(lens.path)}
-                              className="flex items-center gap-3 p-3 rounded-lg bg-lattice-surface/50 border border-lattice-border hover:border-gray-500 hover:bg-lattice-surface transition-all text-left group"
-                              aria-label={`Open ${lens.name}: ${lens.description}`}
-                            >
-                              <div className="p-1.5 rounded-lg bg-lattice-void/50 text-gray-400 group-hover:text-white transition-colors">
-                                <Icon className="w-4 h-4" />
-                              </div>
-                              <div className="flex-1 min-w-0">
-                                <span className="text-sm font-medium text-white truncate block">{lens.name}</span>
-                                <p className="text-xs text-gray-500 truncate">{lens.description}</p>
-                              </div>
-                            </button>
-                          );
-                        })}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
+          {/* Search result count */}
+          {search && (
+            <p className="mt-3 text-xs text-gray-500">
+              {filteredCount} of {totalCount} lenses match &ldquo;{search}&rdquo;
+            </p>
           )}
         </div>
-      )}
+      </div>
+
+      {/* Content */}
+      <div className="max-w-7xl mx-auto px-4 lg:px-6 py-6 space-y-8">
+        {/* Core 5 Hero Section (only when not searching) */}
+        {!search && (
+          <section>
+            <div className="flex items-center gap-2 mb-4">
+              <Sparkles className="w-4 h-4 text-neon-cyan" />
+              <h2 className="text-sm font-semibold uppercase tracking-wider text-neon-cyan">
+                Core Workspaces
+              </h2>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-3">
+              {CORE_LENSES.map(core => (
+                <CoreLensHeroCard key={core.id} core={core} />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Category Sections */}
+        {CATEGORY_ORDER.map(category => {
+          const lenses = grouped.get(category);
+          if (!lenses || lenses.length === 0) return null;
+          // Skip core category items in non-search mode (shown in hero section)
+          if (!search && category === 'core') {
+            const nonCoreItems = lenses.filter(l => !['chat', 'board', 'graph', 'code', 'studio'].includes(l.id));
+            if (nonCoreItems.length === 0) return null;
+          }
+
+          const catMeta = LENS_CATEGORIES[category];
+          const desc = CATEGORY_DESCRIPTIONS[category];
+          const displayLenses = !search && category === 'core'
+            ? lenses.filter(l => !['chat', 'board', 'graph', 'code', 'studio'].includes(l.id))
+            : lenses;
+
+          return (
+            <section key={category}>
+              <div className="flex items-center justify-between mb-3">
+                <div>
+                  <div className="flex items-center gap-2">
+                    <h2 className={cn('text-sm font-semibold uppercase tracking-wider', catMeta?.color || 'text-gray-400')}>
+                      {catMeta?.label || category}
+                    </h2>
+                    <span className="text-xs text-gray-600">({displayLenses.length})</span>
+                  </div>
+                  {desc && !search && (
+                    <p className="text-xs text-gray-600 mt-0.5">{desc}</p>
+                  )}
+                </div>
+              </div>
+
+              {viewMode === 'grid' ? (
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-2.5">
+                  {displayLenses.sort((a, b) => a.order - b.order).map(lens => (
+                    <LensCard key={lens.id} lens={lens} />
+                  ))}
+                </div>
+              ) : (
+                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-1.5">
+                  {displayLenses.sort((a, b) => a.order - b.order).map(lens => (
+                    <LensCardCompact key={lens.id} lens={lens} />
+                  ))}
+                </div>
+              )}
+            </section>
+          );
+        })}
+
+        {/* No results */}
+        {filteredLenses.length === 0 && search && (
+          <div className="text-center py-16">
+            <Search className="w-10 h-10 mx-auto mb-4 text-gray-700" />
+            <p className="text-gray-400">No lenses match &ldquo;{search}&rdquo;</p>
+            <p className="text-gray-600 text-sm mt-1">Try a different keyword or browse the categories</p>
+            <button
+              onClick={() => setSearch('')}
+              className="mt-4 px-4 py-2 text-sm rounded-lg bg-lattice-surface border border-lattice-border hover:border-neon-cyan/50 text-gray-300 hover:text-white transition-all"
+            >
+              Clear search
+            </button>
+          </div>
+        )}
+
+        {/* Footer stats */}
+        <div className="border-t border-lattice-border pt-6 pb-8 text-center">
+          <p className="text-xs text-gray-600">
+            {totalCount} lenses &middot; {Object.keys(LENS_CATEGORIES).length} categories &middot; Sovereign by design
+          </p>
+        </div>
+      </div>
     </div>
   );
 }
 
-/** Hero card for a core lens showing its absorbed sub-lenses */
-function CoreLensCard({
-  core,
-  router,
-}: {
-  core: CoreLensConfig;
-  router: ReturnType<typeof useRouter>;
-}) {
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+function CoreLensHeroCard({ core }: { core: CoreLensConfig }) {
   const absorbed = useMemo(() => getAbsorbedLenses(core.id), [core.id]);
   const Icon = core.icon;
 
-  // Make first 2 cards span full width on lg for a 2+3 layout
-  const isWide = core.id === 'chat' || core.id === 'board';
-
   return (
-    <button
-      onClick={() => router.push(core.path)}
-      className={cn(
-        'group relative flex flex-col p-6 rounded-xl border transition-all text-left',
-        'bg-lattice-surface/60 border-lattice-border',
-        `hover:border-${core.color}/50 hover:shadow-lg hover:shadow-${core.color}/5`,
-        isWide && 'lg:col-span-1'
-      )}
-      aria-label={`Open ${core.name}: ${core.description}`}
+    <Link
+      href={core.path}
+      className="group relative flex flex-col p-5 rounded-xl border border-lattice-border bg-gradient-to-br from-lattice-surface/80 to-lattice-deep hover:border-neon-cyan/40 transition-all overflow-hidden"
     >
-      {/* Icon + Title */}
-      <div className="flex items-center gap-3 mb-3">
-        <div className={cn(
-          'p-2.5 rounded-xl transition-colors',
-          `bg-${core.color}/10 text-${core.color}`,
-          `group-hover:bg-${core.color}/20`
-        )}>
-          <Icon className="w-6 h-6" />
+      {/* Gradient glow */}
+      <div className="absolute top-0 right-0 w-24 h-24 bg-gradient-to-bl from-neon-cyan/5 to-transparent rounded-bl-full" />
+
+      <div className="flex items-center gap-3 mb-3 relative">
+        <div className="p-2 rounded-lg bg-neon-cyan/10 text-neon-cyan">
+          <Icon className="w-5 h-5" />
         </div>
-        <div>
-          <h2 className="text-lg font-bold text-white">{core.name}</h2>
-          <p className={cn('text-xs font-medium', `text-${core.color}`)}>{core.tagline}</p>
+        <div className="flex-1 min-w-0">
+          <h3 className="font-bold text-white">{core.name}</h3>
+          <p className="text-[10px] text-gray-500">{core.tagline}</p>
         </div>
-        <ArrowRight className={cn(
-          'w-5 h-5 ml-auto text-gray-600 transition-all',
-          'group-hover:text-white group-hover:translate-x-1'
-        )} />
+        <ArrowRight className="w-4 h-4 text-gray-600 group-hover:text-white group-hover:translate-x-0.5 transition-all" />
       </div>
 
-      {/* Description */}
-      <p className="text-sm text-gray-400 mb-4">{core.description}</p>
+      <p className="text-xs text-gray-400 mb-3 line-clamp-2">{core.description}</p>
 
-      {/* Absorbed lenses as badges */}
       {absorbed.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 mt-auto">
-          {absorbed.map((lens) => {
-            const SubIcon = lens.icon;
-            return (
-              <span
-                key={lens.id}
-                className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-lattice-void/50 text-xs text-gray-400"
-                title={lens.description}
-              >
-                <SubIcon className="w-3 h-3" />
-                {lens.tabLabel || lens.name}
-              </span>
-            );
-          })}
+        <div className="flex flex-wrap gap-1 mt-auto">
+          {absorbed.slice(0, 4).map(lens => (
+            <span key={lens.id} className="px-1.5 py-0.5 rounded text-[10px] bg-lattice-deep text-gray-500">
+              {lens.tabLabel || lens.name}
+            </span>
+          ))}
+          {absorbed.length > 4 && (
+            <span className="px-1.5 py-0.5 rounded text-[10px] bg-lattice-deep text-gray-600">
+              +{absorbed.length - 4}
+            </span>
+          )}
         </div>
       )}
-    </button>
+    </Link>
+  );
+}
+
+function LensCard({ lens }: { lens: LensEntry }) {
+  const Icon = lens.icon;
+  return (
+    <Link
+      href={lens.path}
+      className="group flex items-start gap-3 p-3.5 rounded-lg border border-lattice-border/60 bg-lattice-surface/30 hover:bg-lattice-surface/70 hover:border-gray-600 transition-all"
+    >
+      <div className="p-2 rounded-lg bg-lattice-deep text-gray-400 group-hover:text-white transition-colors flex-shrink-0">
+        <Icon className="w-4 h-4" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-white truncate">{lens.name}</span>
+          {lens.coreLens && (
+            <span className="text-[9px] px-1 py-0.5 rounded bg-lattice-deep text-gray-600 flex-shrink-0">
+              {lens.coreLens}
+            </span>
+          )}
+        </div>
+        <p className="text-xs text-gray-500 truncate mt-0.5">{lens.description}</p>
+      </div>
+    </Link>
+  );
+}
+
+function LensCardCompact({ lens }: { lens: LensEntry }) {
+  const Icon = lens.icon;
+  return (
+    <Link
+      href={lens.path}
+      className="group flex items-center gap-2 px-2.5 py-2 rounded-md border border-lattice-border/40 hover:bg-lattice-surface/60 hover:border-gray-600 transition-all"
+    >
+      <Icon className="w-3.5 h-3.5 text-gray-500 group-hover:text-white transition-colors flex-shrink-0" />
+      <span className="text-xs text-gray-300 group-hover:text-white truncate">{lens.name}</span>
+    </Link>
   );
 }

--- a/concord-frontend/app/login/page.tsx
+++ b/concord-frontend/app/login/page.tsx
@@ -141,9 +141,9 @@ function LoginForm() {
           <div className="mt-6 text-center">
             <p className="text-gray-400 text-sm">
               Don&apos;t have an account?{' '}
-              <a href="/register" className="text-neon-cyan hover:text-neon-blue transition-colors font-medium">
+              <Link href="/register" className="text-neon-cyan hover:text-neon-blue transition-colors font-medium">
                 Create one
-              </a>
+              </Link>
             </p>
           </div>
         </div>

--- a/concord-frontend/app/register/page.tsx
+++ b/concord-frontend/app/register/page.tsx
@@ -184,9 +184,9 @@ export default function RegisterPage() {
           <div className="mt-6 text-center">
             <p className="text-gray-400 text-sm">
               Already have an account?{' '}
-              <a href="/login" className="text-neon-cyan hover:text-neon-blue transition-colors font-medium">
+              <Link href="/login" className="text-neon-cyan hover:text-neon-blue transition-colors font-medium">
                 Sign in
-              </a>
+              </Link>
             </p>
           </div>
         </div>


### PR DESCRIPTION
- Replace dead 2D ResonanceEmpireGraph with 3D KnowledgeSpace3D visualization
  that renders actual DTU data from /api/resonance/quick in an interactive
  spiral galaxy layout with connections
- Fix notification bell: add click handler and dropdown panel that fetches
  real events from /api/events/paginated with timestamps and routing
- Fix all navigation links: replace plain <a> tags with Next.js <Link> in
  QuickAction, login, and register pages to prevent full page reloads that
  broke auth persistence across lens switches
- Use client-side router.push() instead of window.location.href for
  navigation to preserve React state and session cookies
- Connect dashboard to /api/system/health and /api/guidance/suggestions
  endpoints for live health status and guidance display
- Add Core 5 workspace quick-access grid to dashboard with proper Link nav
- Rebuild Hub page as full Lens Explorer showing all 106 lenses in a
  searchable, categorized grid with grid/compact view toggle, category
  descriptions, and hero cards for core workspaces
- Clean build succeeds with all pages compiling (frontend only, no server changes)

https://claude.ai/code/session_01Hvzq7FCxrwwev1fyYEE8KP