### PR TITLE
fix(ci): use forks pool in vitest to prevent Channel closed OOM crashes

### DIFF
--- a/concord-frontend/vitest.config.ts
+++ b/concord-frontend/vitest.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./tests/setup.ts'],
     include: ['tests/**/*.test.{ts,tsx}', 'components/**/*.test.{ts,tsx}'],
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        maxForks: process.env.CI ? 2 : undefined,
+      },
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],


### PR DESCRIPTION
The default thread pool can exhaust memory on CI runners, causing ERR_IPC_CHANNEL_CLOSED errors. Switch to forks pool and limit to 2 workers in CI for stability.

https://claude.ai/code/session_01KXB6gaPB7khrC7NPEA4qFh