### PR TITLE
fix: pre-launch audit — wire missing system ticks, council gate, persistence, navigation, and cross-system integrations

### DIFF
--- a/concord-frontend/components/shell/Sidebar.tsx
+++ b/concord-frontend/components/shell/Sidebar.tsx
@@ -17,7 +17,7 @@ import {
   getExtensionLenses,
   type CoreLensConfig,
 } from '@/lib/lens-registry';
-import { Home, ChevronLeft, ChevronRight, ChevronDown, X, Compass, Puzzle } from 'lucide-react';
+import { Home, ChevronLeft, ChevronRight, ChevronDown, X, Compass, Puzzle, FlaskConical, Search, Users, Cpu, Building2, Download } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export function Sidebar() {
@@ -159,6 +159,41 @@ export function Sidebar() {
                 <span className="text-sm font-medium truncate">Lens Hub</span>
               )}
             </Link>
+          </div>
+
+          {/* System Pages */}
+          {showLabel && (
+            <p className="px-3 py-1 text-xs uppercase tracking-wider text-neon-cyan mb-1">
+              Systems
+            </p>
+          )}
+          <div className="space-y-0.5 mb-4">
+            {[
+              { href: '/hypothesis-lab', label: 'Hypothesis Lab', Icon: FlaskConical },
+              { href: '/research', label: 'Research', Icon: Search },
+              { href: '/council', label: 'Council', Icon: Users },
+              { href: '/agents', label: 'Agents', Icon: Cpu },
+              { href: '/cri', label: 'CRI', Icon: Building2 },
+              { href: '/ingest', label: 'Ingest', Icon: Download },
+            ].map(({ href, label, Icon }) => (
+              <Link
+                key={href}
+                href={href}
+                className={cn(
+                  'flex items-center gap-3 px-3 py-2 rounded-lg transition-all',
+                  pathname === href
+                    ? 'bg-neon-blue/20 text-neon-blue'
+                    : 'text-gray-400 hover:bg-lattice-elevated hover:text-white',
+                  !showLabel && 'justify-center'
+                )}
+                title={!showLabel ? label : undefined}
+              >
+                <Icon className="w-4.5 h-4.5 flex-shrink-0" />
+                {showLabel && (
+                  <span className="text-sm font-medium truncate">{label}</span>
+                )}
+              </Link>
+            ))}
           </div>
 
           {/* Extensions Toggle */}

--- a/server/emergent/culture-layer.js
+++ b/server/emergent/culture-layer.js
@@ -1071,6 +1071,29 @@ export function cultureTick(tick) {
  *
  * @returns {{ ok: boolean, metrics: object }}
  */
+/**
+ * Get all established traditions for cross-system integration.
+ * Used by the capability bridge to influence governance strictness.
+ *
+ * @returns {Array} Established traditions
+ */
+export function getEstablishedTraditions() {
+  try {
+    return Array.from(_traditions.values())
+      .filter(t => t.status === TRADITION_STATUS.ESTABLISHED)
+      .map(t => ({
+        id: t.id,
+        type: t.type,
+        label: t.label,
+        influence: t.influence,
+        adherence: t.adherence,
+        establishedAt: t.establishedAt,
+      }));
+  } catch {
+    return [];
+  }
+}
+
 export function getCultureMetrics() {
   try {
     const byType = {};

--- a/server/emergent/hlr-engine.js
+++ b/server/emergent/hlr-engine.js
@@ -1325,6 +1325,34 @@ export function getHLRMetrics() {
   };
 }
 
+/**
+ * Get recent HLR findings for cross-system integration.
+ * Returns traces that have proposed DTUs or patterns, sorted by recency.
+ *
+ * @param {number} [limit=20] - Max findings to return
+ * @returns {Array} Recent findings with conclusions and patterns
+ */
+export function getRecentFindings(limit = 20) {
+  try {
+    const all = Array.from(_traces.values());
+    all.sort((a, b) => new Date(b.startedAt || 0).getTime() - new Date(a.startedAt || 0).getTime());
+    return all.slice(0, limit).map(t => ({
+      traceId: t.traceId,
+      topic: t.topic,
+      domain: t.domain,
+      conclusion: t.conclusion || null,
+      summary: t.summary || null,
+      patterns: t.patterns || [],
+      proposedDTUs: t.proposedDTUs || [],
+      confidence: t.confidence || 0,
+      startedAt: t.startedAt,
+      _hypothesized: t._hypothesized || false,
+    }));
+  } catch {
+    return [];
+  }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // CHAIN GENERATION HELPERS
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/server/emergent/persistence.js
+++ b/server/emergent/persistence.js
@@ -118,6 +118,23 @@ export function serializeEmergentState(STATE) {
     _sectorAssignments: es._sectorAssignments || {},
     // Persist entity emergence data if present
     _entityEmergence: es._entityEmergence || {},
+    // ── New system state (v5.5+) ──────────────────────────────────────────
+    // Culture traditions and observations
+    _traditions: es._traditions instanceof Map ? serializeMap(es._traditions) : (es._traditions || {}),
+    _cultureObservations: Array.isArray(es._cultureObservations) ? es._cultureObservations.slice(-500) : [],
+    // Creative works gallery
+    _creativeWorks: es._creativeWorks instanceof Map ? serializeMap(es._creativeWorks) : (es._creativeWorks || {}),
+    // Relational emotion bonds
+    _emotionBonds: es._emotionBonds instanceof Map ? serializeMap(es._emotionBonds) : (es._emotionBonds || {}),
+    // Entity economy accounts
+    _economyAccounts: es._economyAccounts instanceof Map ? serializeMap(es._economyAccounts) : (es._economyAccounts || {}),
+    // Entity autonomy state (refusals, consents, dissents)
+    _autonomyProfiles: es._autonomyProfiles instanceof Map ? serializeMap(es._autonomyProfiles) : (es._autonomyProfiles || {}),
+    // Entity teaching profiles
+    _teachingProfiles: es._teachingProfiles instanceof Map ? serializeMap(es._teachingProfiles) : (es._teachingProfiles || {}),
+    // History eras
+    _eras: es._eras instanceof Map ? serializeMap(es._eras) : (es._eras || {}),
+    _eraProgression: Array.isArray(es._eraProgression) ? es._eraProgression : [],
   };
 }
 
@@ -191,6 +208,42 @@ export function deserializeEmergentState(STATE, saved) {
   // Restore entity emergence data
   if (saved._entityEmergence) {
     es._entityEmergence = saved._entityEmergence;
+  }
+
+  // ── Restore new system state (v5.5+) ──────────────────────────────────────
+  if (saved._traditions) {
+    es._traditions = typeof saved._traditions === "object" && !(saved._traditions instanceof Map)
+      ? deserializeToMap(saved._traditions) : (saved._traditions || new Map());
+  }
+  if (Array.isArray(saved._cultureObservations)) {
+    es._cultureObservations = saved._cultureObservations;
+  }
+  if (saved._creativeWorks) {
+    es._creativeWorks = typeof saved._creativeWorks === "object" && !(saved._creativeWorks instanceof Map)
+      ? deserializeToMap(saved._creativeWorks) : (saved._creativeWorks || new Map());
+  }
+  if (saved._emotionBonds) {
+    es._emotionBonds = typeof saved._emotionBonds === "object" && !(saved._emotionBonds instanceof Map)
+      ? deserializeToMap(saved._emotionBonds) : (saved._emotionBonds || new Map());
+  }
+  if (saved._economyAccounts) {
+    es._economyAccounts = typeof saved._economyAccounts === "object" && !(saved._economyAccounts instanceof Map)
+      ? deserializeToMap(saved._economyAccounts) : (saved._economyAccounts || new Map());
+  }
+  if (saved._autonomyProfiles) {
+    es._autonomyProfiles = typeof saved._autonomyProfiles === "object" && !(saved._autonomyProfiles instanceof Map)
+      ? deserializeToMap(saved._autonomyProfiles) : (saved._autonomyProfiles || new Map());
+  }
+  if (saved._teachingProfiles) {
+    es._teachingProfiles = typeof saved._teachingProfiles === "object" && !(saved._teachingProfiles instanceof Map)
+      ? deserializeToMap(saved._teachingProfiles) : (saved._teachingProfiles || new Map());
+  }
+  if (saved._eras) {
+    es._eras = typeof saved._eras === "object" && !(saved._eras instanceof Map)
+      ? deserializeToMap(saved._eras) : (saved._eras || new Map());
+  }
+  if (Array.isArray(saved._eraProgression)) {
+    es._eraProgression = saved._eraProgression;
   }
 
   es.initialized = true;


### PR DESCRIPTION
- Register 6 new emergent system background ticks in governor heartbeat
  (agent-system, research-jobs, hypothesis auto-transitions, sleep/fatigue,
  death condition checks, culture tick)
- Add council five-voice deliberation gate to autogen pipeline (Stage 5b)
  so all DTU candidates undergo governance review before installation
- Extend persistence serialization to cover new system state (traditions,
  creative works, emotion bonds, economy accounts, autonomy profiles,
  teaching profiles, eras) preventing data loss on restart
- Add 6 new system pages to sidebar navigation (Hypothesis Lab, Research,
  Council, Agents, CRI, Ingest) with proper icons and active state
- Unify Ollama model default to llama3.2 across both LLM_PIPELINE and
  standalone OLLAMA_MODEL constant (was tinyllama in pipeline)
- Wire 4 missing cross-system integrations via capability bridge:
  pain/avoidance → autogen domain filtering, culture → governance
  strictness, creative masterworks → DTU promotion, HLR → hypothesis
- Add getRecentFindings() to hlr-engine.js for cross-system consumption
- Add getEstablishedTraditions() to culture-layer.js for governance bridge

https://claude.ai/code/session_0163aNJgiA4tHsatZFZrvh8V