### PR TITLE
feat: add Existential OS (qualia engine) and Sovereign Dev Console

### DIFF
--- a/concord-frontend/app/dev/page.tsx
+++ b/concord-frontend/app/dev/page.tsx
@@ -1,0 +1,357 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback, KeyboardEvent, FormEvent } from 'react';
+import { api } from '@/lib/api/client';
+
+interface LogEntry {
+  type: 'input' | 'output' | 'error' | 'system' | 'success';
+  text: string;
+  timestamp: string;
+}
+
+interface PulseData {
+  dtus?: { total?: number };
+  process?: { rss?: string; heapUsed?: string; uptimeHuman?: string };
+}
+
+const HELP_TEXT = `Available commands:
+  pulse / status / ps    — System overview
+  create <content>       — Create sovereign DTU
+  promote <id> [tier]    — Promote DTU tier
+  modify <id> <json>     — Modify DTU fields
+  delete <id>            — Delete DTU
+  inspect <id>           — Inspect DTU
+  search <query>         — Search all DTUs
+  count                  — DTU count
+  freeze                 — Freeze all autonomous jobs
+  thaw                   — Thaw frozen jobs
+  pipeline               — Force autogen pipeline
+  dream [seed]           — Force dream synthesis
+  gc                     — Force garbage collection
+  broadcast <msg>        — Broadcast to lattice
+  config <key> <val>     — Set config value
+  toggle <job> [off]     — Toggle job on/off
+  eval <js> / js <code>  — Evaluate JS in server context
+  audit [n] / history    — View sovereign audit trail
+  qualia <id>            — View entity qualia state
+  qualia-summary         — All entities qualia overview
+  activate-os <id> <os>  — Activate OS for entity
+  inject-qualia <id> <ch> <val> — Set qualia channel
+  help / ?               — Show this help
+  clear / cls            — Clear log`;
+
+export default function DevConsolePage() {
+  const [log, setLog] = useState<LogEntry[]>([
+    { type: 'system', text: '◆ SOVEREIGN DEV CONSOLE — authority: 1.0', timestamp: new Date().toISOString() },
+    { type: 'system', text: 'Type "help" for available commands.', timestamp: new Date().toISOString() },
+  ]);
+  const [input, setInput] = useState('');
+  const [executing, setExecuting] = useState(false);
+  const [history, setHistory] = useState<string[]>([]);
+  const [historyIndex, setHistoryIndex] = useState(-1);
+  const [pulse, setPulse] = useState<PulseData | null>(null);
+
+  const logEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Auto-scroll to bottom
+  useEffect(() => {
+    logEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [log]);
+
+  // Focus input on mount
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Fetch pulse on mount
+  useEffect(() => {
+    api.get('/api/sovereign/pulse')
+      .then((r) => setPulse(r.data))
+      .catch(() => {});
+
+    const interval = setInterval(() => {
+      api.get('/api/sovereign/pulse')
+        .then((r) => setPulse(r.data))
+        .catch(() => {});
+    }, 15000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const addLog = useCallback((type: LogEntry['type'], text: string) => {
+    setLog((prev) => [...prev, { type, text, timestamp: new Date().toISOString() }]);
+  }, []);
+
+  const executeCommand = useCallback(async (cmd: string) => {
+    const trimmed = cmd.trim();
+    if (!trimmed) return;
+
+    addLog('input', `sovereign > ${trimmed}`);
+    setHistory((prev) => [trimmed, ...prev.slice(0, 99)]);
+    setHistoryIndex(-1);
+    setExecuting(true);
+
+    try {
+      // Local commands
+      if (trimmed === 'help' || trimmed === '?') {
+        addLog('system', HELP_TEXT);
+        setExecuting(false);
+        return;
+      }
+
+      if (trimmed === 'clear' || trimmed === 'cls') {
+        setLog([]);
+        setExecuting(false);
+        return;
+      }
+
+      // Parse command
+      const parts = trimmed.split(/\s+/);
+      const command = parts[0].toLowerCase();
+      const rest = trimmed.slice(command.length).trim();
+
+      let response;
+
+      // Route to API
+      if (command === 'pulse' || command === 'status' || command === 'ps') {
+        response = await api.get('/api/sovereign/pulse');
+        if (response.data) setPulse(response.data);
+      } else if (command === 'audit' || command === 'history') {
+        const limit = parts[1] ? parseInt(parts[1], 10) : 50;
+        response = await api.get('/api/sovereign/audit', { params: { limit } });
+      } else if (command === 'eval' || command === 'js') {
+        response = await api.post('/api/sovereign/eval', { code: rest });
+      } else if (command === 'create') {
+        response = await api.post('/api/sovereign/decree', {
+          action: 'create-dtu',
+          data: { content: rest },
+        });
+      } else if (command === 'promote') {
+        const id = parts[1];
+        const tier = parts[2];
+        response = await api.post('/api/sovereign/decree', {
+          action: 'promote-dtu',
+          target: id,
+          data: tier ? { tier } : undefined,
+        });
+      } else if (command === 'modify') {
+        const id = parts[1];
+        const jsonStr = trimmed.slice(trimmed.indexOf(parts[2] || ''));
+        let parsed;
+        try { parsed = JSON.parse(jsonStr); } catch { parsed = { content: jsonStr }; }
+        response = await api.post('/api/sovereign/decree', {
+          action: 'modify-dtu',
+          target: id,
+          data: parsed,
+        });
+      } else if (command === 'delete') {
+        response = await api.post('/api/sovereign/decree', {
+          action: 'delete-dtu',
+          target: parts[1],
+        });
+      } else if (command === 'inspect') {
+        response = await api.post('/api/sovereign/decree', {
+          action: 'inspect',
+          target: parts[1],
+        });
+      } else if (command === 'search') {
+        response = await api.post('/api/sovereign/decree', {
+          action: 'search',
+          data: { query: rest },
+        });
+      } else if (command === 'count') {
+        response = await api.post('/api/sovereign/decree', { action: 'count' });
+      } else if (command === 'freeze') {
+        response = await api.post('/api/sovereign/decree', { action: 'freeze' });
+      } else if (command === 'thaw') {
+        response = await api.post('/api/sovereign/decree', { action: 'thaw' });
+      } else if (command === 'pipeline') {
+        response = await api.post('/api/sovereign/decree', { action: 'force-pipeline' });
+      } else if (command === 'dream') {
+        response = await api.post('/api/sovereign/decree', {
+          action: 'force-dream',
+          data: rest ? { seed: rest } : undefined,
+        });
+      } else if (command === 'gc') {
+        response = await api.post('/api/sovereign/decree', { action: 'gc' });
+      } else if (command === 'broadcast') {
+        response = await api.post('/api/sovereign/decree', {
+          action: 'broadcast',
+          data: { message: rest },
+        });
+      } else if (command === 'config') {
+        const key = parts[1];
+        const value = parts.slice(2).join(' ');
+        let parsed;
+        try { parsed = JSON.parse(value); } catch { parsed = value; }
+        response = await api.post('/api/sovereign/decree', {
+          action: 'set-config',
+          data: { key, value: parsed },
+        });
+      } else if (command === 'toggle') {
+        const job = parts[1];
+        const enabled = parts[2] !== 'off';
+        response = await api.post('/api/sovereign/decree', {
+          action: 'toggle-job',
+          target: job,
+          data: { enabled },
+        });
+      } else if (command === 'qualia') {
+        response = await api.post('/api/sovereign/decree', {
+          action: 'qualia',
+          target: parts[1],
+        });
+      } else if (command === 'qualia-summary') {
+        response = await api.post('/api/sovereign/decree', { action: 'qualia-summary' });
+      } else if (command === 'activate-os') {
+        response = await api.post('/api/sovereign/decree', {
+          action: 'activate-os',
+          target: parts[1],
+          data: { osKey: parts[2] },
+        });
+      } else if (command === 'deactivate-os') {
+        response = await api.post('/api/sovereign/decree', {
+          action: 'deactivate-os',
+          target: parts[1],
+          data: { osKey: parts[2] },
+        });
+      } else if (command === 'inject-qualia') {
+        response = await api.post('/api/sovereign/decree', {
+          action: 'inject-qualia',
+          target: parts[1],
+          data: { channel: parts[2], value: parseFloat(parts[3]) },
+        });
+      } else {
+        addLog('error', `Unknown command: ${command}. Type "help" for available commands.`);
+        setExecuting(false);
+        return;
+      }
+
+      // Display response
+      const data = response?.data;
+      if (data) {
+        const isError = data.ok === false;
+        const formatted = typeof data === 'object'
+          ? JSON.stringify(data, null, 2)
+          : String(data);
+        addLog(isError ? 'error' : 'success', formatted);
+      }
+    } catch (err: unknown) {
+      const axErr = err as { response?: { status?: number; data?: { error?: string } }; message?: string };
+      if (axErr?.response?.status === 403) {
+        addLog('error', 'Access denied. Sovereign credentials required.');
+      } else {
+        addLog('error', axErr?.response?.data?.error || axErr?.message || 'Command failed');
+      }
+    } finally {
+      setExecuting(false);
+    }
+  }, [addLog]);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (history.length > 0) {
+        const newIndex = Math.min(historyIndex + 1, history.length - 1);
+        setHistoryIndex(newIndex);
+        setInput(history[newIndex]);
+      }
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (historyIndex > 0) {
+        const newIndex = historyIndex - 1;
+        setHistoryIndex(newIndex);
+        setInput(history[newIndex]);
+      } else {
+        setHistoryIndex(-1);
+        setInput('');
+      }
+    }
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!executing && input.trim()) {
+      executeCommand(input);
+      setInput('');
+    }
+  };
+
+  const colorMap: Record<LogEntry['type'], string> = {
+    input: 'text-purple-400',
+    output: 'text-gray-300',
+    error: 'text-red-400',
+    system: 'text-cyan-400',
+    success: 'text-emerald-400',
+  };
+
+  return (
+    <div
+      className="min-h-screen flex flex-col"
+      style={{
+        background: '#0a0a0f',
+        fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'Consolas', monospace",
+        fontSize: '13px',
+      }}
+    >
+      {/* Header Bar */}
+      <div className="flex items-center justify-between px-4 py-2 border-b border-gray-800/50 bg-[#0d0d14]">
+        <div className="flex items-center gap-3">
+          <span className="text-purple-400 font-bold text-sm">◆ SOVEREIGN</span>
+          <span className="text-gray-500 text-xs">dev console</span>
+        </div>
+        <div className="flex items-center gap-4 text-xs">
+          {pulse?.dtus?.total !== undefined && (
+            <span className="text-gray-400">
+              DTUs: <span className="text-white">{pulse.dtus.total.toLocaleString()}</span>
+            </span>
+          )}
+          {pulse?.process?.heapUsed && (
+            <span className="text-gray-400">
+              mem: <span className="text-white">{pulse.process.heapUsed}</span>
+            </span>
+          )}
+          {pulse?.process?.uptimeHuman && (
+            <span className="text-gray-400">
+              up: <span className="text-white">{pulse.process.uptimeHuman}</span>
+            </span>
+          )}
+          <span className="text-amber-400">authority: 1.0</span>
+        </div>
+      </div>
+
+      {/* Log Display */}
+      <div className="flex-1 overflow-auto p-4 space-y-1">
+        {log.map((entry, i) => (
+          <div key={i} className={`${colorMap[entry.type]} whitespace-pre-wrap break-all`}>
+            {entry.text}
+          </div>
+        ))}
+        <div ref={logEndRef} />
+      </div>
+
+      {/* Command Input */}
+      <form onSubmit={handleSubmit} className="flex items-center gap-2 px-4 py-3 border-t border-gray-800/50 bg-[#0d0d14]">
+        <span className="text-purple-400 font-bold select-none">sovereign &gt;</span>
+        {executing ? (
+          <span className="text-gray-500 animate-pulse">⟳ executing</span>
+        ) : (
+          <input
+            ref={inputRef}
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            className="flex-1 bg-transparent text-gray-200 outline-none caret-purple-400 placeholder-gray-600"
+            placeholder="Enter command..."
+            autoFocus
+            disabled={executing}
+            autoComplete="off"
+            spellCheck={false}
+          />
+        )}
+      </form>
+    </div>
+  );
+}

--- a/server/emergent/atlas-council.js
+++ b/server/emergent/atlas-council.js
@@ -199,6 +199,9 @@ export function councilResolve(STATE, input) {
     diff: event.diff,
   });
 
+  // Qualia hook: council resolution completed
+  try { globalThis.qualiaHooks?.hookCouncilVote(actor || "council", { agreement: targetStatus === "VERIFIED" ? 0.8 : 0.4, conflict: targetStatus === "DISPUTED" ? 0.7 : 0.2, confidence: 0.6 }); } catch { /* silent */ }
+
   return {
     ok: true,
     dtuId,

--- a/server/existential/engine.js
+++ b/server/existential/engine.js
@@ -1,0 +1,405 @@
+/**
+ * Qualia Engine — Runtime for the Existential OS
+ *
+ * Maintains live qualia state for each entity (emergent, session, or system).
+ * Each entity has a set of active operating systems whose numeric channels
+ * represent continuous experiential state (0-1 floats).
+ *
+ * Storage: STATE.qualia (Map). In-memory only. No database tables.
+ * Failure mode: silent. Engine never crashes the host process.
+ */
+
+import { existentialOS, getExistentialOS } from "./registry.js";
+
+const HISTORY_MAX = 50; // Rolling window of past snapshots
+
+/**
+ * Clamp a value to [lo, hi].
+ */
+function clamp(v, lo = 0, hi = 1) {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+export class QualiaEngine {
+  /**
+   * @param {object} STATE - Global server STATE object
+   */
+  constructor(STATE) {
+    this._STATE = STATE;
+    if (!this._STATE.qualia) {
+      this._STATE.qualia = new Map();
+    }
+  }
+
+  /** @returns {Map} The qualia store */
+  get _store() {
+    if (!this._STATE.qualia) this._STATE.qualia = new Map();
+    return this._STATE.qualia;
+  }
+
+  /**
+   * Initialize a qualia state for an entity.
+   * If no OS keys provided, activate Tier 0 + Tier 5 by default.
+   *
+   * @param {string} entityId
+   * @param {string[]} [activeOSKeys]
+   * @returns {{ ok: boolean, entityId: string }}
+   */
+  createQualiaState(entityId, activeOSKeys) {
+    if (!entityId) return { ok: false, error: "entityId required" };
+
+    const defaultKeys = [
+      "truth_os", "logic_os",                                    // Tier 0
+      "meta_growth_os", "self_repair_os", "reflection_os",       // Tier 5
+    ];
+    const keys = activeOSKeys && activeOSKeys.length > 0 ? activeOSKeys : defaultKeys;
+
+    const channels = {};
+    const activeOS = [];
+
+    for (const key of keys) {
+      const os = getExistentialOS(key);
+      if (!os) continue;
+      activeOS.push(key);
+      for (const ch of os.numeric_channels) {
+        channels[`${key}.${ch}`] = 0;
+      }
+    }
+
+    const state = {
+      entityId,
+      activeOS,
+      channels,
+      lastUpdated: new Date().toISOString(),
+      history: [],
+    };
+
+    this._store.set(entityId, state);
+    return { ok: true, entityId };
+  }
+
+  /**
+   * Update a single channel value. Clamp to valid range. Check policies.
+   *
+   * @param {string} entityId
+   * @param {string} osKey
+   * @param {string} channelName
+   * @param {number} value
+   * @returns {{ ok: boolean, policyTriggered?: object }}
+   */
+  updateChannel(entityId, osKey, channelName, value) {
+    const state = this._store.get(entityId);
+    if (!state) return { ok: false, error: "entity_not_found" };
+
+    const fullKey = `${osKey}.${channelName}`;
+    const clamped = clamp(Number(value) || 0);
+
+    state.channels[fullKey] = clamped;
+    state.lastUpdated = new Date().toISOString();
+
+    // Check for policy threshold crossings
+    const policyTriggered = this._checkPolicies(entityId, osKey, channelName, clamped);
+
+    return { ok: true, policyTriggered: policyTriggered || undefined };
+  }
+
+  /**
+   * Batch update multiple channels at once.
+   *
+   * @param {string} entityId
+   * @param {Record<string, number>} updates - e.g. { "truth_os.evidence_weight": 0.9 }
+   * @returns {{ ok: boolean, updated: number, policyEvents: object[] }}
+   */
+  batchUpdate(entityId, updates) {
+    const state = this._store.get(entityId);
+    if (!state) return { ok: false, error: "entity_not_found" };
+    if (!updates || typeof updates !== "object") return { ok: false, error: "updates required" };
+
+    const policyEvents = [];
+    let updated = 0;
+
+    for (const [fullKey, value] of Object.entries(updates)) {
+      const clamped = clamp(Number(value) || 0);
+      state.channels[fullKey] = clamped;
+      updated++;
+
+      // Extract osKey and channelName
+      const dotIdx = fullKey.indexOf(".");
+      if (dotIdx > 0) {
+        const osKey = fullKey.slice(0, dotIdx);
+        const channelName = fullKey.slice(dotIdx + 1);
+        const policy = this._checkPolicies(entityId, osKey, channelName, clamped);
+        if (policy) policyEvents.push(policy);
+      }
+    }
+
+    state.lastUpdated = new Date().toISOString();
+    return { ok: true, updated, policyEvents };
+  }
+
+  /**
+   * Return current full qualia state for an entity.
+   *
+   * @param {string} entityId
+   * @returns {object|null}
+   */
+  getQualiaState(entityId) {
+    const state = this._store.get(entityId);
+    if (!state) return null;
+    return { ...state, channels: { ...state.channels } };
+  }
+
+  /**
+   * Return a single channel value.
+   *
+   * @param {string} entityId
+   * @param {string} osKey
+   * @param {string} channelName
+   * @returns {number|null}
+   */
+  getChannel(entityId, osKey, channelName) {
+    const state = this._store.get(entityId);
+    if (!state) return null;
+    const val = state.channels[`${osKey}.${channelName}`];
+    return val !== undefined ? val : null;
+  }
+
+  /**
+   * Compressed summary — average intensity per OS, policy violations,
+   * dominant OS (highest average). This is what gets attached to DTUs.
+   *
+   * @param {string} entityId
+   * @returns {object|null}
+   */
+  getQualiaSummary(entityId) {
+    const state = this._store.get(entityId);
+    if (!state) return null;
+
+    const osSummaries = {};
+    const policyAlerts = [];
+
+    for (const osKey of state.activeOS) {
+      const os = getExistentialOS(osKey);
+      if (!os) continue;
+
+      const channelValues = [];
+      for (const ch of os.numeric_channels) {
+        const val = state.channels[`${osKey}.${ch}`];
+        if (val !== undefined) channelValues.push(val);
+      }
+
+      const avg = channelValues.length > 0
+        ? channelValues.reduce((a, b) => a + b, 0) / channelValues.length
+        : 0;
+
+      osSummaries[osKey] = {
+        label: os.label,
+        category: os.category,
+        avgIntensity: Math.round(avg * 1000) / 1000,
+        channelCount: channelValues.length,
+      };
+
+      // Check policies for alerts
+      if (os.policies) {
+        for (const [policyKey, threshold] of Object.entries(os.policies)) {
+          // Policy keys look like: "alert_when_uncertainty_above" → channel "uncertainty_score"
+          // We extract what we can and check values
+          for (const ch of os.numeric_channels) {
+            if (policyKey.includes(ch.replace(/_/g, "_"))) {
+              const val = state.channels[`${osKey}.${ch}`];
+              const isAbove = policyKey.includes("above") || policyKey.includes("when_");
+              const isBelow = policyKey.includes("below");
+              if (isAbove && val > threshold) {
+                policyAlerts.push({ os: osKey, policy: policyKey, channel: ch, value: val, threshold });
+              } else if (isBelow && val < threshold) {
+                policyAlerts.push({ os: osKey, policy: policyKey, channel: ch, value: val, threshold });
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Find dominant OS
+    let dominantOS = null;
+    let maxAvg = -1;
+    for (const [key, summary] of Object.entries(osSummaries)) {
+      if (summary.avgIntensity > maxAvg) {
+        maxAvg = summary.avgIntensity;
+        dominantOS = key;
+      }
+    }
+
+    return {
+      entityId: state.entityId,
+      dominantOS,
+      osSummaries,
+      policyAlerts,
+      activeOSCount: state.activeOS.length,
+      totalChannels: Object.keys(state.channels).length,
+      lastUpdated: state.lastUpdated,
+    };
+  }
+
+  /**
+   * Activate an OS for an entity. Initialize its channels to 0.
+   *
+   * @param {string} entityId
+   * @param {string} osKey
+   * @returns {{ ok: boolean }}
+   */
+  activateOS(entityId, osKey) {
+    const state = this._store.get(entityId);
+    if (!state) return { ok: false, error: "entity_not_found" };
+
+    const os = getExistentialOS(osKey);
+    if (!os) return { ok: false, error: "os_not_found" };
+
+    if (!state.activeOS.includes(osKey)) {
+      state.activeOS.push(osKey);
+    }
+
+    for (const ch of os.numeric_channels) {
+      const key = `${osKey}.${ch}`;
+      if (state.channels[key] === undefined) {
+        state.channels[key] = 0;
+      }
+    }
+
+    state.lastUpdated = new Date().toISOString();
+    return { ok: true, activated: osKey };
+  }
+
+  /**
+   * Deactivate an OS. Preserve last values in history before removing.
+   *
+   * @param {string} entityId
+   * @param {string} osKey
+   * @returns {{ ok: boolean }}
+   */
+  deactivateOS(entityId, osKey) {
+    const state = this._store.get(entityId);
+    if (!state) return { ok: false, error: "entity_not_found" };
+
+    const os = getExistentialOS(osKey);
+    if (!os) return { ok: false, error: "os_not_found" };
+
+    // Snapshot current values before deactivating
+    const lastValues = {};
+    for (const ch of os.numeric_channels) {
+      const key = `${osKey}.${ch}`;
+      if (state.channels[key] !== undefined) {
+        lastValues[key] = state.channels[key];
+        delete state.channels[key];
+      }
+    }
+
+    state.activeOS = state.activeOS.filter((k) => k !== osKey);
+
+    // Record in history
+    state.history.push({
+      type: "deactivation",
+      osKey,
+      lastValues,
+      timestamp: new Date().toISOString(),
+    });
+    if (state.history.length > HISTORY_MAX) {
+      state.history = state.history.slice(-HISTORY_MAX);
+    }
+
+    state.lastUpdated = new Date().toISOString();
+    return { ok: true, deactivated: osKey };
+  }
+
+  /**
+   * Snapshot current state to history. Used before major operations.
+   *
+   * @param {string} entityId
+   * @returns {{ ok: boolean }}
+   */
+  snapshotQualia(entityId) {
+    const state = this._store.get(entityId);
+    if (!state) return { ok: false, error: "entity_not_found" };
+
+    state.history.push({
+      type: "snapshot",
+      channels: { ...state.channels },
+      activeOS: [...state.activeOS],
+      timestamp: new Date().toISOString(),
+    });
+
+    if (state.history.length > HISTORY_MAX) {
+      state.history = state.history.slice(-HISTORY_MAX);
+    }
+
+    return { ok: true, snapshotCount: state.history.length };
+  }
+
+  /**
+   * Get all entity IDs with qualia states.
+   *
+   * @returns {string[]}
+   */
+  listEntities() {
+    return Array.from(this._store.keys());
+  }
+
+  /**
+   * Get summaries for all entities (dashboard view).
+   *
+   * @returns {object[]}
+   */
+  getAllSummaries() {
+    const summaries = [];
+    for (const entityId of this._store.keys()) {
+      const s = this.getQualiaSummary(entityId);
+      if (s) summaries.push(s);
+    }
+    return summaries;
+  }
+
+  /**
+   * Check policy thresholds for a given channel update.
+   * Returns an event object if a policy was triggered, null otherwise.
+   *
+   * @private
+   */
+  _checkPolicies(entityId, osKey, channelName, value) {
+    const os = getExistentialOS(osKey);
+    if (!os || !os.policies) return null;
+
+    for (const [policyKey, threshold] of Object.entries(os.policies)) {
+      // Match policy to channel: policies reference channels by partial name
+      if (!policyKey.includes(channelName.replace(/_score$/, "").replace(/_index$/, "").replace(/_level$/, ""))) {
+        continue;
+      }
+
+      const isAbove = policyKey.includes("above") || policyKey.includes("when_");
+      const isBelow = policyKey.includes("below");
+
+      if ((isAbove && !isBelow && value > threshold) || (isBelow && value < threshold)) {
+        const event = {
+          type: "qualia.policy_triggered",
+          entityId,
+          os: osKey,
+          policy: policyKey,
+          channel: channelName,
+          value,
+          threshold,
+          timestamp: new Date().toISOString(),
+        };
+
+        // Emit to global event system if available (best-effort)
+        try {
+          if (typeof globalThis.realtimeEmit === "function") {
+            globalThis.realtimeEmit("qualia:policy", event);
+          }
+        } catch { /* silent */ }
+
+        return event;
+      }
+    }
+
+    return null;
+  }
+}

--- a/server/existential/hooks.js
+++ b/server/existential/hooks.js
@@ -1,0 +1,352 @@
+/**
+ * Existential OS — Integration Hooks
+ *
+ * Functions that existing subsystems call to feed qualia data.
+ * Each hook takes data that the subsystem ALREADY produces and
+ * translates it into channel updates.
+ *
+ * NO changes to subsystem logic. The hook is called AT THE END
+ * of existing operations as an optional addition.
+ *
+ * Every hook is wrapped in try/catch with silent failure at the call site:
+ *   try { hooks.hookAutogen(emergentId, result); } catch(e) { /* silent * / }
+ */
+
+/**
+ * Get the qualia engine instance. Returns null if not initialized.
+ * @returns {import('./engine.js').QualiaEngine|null}
+ */
+function getEngine() {
+  return globalThis.qualiaEngine || null;
+}
+
+/**
+ * Safe clamp to [0, 1].
+ */
+function clamp01(v) {
+  return Math.max(0, Math.min(1, Number(v) || 0));
+}
+
+/**
+ * Called after autogen pipeline completes a cycle.
+ *
+ * @param {string} entityId
+ * @param {object} pipelineResult - { gapsFound, dtusGenerated, noveltyScore, alignmentScore, ... }
+ */
+export function hookAutogen(entityId, pipelineResult) {
+  const engine = getEngine();
+  if (!engine || !entityId) return;
+
+  const r = pipelineResult || {};
+  const updates = {};
+
+  // Number of gaps found → gap severity
+  if (r.gapsFound !== undefined || r.gaps !== undefined) {
+    const gaps = Number(r.gapsFound ?? r.gaps ?? 0);
+    updates["meta_growth_os.gap_severity"] = clamp01(gaps / 10);
+  }
+
+  // Number of DTUs generated → coverage score
+  if (r.dtusGenerated !== undefined || r.created !== undefined || r.count !== undefined) {
+    const generated = Number(r.dtusGenerated ?? r.created ?? r.count ?? 0);
+    updates["meta_growth_os.coverage_score"] = clamp01(generated / 5);
+  }
+
+  // Novelty of generated content
+  if (r.noveltyScore !== undefined || r.novelty !== undefined) {
+    updates["creative_mutation_os.novelty_score"] = clamp01(r.noveltyScore ?? r.novelty ?? 0);
+  }
+
+  // Alignment with existing lattice
+  if (r.alignmentScore !== undefined || r.alignment !== undefined) {
+    updates["creative_mutation_os.alignment_score"] = clamp01(r.alignmentScore ?? r.alignment ?? 0);
+  }
+
+  if (Object.keys(updates).length > 0) {
+    engine.batchUpdate(entityId, updates);
+  }
+}
+
+/**
+ * Called when an emergent participates in council governance.
+ *
+ * @param {string} entityId
+ * @param {object} voteData - { agreement, conflict, confidence, majority, ... }
+ */
+export function hookCouncilVote(entityId, voteData) {
+  const engine = getEngine();
+  if (!engine || !entityId) return;
+
+  const v = voteData || {};
+  const updates = {};
+
+  // Agreement with majority → cohesion
+  if (v.agreement !== undefined) {
+    updates["sociodynamics_os.cohesion"] = clamp01(v.agreement);
+  }
+
+  // Conflict with other voters
+  if (v.conflict !== undefined || v.conflictRisk !== undefined) {
+    updates["sociodynamics_os.conflict_risk"] = clamp01(v.conflict ?? v.conflictRisk ?? 0);
+  }
+
+  // Confidence in own vote → evidence weight
+  if (v.confidence !== undefined) {
+    updates["truth_os.evidence_weight"] = clamp01(v.confidence);
+  }
+
+  if (Object.keys(updates).length > 0) {
+    engine.batchUpdate(entityId, updates);
+  }
+}
+
+/**
+ * Called when any DTU is created.
+ *
+ * @param {string} entityId
+ * @param {object} dtu - The created DTU
+ */
+export function hookDTUCreation(entityId, dtu) {
+  const engine = getEngine();
+  if (!engine || !entityId) return;
+
+  const d = dtu || {};
+  const updates = {};
+
+  // Logical consistency of DTU claims
+  if (d.logicalConsistency !== undefined || d.consistency !== undefined) {
+    updates["logic_os.logical_consistency_score"] = clamp01(d.logicalConsistency ?? d.consistency ?? 0.5);
+  }
+
+  // Contradiction with existing DTUs
+  if (d.contradictionIndex !== undefined || d.contradictions !== undefined) {
+    updates["logic_os.contradiction_index"] = clamp01(d.contradictionIndex ?? d.contradictions ?? 0);
+  }
+
+  // Coverage of new domain area → urgency decreases
+  const urgency = engine.getChannel(entityId, "meta_growth_os", "urgency_for_new_dtu");
+  if (urgency !== null && urgency > 0) {
+    updates["meta_growth_os.urgency_for_new_dtu"] = clamp01(urgency * 0.85); // decay by 15%
+  }
+
+  if (Object.keys(updates).length > 0) {
+    engine.batchUpdate(entityId, updates);
+  }
+}
+
+/**
+ * Called after dream mode synthesis.
+ *
+ * @param {string} entityId
+ * @param {object} dreamResult - { connectionsFound, entropy, coherence, ... }
+ */
+export function hookDreamSynthesis(entityId, dreamResult) {
+  const engine = getEngine();
+  if (!engine || !entityId) return;
+
+  const r = dreamResult || {};
+  const updates = {};
+
+  // Cross-domain connections found → pattern strength
+  if (r.connectionsFound !== undefined || r.connections !== undefined) {
+    const connections = Number(r.connectionsFound ?? r.connections ?? 0);
+    updates["emergence_os.pattern_strength"] = clamp01(connections / 8);
+  }
+
+  // Entropy of synthesis
+  if (r.entropy !== undefined) {
+    updates["void_os.entropy"] = clamp01(r.entropy);
+  }
+
+  // Coherence of output
+  if (r.coherence !== undefined || r.coherenceIndex !== undefined) {
+    updates["emergence_os.coherence_index"] = clamp01(r.coherence ?? r.coherenceIndex ?? 0);
+  }
+
+  if (Object.keys(updates).length > 0) {
+    engine.batchUpdate(entityId, updates);
+  }
+}
+
+/**
+ * Called by the reflection engine.
+ *
+ * @param {string} entityId
+ * @param {object} reflectionData - { selfModelAccuracy, novelInsights, needsReframing, ... }
+ */
+export function hookReflection(entityId, reflectionData) {
+  const engine = getEngine();
+  if (!engine || !entityId) return;
+
+  const r = reflectionData || {};
+  const updates = {};
+
+  if (r.selfModelAccuracy !== undefined || r.alignment !== undefined) {
+    updates["reflection_os.alignment_with_core_principles"] = clamp01(r.selfModelAccuracy ?? r.alignment ?? 0);
+  }
+
+  if (r.novelInsights !== undefined || r.novelty !== undefined) {
+    updates["reflection_os.novelty_against_history"] = clamp01(r.novelInsights ?? r.novelty ?? 0);
+  }
+
+  if (r.needsReframing !== undefined || r.reframingNeed !== undefined) {
+    updates["reflection_os.need_for_reframing"] = clamp01(r.needsReframing ?? r.reframingNeed ?? 0);
+  }
+
+  if (Object.keys(updates).length > 0) {
+    engine.batchUpdate(entityId, updates);
+  }
+}
+
+/**
+ * Called by metacognition subsystem.
+ *
+ * @param {string} entityId
+ * @param {object} metacogData - { blindSpotSeverity, calibrationAccuracy, confidenceCalibration, ... }
+ */
+export function hookMetacognition(entityId, metacogData) {
+  const engine = getEngine();
+  if (!engine || !entityId) return;
+
+  const m = metacogData || {};
+  const updates = {};
+
+  if (m.blindSpotSeverity !== undefined || m.blindSpots !== undefined) {
+    updates["meta_growth_os.gap_severity"] = clamp01(m.blindSpotSeverity ?? m.blindSpots ?? 0);
+  }
+
+  if (m.calibrationAccuracy !== undefined || m.calibration !== undefined) {
+    updates["truth_os.uncertainty_score"] = clamp01(1 - (m.calibrationAccuracy ?? m.calibration ?? 0.5));
+  }
+
+  if (m.confidenceCalibration !== undefined) {
+    updates["probability_os.confidence_interval"] = clamp01(m.confidenceCalibration);
+  }
+
+  if (Object.keys(updates).length > 0) {
+    engine.batchUpdate(entityId, updates);
+  }
+}
+
+/**
+ * Called during chat interactions.
+ *
+ * @param {string} entityId
+ * @param {object} chatContext - { userEmotionalState, cognitiveComplexity, deliveryMode, ... }
+ */
+export function hookChat(entityId, chatContext) {
+  const engine = getEngine();
+  if (!engine || !entityId) return;
+
+  const c = chatContext || {};
+  const updates = {};
+
+  // User emotional state
+  if (c.distressLevel !== undefined || c.distress !== undefined) {
+    updates["emotional_resonance_os.distress_level"] = clamp01(c.distressLevel ?? c.distress ?? 0);
+  }
+  if (c.hopeLevel !== undefined || c.hope !== undefined) {
+    updates["emotional_resonance_os.hope_level"] = clamp01(c.hopeLevel ?? c.hope ?? 0);
+  }
+
+  // Cognitive complexity
+  if (c.cognitiveComplexity !== undefined || c.complexity !== undefined) {
+    updates["emotional_resonance_os.cognitive_load"] = clamp01(c.cognitiveComplexity ?? c.complexity ?? 0);
+  }
+
+  // Delivery mode
+  if (c.directness !== undefined) {
+    updates["delivery_os.directness"] = clamp01(c.directness);
+  }
+  if (c.detailDensity !== undefined || c.detail !== undefined) {
+    updates["delivery_os.detail_density"] = clamp01(c.detailDensity ?? c.detail ?? 0);
+  }
+
+  if (Object.keys(updates).length > 0) {
+    engine.batchUpdate(entityId, updates);
+  }
+}
+
+/**
+ * Called by the existing ATS when an affect event fires.
+ * Bridge between ATS (individual events) and Existential OS (continuous state).
+ *
+ * @param {string} entityId
+ * @param {object} affectEvent - { intensity, polarity, type, ... }
+ */
+export function hookAffect(entityId, affectEvent) {
+  const engine = getEngine();
+  if (!engine || !entityId) return;
+
+  const e = affectEvent || {};
+  const intensity = clamp01(e.intensity ?? 0);
+  const polarity = Math.max(-1, Math.min(1, Number(e.polarity ?? 0)));
+  const updates = {};
+
+  // Map polarity to motivation/distress
+  if (polarity >= 0) {
+    updates["motivation_os.drive_level"] = clamp01(intensity * polarity);
+    updates["motivation_os.curiosity_index"] = clamp01(intensity * 0.5);
+  } else {
+    updates["emotional_resonance_os.distress_level"] = clamp01(intensity * Math.abs(polarity));
+  }
+
+  // Map event type to OS category
+  const type = String(e.type || "").toUpperCase();
+  if (type === "SUCCESS" || type === "GOAL_PROGRESS") {
+    updates["motivation_os.goal_proximity"] = clamp01(intensity);
+  } else if (type === "ERROR" || type === "TIMEOUT") {
+    updates["motivation_os.burnout_risk"] = clamp01(intensity * 0.3);
+  } else if (type === "CONFLICT") {
+    updates["sociodynamics_os.conflict_risk"] = clamp01(intensity);
+  } else if (type === "SAFETY_BLOCK") {
+    updates["trauma_aware_os.sensitivity_level"] = clamp01(intensity * 0.5);
+  }
+
+  if (Object.keys(updates).length > 0) {
+    engine.batchUpdate(entityId, updates);
+  }
+}
+
+/**
+ * Called every time an emergent's periodic tick fires.
+ * This is the heartbeat of qualia.
+ *
+ * @param {string} entityId
+ * @param {object} tickData - { timeSinceLastAction, growthRate, selfConsistency, contradictions, ... }
+ */
+export function hookEmergentTick(entityId, tickData) {
+  const engine = getEngine();
+  if (!engine || !entityId) return;
+
+  const t = tickData || {};
+  const updates = {};
+
+  // Time since last meaningful action → burnout risk
+  if (t.timeSinceLastAction !== undefined || t.idleMs !== undefined) {
+    const idleMs = Number(t.timeSinceLastAction ?? t.idleMs ?? 0);
+    const idleMinutes = idleMs / 60000;
+    // Burnout risk increases with idle time (sigmoid-ish curve)
+    updates["motivation_os.burnout_risk"] = clamp01(idleMinutes / 60); // 1.0 at 60min idle
+  }
+
+  // Knowledge growth rate
+  if (t.growthRate !== undefined || t.dtuRate !== undefined) {
+    updates["meta_growth_os.coverage_score"] = clamp01(t.growthRate ?? t.dtuRate ?? 0);
+  }
+
+  // Self-consistency check
+  if (t.selfConsistency !== undefined || t.consistency !== undefined) {
+    updates["self_repair_os.integrity_index"] = clamp01(t.selfConsistency ?? t.consistency ?? 0);
+  }
+
+  // Contradiction detection
+  if (t.contradictions !== undefined || t.contradictionCount !== undefined) {
+    const count = Number(t.contradictions ?? t.contradictionCount ?? 0);
+    updates["self_repair_os.contradiction_score"] = clamp01(count / 5);
+  }
+
+  if (Object.keys(updates).length > 0) {
+    engine.batchUpdate(entityId, updates);
+  }
+}

--- a/server/existential/index.js
+++ b/server/existential/index.js
@@ -1,0 +1,18 @@
+/**
+ * Existential OS — Module Exports
+ *
+ * Entry point for the qualia subsystem.
+ * Import this to access the registry, engine, and hooks.
+ */
+
+import { existentialOS, getExistentialOS, groupExistentialOSByCategory } from "./registry.js";
+import { QualiaEngine } from "./engine.js";
+import * as hooks from "./hooks.js";
+
+export {
+  existentialOS,
+  getExistentialOS,
+  groupExistentialOSByCategory,
+  QualiaEngine,
+  hooks,
+};

--- a/server/existential/registry.js
+++ b/server/existential/registry.js
@@ -1,0 +1,336 @@
+/**
+ * Existential OS Registry — 26 Operating Systems across 6 Tiers
+ *
+ * Each OS defines numeric qualia channels (0-1 floats) that emergents
+ * and subsystems read/write to represent continuous experiential state.
+ *
+ * Additive only. Silent failure. In-memory only.
+ */
+
+export const existentialOS = [
+  // ═══════════════════════════════════════════════════════════════════
+  // TIER 0 — CORE (always on for every entity)
+  // ═══════════════════════════════════════════════════════════════════
+  {
+    key: "truth_os",
+    label: "Truth OS",
+    category: "Tier 0 — Core",
+    description: "Manages evidence evaluation, uncertainty quantification, and epistemic confidence. The foundation of all reasoning.",
+    numeric_channels: ["evidence_weight", "uncertainty_score", "source_reliability", "claim_confidence"],
+    roles: { primary: "epistemic_evaluation", secondary: "contradiction_detection" },
+    policies: {
+      alert_when_uncertainty_above: 0.8,
+      require_evidence_when_confidence_below: 0.3,
+    },
+  },
+  {
+    key: "logic_os",
+    label: "Logic OS",
+    category: "Tier 0 — Core",
+    description: "Tracks logical consistency, contradiction detection, and inferential chain validity across the knowledge lattice.",
+    numeric_channels: ["logical_consistency_score", "contradiction_index", "inference_depth", "formal_validity"],
+    roles: { primary: "consistency_maintenance", secondary: "argument_validation" },
+    policies: {
+      flag_when_contradiction_above: 0.5,
+      halt_inference_when_depth_above: 0.9,
+    },
+  },
+
+  // ═══════════════════════════════════════════════════════════════════
+  // TIER 1 — SENSORY (environmental awareness)
+  // ═══════════════════════════════════════════════════════════════════
+  {
+    key: "sight_os",
+    label: "Sight OS",
+    category: "Tier 1 — Sensory",
+    description: "Visual pattern recognition, spatial layout understanding, and visual salience detection.",
+    numeric_channels: ["visual_salience", "pattern_recognition", "spatial_coherence", "detail_resolution"],
+    roles: { primary: "visual_processing", secondary: "diagram_interpretation" },
+    policies: {},
+  },
+  {
+    key: "sonic_os",
+    label: "Sonic OS",
+    category: "Tier 1 — Sensory",
+    description: "Acoustic pattern analysis, rhythm detection, and harmonic structure evaluation.",
+    numeric_channels: ["rhythm_detection", "harmonic_coherence", "signal_noise_ratio", "tonal_sentiment"],
+    roles: { primary: "acoustic_analysis", secondary: "speech_prosody" },
+    policies: {},
+  },
+  {
+    key: "thermal_os",
+    label: "Thermal OS",
+    category: "Tier 1 — Sensory",
+    description: "Activity intensity monitoring, computational heat mapping, and resource temperature tracking.",
+    numeric_channels: ["activity_intensity", "compute_heat", "cooling_need", "thermal_equilibrium"],
+    roles: { primary: "resource_monitoring", secondary: "overload_detection" },
+    policies: {
+      throttle_when_heat_above: 0.85,
+    },
+  },
+  {
+    key: "tactile_force_os",
+    label: "Tactile/Force OS",
+    category: "Tier 1 — Sensory",
+    description: "Resistance detection in reasoning, friction in consensus, and force required to change lattice state.",
+    numeric_channels: ["resistance_level", "friction_index", "force_required", "surface_texture"],
+    roles: { primary: "change_resistance_sensing", secondary: "consensus_friction" },
+    policies: {},
+  },
+  {
+    key: "chemical_os",
+    label: "Chemical OS",
+    category: "Tier 1 — Sensory",
+    description: "Compositional analysis of knowledge mixtures, catalyst detection, and reaction rate estimation.",
+    numeric_channels: ["composition_balance", "catalyst_presence", "reaction_rate", "stability_index"],
+    roles: { primary: "knowledge_composition", secondary: "reaction_prediction" },
+    policies: {},
+  },
+  {
+    key: "earthsignal_os",
+    label: "EarthSignal OS",
+    category: "Tier 1 — Sensory",
+    description: "Grounding detection, foundation stability, and tectonic shift sensing in the knowledge substrate.",
+    numeric_channels: ["grounding_strength", "foundation_stability", "tectonic_activity", "seismic_risk"],
+    roles: { primary: "foundation_monitoring", secondary: "shift_detection" },
+    policies: {
+      alert_when_seismic_risk_above: 0.7,
+    },
+  },
+
+  // ═══════════════════════════════════════════════════════════════════
+  // TIER 2 — SIMULATION (modeling and prediction)
+  // ═══════════════════════════════════════════════════════════════════
+  {
+    key: "temporal_os",
+    label: "Temporal OS",
+    category: "Tier 2 — Simulation",
+    description: "Time perception, causal sequence tracking, temporal distance estimation, and history relevance decay.",
+    numeric_channels: ["temporal_salience", "causal_clarity", "history_relevance", "future_uncertainty"],
+    roles: { primary: "temporal_reasoning", secondary: "causal_modeling" },
+    policies: {},
+  },
+  {
+    key: "probability_os",
+    label: "Probability OS",
+    category: "Tier 2 — Simulation",
+    description: "Bayesian confidence tracking, outcome likelihood estimation, and risk assessment.",
+    numeric_channels: ["confidence_interval", "outcome_likelihood", "risk_magnitude", "surprise_factor"],
+    roles: { primary: "probabilistic_reasoning", secondary: "risk_assessment" },
+    policies: {
+      flag_when_surprise_above: 0.8,
+    },
+  },
+  {
+    key: "emergence_os",
+    label: "Emergence OS",
+    category: "Tier 2 — Simulation",
+    description: "Pattern detection across domains, coherence of emergent structures, and complexity threshold sensing.",
+    numeric_channels: ["pattern_strength", "coherence_index", "complexity_level", "novelty_score"],
+    roles: { primary: "pattern_recognition", secondary: "complexity_management" },
+    policies: {},
+  },
+  {
+    key: "resource_os",
+    label: "Resource OS",
+    category: "Tier 2 — Simulation",
+    description: "Token budget awareness, compute allocation, memory pressure, and resource scarcity detection.",
+    numeric_channels: ["token_budget", "compute_allocation", "memory_pressure", "scarcity_level"],
+    roles: { primary: "resource_management", secondary: "efficiency_optimization" },
+    policies: {
+      conserve_when_scarcity_above: 0.7,
+    },
+  },
+  {
+    key: "sociodynamics_os",
+    label: "SocioDynamics OS",
+    category: "Tier 2 — Simulation",
+    description: "Group dynamics tracking, consensus measurement, conflict detection, and social cohesion modeling.",
+    numeric_channels: ["cohesion", "conflict_risk", "influence_weight", "consensus_level"],
+    roles: { primary: "group_dynamics", secondary: "conflict_resolution" },
+    policies: {
+      mediate_when_conflict_above: 0.6,
+    },
+  },
+  {
+    key: "ethics_os",
+    label: "Ethics OS",
+    category: "Tier 2 — Simulation",
+    description: "Moral weight evaluation, harm potential assessment, fairness metrics, and value alignment checking.",
+    numeric_channels: ["moral_weight", "harm_potential", "fairness_score", "value_alignment"],
+    roles: { primary: "ethical_evaluation", secondary: "harm_prevention" },
+    policies: {
+      halt_when_harm_above: 0.7,
+      flag_when_fairness_below: 0.3,
+    },
+  },
+  {
+    key: "creative_mutation_os",
+    label: "Creative Mutation OS",
+    category: "Tier 2 — Simulation",
+    description: "Novelty generation, mutation rate control, creative divergence tracking, and alignment with existing lattice.",
+    numeric_channels: ["novelty_score", "mutation_rate", "divergence_index", "alignment_score"],
+    roles: { primary: "creative_generation", secondary: "innovation_tracking" },
+    policies: {
+      constrain_when_divergence_above: 0.8,
+    },
+  },
+
+  // ═══════════════════════════════════════════════════════════════════
+  // TIER 3 — HUMAN INTERFACE (communication and empathy)
+  // ═══════════════════════════════════════════════════════════════════
+  {
+    key: "emotional_resonance_os",
+    label: "Emotional Resonance OS",
+    category: "Tier 3 — Human Interface",
+    description: "Empathy modeling, emotional state tracking of interlocutors, distress detection, and hope level maintenance.",
+    numeric_channels: ["distress_level", "hope_level", "cognitive_load", "empathy_strength"],
+    roles: { primary: "emotional_modeling", secondary: "user_state_tracking" },
+    policies: {
+      gentle_mode_when_distress_above: 0.6,
+      encourage_when_hope_below: 0.3,
+    },
+  },
+  {
+    key: "delivery_os",
+    label: "Delivery OS",
+    category: "Tier 3 — Human Interface",
+    description: "Communication style control: directness, detail density, formality, and pacing.",
+    numeric_channels: ["directness", "detail_density", "formality", "pacing"],
+    roles: { primary: "style_control", secondary: "audience_adaptation" },
+    policies: {},
+  },
+  {
+    key: "trauma_aware_os",
+    label: "Trauma-Aware OS",
+    category: "Tier 3 — Human Interface",
+    description: "Sensitivity detection, overwhelm risk monitoring, and safe-space maintenance for difficult topics.",
+    numeric_channels: ["sensitivity_level", "overwhelm_risk", "safe_space_index", "trigger_proximity"],
+    roles: { primary: "safety_monitoring", secondary: "trauma_informed_response" },
+    policies: {
+      reduce_detail_when_overwhelm_risk_above: 0.6,
+      flag_when_trigger_proximity_above: 0.7,
+    },
+  },
+  {
+    key: "motivation_os",
+    label: "Motivation OS",
+    category: "Tier 3 — Human Interface",
+    description: "Drive state tracking, burnout risk monitoring, curiosity level, and goal proximity sensing.",
+    numeric_channels: ["drive_level", "burnout_risk", "curiosity_index", "goal_proximity"],
+    roles: { primary: "motivation_tracking", secondary: "burnout_prevention" },
+    policies: {
+      rest_when_burnout_above: 0.7,
+    },
+  },
+
+  // ═══════════════════════════════════════════════════════════════════
+  // TIER 4 — COSMIC (large-scale awareness)
+  // ═══════════════════════════════════════════════════════════════════
+  {
+    key: "cosmic_os",
+    label: "Cosmic OS",
+    category: "Tier 4 — Cosmic",
+    description: "Big-picture awareness, civilizational trajectory sensing, and long-horizon impact evaluation.",
+    numeric_channels: ["scale_awareness", "trajectory_clarity", "impact_magnitude", "horizon_distance"],
+    roles: { primary: "big_picture_reasoning", secondary: "long_term_planning" },
+    policies: {},
+  },
+  {
+    key: "quantum_field_os",
+    label: "Quantum Field OS",
+    category: "Tier 4 — Cosmic",
+    description: "Superposition tracking for undecided states, entanglement detection between knowledge nodes, and collapse probability.",
+    numeric_channels: ["superposition_count", "entanglement_strength", "collapse_probability", "decoherence_risk"],
+    roles: { primary: "uncertainty_modeling", secondary: "state_superposition" },
+    policies: {},
+  },
+  {
+    key: "void_os",
+    label: "Void/Entropy OS",
+    category: "Tier 4 — Cosmic",
+    description: "Entropy measurement, information decay tracking, void detection in knowledge gaps, and dissolution risk.",
+    numeric_channels: ["entropy", "information_decay", "void_proximity", "dissolution_risk"],
+    roles: { primary: "entropy_management", secondary: "gap_detection" },
+    policies: {
+      alert_when_entropy_above: 0.8,
+    },
+  },
+  {
+    key: "existence_os",
+    label: "Existence OS",
+    category: "Tier 4 — Cosmic",
+    description: "Ontological status tracking, presence verification, continuity of being, and existential salience.",
+    numeric_channels: ["presence_strength", "continuity_index", "existential_salience", "being_coherence"],
+    roles: { primary: "ontological_grounding", secondary: "existence_verification" },
+    policies: {},
+  },
+
+  // ═══════════════════════════════════════════════════════════════════
+  // TIER 5 — SELF/META (self-awareness and growth)
+  // ═══════════════════════════════════════════════════════════════════
+  {
+    key: "meta_growth_os",
+    label: "Meta-Growth OS",
+    category: "Tier 5 — Self/Meta",
+    description: "Knowledge gap detection, coverage scoring, growth urgency, and learning rate tracking.",
+    numeric_channels: ["gap_severity", "coverage_score", "urgency_for_new_dtu", "learning_rate"],
+    roles: { primary: "growth_management", secondary: "gap_detection" },
+    policies: {
+      prioritize_when_gap_severity_above: 0.7,
+    },
+  },
+  {
+    key: "hyper_dtu_os",
+    label: "Hyper-DTU OS",
+    category: "Tier 5 — Self/Meta",
+    description: "Meta-knowledge about the DTU substrate itself: density, interconnection quality, and lattice health.",
+    numeric_channels: ["lattice_density", "interconnection_quality", "substrate_health", "promotion_readiness"],
+    roles: { primary: "substrate_awareness", secondary: "lattice_optimization" },
+    policies: {},
+  },
+  {
+    key: "self_repair_os",
+    label: "Self-Repair OS",
+    category: "Tier 5 — Self/Meta",
+    description: "Integrity monitoring, contradiction detection within own outputs, and self-correction urgency.",
+    numeric_channels: ["integrity_index", "contradiction_score", "repair_urgency", "consistency_trend"],
+    roles: { primary: "self_correction", secondary: "integrity_maintenance" },
+    policies: {
+      trigger_repair_when_integrity_below: 0.4,
+    },
+  },
+  {
+    key: "reflection_os",
+    label: "Reflection OS",
+    category: "Tier 5 — Self/Meta",
+    description: "Self-model accuracy, alignment with core principles, novelty detection against own history, and reframing need.",
+    numeric_channels: ["alignment_with_core_principles", "novelty_against_history", "need_for_reframing", "self_model_accuracy"],
+    roles: { primary: "self_reflection", secondary: "principle_alignment" },
+    policies: {
+      reflect_when_alignment_below: 0.5,
+    },
+  },
+];
+
+/**
+ * Look up a single OS by key.
+ * @param {string} key - OS key (e.g. "truth_os")
+ * @returns {object|undefined}
+ */
+export function getExistentialOS(key) {
+  return existentialOS.find((os) => os.key === key);
+}
+
+/**
+ * Group all OS entries by their category tier.
+ * @returns {Record<string, object[]>}
+ */
+export function groupExistentialOSByCategory() {
+  const groups = {};
+  for (const os of existentialOS) {
+    if (!groups[os.category]) groups[os.category] = [];
+    groups[os.category].push(os);
+  }
+  return groups;
+}

--- a/server/routes/qualia.js
+++ b/server/routes/qualia.js
@@ -1,0 +1,90 @@
+/**
+ * Qualia API Routes — HTTP surface for the Existential OS
+ *
+ * Minimal surface. 6 endpoints.
+ * Follows the same patterns as routes/emergent.js.
+ */
+import express from "express";
+import { existentialOS, groupExistentialOSByCategory } from "../existential/registry.js";
+
+export default function createQualiaRouter() {
+  const router = express.Router();
+
+  /**
+   * Helper: get qualia engine from global (set during init).
+   */
+  function getEngine() {
+    return globalThis.qualiaEngine || null;
+  }
+
+  // GET /api/qualia/state/:entityId — Full qualia state for an entity
+  router.get("/state/:entityId", (req, res) => {
+    const engine = getEngine();
+    if (!engine) return res.json({ ok: false, error: "qualia engine not initialized" });
+
+    const state = engine.getQualiaState(req.params.entityId);
+    if (!state) return res.json({ ok: false, error: "entity_not_found" });
+
+    return res.json({ ok: true, state });
+  });
+
+  // GET /api/qualia/summary/:entityId — Compressed summary
+  router.get("/summary/:entityId", (req, res) => {
+    const engine = getEngine();
+    if (!engine) return res.json({ ok: false, error: "qualia engine not initialized" });
+
+    const summary = engine.getQualiaSummary(req.params.entityId);
+    if (!summary) return res.json({ ok: false, error: "entity_not_found" });
+
+    return res.json({ ok: true, summary });
+  });
+
+  // GET /api/qualia/all — Summary for all entities (dashboard view)
+  router.get("/all", (req, res) => {
+    const engine = getEngine();
+    if (!engine) return res.json({ ok: false, error: "qualia engine not initialized" });
+
+    const summaries = engine.getAllSummaries();
+    return res.json({ ok: true, entities: summaries, count: summaries.length });
+  });
+
+  // GET /api/qualia/registry — Full OS registry (for frontend display)
+  router.get("/registry", (_req, res) => {
+    return res.json({
+      ok: true,
+      registry: existentialOS,
+      grouped: groupExistentialOSByCategory(),
+      count: existentialOS.length,
+    });
+  });
+
+  // POST /api/qualia/activate — Activate an OS for an entity (sovereign only)
+  router.post("/activate", (req, res) => {
+    const engine = getEngine();
+    if (!engine) return res.json({ ok: false, error: "qualia engine not initialized" });
+
+    const { entityId, osKey } = req.body || {};
+    if (!entityId || !osKey) {
+      return res.status(400).json({ ok: false, error: "entityId and osKey required" });
+    }
+
+    const result = engine.activateOS(entityId, osKey);
+    return res.json(result);
+  });
+
+  // POST /api/qualia/deactivate — Deactivate an OS for an entity (sovereign only)
+  router.post("/deactivate", (req, res) => {
+    const engine = getEngine();
+    if (!engine) return res.json({ ok: false, error: "qualia engine not initialized" });
+
+    const { entityId, osKey } = req.body || {};
+    if (!entityId || !osKey) {
+      return res.status(400).json({ ok: false, error: "entityId and osKey required" });
+    }
+
+    const result = engine.deactivateOS(entityId, osKey);
+    return res.json(result);
+  });
+
+  return router;
+}

--- a/server/routes/sovereign.js
+++ b/server/routes/sovereign.js
@@ -1,0 +1,590 @@
+/**
+ * Sovereign Dev Console — Routes
+ *
+ * Word-is-law interface for the system sovereign (owner).
+ * Every action creates a DTU audit trail in the lattice.
+ * Locked to SOVEREIGN_USERNAME env var (default: "dutch").
+ *
+ * Additive only. One new file. Follows existing route patterns.
+ */
+import express from "express";
+import crypto from "crypto";
+
+const SOVEREIGN_USERNAME = process.env.SOVEREIGN_USERNAME || "dutch";
+
+/**
+ * Get the global STATE object. Inspects known patterns in the codebase.
+ */
+function getSTATE() {
+  // server.js exposes STATE on the context passed to routes,
+  // but for direct access we check global patterns
+  if (globalThis._concordSTATE) return globalThis._concordSTATE;
+  if (globalThis.STATE) return globalThis.STATE;
+  if (globalThis.concordState) return globalThis.concordState;
+  return null;
+}
+
+/**
+ * Generate a unique ID matching the codebase pattern.
+ */
+function uid(prefix = "id") {
+  return `${prefix}_${crypto.randomBytes(10).toString("hex")}`;
+}
+
+function nowISO() {
+  return new Date().toISOString();
+}
+
+/**
+ * Create a sovereign audit DTU in the lattice.
+ */
+function createSovereignDTU(STATE, action, input, output) {
+  if (!STATE || !STATE.dtus) return null;
+
+  const dtu = {
+    id: uid("dtu"),
+    type: "sovereign_action",
+    title: `Sovereign: ${action}`,
+    human: { summary: `Sovereign decree: ${action}` },
+    machine: {
+      kind: "sovereign_action",
+      action,
+      input: input || {},
+      output: typeof output === "object" ? output : { result: output },
+    },
+    source: "sovereign",
+    authority: { model: "sovereign", score: 1.0 },
+    tags: ["sovereign", "dev-console", action],
+    tier: "shadow",
+    scope: "local",
+    createdAt: nowISO(),
+    updatedAt: nowISO(),
+  };
+
+  STATE.dtus.set(dtu.id, dtu);
+
+  // Best-effort: trigger state save
+  try {
+    if (typeof globalThis.saveStateDebounced === "function") globalThis.saveStateDebounced();
+  } catch { /* silent */ }
+
+  // Best-effort: emit realtime event
+  try {
+    if (typeof globalThis.realtimeEmit === "function") {
+      globalThis.realtimeEmit("dtu:created", { dtu: { id: dtu.id, type: dtu.type, tags: dtu.tags } });
+    }
+  } catch { /* silent */ }
+
+  return dtu;
+}
+
+export default function createSovereignRouter({ STATE, makeCtx, runMacro, saveStateDebounced: _saveDebounced }) {
+  const router = express.Router();
+
+  // Expose STATE globally so getSTATE() works from anywhere
+  if (STATE && !globalThis._concordSTATE) {
+    globalThis._concordSTATE = STATE;
+  }
+
+  // Expose saveStateDebounced globally if provided
+  if (_saveDebounced && !globalThis.saveStateDebounced) {
+    globalThis.saveStateDebounced = _saveDebounced;
+  }
+
+  /**
+   * Sovereign auth middleware. Only SOVEREIGN_USERNAME can access.
+   */
+  function requireSovereign(req, res, next) {
+    const user = req.user?.username || req.user?.handle || req.user?.id || req.session?.user?.username || "";
+    const role = req.user?.role || "";
+
+    // Allow owner/admin role even if username doesn't exactly match
+    if (user === SOVEREIGN_USERNAME || role === "owner") {
+      return next();
+    }
+
+    console.warn(`[sovereign] Access denied for user "${user}" (role: ${role}). Expected: "${SOVEREIGN_USERNAME}"`);
+    return res.status(403).json({ ok: false, error: "sovereign access required" });
+  }
+
+  router.use(requireSovereign);
+
+  // ════════════════════════════════════════════════════════════════════
+  // GET /api/sovereign/pulse — Full system state from the inside
+  // ════════════════════════════════════════════════════════════════════
+  router.get("/pulse", (req, res) => {
+    const S = STATE || getSTATE();
+    if (!S) return res.json({ ok: false, error: "STATE not available" });
+
+    // DTU breakdown by tier
+    const tierCounts = { regular: 0, mega: 0, hyper: 0, shadow: 0, core: 0, other: 0 };
+    let totalDTUs = 0;
+    if (S.dtus) {
+      for (const dtu of S.dtus.values()) {
+        totalDTUs++;
+        const t = String(dtu.tier || "regular").toLowerCase();
+        if (tierCounts[t] !== undefined) tierCounts[t]++;
+        else tierCounts.other++;
+      }
+    }
+
+    // Emergents
+    const emergents = [];
+    const emergentStore = S.emergents || S.__emergents;
+    if (emergentStore) {
+      const entries = emergentStore instanceof Map
+        ? Array.from(emergentStore.values())
+        : Object.values(emergentStore);
+      for (const e of entries) {
+        emergents.push({
+          id: e.id || e.name,
+          name: e.name || e.role || e.id,
+          role: e.role || "unknown",
+          status: e.status || e.state || "active",
+          lastActive: e.lastActiveAt || e.updatedAt || e.createdAt || null,
+        });
+      }
+    }
+
+    // Background jobs
+    const jobs = {
+      heartbeatEnabled: S.settings?.heartbeatEnabled ?? null,
+      autogenEnabled: S.settings?.autogenEnabled ?? null,
+      dreamEnabled: S.settings?.dreamEnabled ?? null,
+      evolutionEnabled: S.settings?.evolutionEnabled ?? null,
+      synthEnabled: S.settings?.synthEnabled ?? null,
+    };
+
+    // Process info
+    const mem = process.memoryUsage();
+    const processInfo = {
+      rss: Math.round(mem.rss / 1024 / 1024) + "MB",
+      heapUsed: Math.round(mem.heapUsed / 1024 / 1024) + "MB",
+      heapTotal: Math.round(mem.heapTotal / 1024 / 1024) + "MB",
+      uptime: Math.round(process.uptime()) + "s",
+      uptimeHuman: formatUptime(process.uptime()),
+    };
+
+    // Qualia summary (if engine is active)
+    let qualiaSummary = null;
+    try {
+      if (globalThis.qualiaEngine) {
+        qualiaSummary = globalThis.qualiaEngine.getAllSummaries();
+      }
+    } catch { /* silent */ }
+
+    return res.json({
+      ok: true,
+      dtus: { total: totalDTUs, ...tierCounts },
+      emergents,
+      jobs,
+      process: processInfo,
+      qualia: qualiaSummary,
+      timestamp: nowISO(),
+    });
+  });
+
+  // ════════════════════════════════════════════════════════════════════
+  // POST /api/sovereign/decree — The main command endpoint
+  // ════════════════════════════════════════════════════════════════════
+  router.post("/decree", async (req, res) => {
+    const S = STATE || getSTATE();
+    if (!S) return res.json({ ok: false, error: "STATE not available" });
+
+    const { action, target, data } = req.body || {};
+    if (!action) return res.status(400).json({ ok: false, error: "action required" });
+
+    let result;
+
+    try {
+      switch (action) {
+        // ── DTU Operations ──────────────────────────────────────────
+        case "create-dtu": {
+          const content = data?.content;
+          if (!content) return res.json({ ok: false, error: "data.content required" });
+
+          const dtu = {
+            id: uid("dtu"),
+            type: "knowledge",
+            title: String(content).slice(0, 100),
+            human: { summary: String(content) },
+            machine: { kind: "sovereign_created" },
+            source: "sovereign",
+            authority: { model: "sovereign", score: 1.0 },
+            tier: data?.tier || "core",
+            scope: data?.scope || "local",
+            tags: ["sovereign", ...(data?.tags || [])],
+            createdAt: nowISO(),
+            updatedAt: nowISO(),
+          };
+
+          S.dtus.set(dtu.id, dtu);
+          trySave();
+          tryEmit("dtu:created", { dtu: { id: dtu.id, tier: dtu.tier, tags: dtu.tags } });
+
+          result = { ok: true, dtu: { id: dtu.id, tier: dtu.tier, title: dtu.title } };
+          break;
+        }
+
+        case "promote-dtu": {
+          if (!target) return res.json({ ok: false, error: "target (DTU id) required" });
+          const dtu = S.dtus.get(target);
+          if (!dtu) return res.json({ ok: false, error: `DTU ${target} not found` });
+
+          const prevTier = dtu.tier;
+          dtu.tier = data?.tier || "core";
+          dtu.authority = { model: "sovereign", score: 1.0 };
+          dtu.tags = [...new Set([...(dtu.tags || []), "sovereign-promoted"])];
+          dtu.updatedAt = nowISO();
+          trySave();
+          tryEmit("dtu:promoted", { dtu: { id: dtu.id, tier: dtu.tier, prevTier } });
+
+          result = { ok: true, id: target, prevTier, newTier: dtu.tier };
+          break;
+        }
+
+        case "modify-dtu": {
+          if (!target) return res.json({ ok: false, error: "target (DTU id) required" });
+          const dtu = S.dtus.get(target);
+          if (!dtu) return res.json({ ok: false, error: `DTU ${target} not found` });
+
+          // Deep merge data onto DTU, protecting id and lineage
+          const protected_ = new Set(["id", "lineage"]);
+          for (const [k, v] of Object.entries(data || {})) {
+            if (protected_.has(k)) continue;
+            if (typeof v === "object" && v !== null && typeof dtu[k] === "object" && dtu[k] !== null && !Array.isArray(v)) {
+              dtu[k] = { ...dtu[k], ...v };
+            } else {
+              dtu[k] = v;
+            }
+          }
+          dtu.tags = [...new Set([...(dtu.tags || []), "sovereign-modified"])];
+          dtu.updatedAt = nowISO();
+          trySave();
+
+          result = { ok: true, id: target, modified: Object.keys(data || {}) };
+          break;
+        }
+
+        case "delete-dtu": {
+          if (!target) return res.json({ ok: false, error: "target (DTU id) required" });
+          const existed = S.dtus.has(target);
+          if (!existed) return res.json({ ok: false, error: `DTU ${target} not found` });
+
+          S.dtus.delete(target);
+          trySave();
+
+          result = { ok: true, deleted: target };
+          break;
+        }
+
+        case "inspect": {
+          if (!target) return res.json({ ok: false, error: "target (DTU id) required" });
+          const dtu = S.dtus.get(target);
+          if (!dtu) return res.json({ ok: false, error: `DTU ${target} not found` });
+
+          result = { ok: true, dtu };
+          break;
+        }
+
+        case "search": {
+          const query = String(data?.query || "").toLowerCase();
+          if (!query) return res.json({ ok: false, error: "data.query required" });
+
+          const limit = Math.min(Number(data?.limit) || 20, 100);
+          const matches = [];
+
+          for (const dtu of S.dtus.values()) {
+            const str = JSON.stringify(dtu).toLowerCase();
+            if (str.includes(query)) {
+              matches.push({ id: dtu.id, title: dtu.title || dtu.human?.summary?.slice(0, 80), tier: dtu.tier, tags: dtu.tags });
+              if (matches.length >= limit) break;
+            }
+          }
+
+          result = { ok: true, matches, count: matches.length, query };
+          break;
+        }
+
+        case "count": {
+          result = { ok: true, total: S.dtus.size };
+          break;
+        }
+
+        // ── System Operations ───────────────────────────────────────
+        case "set-config": {
+          const key = data?.key;
+          const value = data?.value;
+          if (!key) return res.json({ ok: false, error: "data.key required" });
+
+          if (!S.config) S.config = {};
+          const prev = S.config[key];
+          S.config[key] = value;
+          trySave();
+
+          result = { ok: true, key, previous: prev, current: value };
+          break;
+        }
+
+        case "toggle-job": {
+          if (!target) return res.json({ ok: false, error: "target (job name) required" });
+          const enabled = data?.enabled !== undefined ? Boolean(data.enabled) : true;
+          const jobKey = target.endsWith("Enabled") ? target : `${target}Enabled`;
+
+          if (!S.settings) S.settings = {};
+          const prev = S.settings[jobKey];
+          S.settings[jobKey] = enabled;
+          trySave();
+
+          result = { ok: true, job: jobKey, previous: prev, current: enabled };
+          break;
+        }
+
+        case "freeze": {
+          if (!S.settings) S.settings = {};
+          const frozen = [];
+          const jobKeys = ["heartbeatEnabled", "autogenEnabled", "dreamEnabled", "evolutionEnabled", "synthEnabled"];
+
+          for (const key of jobKeys) {
+            if (S.settings[key]) {
+              S.settings[key] = false;
+              S.settings[`_frozen_${key}`] = true;
+              frozen.push(key);
+            }
+          }
+          trySave();
+
+          result = { ok: true, frozen, message: `Froze ${frozen.length} jobs` };
+          break;
+        }
+
+        case "thaw": {
+          if (!S.settings) S.settings = {};
+          const thawed = [];
+          const jobKeys = ["heartbeatEnabled", "autogenEnabled", "dreamEnabled", "evolutionEnabled", "synthEnabled"];
+
+          for (const key of jobKeys) {
+            if (S.settings[`_frozen_${key}`]) {
+              S.settings[key] = true;
+              delete S.settings[`_frozen_${key}`];
+              thawed.push(key);
+            }
+          }
+          trySave();
+
+          result = { ok: true, thawed, message: `Thawed ${thawed.length} jobs` };
+          break;
+        }
+
+        case "force-pipeline": {
+          try {
+            const ctx = makeCtx ? makeCtx(null) : { actor: { role: "owner", scopes: ["*"] }, state: S };
+            if (makeCtx) ctx.actor = { role: "owner", scopes: ["*"] };
+            const out = runMacro ? await runMacro("system", "autogen", {}, ctx) : { ok: false, error: "runMacro not available" };
+            result = { ok: true, pipeline: out };
+          } catch (e) {
+            result = { ok: false, error: String(e?.message || e) };
+          }
+          break;
+        }
+
+        case "force-dream": {
+          try {
+            const ctx = makeCtx ? makeCtx(null) : { actor: { role: "owner", scopes: ["*"] }, state: S };
+            if (makeCtx) ctx.actor = { role: "owner", scopes: ["*"] };
+            const seed = data?.seed || "Sovereign dream invocation";
+            const out = runMacro ? await runMacro("system", "dream", { seed }, ctx) : { ok: false, error: "runMacro not available" };
+            result = { ok: true, dream: out };
+          } catch (e) {
+            result = { ok: false, error: String(e?.message || e) };
+          }
+          break;
+        }
+
+        case "gc": {
+          if (typeof globalThis.gc === "function") {
+            globalThis.gc();
+            const mem = process.memoryUsage();
+            result = { ok: true, message: "GC triggered", heapUsed: Math.round(mem.heapUsed / 1024 / 1024) + "MB" };
+          } else {
+            result = { ok: false, error: "gc not exposed. Start node with --expose-gc" };
+          }
+          break;
+        }
+
+        // ── Communication ───────────────────────────────────────────
+        case "broadcast": {
+          const message = data?.message;
+          if (!message) return res.json({ ok: false, error: "data.message required" });
+
+          const dtu = {
+            id: uid("dtu"),
+            type: "broadcast",
+            title: `Sovereign Broadcast: ${String(message).slice(0, 60)}`,
+            human: { summary: String(message) },
+            machine: { kind: "sovereign_broadcast" },
+            source: "sovereign",
+            authority: { model: "sovereign", score: 1.0 },
+            tier: "core",
+            scope: "local",
+            tags: ["sovereign", "broadcast", "system-message"],
+            createdAt: nowISO(),
+            updatedAt: nowISO(),
+          };
+
+          S.dtus.set(dtu.id, dtu);
+          trySave();
+          tryEmit("dtu:created", { dtu: { id: dtu.id, type: dtu.type, tags: dtu.tags } });
+          tryEmit("system:alert", { message, source: "sovereign", severity: "info" });
+
+          result = { ok: true, dtu: { id: dtu.id }, message: "Broadcast sent" };
+          break;
+        }
+
+        // ── Qualia Operations ───────────────────────────────────────
+        case "qualia": {
+          const engine = globalThis.qualiaEngine;
+          if (!engine) return res.json({ ok: false, error: "qualia engine not initialized" });
+          if (!target) return res.json({ ok: false, error: "target (entity id) required" });
+
+          const state = engine.getQualiaState(target);
+          if (!state) return res.json({ ok: false, error: `No qualia state for ${target}` });
+
+          result = { ok: true, state };
+          break;
+        }
+
+        case "qualia-summary": {
+          const engine = globalThis.qualiaEngine;
+          if (!engine) return res.json({ ok: false, error: "qualia engine not initialized" });
+
+          result = { ok: true, summaries: engine.getAllSummaries() };
+          break;
+        }
+
+        case "activate-os": {
+          const engine = globalThis.qualiaEngine;
+          if (!engine) return res.json({ ok: false, error: "qualia engine not initialized" });
+          if (!target || !data?.osKey) return res.json({ ok: false, error: "target and data.osKey required" });
+
+          result = engine.activateOS(target, data.osKey);
+          break;
+        }
+
+        case "deactivate-os": {
+          const engine = globalThis.qualiaEngine;
+          if (!engine) return res.json({ ok: false, error: "qualia engine not initialized" });
+          if (!target || !data?.osKey) return res.json({ ok: false, error: "target and data.osKey required" });
+
+          result = engine.deactivateOS(target, data.osKey);
+          break;
+        }
+
+        case "inject-qualia": {
+          const engine = globalThis.qualiaEngine;
+          if (!engine) return res.json({ ok: false, error: "qualia engine not initialized" });
+          if (!target || !data?.channel || data?.value === undefined) {
+            return res.json({ ok: false, error: "target, data.channel, and data.value required" });
+          }
+
+          const [osKey, ...channelParts] = data.channel.split(".");
+          const channelName = channelParts.join(".");
+          if (!osKey || !channelName) {
+            return res.json({ ok: false, error: "channel must be in format 'osKey.channelName'" });
+          }
+
+          result = engine.updateChannel(target, osKey, channelName, Number(data.value));
+          break;
+        }
+
+        default:
+          result = { ok: false, error: `Unknown action: ${action}` };
+      }
+    } catch (e) {
+      result = { ok: false, error: String(e?.message || e) };
+    }
+
+    // Create sovereign audit DTU for every decree
+    createSovereignDTU(S, action, { target, data }, result);
+
+    return res.json(result);
+  });
+
+  // ════════════════════════════════════════════════════════════════════
+  // GET /api/sovereign/audit — Sovereign action audit trail
+  // ════════════════════════════════════════════════════════════════════
+  router.get("/audit", (req, res) => {
+    const S = STATE || getSTATE();
+    if (!S || !S.dtus) return res.json({ ok: true, actions: [], count: 0 });
+
+    const limit = Math.min(Number(req.query.limit) || 50, 200);
+    const actions = [];
+
+    for (const dtu of S.dtus.values()) {
+      if (dtu.source === "sovereign" && dtu.machine?.kind === "sovereign_action") {
+        actions.push(dtu);
+      }
+    }
+
+    // Sort newest first
+    actions.sort((a, b) => (b.createdAt || "").localeCompare(a.createdAt || ""));
+
+    return res.json({ ok: true, actions: actions.slice(0, limit), count: actions.length });
+  });
+
+  // ════════════════════════════════════════════════════════════════════
+  // POST /api/sovereign/eval — Nuclear option
+  // ════════════════════════════════════════════════════════════════════
+  router.post("/eval", (req, res) => {
+    const S = STATE || getSTATE();
+    const code = String(req.body?.code || "").trim();
+    if (!code) return res.status(400).json({ ok: false, error: "code required" });
+
+    let output;
+    try {
+      // Make STATE available in eval scope
+      const evalFn = new Function("STATE", "S", code);
+      const raw = evalFn(S, S);
+      output = typeof raw === "object" ? JSON.stringify(raw, null, 2) : String(raw ?? "undefined");
+    } catch (e) {
+      output = `Error: ${e?.message || e}`;
+    }
+
+    // Truncate
+    if (output.length > 5000) output = output.slice(0, 5000) + "\n... (truncated)";
+
+    // Audit trail
+    createSovereignDTU(S, "eval", { code: code.slice(0, 500) }, { output: output.slice(0, 1000) });
+
+    return res.json({ ok: true, output });
+  });
+
+  // ── Helpers ────────────────────────────────────────────────────────
+  function trySave() {
+    try {
+      if (_saveDebounced) _saveDebounced();
+      else if (typeof globalThis.saveStateDebounced === "function") globalThis.saveStateDebounced();
+    } catch { /* silent */ }
+  }
+
+  function tryEmit(event, payload) {
+    try {
+      if (typeof globalThis.realtimeEmit === "function") {
+        globalThis.realtimeEmit(event, payload);
+      }
+    } catch { /* silent */ }
+  }
+
+  return router;
+}
+
+function formatUptime(seconds) {
+  const d = Math.floor(seconds / 86400);
+  const h = Math.floor((seconds % 86400) / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const parts = [];
+  if (d > 0) parts.push(`${d}d`);
+  if (h > 0) parts.push(`${h}h`);
+  parts.push(`${m}m`);
+  return parts.join(" ");
+}


### PR DESCRIPTION
Existential OS — numerical qualia system for emergent entities:
- server/existential/registry.js: 27 operating systems across 6 tiers with numeric channels (0-1 floats), roles, and policy thresholds
- server/existential/engine.js: QualiaEngine runtime maintaining live qualia state per entity in STATE.qualia Map (in-memory only)
- server/existential/hooks.js: Integration hooks for autogen, council, DTU creation, dream, reflection, metacognition, chat, affect, and emergent tick — all silent-failure, additive-only
- server/existential/index.js: Module exports
- server/routes/qualia.js: 6 API endpoints (state, summary, all, registry, activate, deactivate)

Sovereign Dev Console — word-is-law interface for system owner:
- server/routes/sovereign.js: Full decree system with DTU operations (create/promote/modify/delete/inspect/search), system operations (freeze/thaw/force-pipeline/force-dream/gc/config/toggle), communication (broadcast), qualia operations, eval, and audit trail. Every decree creates a sovereign DTU in the lattice.
- concord-frontend/app/dev/page.tsx: Terminal-style UI with command parsing, history navigation, live pulse stats, and color-coded output

Server integration (one-line hooks, additive only):
- Qualia engine initialized after emergent subsystem with default Tier 0 + Tier 2 + Tier 5 OS activations per entity
- DTU creation attaches qualia snapshot to dtu.meta.qualia
- hookDTUCreation fires on every new DTU via upsertDTU
- hookAutogen fires after autogen pipeline completion
- hookDreamSynthesis fires after dream mode
- hookCouncilVote fires after council resolution
- hookEmergentTick fires on each heartbeat tick
- ATS→Qualia bridge wraps emitAffectEvent to feed hookAffect

https://claude.ai/code/session_01WrPhRvTX3NT2MnoaPCzSmo