### PR TITLE
fix: sync mobile package-lock.json with typescript@5.9.3

### DIFF
--- a/concord-mobile/package-lock.json
+++ b/concord-mobile/package-lock.json
@@ -50,7 +50,7 @@
         "jest": "^29.7.0",
         "jest-expo": "~52.0.0",
         "react-test-renderer": "18.3.1",
-        "typescript": "~5.7.0",
+        "typescript": "^5.9.3",
         "typescript-eslint": "^8.57.0"
       }
     },
@@ -16491,9 +16491,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
The lock file had typescript@5.7.3 but package.json required ^5.9.3, causing npm ci to fail in CI. This broke the mobile-test, and security-scan jobs.

https://claude.ai/code/session_01KXB6gaPB7khrC7NPEA4qFh