### PR TITLE
fix: surgical patches for auth, graph rendering, DTU interaction, and…

### DIFF
--- a/concord-frontend/app/lenses/graph/page.tsx
+++ b/concord-frontend/app/lenses/graph/page.tsx
@@ -309,7 +309,8 @@ export default function GraphLensPage() {
 
   const initializeGraphData = useCallback(() => {
     const dtuList = dtus?.dtus || [];
-    const linkList = links?.links || [];
+    // Normalize: backend force graph returns 'links', visual returns 'edges'
+    const linkList = links?.links || links?.edges || graphForceData?.links || graphForceData?.edges || graphVisualData?.edges || graphVisualData?.links || [];
     const width = dimensions.width;
     const height = dimensions.height;
 

--- a/concord-frontend/app/login/page.tsx
+++ b/concord-frontend/app/login/page.tsx
@@ -28,8 +28,12 @@ function LoginForm() {
       if (res.data?.ok) {
         // Mark as entered so HomeClient shows dashboard
         localStorage.setItem('concord_entered', 'true');
+        // Ensure CSRF cookie is fresh for the dashboard
+        try { await api.get('/api/auth/csrf-token'); } catch {}
         // Connect WebSocket now that we have a session cookie
         connectSocket();
+        // Small delay to ensure cookies propagate before navigation
+        await new Promise(r => setTimeout(r, 100));
         // Redirect to the page they were trying to reach, or home
         const from = searchParams.get('from');
         router.push(from || '/');
@@ -59,9 +63,9 @@ function LoginForm() {
             <div className="w-12 h-12 rounded-lg bg-gradient-to-br from-neon-cyan to-neon-blue flex items-center justify-center">
               <Brain className="w-7 h-7 text-white" />
             </div>
-            <span className="text-3xl font-bold text-white">Concord</span>
+            <span className="text-3xl font-bold text-white">Concordos</span>
           </Link>
-          <p className="text-gray-400 mt-3">Sign in to your cognitive engine</p>
+          <p className="text-gray-400 mt-3">Sign in to your sovereign cognitive engine</p>
         </div>
 
         {/* Form card */}

--- a/concord-frontend/app/register/page.tsx
+++ b/concord-frontend/app/register/page.tsx
@@ -65,7 +65,7 @@ export default function RegisterPage() {
             <div className="w-12 h-12 rounded-lg bg-gradient-to-br from-neon-cyan to-neon-blue flex items-center justify-center">
               <Brain className="w-7 h-7 text-white" />
             </div>
-            <span className="text-3xl font-bold text-white">Concord</span>
+            <span className="text-3xl font-bold text-white">Concordos</span>
           </Link>
           <p className="text-gray-400 mt-3">Create your sovereign account</p>
         </div>

--- a/concord-frontend/components/shell/AppShell.tsx
+++ b/concord-frontend/components/shell/AppShell.tsx
@@ -13,6 +13,7 @@ import { FirstWinWizard } from '@/components/guidance/FirstWinWizard';
 import { LensErrorBoundary } from '@/components/common/LensErrorBoundary';
 import { InstallPrompt } from '@/components/pwa/InstallPrompt';
 import { OfflineFallback } from '@/components/pwa/OfflineFallback';
+import { connectSocket } from '@/lib/realtime/socket';
 
 interface AppShellProps {
   children: React.ReactNode;
@@ -24,6 +25,9 @@ export function AppShell({ children }: AppShellProps) {
 
   useEffect(() => {
     setMounted(true);
+
+    // Connect WebSocket for real-time updates
+    connectSocket();
 
     // Register service worker for PWA support
     if ('serviceWorker' in navigator) {

--- a/concord-frontend/components/shell/Topbar.tsx
+++ b/concord-frontend/components/shell/Topbar.tsx
@@ -23,7 +23,7 @@ export function Topbar() {
 
   const { data: resonance } = useQuery({
     queryKey: ['resonance-quick'],
-    queryFn: () => api.get('/api/resonance/quick').then((r) => r.data),
+    queryFn: () => api.get('/api/lattice/resonance').then((r) => r.data).catch(() => null),
     refetchInterval: 30000,
     retry: false,
   });

--- a/concord-frontend/middleware.ts
+++ b/concord-frontend/middleware.ts
@@ -39,11 +39,13 @@ export function middleware(request: NextRequest) {
   }
 
   // Check for session cookie (httpOnly cookie set by backend on login)
-  // The backend sets either 'concord_session' or 'token' cookie
+  // The backend sets 'concord_auth' (httpOnly JWT) and optionally 'concord_refresh'
   const hasSession =
-    request.cookies.has('concord_session') ||
-    request.cookies.has('token') ||
-    request.cookies.has('connect.sid');
+    request.cookies.has('concord_auth') ||          // JWT auth cookie (primary — set by backend on login)
+    request.cookies.has('concord_refresh') ||        // Refresh token cookie
+    request.cookies.has('concord_session') ||        // Legacy fallback
+    request.cookies.has('token') ||                  // Legacy fallback
+    request.cookies.has('connect.sid');              // Express session fallback
 
   if (!hasSession) {
     const loginUrl = new URL('/login', request.url);


### PR DESCRIPTION
… branding

BUG #1 (Critical): Fix auth cookie name mismatch in middleware.ts
- Backend sets 'concord_auth' but middleware checked 'concord_session'
- Added concord_auth and concord_refresh as primary cookie checks
- This alone fixes the redirect loop that prevented all navigation

BUG #2: Wire real graph data into Resonance Universe
- Add apiHelpers.graph.visual() query to DashboardPage
- Graph now fetches actual lattice topology from backend

BUG #3: Make DTUs clickable with InspectorDrawer
- Add InspectorDrawer integration to dashboard
- Wire onClick handler to DTUEmpireCard components
- Normalize DTU data shape (summary/title/content field variations)

BUG #4: CSRF token flow hardening
- Proactively refresh CSRF after auth check in HomeClient
- Refresh CSRF after login before redirect in login page
- Small delay before navigation to ensure cookies propagate

BUG #5+6: Rebrand login and register pages to Concordos

BUG #7: Normalize graph force data edges vs links
- Handle both 'links' and 'edges' field names from backend

BUG #8: Socket auto-connect on AppShell mount
- connectSocket() called in AppShell useEffect so WebSocket reconnects on page refresh, not only after login

BUG #9: Fix Topbar resonance query endpoint
- Changed from /api/resonance/quick to /api/lattice/resonance
- Added .catch(() => null) to prevent error toasts

https://claude.ai/code/session_01WrPhRvTX3NT2MnoaPCzSmo