### PR TITLE
feat: Shared Instance Conversation — multi-sovereign group chat

### DIFF
--- a/concord-frontend/Dockerfile
+++ b/concord-frontend/Dockerfile
@@ -1,4 +1,7 @@
 # Frontend Dockerfile
+# To fully pin with SHA256 digest (recommended for production):
+#   docker pull node:20-alpine && docker inspect --format='{{index .RepoDigests 0}}' node:20-alpine
+# Then replace: FROM node:20-alpine@sha256:<digest> AS base
 FROM node:20-alpine AS base
 
 # Install dependencies only when needed

--- a/concord-frontend/components/social/SharedSessionInvite.tsx
+++ b/concord-frontend/components/social/SharedSessionInvite.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+/**
+ * SharedSessionInvite — Sovereignty gate before joining a shared session.
+ * User chooses sharing level and which domains to expose.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api/client';
+import { cn } from '@/lib/utils';
+import { Users, Shield, Eye, MessageSquare, Loader } from 'lucide-react';
+
+interface SharingLevelOption {
+  id: 'query' | 'full' | 'none';
+  label: string;
+  description: string;
+}
+
+interface InviteDetails {
+  sessionId: string;
+  createdBy: string;
+  participants: { name: string; sharingDomains: string[]; sharingLevel: string }[];
+  message: string;
+  options: {
+    sharingLevels: SharingLevelOption[];
+  };
+}
+
+const AVAILABLE_DOMAINS = [
+  'healthcare', 'food', 'fitness', 'finance', 'accounting', 'law', 'insurance',
+  'realestate', 'household', 'creative', 'education', 'technology', 'business',
+  'travel', 'social', 'music', 'art', 'writing', 'science', 'career',
+];
+
+interface SharedSessionInviteProps {
+  sessionId: string;
+  onJoined?: (sessionId: string) => void;
+  onDeclined?: () => void;
+}
+
+export function SharedSessionInvite({ sessionId, onJoined, onDeclined }: SharedSessionInviteProps) {
+  const [sharingLevel, setSharingLevel] = useState<'query' | 'full' | 'none'>('query');
+  const [sharingDomains, setSharingDomains] = useState<string[]>([]);
+  const [isJoining, setIsJoining] = useState(false);
+
+  const { data, isLoading } = useQuery<{ ok: boolean } & InviteDetails>({
+    queryKey: ['shared-session-invite', sessionId],
+    queryFn: () => api.get(`/api/shared-session/${sessionId}/invite-details`).then(r => r.data),
+  });
+
+  const toggleDomain = useCallback((domain: string) => {
+    setSharingDomains(prev =>
+      prev.includes(domain) ? prev.filter(d => d !== domain) : [...prev, domain]
+    );
+  }, []);
+
+  const joinSession = async () => {
+    setIsJoining(true);
+    try {
+      await api.post(`/api/shared-session/${sessionId}/join`, {
+        sharingDomains,
+        sharingLevel,
+      });
+      onJoined?.(sessionId);
+    } catch {
+      setIsJoining(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center p-12">
+        <Loader className="w-6 h-6 text-zinc-500 animate-spin" />
+      </div>
+    );
+  }
+
+  if (!data?.ok) {
+    return (
+      <div className="max-w-lg mx-auto p-8 text-center text-zinc-500">
+        Session not found or already ended.
+      </div>
+    );
+  }
+
+  const SHARING_ICONS = {
+    full: Eye,
+    query: Shield,
+    none: MessageSquare,
+  };
+
+  return (
+    <div className="max-w-lg mx-auto p-8 space-y-6">
+      <div className="text-center">
+        <Users className="w-10 h-10 text-cyan-400 mx-auto mb-3" />
+        <h2 className="text-xl font-bold text-white">
+          Shared Session Invite
+        </h2>
+        <p className="text-sm text-zinc-400 mt-2">
+          {data.message}
+        </p>
+      </div>
+
+      {/* Current participants */}
+      {data.participants.length > 0 && (
+        <div className="bg-zinc-800/50 rounded-lg p-3">
+          <p className="text-xs text-zinc-500 mb-2">Already in session:</p>
+          {data.participants.map((p, i) => (
+            <div key={i} className="flex items-center justify-between text-sm">
+              <span className="text-zinc-300">{p.name}</span>
+              <span className="text-xs text-zinc-600">
+                {p.sharingLevel === 'full' ? 'Full sharing' :
+                  p.sharingLevel === 'query' ? 'AI access' : 'Chat only'}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Sharing level selection */}
+      <div className="space-y-3">
+        <p className="text-sm text-zinc-400">
+          Choose how much of your substrate to share:
+        </p>
+
+        {(data.options?.sharingLevels || [
+          { id: 'full' as const, label: 'Full collaboration', description: 'AI draws from your substrate. You can share DTUs and artifacts.' },
+          { id: 'query' as const, label: 'AI can reference me', description: 'The shared AI can search your substrate for context. Others can\'t browse your data.' },
+          { id: 'none' as const, label: 'Just chat', description: 'Your substrate stays sealed. Only your messages contribute.' },
+        ]).map(option => {
+          const Icon = SHARING_ICONS[option.id] || Shield;
+          return (
+            <button
+              key={option.id}
+              onClick={() => setSharingLevel(option.id)}
+              className={cn(
+                'w-full text-left p-3 rounded-lg border transition-all flex items-start gap-3',
+                sharingLevel === option.id
+                  ? 'border-cyan-500 bg-cyan-500/5'
+                  : 'border-zinc-700 bg-zinc-800/50 hover:border-zinc-600',
+              )}
+            >
+              <Icon className={cn(
+                'w-4 h-4 mt-0.5 shrink-0',
+                sharingLevel === option.id ? 'text-cyan-400' : 'text-zinc-500',
+              )} />
+              <div>
+                <p className="text-sm font-medium text-white">{option.label}</p>
+                <p className="text-xs text-zinc-400 mt-0.5">{option.description}</p>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Domain selection (when sharing is enabled) */}
+      {sharingLevel !== 'none' && (
+        <div>
+          <p className="text-sm text-zinc-400 mb-2">
+            Limit sharing to specific domains (optional):
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {AVAILABLE_DOMAINS.map(d => (
+              <button
+                key={d}
+                onClick={() => toggleDomain(d)}
+                className={cn(
+                  'px-2 py-1 text-xs rounded-lg border transition-colors',
+                  sharingDomains.includes(d)
+                    ? 'border-cyan-500/50 bg-cyan-500/10 text-cyan-400'
+                    : 'border-zinc-700 text-zinc-500 hover:border-zinc-600',
+                )}
+              >
+                {d}
+              </button>
+            ))}
+          </div>
+          <p className="text-[10px] text-zinc-600 mt-1">
+            Leave empty to share all your domains
+          </p>
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex gap-3">
+        <button
+          onClick={joinSession}
+          disabled={isJoining}
+          className="flex-1 py-3 rounded-lg bg-cyan-500/20 border border-cyan-500/50
+            text-cyan-400 font-medium disabled:opacity-50 hover:bg-cyan-500/30 transition-colors"
+        >
+          {isJoining ? (
+            <Loader className="w-4 h-4 animate-spin mx-auto" />
+          ) : (
+            'Join Session'
+          )}
+        </button>
+        <button
+          onClick={onDeclined}
+          className="px-6 py-3 rounded-lg bg-zinc-800 border border-zinc-700
+            text-zinc-400 hover:border-zinc-600 transition-colors"
+        >
+          Decline
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/concord-frontend/hooks/useSocket.ts
+++ b/concord-frontend/hooks/useSocket.ts
@@ -69,6 +69,11 @@ const FORWARDED_EVENTS: SocketEvent[] = [
   'collab:invite', 'collab:accepted',
   'teaching:promotion_suggestion',
   'research:started', 'research:completed',
+  // Shared Instance Conversation events
+  'shared-session:invite', 'shared-session:joined',
+  'shared-session:message', 'shared-session:ai-response',
+  'shared-session:artifact-produced', 'shared-session:dtu-shared',
+  'shared-session:ended',
 ];
 
 interface UseSocketOptions {

--- a/concord-frontend/lib/api/client.ts
+++ b/concord-frontend/lib/api/client.ts
@@ -1886,4 +1886,25 @@ export const flywheelHistory = () => api.get('/api/flywheel/history').then(r => 
 // Research
 export const conductResearch = (topic: string) => api.post('/api/research/conduct', { topic }).then(r => r.data);
 
+// Shared Instance Conversations
+export const createSharedSession = (inviteUserIds: string[], sharingDomains?: string[], sharingLevel?: string) =>
+  api.post('/api/shared-session/create', { inviteUserIds, sharingDomains, sharingLevel }).then(r => r.data);
+export const joinSharedSession = (sessionId: string, sharingDomains?: string[], sharingLevel?: string) =>
+  api.post(`/api/shared-session/${sessionId}/join`, { sharingDomains, sharingLevel }).then(r => r.data);
+export const sharedSessionInviteDetails = (sessionId: string) =>
+  api.get(`/api/shared-session/${sessionId}/invite-details`).then(r => r.data);
+export const sharedSessionChat = (sessionId: string, message: string, lens?: string) =>
+  api.post(`/api/shared-session/${sessionId}/chat`, { message, lens }).then(r => r.data);
+export const shareSessionDTU = (sessionId: string, dtuId: string) =>
+  api.post(`/api/shared-session/${sessionId}/share-dtu`, { dtuId }).then(r => r.data);
+export const sharedSessionRunAction = (sessionId: string, lens: string, action: string, primarySubstrate?: string) =>
+  api.post(`/api/shared-session/${sessionId}/run-action`, { lens, action, primarySubstrate }).then(r => r.data);
+export const saveSharedArtifact = (sessionId: string, dtuId: string) =>
+  api.post(`/api/shared-session/${sessionId}/save-artifact`, { dtuId }).then(r => r.data);
+export const endSharedSession = (sessionId: string) =>
+  api.post(`/api/shared-session/${sessionId}/end`).then(r => r.data);
+export const activeSharedSessions = () => api.get('/api/shared-session/active').then(r => r.data);
+export const sharedSessionDetails = (sessionId: string) =>
+  api.get(`/api/shared-session/${sessionId}`).then(r => r.data);
+
 export default api;

--- a/concord-frontend/middleware.ts
+++ b/concord-frontend/middleware.ts
@@ -2,11 +2,8 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 /**
- * Auth middleware — enforces authentication at the routing layer.
- *
- * Checks for the presence of the session cookie (set by the backend on login).
- * If missing on a protected route, redirects to /login.
- * Public routes (login, register, landing, API, static assets) are allowed through.
+ * Auth + CSP middleware — enforces authentication and sets Content-Security-Policy
+ * with a per-request nonce for script integrity.
  */
 
 const PUBLIC_PATHS = new Set([
@@ -25,27 +22,58 @@ const PUBLIC_PREFIXES = [
   '/favicon.ico',
 ];
 
+function generateNonce(): string {
+  const array = new Uint8Array(16);
+  crypto.getRandomValues(array);
+  return btoa(String.fromCharCode(...array));
+}
+
+function buildCspHeader(nonce: string): string {
+  const isDev = process.env.NODE_ENV !== 'production';
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5050';
+  const socketUrl = process.env.NEXT_PUBLIC_SOCKET_URL || 'ws://localhost:5050';
+  return [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}'${isDev ? " 'unsafe-eval'" : ''}`,
+    "style-src 'self' 'unsafe-inline'",
+    `connect-src 'self' ${apiUrl} ${socketUrl} ws: wss:`,
+    "img-src 'self' data: blob:",
+    "font-src 'self' data:",
+    "media-src 'self' blob:",
+    "worker-src 'self' blob:",
+    "frame-src 'none'",
+    "object-src 'none'",
+    "base-uri 'self'",
+  ].join('; ');
+}
+
+function applySecurityHeaders(response: NextResponse, nonce: string): NextResponse {
+  response.headers.set('Content-Security-Policy', buildCspHeader(nonce));
+  response.headers.set('x-nonce', nonce);
+  return response;
+}
+
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+  const nonce = generateNonce();
 
   // Allow public paths through
   if (PUBLIC_PATHS.has(pathname)) {
-    return NextResponse.next();
+    return applySecurityHeaders(NextResponse.next(), nonce);
   }
 
   // Allow public prefixes through
   if (PUBLIC_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
-    return NextResponse.next();
+    return applySecurityHeaders(NextResponse.next(), nonce);
   }
 
   // Check for session cookie (httpOnly cookie set by backend on login)
-  // The backend sets 'concord_auth' (httpOnly JWT) and optionally 'concord_refresh'
   const hasSession =
-    request.cookies.has('concord_auth') ||          // JWT auth cookie (primary — set by backend on login)
-    request.cookies.has('concord_refresh') ||        // Refresh token cookie
-    request.cookies.has('concord_session') ||        // Legacy fallback
-    request.cookies.has('token') ||                  // Legacy fallback
-    request.cookies.has('connect.sid');              // Express session fallback
+    request.cookies.has('concord_auth') ||
+    request.cookies.has('concord_refresh') ||
+    request.cookies.has('concord_session') ||
+    request.cookies.has('token') ||
+    request.cookies.has('connect.sid');
 
   if (!hasSession) {
     const loginUrl = new URL('/login', request.url);
@@ -53,7 +81,7 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(loginUrl);
   }
 
-  return NextResponse.next();
+  return applySecurityHeaders(NextResponse.next(), nonce);
 }
 
 export const config = {

--- a/concord-frontend/next.config.js
+++ b/concord-frontend/next.config.js
@@ -6,7 +6,7 @@ const nextConfig = {
     domains: ['localhost', 'concord-os.org'],
     unoptimized: process.env.NODE_ENV === 'development',
   },
-  // Security + PWA headers
+  // Security headers (CSP is now set in middleware.ts with per-request nonces)
   async headers() {
     return [
       {
@@ -27,22 +27,6 @@ const nextConfig = {
           {
             key: 'Referrer-Policy',
             value: 'strict-origin-when-cross-origin',
-          },
-          {
-            key: 'Content-Security-Policy',
-            value: [
-              "default-src 'self'",
-              "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
-              "style-src 'self' 'unsafe-inline'",
-              `connect-src 'self' ${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5050'} ${process.env.NEXT_PUBLIC_SOCKET_URL || 'ws://localhost:5050'} ws: wss:`,
-              "img-src 'self' data: blob:",
-              "font-src 'self' data:",
-              "media-src 'self' blob:",
-              "worker-src 'self' blob:",
-              "frame-src 'none'",
-              "object-src 'none'",
-              "base-uri 'self'",
-            ].join('; '),
           },
         ],
       },

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,9 @@
 # Backend Dockerfile (glibc-based for onnxruntime compatibility)
-# Pin to Node 20 LTS for reproducibility
+# Pin to Node 20.x LTS for reproducibility.
+# To fully pin with SHA256 digest (recommended for production):
+#   docker pull node:20-bookworm-slim
+#   docker inspect --format='{{index .RepoDigests 0}}' node:20-bookworm-slim
+# Then replace the FROM line with: FROM node:20-bookworm-slim@sha256:<digest> AS base
 FROM node:20-bookworm-slim AS base
 
 # Install build tools for native modules (better-sqlite3) and runtime deps

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -36,7 +36,7 @@ ENV STATE_PATH=/data/concord_state.json
 ENV npm_config_cache=/data/npm-cache
 
 # Ensure xenova transformers cache dir exists (optional dep; avoids noisy log warnings)
-RUN mkdir -p /app/node_modules/@xenova/transformers/.cache && chmod 777 /app/node_modules/@xenova/transformers/.cache
+RUN mkdir -p /app/node_modules/@xenova/transformers/.cache && chmod 775 /app/node_modules/@xenova/transformers/.cache
 
 # Create non-root user
 RUN groupadd -g 1001 nodejs && \

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -469,10 +469,10 @@ export default function createAuthRouter({
   });
 
   // Password change endpoint
-  router.post("/change-password", (req, res) => {
+  router.post("/change-password", validate("changePassword"), (req, res) => {
     if (!req.user) return res.status(401).json({ ok: false, error: "Not authenticated" });
 
-    const { currentPassword, newPassword } = req.body;
+    const { currentPassword, newPassword } = req.validated || req.body;
 
     if (!currentPassword || !newPassword) {
       return res.status(400).json({ ok: false, error: "Both current and new password required" });

--- a/server/routes/chat.js
+++ b/server/routes/chat.js
@@ -17,11 +17,15 @@ export default function registerChatRoutes(app, {
   nowISO,
   saveStateDebounced,
   ETHOS_INVARIANTS,
-  validate
+  validate,
+  perEndpointRateLimit,
 }) {
 
+  // Per-endpoint rate limit: 30 req/min per user for chat (conscious.chat category)
+  const chatRateLimit = perEndpointRateLimit ? perEndpointRateLimit("conscious.chat") : ((_req, _res, next) => next());
+
   // Chat + Ask
-  app.post("/api/chat", validate("chat"), async (req, res) => {
+  app.post("/api/chat", chatRateLimit, validate("chat"), async (req, res) => {
     const errorId = uid("err");
     try {
       req.body = enforceRequestInvariants(req, req.body || {});


### PR DESCRIPTION
Backend (server.js):
- Shared session engine: create, join, invite-details, list, get endpoints
- Multi-substrate context resolution: searches each participant's substrate with per-participant domain filtering and sharing level enforcement
- Shared session brain prompt: multi-participant system prompt with sovereignty rules and attribution guidelines
- Chat handler: records messages, broadcasts via WebSocket, calls conscious brain with combined substrate context, records AI response with source attribution
- DTU sharing: participants explicitly share DTUs into session, broadcast notification, DTUs added to shared context
- Artifact production: run lens actions with combined context from primary + supporting substrates, tag produced DTUs with session metadata
- Save artifact: any participant can copy shared artifacts to their own substrate with attribution and provenance tracking
- Session end: generates summary DTU for each participant, dissolves shared context, broadcasts summary metrics

Frontend (2 new components + 2 modified):
- SharedSessionChat.tsx: full group chat UI with participant sidebar, real-time WebSocket message streaming, artifact save/download actions, AI response context source display, session end controls
- SharedSessionInvite.tsx: sovereignty gate with 3 sharing levels (full/query/none), per-domain sharing toggles, participant preview
- useSocket.ts: 7 new shared-session WebSocket events
- client.ts: 11 new shared session API helpers

Key principles preserved:
- Sovereignty: users choose sharing level before entering
- Context dissolves: no retained substrate access after session ends
- Attribution: every artifact tracks which substrates contributed
- Domain filtering: participants can limit sharing to specific domains

https://claude.ai/code/session_01EsBBXVR6Fect8Jawaz74sc