### PR TITLE
fix: rename eslint.config.js to .mjs for consistent ESM resolution on CI

### DIFF
--- a/concord-mobile/eslint.config.mjs
+++ b/concord-mobile/eslint.config.mjs
@@ -1,6 +1,6 @@
-const tseslint = require('typescript-eslint');
+import tseslint from 'typescript-eslint';
 
-module.exports = tseslint.config(
+export default tseslint.config(
   {
     ignores: ['node_modules/', 'coverage/', 'android/', 'ios/', 'native/', 'babel.config.js'],
   },

--- a/concord-mobile/src/mesh/sync/sync-resolver.ts
+++ b/concord-mobile/src/mesh/sync/sync-resolver.ts
@@ -75,7 +75,7 @@ function contentHashHex(dtu: DTU): string {
   return Array.from(hash).map(b => b.toString(16).padStart(2, '0')).join('');
 }
 
-export function createSyncResolver(deviceId: string): SyncResolver {
+export function createSyncResolver(_deviceId: string): SyncResolver {
   const metaMap = new Map<string, SyncMeta>();
 
   function detectConflict(local: DTU, remote: DTU): ConflictRecord | null {


### PR DESCRIPTION
The mobile lint job passes locally (Node 22) but fails on CI (Node 20). Root cause: CJS eslint.config.js with ESM imports can behave differently across Node versions. Renaming to .mjs makes the module format explicit and avoids ambiguity. Also fixes unused param deviceId → _deviceId.

https://claude.ai/code/session_01KXB6gaPB7khrC7NPEA4qFh