### PR TITLE
fix(e2e): enable fullPageMode for legal pages to fix DMCA title test

### DIFF
--- a/concord-frontend/app/legal/layout.tsx
+++ b/concord-frontend/app/legal/layout.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useUIStore } from '@/store/ui';
 
 const NAV_ITEMS = [
   { href: '/legal/terms', label: 'Terms of Service' },
@@ -13,6 +15,15 @@ const LAST_UPDATED = 'March 1, 2026';
 
 export default function LegalLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const setFullPageMode = useUIStore((s) => s.setFullPageMode);
+
+  // Legal pages have their own chrome (header + sidebar nav), so disable the
+  // AppShell Topbar/Sidebar to avoid a duplicate h1 ("Chat") conflicting with
+  // the page's own h1 (e.g. "DMCA Policy").
+  useEffect(() => {
+    setFullPageMode(true);
+    return () => setFullPageMode(false);
+  }, [setFullPageMode]);
 
   return (
     <div className="min-h-screen bg-lattice-deep">


### PR DESCRIPTION
The AppShell Topbar renders an h1 with the active lens name ("Chat" by default), which appears before the DMCA page's own h1. This caused the "dmca page displays page title" test to fail because page.locator('h1') .first() picked up "Chat" instead of "DMCA Policy".

Legal pages already have their own complete chrome (header, sidebar nav), so setting fullPageMode=true prevents the AppShell from rendering its duplicate Topbar/Sidebar. This also prevents authenticated API calls (resonance, events) from firing on public legal pages, which should reduce the flaky Firefox timeout on the DMCA form input test.

https://claude.ai/code/session_01KXB6gaPB7khrC7NPEA4qFh