### PR TITLE
fix(e2e): use concord_refresh cookie to avoid backend JWT rejection

### DIFF
--- a/concord-frontend/components/shell/AppShell.tsx
+++ b/concord-frontend/components/shell/AppShell.tsx
@@ -6,9 +6,6 @@ import { Sidebar } from './Sidebar';
 import { Topbar } from './Topbar';
 import { CommandPalette } from './CommandPalette';
 import { useUIStore } from '@/store/ui';
-
-/** Routes that render their own chrome and should skip the AppShell layout. */
-const STANDALONE_PREFIXES = ['/legal/'];
 import { Toasts } from '@/components/common/Toasts';
 import { OperatorErrorBanner } from '@/components/common/OperatorErrorBanner';
 import { SystemStatus } from '@/components/common/SystemStatus';
@@ -19,6 +16,9 @@ import { InstallPrompt } from '@/components/pwa/InstallPrompt';
 import { OfflineFallback } from '@/components/pwa/OfflineFallback';
 import { QuickCapture, useQuickCapture } from '@/components/capture/QuickCapture';
 import { NowPlayingBar } from '@/components/music/NowPlayingBar';
+
+/** Routes that render their own chrome and should skip the AppShell layout. */
+const STANDALONE_PREFIXES = ['/legal/'];
 
 interface AppShellProps {
   children: React.ReactNode;

--- a/concord-frontend/tests/e2e/accessibility.spec.ts
+++ b/concord-frontend/tests/e2e/accessibility.spec.ts
@@ -1,11 +1,13 @@
 import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 
-// Helper to authenticate
+// Helper: set a session cookie so middleware allows access to protected routes.
+// Uses concord_refresh (not concord_auth) to avoid backend JWT validation
+// of the fake test token — the middleware accepts either cookie.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function authenticate(context: any) {
   await context.addCookies([{
-    name: 'concord_auth',
+    name: 'concord_refresh',
     value: 'e2e_test_token',
     domain: 'localhost',
     path: '/',

--- a/concord-frontend/tests/e2e/admin-dashboard.spec.ts
+++ b/concord-frontend/tests/e2e/admin-dashboard.spec.ts
@@ -2,11 +2,13 @@ import { test, expect } from '@playwright/test';
 
 /**
  * Helper: set a session cookie so middleware allows access to protected routes.
+ * Uses concord_refresh (not concord_auth) to avoid backend JWT validation
+ * of the fake test token — the middleware accepts either cookie.
  */
 async function authenticateContext(context: import('@playwright/test').BrowserContext) {
   await context.addCookies([
     {
-      name: 'concord_auth',
+      name: 'concord_refresh',
       value: 'e2e_test_token',
       domain: 'localhost',
       path: '/',

--- a/concord-frontend/tests/e2e/auth.spec.ts
+++ b/concord-frontend/tests/e2e/auth.spec.ts
@@ -512,10 +512,10 @@ test.describe('Authentication Flow', () => {
   // ── Session Management ──────────────────────────────────────────
 
   test('session cookie grants access to protected routes', async ({ page, context }) => {
-    // Set a mock auth cookie matching what the middleware checks
+    // Set a mock refresh cookie matching what the middleware checks
     await context.addCookies([
       {
-        name: 'concord_auth',
+        name: 'concord_refresh',
         value: 'e2e_test_token',
         domain: 'localhost',
         path: '/',
@@ -532,7 +532,7 @@ test.describe('Authentication Flow', () => {
   test('session persists across page reloads', async ({ page, context }) => {
     await context.addCookies([
       {
-        name: 'concord_auth',
+        name: 'concord_refresh',
         value: 'e2e_test_token',
         domain: 'localhost',
         path: '/',
@@ -547,7 +547,7 @@ test.describe('Authentication Flow', () => {
 
     // Cookie should still be present after reload
     const cookies = await context.cookies();
-    const authCookie = cookies.find((c) => c.name === 'concord_auth');
+    const authCookie = cookies.find((c) => c.name === 'concord_refresh');
     expect(authCookie).toBeDefined();
 
     // Should still not redirect

--- a/concord-frontend/tests/e2e/chat-modes.spec.ts
+++ b/concord-frontend/tests/e2e/chat-modes.spec.ts
@@ -2,11 +2,13 @@ import { test, expect } from '@playwright/test';
 
 /**
  * Helper: set a session cookie so middleware allows access to protected routes.
+ * Uses concord_refresh (not concord_auth) to avoid backend JWT validation
+ * of the fake test token — the middleware accepts either cookie.
  */
 async function authenticateContext(context: import('@playwright/test').BrowserContext) {
   await context.addCookies([
     {
-      name: 'concord_auth',
+      name: 'concord_refresh',
       value: 'e2e_test_token',
       domain: 'localhost',
       path: '/',
@@ -227,7 +229,7 @@ test.describe('Connect Mode', () => {
     expect(response?.status()).toBeLessThan(500);
     await page.waitForLoadState('networkidle');
 
-    // Skip if redirected to login (auth cookie not recognised)
+    // Skip if redirected to login (refresh cookie not recognised)
     if (/\/login/.test(page.url())) return;
 
     const connectButton = page.locator(

--- a/concord-frontend/tests/e2e/dtu-integrity.spec.ts
+++ b/concord-frontend/tests/e2e/dtu-integrity.spec.ts
@@ -2,11 +2,13 @@ import { test, expect } from '@playwright/test';
 
 /**
  * Helper: set a session cookie so middleware allows access to protected routes.
+ * Uses concord_refresh (not concord_auth) to avoid backend JWT validation
+ * of the fake test token — the middleware accepts either cookie.
  */
 async function authenticateContext(context: import('@playwright/test').BrowserContext) {
   await context.addCookies([
     {
-      name: 'concord_auth',
+      name: 'concord_refresh',
       value: 'e2e_test_token',
       domain: 'localhost',
       path: '/',

--- a/concord-frontend/tests/e2e/media-flow.spec.ts
+++ b/concord-frontend/tests/e2e/media-flow.spec.ts
@@ -2,11 +2,13 @@ import { test, expect } from '@playwright/test';
 
 /**
  * Helper: set a session cookie so middleware allows access to protected routes.
+ * Uses concord_refresh (not concord_auth) to avoid backend JWT validation
+ * of the fake test token — the middleware accepts either cookie.
  */
 async function authenticateContext(context: import('@playwright/test').BrowserContext) {
   await context.addCookies([
     {
-      name: 'concord_auth',
+      name: 'concord_refresh',
       value: 'e2e_test_token',
       domain: 'localhost',
       path: '/',

--- a/concord-frontend/tests/e2e/navigation.spec.ts
+++ b/concord-frontend/tests/e2e/navigation.spec.ts
@@ -2,12 +2,13 @@ import { test, expect } from '@playwright/test';
 
 /**
  * Helper: set a session cookie so middleware allows access to protected routes.
- * The middleware checks for 'concord_auth', 'token', or 'connect.sid'.
+ * Uses concord_refresh (not concord_auth) to avoid backend JWT validation
+ * of the fake test token — the middleware accepts either cookie.
  */
 async function authenticateContext(context: import('@playwright/test').BrowserContext) {
   await context.addCookies([
     {
-      name: 'concord_auth',
+      name: 'concord_refresh',
       value: 'e2e_test_token',
       domain: 'localhost',
       path: '/',

--- a/concord-frontend/tests/e2e/social-flow.spec.ts
+++ b/concord-frontend/tests/e2e/social-flow.spec.ts
@@ -2,11 +2,13 @@ import { test, expect } from '@playwright/test';
 
 /**
  * Helper: set a session cookie so middleware allows access to protected routes.
+ * Uses concord_refresh (not concord_auth) to avoid backend JWT validation
+ * of the fake test token — the middleware accepts either cookie.
  */
 async function authenticateContext(context: import('@playwright/test').BrowserContext) {
   await context.addCookies([
     {
-      name: 'concord_auth',
+      name: 'concord_refresh',
       value: 'e2e_test_token',
       domain: 'localhost',
       path: '/',

--- a/concord-frontend/tests/e2e/wallet-flow.spec.ts
+++ b/concord-frontend/tests/e2e/wallet-flow.spec.ts
@@ -2,11 +2,13 @@ import { test, expect } from '@playwright/test';
 
 /**
  * Helper: set a session cookie so middleware allows access to protected routes.
+ * Uses concord_refresh (not concord_auth) to avoid backend JWT validation
+ * of the fake test token — the middleware accepts either cookie.
  */
 async function authenticateContext(context: import('@playwright/test').BrowserContext) {
   await context.addCookies([
     {
-      name: 'concord_auth',
+      name: 'concord_refresh',
       value: 'e2e_test_token',
       domain: 'localhost',
       path: '/',


### PR DESCRIPTION
E2e tests were setting concord_auth with a fake token, causing the backend to validate it as JWT, fail, and return 401. This triggered the API interceptor redirect to /login mid-test.

Switch to concord_refresh — the Next.js middleware accepts either cookie, but the backend only validates refresh tokens on the refresh endpoint, not on every request. This matches the previous behavior when tests used the legacy concord_session cookie.

Also fix AppShell import ordering (const between imports).

https://claude.ai/code/session_01KXB6gaPB7khrC7NPEA4qFh