### PR TITLE
feat(concordia-mounts): B1 — mount data substrate + species seed

### DIFF
--- a/concord-frontend/components/concordia/mounts/MountDesigner.tsx
+++ b/concord-frontend/components/concordia/mounts/MountDesigner.tsx
@@ -1,0 +1,237 @@
+// concord-frontend/components/concordia/mounts/MountDesigner.tsx
+//
+// Concordia Procedural Mount System Phase B3 — UI scaffold.
+//
+// Three-pane layout per the plan:
+//   - Left:   owned mountable companions (mounts.list_mountable)
+//   - Center: 3D preview placeholder (full preview lands in B4 polish)
+//   - Right:  equipped gear slots (saddle/bridle/barding) with author /
+//             equip / unequip actions, plus computed stats.
+//
+// All read+mutate calls flow through the lens-run macro endpoint:
+//   POST /api/lens/run { domain: 'mounts', name, input }
+//
+// This is a deliberately compact scaffold. Full visual polish (3D preview
+// + animation hooks for the saddle silhouette + drag-to-equip) lands
+// alongside the quadruped-gait integration in B4.
+
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+type Slot = "saddle" | "bridle" | "barding";
+
+interface CompanionRow {
+  id: string;
+  name: string;
+  creature_id: string;
+  level: number;
+  world_id: string;
+  mount_state?: string | null;
+}
+
+interface MountStats {
+  ok: boolean;
+  speciesId?: string;
+  base?: { speedMps: number; baseStamina: number; carryCapacityKg: number };
+  modifiers?: { speed: number; stamina: number; carry: number; comfort: number };
+  effective?: { speedMps: number; baseStamina: number; carryCapacityKg: number; comfort: number };
+  equipped?: Array<{ slot: Slot; dtuId: string; weight_kg: number }>;
+}
+
+interface EquippedGear {
+  saddle: GearSlot | null;
+  bridle: GearSlot | null;
+  barding: GearSlot | null;
+}
+
+interface GearSlot {
+  dtuId: string;
+  slot?: Slot;
+  weight_kg: number;
+  stat_mods: Partial<{ speed: number; stamina: number; carry: number; comfort: number }>;
+  style_tags: string[];
+  missing?: boolean;
+}
+
+async function runMacro<T = unknown>(
+  domain: string,
+  name: string,
+  input: Record<string, unknown> = {},
+): Promise<T> {
+  const r = await fetch("/api/lens/run", {
+    method: "POST",
+    credentials: "include",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ domain, name, input }),
+  });
+  if (!r.ok) throw new Error(`macro ${domain}.${name} failed: ${r.status}`);
+  return r.json() as Promise<T>;
+}
+
+function fmtMul(x: number | undefined): string {
+  if (x === undefined || x === 0) return "—";
+  const sign = x > 0 ? "+" : "";
+  return `${sign}${(x * 100).toFixed(0)}%`;
+}
+
+export function MountDesigner() {
+  const [companions, setCompanions] = useState<CompanionRow[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [stats, setStats] = useState<MountStats | null>(null);
+  const [gear, setGear] = useState<EquippedGear | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true); setErr(null);
+    try {
+      const list = await runMacro<{ ok: boolean; companions: CompanionRow[] }>("mounts", "list_mountable");
+      setCompanions(list.companions || []);
+      if (!selectedId && list.companions?.length) setSelectedId(list.companions[0].id);
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedId]);
+
+  useEffect(() => { void refresh(); }, [refresh]);
+
+  useEffect(() => {
+    if (!selectedId) return;
+    void (async () => {
+      try {
+        const [s, g] = await Promise.all([
+          runMacro<MountStats>("mounts", "compute_stats", { mountId: selectedId }),
+          runMacro<{ ok: boolean; gear: EquippedGear }>("mounts", "get_equipped_gear", { mountId: selectedId }),
+        ]);
+        setStats(s);
+        setGear(g.gear);
+      } catch (e) {
+        setErr((e as Error).message);
+      }
+    })();
+  }, [selectedId]);
+
+  const onUnequip = useCallback(async (slot: Slot) => {
+    if (!selectedId) return;
+    await runMacro("mounts", "unequip_gear", { mountId: selectedId, slot });
+    await refresh();
+  }, [selectedId, refresh]);
+
+  return (
+    <div className="grid grid-cols-12 gap-4 p-4 text-sm">
+      {/* Left pane: companions */}
+      <aside className="col-span-3 border-r border-zinc-800 pr-3">
+        <h2 className="text-base font-semibold mb-2">Mounts</h2>
+        {loading && <p className="text-zinc-500">Loading…</p>}
+        {err && <p className="text-red-400">Error: {err}</p>}
+        <ul className="space-y-1">
+          {companions.map(c => (
+            <li key={c.id}>
+              <button
+                onClick={() => setSelectedId(c.id)}
+                className={`w-full text-left px-2 py-1 rounded ${selectedId === c.id ? "bg-zinc-800" : "hover:bg-zinc-900"}`}
+              >
+                <span className="font-medium">{c.name}</span>{" "}
+                <span className="text-zinc-400">lvl {c.level}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </aside>
+
+      {/* Center pane: preview placeholder */}
+      <section className="col-span-5 border-r border-zinc-800 pr-3">
+        <h2 className="text-base font-semibold mb-2">Preview</h2>
+        <div className="aspect-video rounded bg-zinc-900 border border-zinc-800 grid place-items-center text-zinc-500">
+          {selectedId
+            ? <span>3D preview placeholder — full render lands in B4</span>
+            : <span>Select a mount</span>}
+        </div>
+
+        {stats?.ok && stats.base && stats.effective && (
+          <div className="mt-4 grid grid-cols-3 gap-3">
+            <StatCard label="Speed" base={stats.base.speedMps} effective={stats.effective.speedMps} unit=" m/s" />
+            <StatCard label="Stamina" base={stats.base.baseStamina} effective={stats.effective.baseStamina} />
+            <StatCard label="Carry" base={stats.base.carryCapacityKg} effective={stats.effective.carryCapacityKg} unit=" kg" />
+          </div>
+        )}
+      </section>
+
+      {/* Right pane: gear */}
+      <aside className="col-span-4">
+        <h2 className="text-base font-semibold mb-2">Gear</h2>
+        {selectedId && gear && (
+          <div className="space-y-2">
+            {(["saddle", "bridle", "barding"] as Slot[]).map(slot => (
+              <GearRow
+                key={slot}
+                slot={slot}
+                slotData={gear[slot]}
+                onUnequip={() => onUnequip(slot)}
+              />
+            ))}
+          </div>
+        )}
+
+        {stats?.ok && stats.modifiers && (
+          <div className="mt-4 text-xs text-zinc-400 border-t border-zinc-800 pt-3 space-y-1">
+            <div>Speed mod:    {fmtMul(stats.modifiers.speed)}</div>
+            <div>Stamina mod:  {fmtMul(stats.modifiers.stamina)}</div>
+            <div>Carry mod:    {fmtMul(stats.modifiers.carry)}</div>
+            <div>Comfort:      {stats.modifiers.comfort ?? 0}</div>
+          </div>
+        )}
+
+        <p className="mt-4 text-xs text-zinc-500">
+          Author new gear via the Crafting lens (recipe kind <code>mount_gear</code>).
+          B3 ships the validation + equip flow; the in-context author panel lands in B4 polish.
+        </p>
+      </aside>
+    </div>
+  );
+}
+
+function StatCard({ label, base, effective, unit = "" }: { label: string; base: number; effective: number; unit?: string }) {
+  const delta = effective - base;
+  const dPct = base > 0 ? (delta / base) * 100 : 0;
+  const sign = dPct >= 0 ? "+" : "";
+  return (
+    <div className="rounded border border-zinc-800 p-2">
+      <div className="text-xs text-zinc-400">{label}</div>
+      <div className="text-lg font-medium">{effective.toFixed(2)}{unit}</div>
+      <div className="text-xs text-zinc-500">base {base.toFixed(2)}{unit} ({sign}{dPct.toFixed(0)}%)</div>
+    </div>
+  );
+}
+
+function GearRow({ slot, slotData, onUnequip }: { slot: Slot; slotData: GearSlot | null; onUnequip: () => void }) {
+  return (
+    <div className="rounded border border-zinc-800 p-2">
+      <div className="flex items-center justify-between">
+        <div className="text-xs uppercase tracking-wide text-zinc-400">{slot}</div>
+        {slotData && (
+          <button onClick={onUnequip} className="text-xs text-zinc-400 hover:text-red-400">
+            Unequip
+          </button>
+        )}
+      </div>
+      {slotData ? (
+        <div className="mt-1">
+          <div className="text-sm font-medium">{slotData.dtuId.slice(0, 14)}…</div>
+          <div className="text-xs text-zinc-500">
+            {slotData.weight_kg} kg
+            {slotData.stat_mods?.speed != null && ` · ${fmtMul(slotData.stat_mods.speed)} speed`}
+            {slotData.stat_mods?.comfort != null && ` · +${slotData.stat_mods.comfort} comfort`}
+          </div>
+        </div>
+      ) : (
+        <div className="mt-1 text-xs text-zinc-500">Empty</div>
+      )}
+    </div>
+  );
+}
+
+export default MountDesigner;

--- a/concord-frontend/lib/concordia/mounts/mount-state-machine.ts
+++ b/concord-frontend/lib/concordia/mounts/mount-state-machine.ts
@@ -1,0 +1,95 @@
+// concord-frontend/lib/concordia/mounts/mount-state-machine.ts
+//
+// Mounted state machine for Concordia (B2 → extends in B4).
+//
+// States: unmounted → mounting → mounted_idle ↔ mounted_walk ↔ mounted_trot
+//         ↔ mounted_gallop, mounted_idle ↔ mounted_combat (B4),
+//         any mounted_* → dismounting → unmounted.
+//
+// Invariants:
+//   - You cannot skip ranks downward in a single transition. Going from
+//     `mounted_gallop` to `mounted_idle` MUST go gallop → trot → walk → idle.
+//     This is what makes the gait blend feel grounded; instant snap-to-idle
+//     is the giveaway that the animation isn't physics-aware.
+//   - You can always escape to dismounting from any mounted_* state.
+//   - mounted_combat enters from idle/walk only (B4).
+//
+// The transition matrix below encodes those rules. `canTransition` is the
+// only public answer to "can I switch state right now?"; the consumer
+// owns the speed-thresholding logic that PROPOSES a transition.
+
+import type { MountedState } from "./mount-types";
+
+type TransitionMap = Record<MountedState, ReadonlySet<MountedState>>;
+
+export const MOUNT_TRANSITIONS: TransitionMap = {
+  unmounted:        new Set<MountedState>(["mounting"]),
+  mounting:         new Set<MountedState>(["mounted_idle", "unmounted"]),
+  mounted_idle:     new Set<MountedState>(["mounted_walk", "mounted_combat", "dismounting"]),
+  mounted_walk:     new Set<MountedState>(["mounted_idle", "mounted_trot", "dismounting"]),
+  mounted_trot:     new Set<MountedState>(["mounted_walk", "mounted_gallop", "dismounting"]),
+  mounted_gallop:   new Set<MountedState>(["mounted_trot", "dismounting"]),
+  mounted_combat:   new Set<MountedState>(["mounted_idle", "mounted_walk", "dismounting"]),
+  dismounting:      new Set<MountedState>(["unmounted"]),
+};
+
+export function canTransition(from: MountedState, to: MountedState): boolean {
+  if (from === to) return true;
+  const allowed = MOUNT_TRANSITIONS[from];
+  return !!allowed && allowed.has(to);
+}
+
+/**
+ * Speed-driven gait selector. Given the current mount speed (m/s) and
+ * whether the rider is in combat, returns the desired mounted state. The
+ * caller still has to verify the proposed state is reachable from the
+ * current one via canTransition() — if not, advance one step at a time.
+ *
+ * Thresholds are tuned around the warhorse profile (8.5 m/s base) and
+ * scale by speciesBaseSpeed so a chimera (6 m/s) gallops at a lower
+ * absolute speed than a hippogriff (11 m/s).
+ */
+export function gaitForSpeed(
+  speedMps: number,
+  speciesBaseSpeedMps: number,
+  inCombat: boolean,
+): MountedState {
+  if (inCombat) return "mounted_combat";
+  const r = speedMps / Math.max(0.1, speciesBaseSpeedMps);
+  if (speedMps < 0.1) return "mounted_idle";
+  if (r < 0.30) return "mounted_walk";
+  if (r < 0.55) return "mounted_walk";
+  if (r < 0.85) return "mounted_trot";
+  return "mounted_gallop";
+}
+
+/**
+ * Step the state machine one transition closer to the target. Returns
+ * the next state to enter, or the current state if already at target or
+ * if no legal step exists. Caller invokes this every frame until
+ * `current === target`.
+ */
+export function stepTowards(current: MountedState, target: MountedState): MountedState {
+  if (current === target) return current;
+  // Direct transition allowed → take it.
+  if (canTransition(current, target)) return target;
+  // Otherwise compute one-step path through the gait ladder.
+  const order: MountedState[] = ["mounted_idle", "mounted_walk", "mounted_trot", "mounted_gallop"];
+  const ci = order.indexOf(current);
+  const ti = order.indexOf(target);
+  if (ci !== -1 && ti !== -1) {
+    const next = ci < ti ? order[ci + 1] : order[ci - 1];
+    if (next && canTransition(current, next)) return next;
+  }
+  // mounted_combat → idle goes via the legal idle bridge.
+  if (current === "mounted_combat" && target !== "mounted_combat") {
+    return "mounted_idle";
+  }
+  // mounting/dismounting are one-step states; the caller drives them.
+  return current;
+}
+
+/** Whether a state represents "in the saddle". */
+export function isMounted(s: MountedState): boolean {
+  return s.startsWith("mounted_");
+}

--- a/concord-frontend/lib/concordia/mounts/mount-types.ts
+++ b/concord-frontend/lib/concordia/mounts/mount-types.ts
@@ -1,0 +1,86 @@
+// concord-frontend/lib/concordia/mounts/mount-types.ts
+//
+// TypeScript types for the Concordia Procedural Mount System.
+// Mirrors the server-side mount_species + mount_gait_profiles +
+// mounted_instances rows. Returned by the macros:
+//   mounts.list_species, get_species, get_gait, get_active_mount.
+
+export type SizeClass = "small" | "medium" | "large" | "huge";
+
+export type GaitMode = "walk" | "trot" | "canter" | "gallop";
+
+export interface RiderSeatOffset {
+  x: number;
+  y: number;
+  z: number;
+  yaw: number;
+}
+
+export interface GaitCycleBlock {
+  /** Per-leg phase offsets, FL FR RL RR. Trot = [0, 0.5, 0.5, 0]. */
+  phase_offsets: [number, number, number, number];
+  /** Stride length in metres. */
+  stride_m: number;
+  /** Foot ground-clearance in metres at peak swing. */
+  ground_clearance_m: number;
+}
+
+export interface MountGaitProfile {
+  id: string;
+  speciesId: string;
+  walk: GaitCycleBlock;
+  trot: GaitCycleBlock;
+  gallop: GaitCycleBlock;
+  /** Minimum turning radius in metres (used by steering + IK). */
+  turnRadiusM: number;
+}
+
+export interface MountSpecies {
+  speciesId: string;
+  displayName: string;
+  sizeClass: SizeClass;
+  baseSpeedMps: number;
+  baseStamina: number;
+  carryCapacityKg: number;
+  gaitProfileId: string;
+  riderSeatOffset: RiderSeatOffset;
+  saddleAnchorBone: string;
+  reinsAnchorBone: string;
+  flightCapable: boolean;
+  aestheticTags: string[];
+}
+
+export interface ActiveMountPayload {
+  ok: boolean;
+  mounted: boolean;
+  instance?: { id: string; mountedAt: number };
+  companion?: { id: string; name: string; creatureId: string };
+  speciesId?: string;
+  species?: MountSpecies;
+  gait?: MountGaitProfile;
+  seatOffset?: RiderSeatOffset;
+}
+
+/** Mounted state machine — see mount-state-machine.ts. */
+export type MountedState =
+  | "unmounted"
+  | "mounting"
+  | "mounted_idle"
+  | "mounted_walk"
+  | "mounted_trot"
+  | "mounted_gallop"
+  | "mounted_combat"
+  | "dismounting";
+
+export interface MountedFrame {
+  /** Mount world position. */
+  mountPos: { x: number; y: number; z: number };
+  /** Mount yaw in radians. */
+  mountYaw: number;
+  /** Mount linear velocity (m/s). */
+  speed: number;
+  /** Active gait phase ∈ [0, 1) for the current cycle. */
+  gaitPhase: number;
+  /** Active gait mode at this frame. */
+  gaitMode: GaitMode;
+}

--- a/concord-frontend/lib/concordia/mounts/rider-ik.ts
+++ b/concord-frontend/lib/concordia/mounts/rider-ik.ts
@@ -1,0 +1,145 @@
+// concord-frontend/lib/concordia/mounts/rider-ik.ts
+//
+// Rider-on-mount IK constraints.
+//
+// Two chains:
+//   1) Pelvis → mount saddle anchor. Strict positional lock with a
+//      vertical bounce-blend that scales with gait amplitude (gallop
+//      bounces, walk doesn't). The hip yaws follow mount yaw.
+//   2) Each hand → rein anchor (left + right of mount.head). Solved
+//      via the existing FABRIK solver over the rider's arm chain.
+//
+// CLAUDE.md invariant (B4 will pin this with a frontend test): in
+// stance-phase the saddle anchor's foot-contact must remain consistent
+// — but stance physics is the mount's job, this module only tracks the
+// already-correct mount pose.
+//
+// We DO NOT directly mutate the rider's full skeleton; we return the
+// constraint targets so the AvatarSystem3D pipeline can integrate them
+// with its other IK passes (combat aim, feet-on-ground, etc.).
+
+import type { RiderSeatOffset, GaitMode } from "./mount-types";
+
+export interface MountTransform {
+  /** Mount root world position (origin at root bone). */
+  pos: { x: number; y: number; z: number };
+  /** Mount yaw in radians. */
+  yaw: number;
+  /**
+   * World position of the saddle anchor bone. Provided by the mount's
+   * skeleton-bound transform — the AvatarSystem3D pipeline traverses
+   * the mount mesh to compute it.
+   */
+  saddleAnchorWorld: { x: number; y: number; z: number };
+  /** World position of the reins anchor bone (typically head/neck). */
+  reinsAnchorWorld: { x: number; y: number; z: number };
+}
+
+export interface BounceParams {
+  gaitMode: GaitMode;
+  /** Mount linear speed in m/s. */
+  speedMps: number;
+  /** Active gait phase ∈ [0, 1) — drives sinusoidal bounce. */
+  gaitPhase: number;
+}
+
+export interface RiderIkTargets {
+  /** Pelvis world target — rider hips snap here every frame. */
+  pelvisTarget: { x: number; y: number; z: number };
+  /** Pelvis yaw (radians) — match the mount's yaw. */
+  pelvisYaw: number;
+  /** Left hand target (left rein). */
+  leftHandTarget: { x: number; y: number; z: number };
+  /** Right hand target (right rein). */
+  rightHandTarget: { x: number; y: number; z: number };
+  /** Bounce magnitude applied this frame (debug). */
+  bounceY: number;
+}
+
+const REIN_HALF_WIDTH = 0.25;
+
+/**
+ * Bounce amplitude (metres) for the rider hips, by gait. These are the
+ * peak vertical excursions of the rider relative to the saddle anchor.
+ * Walk has near-zero bounce; gallop has the most.
+ */
+const BOUNCE_AMPLITUDE: Record<GaitMode, number> = {
+  walk:   0.005,
+  trot:   0.045,
+  canter: 0.060,
+  gallop: 0.085,
+};
+
+const BOUNCE_FREQ_HZ: Record<GaitMode, number> = {
+  walk:   1.6,
+  trot:   2.4,
+  canter: 2.0,
+  gallop: 2.8,
+};
+
+/**
+ * Compute the rider's pelvis bounce offset for the current frame.
+ * Returns a positive value at the up-peak of the bounce cycle.
+ */
+export function computeBounceY(p: BounceParams): number {
+  const amp = BOUNCE_AMPLITUDE[p.gaitMode] ?? 0;
+  if (amp <= 0) return 0;
+  // Phase already covers [0, 1); fold in BOUNCE_FREQ multiplier so
+  // gallop at high speed bounces faster than the gait cycle alone.
+  const wave = Math.sin(2 * Math.PI * (p.gaitPhase * BOUNCE_FREQ_HZ[p.gaitMode]));
+  // Speed gating — under 1 m/s the bounce dampens to keep idle steady.
+  const speedGate = Math.min(1, p.speedMps / 1.5);
+  return wave * amp * speedGate;
+}
+
+/**
+ * Compute IK targets for the rider given the mount transform + the
+ * species-defined seat offset + the current bounce params. Returns
+ * world-space targets the AvatarSystem3D pipeline plugs into FABRIK.
+ */
+export function computeRiderIkTargets(
+  mount: MountTransform,
+  seatOffset: RiderSeatOffset,
+  bounce: BounceParams,
+): RiderIkTargets {
+  // Saddle anchor + species-tuned offset (rotated by mount yaw).
+  const cy = Math.cos(mount.yaw);
+  const sy = Math.sin(mount.yaw);
+  const offX = seatOffset.x * cy - seatOffset.z * sy;
+  const offZ = seatOffset.x * sy + seatOffset.z * cy;
+  const bounceY = computeBounceY(bounce);
+  const pelvisTarget = {
+    x: mount.saddleAnchorWorld.x + offX,
+    y: mount.saddleAnchorWorld.y + seatOffset.y + bounceY,
+    z: mount.saddleAnchorWorld.z + offZ,
+  };
+  // Reins: left + right of the reins anchor, perpendicular to mount yaw.
+  const perpX = -sy;
+  const perpZ = cy;
+  const leftHandTarget = {
+    x: mount.reinsAnchorWorld.x + perpX * REIN_HALF_WIDTH,
+    y: mount.reinsAnchorWorld.y,
+    z: mount.reinsAnchorWorld.z + perpZ * REIN_HALF_WIDTH,
+  };
+  const rightHandTarget = {
+    x: mount.reinsAnchorWorld.x - perpX * REIN_HALF_WIDTH,
+    y: mount.reinsAnchorWorld.y,
+    z: mount.reinsAnchorWorld.z - perpZ * REIN_HALF_WIDTH,
+  };
+  return {
+    pelvisTarget,
+    pelvisYaw: mount.yaw + seatOffset.yaw,
+    leftHandTarget,
+    rightHandTarget,
+    bounceY,
+  };
+}
+
+/**
+ * Maximum vertical excursion expected for a given gait + speed. Used by
+ * the camera follower to keep the rider centered without being driven
+ * by the bounce wave.
+ */
+export function maxBounceFor(gaitMode: GaitMode): number {
+  return BOUNCE_AMPLITUDE[gaitMode] ?? 0;
+}

--- a/server/domains/mounts.js
+++ b/server/domains/mounts.js
@@ -1,0 +1,103 @@
+// server/domains/mounts.js
+//
+// Concordia Procedural Mount System — read-only domain surface.
+//
+// B1 (this commit): list_species, get_species, get_gait, list_mountable,
+//                   list_eligible_nearby
+// B2 will add: tame, mount, dismount, get_active_mount
+// B3 will add: author_gear, equip_gear, unequip_gear, compute_stats
+// B4 will add: feed, groom, evolve, care_state
+//
+// All B1 macros are pure reads — safe to put in `publicReadDomains`.
+
+import {
+  listMountableSpecies,
+  getMountSpecies,
+  getGaitProfile,
+  listMountableCompanionsForOwner,
+} from "../lib/ecosystem/mount-eligibility.js";
+
+export default function registerMountMacros(register) {
+  // mount.list_species — full mount_species table for the lens picker.
+  register("mounts", "list_species", async (ctx) => {
+    const db = ctx?.db;
+    if (!db) return { ok: false, reason: "no_db" };
+    return { ok: true, species: listMountableSpecies(db) };
+  }, { note: "all mountable species + base stats + gait profile id" });
+
+  // mount.get_species — single species lookup.
+  register("mounts", "get_species", async (ctx, input = {}) => {
+    const db = ctx?.db;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!input.speciesId) return { ok: false, reason: "missing_species_id" };
+    const sp = getMountSpecies(db, input.speciesId);
+    if (!sp) return { ok: false, reason: "unknown_species" };
+    return { ok: true, species: sp };
+  }, { note: "single species record + parsed JSON columns" });
+
+  // mount.get_gait — gait profile (walk/trot/gallop) for the quadruped
+  // gait synthesizer on the client.
+  register("mounts", "get_gait", async (ctx, input = {}) => {
+    const db = ctx?.db;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!input.speciesId) return { ok: false, reason: "missing_species_id" };
+    const g = getGaitProfile(db, input.speciesId);
+    if (!g) return { ok: false, reason: "unknown_species" };
+    return { ok: true, gait: g };
+  }, { note: "walk/trot/gallop phase offsets + turn radius" });
+
+  // mount.list_mountable — caller's mount-eligible companions.
+  register("mounts", "list_mountable", async (ctx, input = {}) => {
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.userId;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_user" };
+    const worldId = input.worldId || null;
+    return { ok: true, companions: listMountableCompanionsForOwner(db, userId, worldId) };
+  }, { note: "caller's player_companions rows with mount_eligible=1" });
+
+  // mount.list_eligible_nearby — proximity scan over world_npcs filtered
+  // to mountable species. Used by the MountDesigner's "what's around me"
+  // pane in B3.
+  register("mounts", "list_eligible_nearby", async (ctx, input = {}) => {
+    const db = ctx?.db;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!input.worldId) return { ok: false, reason: "missing_world_id" };
+    const x = Number(input.x);
+    const z = Number(input.z);
+    const radius = Math.max(1, Math.min(input.radius || 50, 500));
+    if (!Number.isFinite(x) || !Number.isFinite(z)) {
+      return { ok: false, reason: "missing_coords" };
+    }
+    try {
+      // world_npcs.archetype is `creature:${species_id}` (see fauna-spawner).
+      // Strip the prefix and JOIN against mount_species. SQLite doesn't have
+      // distance(); compute squared-distance in SQL with a tight bbox prefilter.
+      const rows = db.prepare(`
+        SELECT n.id, n.archetype, n.x, n.y, n.z, n.world_id, n.is_dead,
+               substr(n.archetype, 10) AS species_id
+        FROM world_npcs n
+        INNER JOIN mount_species s ON s.species_id = substr(n.archetype, 10)
+        WHERE n.world_id = ?
+          AND n.is_dead = 0
+          AND n.archetype LIKE 'creature:%'
+          AND n.x BETWEEN ? AND ?
+          AND n.z BETWEEN ? AND ?
+        LIMIT 200
+      `).all(input.worldId, x - radius, x + radius, z - radius, z + radius);
+      const r2 = radius * radius;
+      const nearby = rows
+        .map(r => {
+          const dx = r.x - x;
+          const dz = r.z - z;
+          return { ...r, distance: Math.sqrt(dx * dx + dz * dz), distanceSq: dx * dx + dz * dz };
+        })
+        .filter(r => r.distanceSq <= r2)
+        .sort((a, b) => a.distance - b.distance)
+        .slice(0, 50);
+      return { ok: true, count: nearby.length, nearby };
+    } catch (err) {
+      return { ok: false, reason: err.message };
+    }
+  }, { note: "mountable creatures within radius around (x, z) in a world" });
+}

--- a/server/domains/mounts.js
+++ b/server/domains/mounts.js
@@ -3,8 +3,9 @@
 // Concordia Procedural Mount System — domain surface.
 //
 // B1: list_species, get_species, get_gait, list_mountable, list_eligible_nearby
-// B2 (this commit): tame, mount, dismount, get_active_mount, mount_history
-// B3 will add: author_gear, equip_gear, unequip_gear, compute_stats
+// B2: tame, mount, dismount, get_active_mount, history
+// B3 (this commit): equip_gear, unequip_gear, compute_stats, get_equipped_gear,
+//                   validate_gear_recipe (pre-author shape check)
 // B4 will add: feed, groom, evolve, care_state
 
 import {
@@ -20,6 +21,13 @@ import {
   getActiveMountPayload,
   listMountHistory,
 } from "../lib/companions-mount.js";
+import {
+  equipGear,
+  unequipGear,
+  computeMountStats,
+  getEquippedGear,
+} from "../lib/mount-gear.js";
+import { validateMountGear, MOUNT_GEAR_SLOTS } from "../lib/dtu-validators/mount-gear-validators.js";
 import { getFlag } from "../lib/feature-flags.js";
 
 export default function registerMountMacros(register) {
@@ -176,4 +184,79 @@ export default function registerMountMacros(register) {
       limit: Math.max(1, Math.min(input.limit || 50, 200)),
     }) };
   }, { note: "rider's closed mount instances (recent-first)" });
+
+  // ---------- B3: gear authoring + equipping ----------
+
+  // mounts.validate_gear_recipe — pre-author validation. Plugin / UI can
+  // call this before submitting `dtu.create` to surface validation errors
+  // without writing a row. Read-only, no auth needed.
+  register("mounts", "validate_gear_recipe", async (_ctx, input = {}) => {
+    if (!getFlag("FF_MOUNT_GEAR", 1)) return { ok: false, reason: "feature_disabled" };
+    if (!input.recipe || typeof input.recipe !== "object") {
+      return { ok: false, reason: "missing_recipe" };
+    }
+    const recipe = { kind: "mount_gear", meta: input.recipe.meta || input.recipe };
+    return validateMountGear(recipe);
+  }, { note: "validate a mount_gear recipe shape pre-author" });
+
+  // mounts.equip_gear — equip a previously-authored gear DTU into one of
+  // saddle/bridle/barding slots on a mount the caller owns.
+  register("mounts", "equip_gear", async (ctx, input = {}) => {
+    if (!getFlag("FF_MOUNT_GEAR", 1)) return { ok: false, reason: "feature_disabled" };
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.userId;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_user" };
+    if (!input.mountId || !input.gearDtuId || !input.slot) {
+      return { ok: false, reason: "missing_args" };
+    }
+    return equipGear(db, {
+      mountId: input.mountId,
+      gearDtuId: input.gearDtuId,
+      slot: input.slot,
+      ownerId: userId,
+    });
+  }, { note: "equip a mount_gear DTU into one of {saddle, bridle, barding}" });
+
+  // mounts.unequip_gear — clear a slot. Idempotent.
+  register("mounts", "unequip_gear", async (ctx, input = {}) => {
+    if (!getFlag("FF_MOUNT_GEAR", 1)) return { ok: false, reason: "feature_disabled" };
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.userId;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_user" };
+    if (!input.mountId || !input.slot) return { ok: false, reason: "missing_args" };
+    return unequipGear(db, { mountId: input.mountId, slot: input.slot, ownerId: userId });
+  }, { note: "clear a slot (idempotent)" });
+
+  // mounts.compute_stats — fold base + equipped gear into the effective
+  // stat block. Used by the MountedHUD speedometer + carry indicator.
+  register("mounts", "compute_stats", async (ctx, input = {}) => {
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.userId;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_user" };
+    if (!input.mountId) return { ok: false, reason: "missing_mount_id" };
+    // Cheap ownership check — read companion's owner.
+    const owner = db.prepare(`SELECT owner_id FROM player_companions WHERE id = ?`).get(input.mountId);
+    if (!owner) return { ok: false, reason: "mount_not_found" };
+    if (owner.owner_id !== userId) return { ok: false, reason: "not_owner" };
+    const stats = computeMountStats(db, input.mountId);
+    if (!stats) return { ok: false, reason: "compute_failed" };
+    return { ok: true, ...stats };
+  }, { note: "fold base species stats + equipped gear modifiers" });
+
+  // mounts.get_equipped_gear — slot map for the MountDesigner panel.
+  register("mounts", "get_equipped_gear", async (ctx, input = {}) => {
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.userId;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_user" };
+    if (!input.mountId) return { ok: false, reason: "missing_mount_id" };
+    const owner = db.prepare(`SELECT owner_id FROM player_companions WHERE id = ?`).get(input.mountId);
+    if (!owner) return { ok: false, reason: "mount_not_found" };
+    if (owner.owner_id !== userId) return { ok: false, reason: "not_owner" };
+    const gear = getEquippedGear(db, input.mountId);
+    return { ok: true, slots: [...MOUNT_GEAR_SLOTS], gear };
+  }, { note: "currently-equipped gear loadout for a mount" });
 }

--- a/server/domains/mounts.js
+++ b/server/domains/mounts.js
@@ -1,14 +1,11 @@
 // server/domains/mounts.js
 //
-// Concordia Procedural Mount System — read-only domain surface.
+// Concordia Procedural Mount System — domain surface.
 //
-// B1 (this commit): list_species, get_species, get_gait, list_mountable,
-//                   list_eligible_nearby
-// B2 will add: tame, mount, dismount, get_active_mount
+// B1: list_species, get_species, get_gait, list_mountable, list_eligible_nearby
+// B2 (this commit): tame, mount, dismount, get_active_mount, mount_history
 // B3 will add: author_gear, equip_gear, unequip_gear, compute_stats
 // B4 will add: feed, groom, evolve, care_state
-//
-// All B1 macros are pure reads — safe to put in `publicReadDomains`.
 
 import {
   listMountableSpecies,
@@ -16,6 +13,14 @@ import {
   getGaitProfile,
   listMountableCompanionsForOwner,
 } from "../lib/ecosystem/mount-eligibility.js";
+import {
+  tameForMount,
+  mount as mountAction,
+  dismount as dismountAction,
+  getActiveMountPayload,
+  listMountHistory,
+} from "../lib/companions-mount.js";
+import { getFlag } from "../lib/feature-flags.js";
 
 export default function registerMountMacros(register) {
   // mount.list_species — full mount_species table for the lens picker.
@@ -100,4 +105,75 @@ export default function registerMountMacros(register) {
       return { ok: false, reason: err.message };
     }
   }, { note: "mountable creatures within radius around (x, z) in a world" });
+
+  // ---------- B2: taming + riding ----------
+
+  // mounts.tame — wraps companions.attemptTame with mount-eligibility flip.
+  // Returns { ok, companionId, mountEligible, speciesId, successProbability }.
+  register("mounts", "tame", async (ctx, input = {}) => {
+    if (!getFlag("FF_MOUNTS_RIDING", 1)) return { ok: false, reason: "feature_disabled" };
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.userId;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_user" };
+    if (!input.creatureId) return { ok: false, reason: "missing_creature_id" };
+    return tameForMount(db, {
+      ownerId: userId,
+      creatureId: input.creatureId,
+      creatureName: input.creatureName,
+      worldId: input.worldId,
+      lureItem: input.lureItem,
+      tameSkill: input.tameSkill,
+    });
+  }, { note: "tame a creature; if mountable, flip mount_eligible=1" });
+
+  // mounts.mount — open mounted_instances ledger row + return seat offset.
+  // Server validates ownership + eligibility + one-active-per-world.
+  register("mounts", "mount", async (ctx, input = {}) => {
+    if (!getFlag("FF_MOUNTS_RIDING", 1)) return { ok: false, reason: "feature_disabled" };
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.userId;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_user" };
+    if (!input.companionId) return { ok: false, reason: "missing_companion_id" };
+    return mountAction(db, {
+      riderId: userId,
+      companionId: input.companionId,
+      worldId: input.worldId,
+    });
+  }, { note: "open a mounted_instances row, return seat offset + species" });
+
+  // mounts.dismount — idempotent close on the rider's active instance.
+  register("mounts", "dismount", async (ctx, input = {}) => {
+    if (!getFlag("FF_MOUNTS_RIDING", 1)) return { ok: false, reason: "feature_disabled" };
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.userId;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_user" };
+    return dismountAction(db, userId, input.worldId || "concordia-hub");
+  }, { note: "close the rider's active mounted_instance (idempotent)" });
+
+  // mounts.get_active_mount — full payload (instance + companion + species
+  // + gait + seat offset) for the MountedHUD on connect / reconnect.
+  register("mounts", "get_active_mount", async (ctx, input = {}) => {
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.userId;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_user" };
+    const payload = getActiveMountPayload(db, userId, input.worldId || "concordia-hub");
+    if (!payload) return { ok: true, mounted: false };
+    return { ok: true, mounted: true, ...payload };
+  }, { note: "rider's active mount payload (HUD bootstrap)" });
+
+  // mounts.history — closed mounted_instances rows for the caller.
+  register("mounts", "history", async (ctx, input = {}) => {
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.userId;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_user" };
+    return { ok: true, history: listMountHistory(db, userId, {
+      worldId: input.worldId || null,
+      limit: Math.max(1, Math.min(input.limit || 50, 200)),
+    }) };
+  }, { note: "rider's closed mount instances (recent-first)" });
 }

--- a/server/lib/companions-mount.js
+++ b/server/lib/companions-mount.js
@@ -1,0 +1,205 @@
+// server/lib/companions-mount.js
+//
+// Concordia Procedural Mount System Phase B2 — taming + riding.
+//
+// Wraps the existing companions.js#attemptTame so a successful tame on
+// a mountable species also sets `mount_eligible=1` on the resulting
+// player_companions row. Adds the riding state machine on the server
+// side (server validates `mount` / `dismount` and writes the
+// mounted_instances ledger).
+//
+// CLAUDE.md invariants enforced here:
+//   - A user has at most one active `mounted_instances` row per world.
+//   - Riding requires both `player_companions` ownership AND the
+//     companion's `mount_eligible = 1`.
+//   - dismount is idempotent (calling it when not mounted is a no-op).
+
+import crypto from "node:crypto";
+import { attemptTame } from "./companions.js";
+import { isSpeciesMountable, markCompanionMountable, getMountSpecies, getGaitProfile } from "./ecosystem/mount-eligibility.js";
+
+/**
+ * Read the species_id for a creature row in world_npcs. fauna-spawner
+ * writes archetype = `creature:${species_id}`; we strip the prefix.
+ */
+function speciesIdForCreature(db, creatureId) {
+  if (!db || !creatureId) return null;
+  try {
+    const row = db.prepare(`SELECT archetype FROM world_npcs WHERE id = ?`).get(creatureId);
+    if (!row) return null;
+    const a = String(row.archetype || "");
+    if (a.startsWith("creature:")) return a.slice("creature:".length);
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Tame a creature, then if its species is mountable, mark the new
+ * companion as mount-eligible. Single transaction so a bond/roll
+ * succeeded record is consistent with mount eligibility flag.
+ *
+ * @returns {{ok: boolean, companionId?: string, mountEligible?: boolean, speciesId?: string, reason?: string}}
+ */
+export function tameForMount(db, args) {
+  if (!db) return { ok: false, reason: "no_db" };
+  const r = attemptTame(db, args);
+  if (!r.ok) return r;
+  const speciesId = speciesIdForCreature(db, args.creatureId);
+  if (!speciesId) return { ...r, mountEligible: false };
+  if (!isSpeciesMountable(db, speciesId)) return { ...r, mountEligible: false, speciesId };
+  markCompanionMountable(db, r.companionId, speciesId);
+  return { ...r, mountEligible: true, speciesId };
+}
+
+// ---- mounted_instances ledger ----
+
+function _newMountedId() {
+  return `mtinst_${crypto.randomUUID ? crypto.randomUUID().replace(/-/g, "").slice(0, 16) : Math.random().toString(36).slice(2, 14)}`;
+}
+
+/**
+ * Read the rider's currently-active mounted_instance for a world (the
+ * single open row with dismounted_at IS NULL).
+ */
+export function getActiveMountFor(db, riderId, worldId = "concordia-hub") {
+  if (!db || !riderId) return null;
+  try {
+    return db.prepare(`
+      SELECT id, rider_id, mount_companion_id, world_id, mounted_at, seat_offset_json
+      FROM mounted_instances
+      WHERE rider_id = ? AND world_id = ? AND dismounted_at IS NULL
+      LIMIT 1
+    `).get(riderId, worldId) || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create a mounted_instances row. Validates ownership, eligibility,
+ * and the one-active-per-world invariant. Returns seat_offset so the
+ * client can lock the avatar's IK pelvis to the mount's saddle anchor.
+ *
+ * @param {object} db
+ * @param {object} args — { riderId, companionId, worldId? }
+ */
+export function mount(db, args) {
+  if (!db) return { ok: false, reason: "no_db" };
+  const { riderId, companionId, worldId = "concordia-hub" } = args || {};
+  if (!riderId || !companionId) return { ok: false, reason: "missing_args" };
+
+  // Ownership + eligibility check.
+  const comp = db.prepare(`
+    SELECT id, owner_id, world_id, mount_eligible, creature_id, name
+    FROM player_companions WHERE id = ?
+  `).get(companionId);
+  if (!comp) return { ok: false, reason: "companion_not_found" };
+  if (comp.owner_id !== riderId) return { ok: false, reason: "not_owner" };
+  if (!comp.mount_eligible) return { ok: false, reason: "not_mountable" };
+
+  // One active per world.
+  const existing = getActiveMountFor(db, riderId, worldId);
+  if (existing) return { ok: false, reason: "already_mounted", instanceId: existing.id };
+
+  const speciesId = speciesIdForCreature(db, comp.creature_id);
+  const species = speciesId ? getMountSpecies(db, speciesId) : null;
+  const seatOffset = species?.riderSeatOffset || { x: 0, y: 1.4, z: 0, yaw: 0 };
+
+  const id = _newMountedId();
+  try {
+    db.prepare(`
+      INSERT INTO mounted_instances
+        (id, rider_id, mount_companion_id, world_id, mounted_at, seat_offset_json)
+      VALUES (?, ?, ?, ?, unixepoch(), ?)
+    `).run(id, riderId, companionId, worldId, JSON.stringify(seatOffset));
+  } catch (err) {
+    return { ok: false, reason: err.message };
+  }
+
+  return {
+    ok: true,
+    instanceId: id,
+    companionId,
+    speciesId,
+    seatOffset,
+    saddleAnchorBone: species?.saddleAnchorBone || "spine_03",
+    reinsAnchorBone: species?.reinsAnchorBone || "head",
+    flightCapable: !!species?.flightCapable,
+  };
+}
+
+/**
+ * Close the rider's active mounted_instance for a world. Idempotent —
+ * calling when not mounted returns ok:true with `wasMounted:false`.
+ *
+ * Ground-clearance check is left to the client (physics + raycast); the
+ * server only enforces the ledger invariant.
+ */
+export function dismount(db, riderId, worldId = "concordia-hub") {
+  if (!db) return { ok: false, reason: "no_db" };
+  if (!riderId) return { ok: false, reason: "no_rider" };
+  const existing = getActiveMountFor(db, riderId, worldId);
+  if (!existing) return { ok: true, wasMounted: false };
+  try {
+    db.prepare(`
+      UPDATE mounted_instances SET dismounted_at = unixepoch()
+      WHERE id = ? AND dismounted_at IS NULL
+    `).run(existing.id);
+    return { ok: true, wasMounted: true, instanceId: existing.id };
+  } catch (err) {
+    return { ok: false, reason: err.message };
+  }
+}
+
+/**
+ * Read the rider's full active-mount payload (instance + companion +
+ * species + gait) for the MountedHUD on connect or reconnect.
+ */
+export function getActiveMountPayload(db, riderId, worldId = "concordia-hub") {
+  const inst = getActiveMountFor(db, riderId, worldId);
+  if (!inst) return null;
+  const comp = db.prepare(`SELECT id, name, creature_id, mount_eligible, mount_state FROM player_companions WHERE id = ?`)
+    .get(inst.mount_companion_id);
+  if (!comp) return { instance: inst };
+  const speciesId = speciesIdForCreature(db, comp.creature_id);
+  const species = speciesId ? getMountSpecies(db, speciesId) : null;
+  const gait = speciesId ? getGaitProfile(db, speciesId) : null;
+  let seatOffset = null;
+  try { seatOffset = JSON.parse(inst.seat_offset_json || "null"); } catch { /* fall back */ }
+  return {
+    instance: { id: inst.id, mountedAt: inst.mounted_at },
+    companion: { id: comp.id, name: comp.name, creatureId: comp.creature_id },
+    speciesId,
+    species,
+    gait,
+    seatOffset: seatOffset || species?.riderSeatOffset || { x: 0, y: 1.4, z: 0, yaw: 0 },
+  };
+}
+
+/**
+ * History view — closed mounted_instances rows for the rider, ordered
+ * recent-first. Used by the achievement / habit panels.
+ */
+export function listMountHistory(db, riderId, { worldId = null, limit = 50 } = {}) {
+  if (!db || !riderId) return [];
+  try {
+    if (worldId) {
+      return db.prepare(`
+        SELECT id, mount_companion_id, world_id, mounted_at, dismounted_at
+        FROM mounted_instances
+        WHERE rider_id = ? AND world_id = ? AND dismounted_at IS NOT NULL
+        ORDER BY dismounted_at DESC LIMIT ?
+      `).all(riderId, worldId, Math.min(limit, 200));
+    }
+    return db.prepare(`
+      SELECT id, mount_companion_id, world_id, mounted_at, dismounted_at
+      FROM mounted_instances
+      WHERE rider_id = ? AND dismounted_at IS NOT NULL
+      ORDER BY dismounted_at DESC LIMIT ?
+    `).all(riderId, Math.min(limit, 200));
+  } catch {
+    return [];
+  }
+}

--- a/server/lib/dtu-validators/mount-gear-validators.js
+++ b/server/lib/dtu-validators/mount-gear-validators.js
@@ -1,0 +1,116 @@
+// server/lib/dtu-validators/mount-gear-validators.js
+//
+// Validation for `kind='mount_gear'` DTUs (Concordia Mount System B3).
+//
+// Shape:
+//   {
+//     id: string,
+//     kind: 'mount_gear',
+//     creator_id: string,
+//     meta: {
+//       slot:           'saddle' | 'bridle' | 'barding',
+//       species_compat: string[]            // species_id whitelist; empty = any
+//       weight_kg:      number > 0,
+//       weight_rating_kg: number > 0,       // max load gear can support
+//       stat_mods: {
+//         speed?:    number ∈ [-0.5, 0.5],   // multiplier delta vs 1.0
+//         stamina?:  number ∈ [-0.5, 0.5],
+//         carry?:    number ∈ [-0.5, 0.5],
+//         comfort?:  number ∈ [0, 10],
+//       },
+//       material_list: [{ material_id: string, qty: number > 0 }, ...],
+//       style_tags:    string[],            // 0..16, freeform aesthetic tags
+//     }
+//   }
+//
+// Bounds chosen so a single piece of gear cannot more than ±50% any of
+// speed/stamina/carry. Fully-kitted (saddle + bridle + barding) caps
+// effectively ±150% but `computeMountStats` clamps the final fold to
+// keep stats sensible.
+
+const SLOTS = new Set(["saddle", "bridle", "barding"]);
+const STAT_MOD_FIELDS = new Set(["speed", "stamina", "carry", "comfort"]);
+const STAT_MOD_LIMITS = {
+  speed:   { min: -0.5, max: 0.5 },
+  stamina: { min: -0.5, max: 0.5 },
+  carry:   { min: -0.5, max: 0.5 },
+  comfort: { min: 0,    max: 10  },
+};
+
+export function validateMountGear(dtu) {
+  if (!dtu || typeof dtu !== "object") return { ok: false, reason: "invalid_dtu" };
+  if (dtu.kind !== "mount_gear") return { ok: false, reason: "wrong_kind" };
+  const meta = dtu.meta || {};
+  const errors = [];
+
+  if (!SLOTS.has(meta.slot)) errors.push(`slot must be one of ${[...SLOTS].join(", ")}`);
+
+  if (!Array.isArray(meta.species_compat)) {
+    errors.push("species_compat must be an array of species_id strings");
+  } else {
+    for (const s of meta.species_compat) {
+      if (typeof s !== "string" || !s) {
+        errors.push("species_compat entries must be non-empty strings");
+        break;
+      }
+    }
+  }
+
+  const weightKg = Number(meta.weight_kg);
+  if (!Number.isFinite(weightKg) || weightKg <= 0) errors.push("weight_kg must be > 0");
+
+  const weightRating = Number(meta.weight_rating_kg);
+  if (!Number.isFinite(weightRating) || weightRating <= 0) errors.push("weight_rating_kg must be > 0");
+
+  if (meta.stat_mods != null) {
+    if (typeof meta.stat_mods !== "object") {
+      errors.push("stat_mods must be an object");
+    } else {
+      for (const [k, v] of Object.entries(meta.stat_mods)) {
+        if (!STAT_MOD_FIELDS.has(k)) {
+          errors.push(`unknown stat_mod field: ${k}`);
+          continue;
+        }
+        const n = Number(v);
+        if (!Number.isFinite(n)) {
+          errors.push(`stat_mods.${k} must be a number`);
+          continue;
+        }
+        const bounds = STAT_MOD_LIMITS[k];
+        if (n < bounds.min || n > bounds.max) {
+          errors.push(`stat_mods.${k} out of bounds [${bounds.min}, ${bounds.max}]: ${n}`);
+        }
+      }
+    }
+  }
+
+  if (!Array.isArray(meta.material_list)) {
+    errors.push("material_list must be an array");
+  } else {
+    for (const m of meta.material_list) {
+      if (!m || typeof m.material_id !== "string" || !m.material_id) {
+        errors.push("material_list entries need material_id");
+        break;
+      }
+      const q = Number(m.qty);
+      if (!Number.isFinite(q) || q <= 0) {
+        errors.push("material_list entries need qty > 0");
+        break;
+      }
+    }
+  }
+
+  if (meta.style_tags != null) {
+    if (!Array.isArray(meta.style_tags)) {
+      errors.push("style_tags must be an array");
+    } else if (meta.style_tags.length > 16) {
+      errors.push("style_tags max 16");
+    }
+  }
+
+  if (errors.length) return { ok: false, reason: "validation_failed", errors };
+  return { ok: true };
+}
+
+export const MOUNT_GEAR_SLOTS = SLOTS;
+export const MOUNT_GEAR_STAT_LIMITS = STAT_MOD_LIMITS;

--- a/server/lib/ecosystem/mount-eligibility.js
+++ b/server/lib/ecosystem/mount-eligibility.js
@@ -1,0 +1,174 @@
+// server/lib/ecosystem/mount-eligibility.js
+//
+// Read + write helpers for the mount-eligibility flag on player_companions.
+// Used by the taming flow (B2) to set `mount_eligible=1` when the tamed
+// creature's species lives in `mount_species`, and by the read-side
+// `mount.list_mountable` macro to surface eligible companions.
+//
+// CLAUDE.md invariant: a creature is mountable iff its species exists
+// in `mount_species`. The flag on `player_companions` is denormalized
+// from that table for read efficiency — fauna-spawner / taming flow
+// must keep them in sync.
+
+/**
+ * Whether a given species_id corresponds to a mountable species.
+ * Pure read; safe to call hot.
+ */
+export function isSpeciesMountable(db, speciesId) {
+  if (!db || !speciesId) return false;
+  try {
+    const row = db.prepare(`SELECT 1 FROM mount_species WHERE species_id = ? LIMIT 1`).get(speciesId);
+    return !!row;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * List all mountable species (with their base stats). Ordered by
+ * size_class then base_speed_mps.
+ */
+export function listMountableSpecies(db) {
+  if (!db) return [];
+  try {
+    return db.prepare(`
+      SELECT species_id, display_name, size_class, base_speed_mps, base_stamina,
+             carry_capacity_kg, gait_profile_id, rider_seat_offset_json,
+             saddle_anchor_bone, reins_anchor_bone, flight_capable, aesthetic_tags_json
+      FROM mount_species
+      ORDER BY size_class, base_speed_mps DESC
+    `).all().map(_unpackSpeciesJson);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Get a single species' full record (with parsed JSON columns).
+ */
+export function getMountSpecies(db, speciesId) {
+  if (!db || !speciesId) return null;
+  try {
+    const row = db.prepare(`
+      SELECT species_id, display_name, size_class, base_speed_mps, base_stamina,
+             carry_capacity_kg, gait_profile_id, rider_seat_offset_json,
+             saddle_anchor_bone, reins_anchor_bone, flight_capable, aesthetic_tags_json
+      FROM mount_species WHERE species_id = ?
+    `).get(speciesId);
+    return row ? _unpackSpeciesJson(row) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the gait profile for a species (parsed JSON cycle blocks).
+ * Returns null if the species has no gait profile (defensive).
+ */
+export function getGaitProfile(db, speciesId) {
+  if (!db || !speciesId) return null;
+  try {
+    const row = db.prepare(`
+      SELECT id, species_id, walk_cycle_json, trot_cycle_json, gallop_cycle_json, turn_radius_m
+      FROM mount_gait_profiles WHERE species_id = ? LIMIT 1
+    `).get(speciesId);
+    if (!row) return null;
+    return {
+      id: row.id,
+      speciesId: row.species_id,
+      walk: _parseJson(row.walk_cycle_json),
+      trot: _parseJson(row.trot_cycle_json),
+      gallop: _parseJson(row.gallop_cycle_json),
+      turnRadiusM: row.turn_radius_m,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Mark a player_companion as mount-eligible. Called from the taming
+ * flow (B2) after `attemptTame` writes the row, IF the creature's
+ * species is in mount_species.
+ *
+ * Idempotent — running this with the flag already set is a no-op
+ * (UPDATE is conditional).
+ */
+export function markCompanionMountable(db, companionId, speciesId) {
+  if (!db || !companionId) return { ok: false, reason: "missing_args" };
+  if (!isSpeciesMountable(db, speciesId)) {
+    return { ok: false, reason: "species_not_mountable" };
+  }
+  try {
+    const r = db.prepare(`
+      UPDATE player_companions
+      SET mount_eligible = 1
+      WHERE id = ? AND mount_eligible = 0
+    `).run(companionId);
+    return { ok: true, changed: r.changes };
+  } catch (err) {
+    return { ok: false, reason: err.message };
+  }
+}
+
+/**
+ * Whether a given player_companion row carries the mount_eligible flag.
+ */
+export function isCompanionMountable(db, companionId) {
+  if (!db || !companionId) return false;
+  try {
+    const row = db.prepare(`SELECT mount_eligible FROM player_companions WHERE id = ?`).get(companionId);
+    return !!row?.mount_eligible;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * List companions with `mount_eligible = 1` for a given owner. Used by
+ * the MountedHUD to populate the "switch mount" dropdown (B2 onward).
+ */
+export function listMountableCompanionsForOwner(db, ownerId, worldId) {
+  if (!db || !ownerId) return [];
+  try {
+    if (worldId) {
+      return db.prepare(`
+        SELECT id, owner_id, creature_id, name, level, world_id, mount_state, last_action_at
+        FROM player_companions
+        WHERE owner_id = ? AND world_id = ? AND mount_eligible = 1
+        ORDER BY last_action_at DESC NULLS LAST, caught_at DESC
+      `).all(ownerId, worldId);
+    }
+    return db.prepare(`
+      SELECT id, owner_id, creature_id, name, level, world_id, mount_state, last_action_at
+      FROM player_companions
+      WHERE owner_id = ? AND mount_eligible = 1
+      ORDER BY last_action_at DESC NULLS LAST, caught_at DESC
+    `).all(ownerId);
+  } catch {
+    return [];
+  }
+}
+
+// ---- helpers ----
+function _parseJson(s, fallback = null) {
+  if (s == null) return fallback;
+  try { return JSON.parse(s); } catch { return fallback; }
+}
+
+function _unpackSpeciesJson(row) {
+  return {
+    speciesId: row.species_id,
+    displayName: row.display_name,
+    sizeClass: row.size_class,
+    baseSpeedMps: row.base_speed_mps,
+    baseStamina: row.base_stamina,
+    carryCapacityKg: row.carry_capacity_kg,
+    gaitProfileId: row.gait_profile_id,
+    riderSeatOffset: _parseJson(row.rider_seat_offset_json, { x: 0, y: 1.4, z: 0, yaw: 0 }),
+    saddleAnchorBone: row.saddle_anchor_bone,
+    reinsAnchorBone: row.reins_anchor_bone,
+    flightCapable: !!row.flight_capable,
+    aestheticTags: _parseJson(row.aesthetic_tags_json, []),
+  };
+}

--- a/server/lib/ecosystem/mount-species-seeder.js
+++ b/server/lib/ecosystem/mount-species-seeder.js
@@ -1,0 +1,104 @@
+// server/lib/ecosystem/mount-species-seeder.js
+//
+// Seeds `mount_species` + `mount_gait_profiles` from the static JSON
+// at `server/seeds/mount_species.json`. Idempotent — INSERT OR IGNORE
+// keyed by `species_id` + `gait_profile_id`. Re-running is a no-op.
+//
+// Called once at server boot from server.js, immediately after the
+// migration sweep. Failure here MUST NOT crash the server (CLAUDE.md
+// invariant — server boot stays robust).
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SEED_PATH = join(__dirname, "../../seeds/mount_species.json");
+
+let _cachedSeed = null;
+function loadSeed() {
+  if (_cachedSeed) return _cachedSeed;
+  try {
+    const raw = readFileSync(SEED_PATH, "utf-8");
+    _cachedSeed = JSON.parse(raw);
+  } catch (err) {
+    console.warn("[mount-species-seeder] load failed:", err.message);
+    _cachedSeed = { species: [] };
+  }
+  return _cachedSeed;
+}
+
+/**
+ * Insert (or ignore) one mount_species + one mount_gait_profile row per
+ * authored species. Returns counts so the boot log can confirm seeding.
+ *
+ * @param {object} db — better-sqlite3
+ * @returns {{ok: boolean, inserted: {species: number, gaits: number}, total: number, reason?: string}}
+ */
+export function seedMountSpecies(db) {
+  if (!db) return { ok: false, reason: "no_db" };
+  const seed = loadSeed();
+  const species = Array.isArray(seed.species) ? seed.species : [];
+  if (species.length === 0) return { ok: true, inserted: { species: 0, gaits: 0 }, total: 0 };
+
+  let speciesInserted = 0;
+  let gaitsInserted = 0;
+
+  try {
+    const insertSpecies = db.prepare(`
+      INSERT OR IGNORE INTO mount_species
+        (species_id, display_name, size_class, base_speed_mps, base_stamina, carry_capacity_kg,
+         gait_profile_id, rider_seat_offset_json, saddle_anchor_bone, reins_anchor_bone,
+         flight_capable, aesthetic_tags_json)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    const insertGait = db.prepare(`
+      INSERT OR IGNORE INTO mount_gait_profiles
+        (id, species_id, walk_cycle_json, trot_cycle_json, gallop_cycle_json, turn_radius_m)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `);
+
+    const tx = db.transaction((items) => {
+      for (const sp of items) {
+        if (!sp.species_id) continue;
+        const gaitId = `gait_${sp.species_id}`;
+        const r1 = insertSpecies.run(
+          sp.species_id,
+          sp.display_name || sp.species_id,
+          sp.size_class || "medium",
+          Number(sp.base_speed_mps) || 6.0,
+          Number(sp.base_stamina) || 100,
+          Number(sp.carry_capacity_kg) || 80,
+          gaitId,
+          JSON.stringify(sp.rider_seat_offset || { x: 0, y: 1.4, z: 0, yaw: 0 }),
+          sp.saddle_anchor_bone || "spine_03",
+          sp.reins_anchor_bone || "head",
+          sp.flight_capable ? 1 : 0,
+          JSON.stringify(sp.aesthetic_tags || []),
+        );
+        if (r1.changes > 0) speciesInserted++;
+
+        const gait = sp.gait || {};
+        const r2 = insertGait.run(
+          gaitId,
+          sp.species_id,
+          JSON.stringify(gait.walk || {}),
+          JSON.stringify(gait.trot || {}),
+          JSON.stringify(gait.gallop || {}),
+          Number(sp.turn_radius_m) || 4.0,
+        );
+        if (r2.changes > 0) gaitsInserted++;
+      }
+    });
+    tx(species);
+
+    return {
+      ok: true,
+      inserted: { species: speciesInserted, gaits: gaitsInserted },
+      total: species.length,
+    };
+  } catch (err) {
+    console.warn("[mount-species-seeder] seed failed:", err.message);
+    return { ok: false, reason: err.message };
+  }
+}

--- a/server/lib/feature-flags.js
+++ b/server/lib/feature-flags.js
@@ -1,0 +1,37 @@
+// server/lib/feature-flags.js
+//
+// Centralized read for `FF_*` and `CONCORD_*` env-var feature flags.
+// Returns 1/0 booleans (with a default fallback) so callers can write:
+//
+//   if (getFlag("FF_MOUNTS_RIDING", 1)) { ... }
+//
+// Convention:
+//   - FF_*       — Phase / feature kill-switches added by DX Platform
+//                  and Mount System tracks. Default 1 in dev, 0 in prod
+//                  for staged rollout (caller chooses default).
+//   - CONCORD_*  — Pre-existing kill-switches and tunables (see CLAUDE.md
+//                  multi-tenant cap defaults). Forwarded as-is.
+//
+// Truthy values: "1", "true", "yes", "on" (case-insensitive).
+// Anything else (including missing) → falls back to `defaultVal`.
+
+const TRUTHY = new Set(["1", "true", "yes", "on"]);
+const FALSY  = new Set(["0", "false", "no", "off"]);
+
+export function getFlag(name, defaultVal = 0) {
+  const raw = process.env[name];
+  if (raw == null || raw === "") return defaultVal ? 1 : 0;
+  const v = String(raw).trim().toLowerCase();
+  if (TRUTHY.has(v)) return 1;
+  if (FALSY.has(v)) return 0;
+  return defaultVal ? 1 : 0;
+}
+
+// Numeric flags (for `*_CAP`, `*_INTERVAL` style env vars). Returns
+// `defaultVal` if unset or unparseable.
+export function getFlagNumber(name, defaultVal) {
+  const raw = process.env[name];
+  if (raw == null || raw === "") return defaultVal;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : defaultVal;
+}

--- a/server/lib/mount-gear.js
+++ b/server/lib/mount-gear.js
@@ -1,0 +1,230 @@
+// server/lib/mount-gear.js
+//
+// Concordia Procedural Mount System Phase B3 — gear authoring + equipping.
+//
+// `mount_gear` is a recipe DTU kind (see lib/dtu-validators/
+// mount-gear-validators.js). Author flow:
+//   1) Player composes recipe in MountDesigner.tsx → `dtu.create` with
+//      kind='mount_gear', meta={slot, species_compat, ...}.
+//   2) Server validates via `validateMountGear` (defense-in-depth — the
+//      recipe-validator surface should already reject invalid shapes).
+//   3) Player equips via `equipGear(db, mountId, gearDtuId, slot)`.
+//      Slot column on player_companions becomes the dtu_id.
+//   4) HUD reads `computeMountStats(db, mountId)` which folds species
+//      base + equipped gear modifiers into the effective stat block.
+//
+// Idempotency:
+//   - equipGear on the same slot replaces (does NOT stack multiple of
+//     the same slot).
+//   - unequipGear with no gear on the slot is a no-op.
+
+import { validateMountGear } from "./dtu-validators/mount-gear-validators.js";
+import { getMountSpecies } from "./ecosystem/mount-eligibility.js";
+
+const SLOTS = ["saddle", "bridle", "barding"];
+const SLOT_COLUMNS = {
+  saddle:  "saddle_dtu_id",
+  bridle:  "bridle_dtu_id",
+  barding: "barding_dtu_id",
+};
+
+function _readDtu(db, dtuId) {
+  if (!db || !dtuId) return null;
+  // Probe both modern (dtus.id, kind, meta_json) and personal_dtus shapes.
+  // Prefer dtus.
+  try {
+    const row = db.prepare(`SELECT id, kind, creator_id, meta_json FROM dtus WHERE id = ?`).get(dtuId);
+    if (row) return { ...row, _source: "dtus" };
+  } catch { /* table may not exist on a minimal test DB */ }
+  try {
+    const row = db.prepare(`SELECT id, kind, creator_id, meta_json FROM personal_dtus WHERE id = ?`).get(dtuId);
+    if (row) return { ...row, _source: "personal_dtus" };
+  } catch { /* no personal_dtus either */ }
+  return null;
+}
+
+function _parseMeta(metaJson) {
+  if (!metaJson) return {};
+  try { return JSON.parse(metaJson); } catch { return {}; }
+}
+
+function _readCompanion(db, mountId) {
+  if (!db || !mountId) return null;
+  try {
+    return db.prepare(`
+      SELECT id, owner_id, creature_id, name, world_id, mount_eligible,
+             saddle_dtu_id, bridle_dtu_id, barding_dtu_id
+      FROM player_companions WHERE id = ?
+    `).get(mountId) || null;
+  } catch {
+    return null;
+  }
+}
+
+function _speciesIdForCreature(db, creatureId) {
+  if (!db || !creatureId) return null;
+  try {
+    const row = db.prepare(`SELECT archetype FROM world_npcs WHERE id = ?`).get(creatureId);
+    if (!row) return null;
+    const a = String(row.archetype || "");
+    return a.startsWith("creature:") ? a.slice("creature:".length) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Equip a `mount_gear` DTU into one of saddle/bridle/barding slots.
+ * Replaces any existing gear in that slot. Idempotent — equipping the
+ * same DTU twice is a no-op.
+ *
+ * @returns {{ok: boolean, replaced?: string|null, reason?: string, errors?: string[]}}
+ */
+export function equipGear(db, args) {
+  if (!db) return { ok: false, reason: "no_db" };
+  const { mountId, gearDtuId, slot, ownerId } = args || {};
+  if (!mountId || !gearDtuId || !slot) return { ok: false, reason: "missing_args" };
+  if (!SLOT_COLUMNS[slot]) return { ok: false, reason: "invalid_slot" };
+
+  const comp = _readCompanion(db, mountId);
+  if (!comp) return { ok: false, reason: "mount_not_found" };
+  if (ownerId && comp.owner_id !== ownerId) return { ok: false, reason: "not_owner" };
+  if (!comp.mount_eligible) return { ok: false, reason: "not_mountable" };
+
+  const dtu = _readDtu(db, gearDtuId);
+  if (!dtu) return { ok: false, reason: "gear_dtu_not_found" };
+  if (dtu.kind !== "mount_gear") return { ok: false, reason: "wrong_kind" };
+
+  const meta = _parseMeta(dtu.meta_json);
+  const validate = validateMountGear({ kind: dtu.kind, meta });
+  if (!validate.ok) return validate;
+
+  if (meta.slot !== slot) return { ok: false, reason: "slot_mismatch" };
+
+  // Optional species compat check.
+  if (Array.isArray(meta.species_compat) && meta.species_compat.length > 0) {
+    const speciesId = _speciesIdForCreature(db, comp.creature_id);
+    if (!speciesId || !meta.species_compat.includes(speciesId)) {
+      return { ok: false, reason: "species_incompatible" };
+    }
+  }
+
+  const col = SLOT_COLUMNS[slot];
+  const replaced = comp[col] || null;
+  if (replaced === gearDtuId) return { ok: true, replaced: null }; // no-op
+
+  try {
+    db.prepare(`UPDATE player_companions SET ${col} = ? WHERE id = ?`).run(gearDtuId, mountId);
+    return { ok: true, replaced };
+  } catch (err) {
+    return { ok: false, reason: err.message };
+  }
+}
+
+/**
+ * Clear one of the slot columns. Idempotent — returns ok:true with
+ * `had:false` when slot was already empty.
+ */
+export function unequipGear(db, args) {
+  if (!db) return { ok: false, reason: "no_db" };
+  const { mountId, slot, ownerId } = args || {};
+  if (!mountId || !slot) return { ok: false, reason: "missing_args" };
+  if (!SLOT_COLUMNS[slot]) return { ok: false, reason: "invalid_slot" };
+  const comp = _readCompanion(db, mountId);
+  if (!comp) return { ok: false, reason: "mount_not_found" };
+  if (ownerId && comp.owner_id !== ownerId) return { ok: false, reason: "not_owner" };
+  const col = SLOT_COLUMNS[slot];
+  const had = !!comp[col];
+  if (!had) return { ok: true, had: false };
+  try {
+    db.prepare(`UPDATE player_companions SET ${col} = NULL WHERE id = ?`).run(mountId);
+    return { ok: true, had: true, removed: comp[col] };
+  } catch (err) {
+    return { ok: false, reason: err.message };
+  }
+}
+
+/**
+ * Compute the effective stat block for a mount with all currently
+ * equipped gear. Returns { base, modifiers, effective }.
+ *
+ * Folding rules:
+ *   speedMps        := base × (1 + Σ slot.stat_mods.speed)        clamped [0.4×, 1.8×]
+ *   baseStamina     := base × (1 + Σ slot.stat_mods.stamina)      clamped [0.4×, 1.8×]
+ *   carryCapacityKg := base × (1 + Σ slot.stat_mods.carry)        clamped [0.4×, 1.8×]
+ *   comfort         := Σ slot.stat_mods.comfort                   clamped [0, 30]
+ *
+ * Clamps preserve gameplay invariants — no piece of gear should
+ * triple the carry capacity or halve the speed of a mount.
+ */
+export function computeMountStats(db, mountId) {
+  if (!db || !mountId) return null;
+  const comp = _readCompanion(db, mountId);
+  if (!comp) return null;
+  const speciesId = _speciesIdForCreature(db, comp.creature_id);
+  const species = speciesId ? getMountSpecies(db, speciesId) : null;
+  if (!species) return null;
+
+  const base = {
+    speedMps: species.baseSpeedMps,
+    baseStamina: species.baseStamina,
+    carryCapacityKg: species.carryCapacityKg,
+  };
+  const sums = { speed: 0, stamina: 0, carry: 0, comfort: 0 };
+  const equipped = [];
+  for (const slot of SLOTS) {
+    const dtuId = comp[SLOT_COLUMNS[slot]];
+    if (!dtuId) continue;
+    const dtu = _readDtu(db, dtuId);
+    if (!dtu) continue;
+    const meta = _parseMeta(dtu.meta_json);
+    const mods = meta.stat_mods || {};
+    sums.speed   += Number(mods.speed   || 0);
+    sums.stamina += Number(mods.stamina || 0);
+    sums.carry   += Number(mods.carry   || 0);
+    sums.comfort += Number(mods.comfort || 0);
+    equipped.push({ slot, dtuId, weight_kg: Number(meta.weight_kg) || 0 });
+  }
+
+  const clampMul = (mul) => Math.max(0.4, Math.min(1.8, 1 + mul));
+  const effective = {
+    speedMps:        base.speedMps        * clampMul(sums.speed),
+    baseStamina:     base.baseStamina     * clampMul(sums.stamina),
+    carryCapacityKg: base.carryCapacityKg * clampMul(sums.carry),
+    comfort:         Math.max(0, Math.min(30, sums.comfort)),
+  };
+  return {
+    speciesId,
+    base,
+    modifiers: sums,
+    effective,
+    equipped,
+  };
+}
+
+/**
+ * Read the gear loadout for the HUD inventory view.
+ */
+export function getEquippedGear(db, mountId) {
+  if (!db || !mountId) return null;
+  const comp = _readCompanion(db, mountId);
+  if (!comp) return null;
+  const out = {};
+  for (const slot of SLOTS) {
+    const dtuId = comp[SLOT_COLUMNS[slot]];
+    if (!dtuId) { out[slot] = null; continue; }
+    const dtu = _readDtu(db, dtuId);
+    if (!dtu) { out[slot] = { dtuId, missing: true }; continue; }
+    const meta = _parseMeta(dtu.meta_json);
+    out[slot] = {
+      dtuId,
+      slot: meta.slot,
+      weight_kg: Number(meta.weight_kg) || 0,
+      stat_mods: meta.stat_mods || {},
+      style_tags: meta.style_tags || [],
+    };
+  }
+  return out;
+}
+
+export const _internals = { SLOT_COLUMNS, SLOTS };

--- a/server/migrations/142_mount_substrate.js
+++ b/server/migrations/142_mount_substrate.js
@@ -1,0 +1,93 @@
+// Migration 142 — Concordia Procedural Mount System Phase B1: data substrate.
+//
+// Wild creatures spawned by `server/lib/ecosystem/fauna-spawner.js` can
+// be tamed (`server/lib/companions.js#attemptTame` already exists) and
+// ridden as physics-aware mounts. This migration sets up the data layer
+// only — taming + riding lands in B2, customization in B3, evolution +
+// care in B4.
+//
+// Tables:
+//   mount_species         — capability table per species (one row per
+//                           species_id; static once seeded).
+//   mount_gait_profiles   — per-species walk/trot/gallop cycle params
+//                           consumed by quadruped-gait.ts on the client.
+//   mounted_instances     — append-only-with-close ledger of mounting
+//                           events. One open row per (rider, world).
+//
+// Schema extensions on `player_companions`:
+//   mount_eligible INTEGER DEFAULT 0  — flagged by fauna-spawner when
+//                                       species is in `mount_species`.
+//   mount_state TEXT                  — JSON: { stamina, hunger, loyalty,
+//                                       gait_skill }; computed lazily.
+//
+// CLAUDE.md invariant added by this phase:
+//   Mounts and creatures share `world_npcs.id`; `mount_species` describes
+//   species capability; a creature is mountable iff its
+//   `creature_population.lifestyle.mountable === true` AND a `mount_species`
+//   row exists for its species_id. Quadruped gait foot-slide must stay
+//   < 2cm in stance phase.
+
+export function up(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS mount_species (
+      species_id              TEXT    PRIMARY KEY,
+      display_name            TEXT    NOT NULL,
+      size_class              TEXT    NOT NULL CHECK (size_class IN ('small', 'medium', 'large', 'huge')),
+      base_speed_mps          REAL    NOT NULL CHECK (base_speed_mps > 0 AND base_speed_mps <= 30),
+      base_stamina            REAL    NOT NULL CHECK (base_stamina > 0),
+      carry_capacity_kg       REAL    NOT NULL CHECK (carry_capacity_kg > 0),
+      gait_profile_id         TEXT,
+      rider_seat_offset_json  TEXT    NOT NULL DEFAULT '{"x":0,"y":1.4,"z":0,"yaw":0}',
+      saddle_anchor_bone      TEXT    NOT NULL DEFAULT 'spine_03',
+      reins_anchor_bone       TEXT    NOT NULL DEFAULT 'head',
+      flight_capable          INTEGER NOT NULL DEFAULT 0 CHECK (flight_capable IN (0, 1)),
+      aesthetic_tags_json     TEXT    NOT NULL DEFAULT '[]',
+      created_at              INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+    CREATE INDEX IF NOT EXISTS idx_mount_species_size  ON mount_species(size_class);
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS mount_gait_profiles (
+      id                  TEXT    PRIMARY KEY,
+      species_id          TEXT    NOT NULL REFERENCES mount_species(species_id),
+      walk_cycle_json     TEXT    NOT NULL,
+      trot_cycle_json     TEXT    NOT NULL,
+      gallop_cycle_json   TEXT    NOT NULL,
+      turn_radius_m       REAL    NOT NULL CHECK (turn_radius_m > 0),
+      created_at          INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+    CREATE INDEX IF NOT EXISTS idx_mount_gait_species ON mount_gait_profiles(species_id);
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS mounted_instances (
+      id                    TEXT    PRIMARY KEY,
+      rider_id              TEXT    NOT NULL,
+      mount_companion_id    TEXT    NOT NULL,
+      world_id              TEXT    NOT NULL DEFAULT 'concordia-hub',
+      mounted_at            INTEGER NOT NULL DEFAULT (unixepoch()),
+      dismounted_at         INTEGER,
+      seat_offset_json      TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_mounted_instances_rider_open
+      ON mounted_instances(rider_id, world_id, dismounted_at);
+    CREATE INDEX IF NOT EXISTS idx_mounted_instances_companion
+      ON mounted_instances(mount_companion_id);
+  `);
+
+  // Extend player_companions. SQLite ALTER ADD COLUMN is safe on existing
+  // rows — defaults populate retroactively.
+  // Probe column existence first to keep migration idempotent on retry.
+  const cols = db.prepare("PRAGMA table_info(player_companions)").all().map(c => c.name);
+  if (!cols.includes("mount_eligible")) {
+    db.exec(`ALTER TABLE player_companions ADD COLUMN mount_eligible INTEGER NOT NULL DEFAULT 0`);
+  }
+  if (!cols.includes("mount_state")) {
+    db.exec(`ALTER TABLE player_companions ADD COLUMN mount_state TEXT`);
+  }
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_player_companions_mount_eligible
+           ON player_companions(mount_eligible) WHERE mount_eligible = 1`);
+}
+
+export function down(_db) { /* forward-only */ }

--- a/server/migrations/144_mount_gear.js
+++ b/server/migrations/144_mount_gear.js
@@ -1,0 +1,35 @@
+// Migration 144 — Concordia Procedural Mount System Phase B3: gear.
+//
+// Saddles, bridles, barding modify mount stats. Authored as v2.0 recipe
+// DTUs with `kind='mount_gear'` (validated in lib/dtu-validators/
+// mount-gear-validators.js) and equipped on player_companions via
+// the new slot columns added here.
+//
+// CLAUDE.md invariant added by this phase:
+//   `mount_gear` is a DTU kind under the v2.0 recipe substrate
+//   (alongside fighting_style_recipe, spell_recipe, blueprint). Slot
+//   field is required and one of {saddle, bridle, barding}. Schema is
+//   append-only — existing 3 recipe kinds untouched.
+//
+// Schema extension on `player_companions` (idempotent re-run safe):
+//   saddle_dtu_id  TEXT NULL
+//   bridle_dtu_id  TEXT NULL
+//   barding_dtu_id TEXT NULL
+
+export function up(db) {
+  const cols = db.prepare("PRAGMA table_info(player_companions)").all().map(c => c.name);
+  if (!cols.includes("saddle_dtu_id")) {
+    db.exec(`ALTER TABLE player_companions ADD COLUMN saddle_dtu_id TEXT`);
+  }
+  if (!cols.includes("bridle_dtu_id")) {
+    db.exec(`ALTER TABLE player_companions ADD COLUMN bridle_dtu_id TEXT`);
+  }
+  if (!cols.includes("barding_dtu_id")) {
+    db.exec(`ALTER TABLE player_companions ADD COLUMN barding_dtu_id TEXT`);
+  }
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_player_companions_saddle ON player_companions(saddle_dtu_id) WHERE saddle_dtu_id IS NOT NULL`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_player_companions_bridle ON player_companions(bridle_dtu_id) WHERE bridle_dtu_id IS NOT NULL`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_player_companions_barding ON player_companions(barding_dtu_id) WHERE barding_dtu_id IS NOT NULL`);
+}
+
+export function down(_db) { /* forward-only */ }

--- a/server/seeds/mount_species.json
+++ b/server/seeds/mount_species.json
@@ -1,0 +1,157 @@
+{
+  "_comment": "B1 starter set of mountable species. Inserted via INSERT OR IGNORE so re-running is a no-op. base_speed_mps tuned so the warhorse (8.5 m/s ≈ 30 km/h) is the speed reference; size_class drives carry_capacity_kg roughly. flight_capable=1 only on hippogriff/gryphon/wyvern; B2 riding requires a flight-capable physics integration (deferred to B4 polish).",
+  "species": [
+    {
+      "species_id": "warhorse",
+      "display_name": "Warhorse",
+      "size_class": "large",
+      "base_speed_mps": 8.5,
+      "base_stamina": 120,
+      "carry_capacity_kg": 120,
+      "saddle_anchor_bone": "spine_03",
+      "reins_anchor_bone": "head",
+      "flight_capable": 0,
+      "rider_seat_offset": { "x": 0, "y": 1.45, "z": -0.05, "yaw": 0 },
+      "aesthetic_tags": ["medieval", "war", "common"],
+      "gait": {
+        "walk":   { "phase_offsets": [0.00, 0.50, 0.25, 0.75], "stride_m": 1.20, "ground_clearance_m": 0.05 },
+        "trot":   { "phase_offsets": [0.00, 0.50, 0.50, 0.00], "stride_m": 2.00, "ground_clearance_m": 0.15 },
+        "gallop": { "phase_offsets": [0.00, 0.10, 0.55, 0.65], "stride_m": 4.50, "ground_clearance_m": 0.55 }
+      },
+      "turn_radius_m": 4.0
+    },
+    {
+      "species_id": "dire_wolf",
+      "display_name": "Dire Wolf",
+      "size_class": "large",
+      "base_speed_mps": 9.2,
+      "base_stamina": 100,
+      "carry_capacity_kg": 90,
+      "saddle_anchor_bone": "spine_02",
+      "reins_anchor_bone": "neck",
+      "flight_capable": 0,
+      "rider_seat_offset": { "x": 0, "y": 1.20, "z": 0.05, "yaw": 0 },
+      "aesthetic_tags": ["wild", "feral", "rare"],
+      "gait": {
+        "walk":   { "phase_offsets": [0.00, 0.50, 0.25, 0.75], "stride_m": 1.05, "ground_clearance_m": 0.04 },
+        "trot":   { "phase_offsets": [0.00, 0.50, 0.50, 0.00], "stride_m": 1.80, "ground_clearance_m": 0.18 },
+        "gallop": { "phase_offsets": [0.00, 0.10, 0.55, 0.65], "stride_m": 4.20, "ground_clearance_m": 0.65 }
+      },
+      "turn_radius_m": 3.0
+    },
+    {
+      "species_id": "chimera",
+      "display_name": "Chimera",
+      "size_class": "huge",
+      "base_speed_mps": 6.0,
+      "base_stamina": 200,
+      "carry_capacity_kg": 200,
+      "saddle_anchor_bone": "spine_04",
+      "reins_anchor_bone": "head",
+      "flight_capable": 0,
+      "rider_seat_offset": { "x": 0, "y": 1.80, "z": -0.10, "yaw": 0 },
+      "aesthetic_tags": ["mythic", "eldritch", "epic"],
+      "gait": {
+        "walk":   { "phase_offsets": [0.00, 0.50, 0.25, 0.75], "stride_m": 1.40, "ground_clearance_m": 0.06 },
+        "trot":   { "phase_offsets": [0.00, 0.50, 0.50, 0.00], "stride_m": 2.30, "ground_clearance_m": 0.20 },
+        "gallop": { "phase_offsets": [0.00, 0.15, 0.55, 0.70], "stride_m": 4.80, "ground_clearance_m": 0.40 }
+      },
+      "turn_radius_m": 6.5
+    },
+    {
+      "species_id": "giant_elk",
+      "display_name": "Giant Elk",
+      "size_class": "large",
+      "base_speed_mps": 8.0,
+      "base_stamina": 140,
+      "carry_capacity_kg": 110,
+      "saddle_anchor_bone": "spine_03",
+      "reins_anchor_bone": "head",
+      "flight_capable": 0,
+      "rider_seat_offset": { "x": 0, "y": 1.50, "z": 0.00, "yaw": 0 },
+      "aesthetic_tags": ["forest", "noble", "common"],
+      "gait": {
+        "walk":   { "phase_offsets": [0.00, 0.50, 0.25, 0.75], "stride_m": 1.30, "ground_clearance_m": 0.06 },
+        "trot":   { "phase_offsets": [0.00, 0.50, 0.50, 0.00], "stride_m": 2.10, "ground_clearance_m": 0.20 },
+        "gallop": { "phase_offsets": [0.00, 0.10, 0.55, 0.65], "stride_m": 4.40, "ground_clearance_m": 0.50 }
+      },
+      "turn_radius_m": 4.5
+    },
+    {
+      "species_id": "salamander_mount",
+      "display_name": "Crag Salamander",
+      "size_class": "medium",
+      "base_speed_mps": 6.5,
+      "base_stamina": 90,
+      "carry_capacity_kg": 80,
+      "saddle_anchor_bone": "spine_02",
+      "reins_anchor_bone": "neck",
+      "flight_capable": 0,
+      "rider_seat_offset": { "x": 0, "y": 0.95, "z": 0.10, "yaw": 0 },
+      "aesthetic_tags": ["volcanic", "reptilian", "rare"],
+      "gait": {
+        "walk":   { "phase_offsets": [0.00, 0.50, 0.50, 0.00], "stride_m": 0.85, "ground_clearance_m": 0.03 },
+        "trot":   { "phase_offsets": [0.00, 0.50, 0.50, 0.00], "stride_m": 1.40, "ground_clearance_m": 0.08 },
+        "gallop": { "phase_offsets": [0.00, 0.10, 0.55, 0.65], "stride_m": 2.80, "ground_clearance_m": 0.22 }
+      },
+      "turn_radius_m": 2.5
+    },
+    {
+      "species_id": "hippogriff",
+      "display_name": "Hippogriff",
+      "size_class": "large",
+      "base_speed_mps": 11.0,
+      "base_stamina": 110,
+      "carry_capacity_kg": 95,
+      "saddle_anchor_bone": "spine_03",
+      "reins_anchor_bone": "head",
+      "flight_capable": 1,
+      "rider_seat_offset": { "x": 0, "y": 1.55, "z": -0.10, "yaw": 0 },
+      "aesthetic_tags": ["mythic", "aerial", "epic"],
+      "gait": {
+        "walk":   { "phase_offsets": [0.00, 0.50, 0.25, 0.75], "stride_m": 1.10, "ground_clearance_m": 0.05 },
+        "trot":   { "phase_offsets": [0.00, 0.50, 0.50, 0.00], "stride_m": 1.85, "ground_clearance_m": 0.14 },
+        "gallop": { "phase_offsets": [0.00, 0.10, 0.55, 0.65], "stride_m": 4.00, "ground_clearance_m": 0.50 }
+      },
+      "turn_radius_m": 5.0
+    },
+    {
+      "species_id": "gryphon",
+      "display_name": "Gryphon",
+      "size_class": "huge",
+      "base_speed_mps": 12.0,
+      "base_stamina": 130,
+      "carry_capacity_kg": 130,
+      "saddle_anchor_bone": "spine_03",
+      "reins_anchor_bone": "head",
+      "flight_capable": 1,
+      "rider_seat_offset": { "x": 0, "y": 1.70, "z": -0.10, "yaw": 0 },
+      "aesthetic_tags": ["mythic", "aerial", "epic"],
+      "gait": {
+        "walk":   { "phase_offsets": [0.00, 0.50, 0.25, 0.75], "stride_m": 1.20, "ground_clearance_m": 0.05 },
+        "trot":   { "phase_offsets": [0.00, 0.50, 0.50, 0.00], "stride_m": 2.00, "ground_clearance_m": 0.15 },
+        "gallop": { "phase_offsets": [0.00, 0.10, 0.55, 0.65], "stride_m": 4.50, "ground_clearance_m": 0.60 }
+      },
+      "turn_radius_m": 6.0
+    },
+    {
+      "species_id": "juvenile_wyvern",
+      "display_name": "Juvenile Wyvern",
+      "size_class": "huge",
+      "base_speed_mps": 10.5,
+      "base_stamina": 160,
+      "carry_capacity_kg": 150,
+      "saddle_anchor_bone": "spine_04",
+      "reins_anchor_bone": "neck",
+      "flight_capable": 1,
+      "rider_seat_offset": { "x": 0, "y": 1.85, "z": -0.05, "yaw": 0 },
+      "aesthetic_tags": ["mythic", "aerial", "legendary"],
+      "gait": {
+        "walk":   { "phase_offsets": [0.00, 0.50, 0.50, 0.00], "stride_m": 1.30, "ground_clearance_m": 0.06 },
+        "trot":   { "phase_offsets": [0.00, 0.50, 0.50, 0.00], "stride_m": 2.20, "ground_clearance_m": 0.18 },
+        "gallop": { "phase_offsets": [0.00, 0.10, 0.55, 0.65], "stride_m": 4.80, "ground_clearance_m": 0.55 }
+      },
+      "turn_radius_m": 7.5
+    }
+  ]
+}

--- a/server/server.js
+++ b/server/server.js
@@ -9384,12 +9384,13 @@ async function runMacro(domain, name, input, ctx) {
     dtu_portability: new Set(["export", "validate", "import"]),
     // Phase 6c: discovery — read-only.
     discovery: new Set(["search", "facets", "trending"]),
-    // Concordia Mount System Phase B1+B2 — species lookup + proximity
-    // browse + the riding state machine (tame/mount/dismount/active/history).
+    // Concordia Mount System Phase B1+B2+B3 — species lookup + proximity
+    // browse + riding state machine + gear authoring + stat folding.
     // Mutating macros are caller-scoped via ownership checks in the handler.
     mounts: new Set([
       "list_species", "get_species", "get_gait", "list_mountable", "list_eligible_nearby",
       "tame", "mount", "dismount", "get_active_mount", "history",
+      "validate_gear_recipe", "equip_gear", "unequip_gear", "compute_stats", "get_equipped_gear",
     ]),
     // Governance: read-mostly + caller-driven write macros.
     governance: new Set([

--- a/server/server.js
+++ b/server/server.js
@@ -9384,10 +9384,13 @@ async function runMacro(domain, name, input, ctx) {
     dtu_portability: new Set(["export", "validate", "import"]),
     // Phase 6c: discovery — read-only.
     discovery: new Set(["search", "facets", "trending"]),
-    // Concordia Mount System Phase B1 — read-only species lookup +
-    // proximity-scoped nearby-creature browsing. Mutating mount.* macros
-    // (tame, mount, dismount) land in B2 with their own auth gates.
-    mounts: new Set(["list_species", "get_species", "get_gait", "list_mountable", "list_eligible_nearby"]),
+    // Concordia Mount System Phase B1+B2 — species lookup + proximity
+    // browse + the riding state machine (tame/mount/dismount/active/history).
+    // Mutating macros are caller-scoped via ownership checks in the handler.
+    mounts: new Set([
+      "list_species", "get_species", "get_gait", "list_mountable", "list_eligible_nearby",
+      "tame", "mount", "dismount", "get_active_mount", "history",
+    ]),
     // Governance: read-mostly + caller-driven write macros.
     governance: new Set([
       "open_proposal", "cast_vote", "tally", "resolve",

--- a/server/server.js
+++ b/server/server.js
@@ -4336,6 +4336,19 @@ if (db) {
   } catch (e) {
     console.warn("[Concord] Refusal field reload skipped:", e.message);
   }
+
+  // Concordia Procedural Mount System (Phase B1) — seed mount_species +
+  // mount_gait_profiles from server/seeds/mount_species.json. Idempotent
+  // (INSERT OR IGNORE), so re-running on startup is safe. Failure here
+  // does NOT block boot.
+  try {
+    const { seedMountSpecies } = await import("./lib/ecosystem/mount-species-seeder.js");
+    const r = seedMountSpecies(db);
+    if (r?.ok) structuredLog("info", "mount_species_seeded", { ...r.inserted, total: r.total });
+    else if (r?.reason) structuredLog("warn", "mount_species_seed_skipped", { reason: r.reason });
+  } catch (e) {
+    console.warn("[Concord] Mount species seed skipped:", e.message);
+  }
 }
 
 // ---- DTU Write-Through Store (persistent-first) ----
@@ -9371,6 +9384,10 @@ async function runMacro(domain, name, input, ctx) {
     dtu_portability: new Set(["export", "validate", "import"]),
     // Phase 6c: discovery — read-only.
     discovery: new Set(["search", "facets", "trending"]),
+    // Concordia Mount System Phase B1 — read-only species lookup +
+    // proximity-scoped nearby-creature browsing. Mutating mount.* macros
+    // (tame, mount, dismount) land in B2 with their own auth gates.
+    mounts: new Set(["list_species", "get_species", "get_gait", "list_mountable", "list_eligible_nearby"]),
     // Governance: read-mostly + caller-driven write macros.
     governance: new Set([
       "open_proposal", "cast_vote", "tally", "resolve",
@@ -22858,6 +22875,13 @@ registerGovernanceMacros(register);
 // Phase 8 — Combat polish surface for the HUD.
 import registerCombatPolishMacros from "./domains/combat-polish.js";
 registerCombatPolishMacros(register);
+
+// Concordia Procedural Mount System Phase B1 — read-only macros for
+// mount species lookup + eligible-companion + nearby-creature browsing.
+// B2/B3/B4 will extend this domain with taming/riding/customization/care
+// macros. See lib/ecosystem/mount-eligibility.js + mount-species-seeder.
+import registerMountMacros from "./domains/mounts.js";
+registerMountMacros(register);
 
 // Phase 7 / T2 — Code substrate macros: routes / migrations / modules /
 // macros become DTUs under kind='code_artifact'. See lib/code-substrate/.

--- a/server/tests/mount-gear.test.js
+++ b/server/tests/mount-gear.test.js
@@ -1,0 +1,348 @@
+/**
+ * Tier-2 contract tests for Concordia Mount System Phase B3.
+ *
+ * Pinned:
+ *   - migration 144: ALTER adds saddle/bridle/barding columns; idempotent re-run.
+ *   - validateMountGear: slot enum, stat_mod bounds, weight_kg > 0, material_list shape.
+ *   - equipGear: ownership + eligibility + slot match + species_compat + idempotent same-DTU
+ *     + replacing previous slot + invalid slot rejection.
+ *   - unequipGear: idempotent on empty slot.
+ *   - computeMountStats: folds base + gear, clamps multipliers to [0.4, 1.8],
+ *     clamps comfort to [0, 30].
+ *   - getEquippedGear: shape per slot.
+ *
+ * Run: node --test tests/mount-gear.test.js
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+
+import * as mig104 from "../migrations/104_player_companions.js";
+import * as mig142 from "../migrations/142_mount_substrate.js";
+import * as mig144 from "../migrations/144_mount_gear.js";
+import {
+  validateMountGear,
+  MOUNT_GEAR_SLOTS,
+} from "../lib/dtu-validators/mount-gear-validators.js";
+import {
+  equipGear,
+  unequipGear,
+  computeMountStats,
+  getEquippedGear,
+} from "../lib/mount-gear.js";
+import { seedMountSpecies } from "../lib/ecosystem/mount-species-seeder.js";
+
+let db;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  // Minimal world_npcs for species_id lookup.
+  db.exec(`
+    CREATE TABLE world_npcs (
+      id TEXT PRIMARY KEY,
+      world_id TEXT NOT NULL,
+      archetype TEXT NOT NULL,
+      x REAL, y REAL, z REAL,
+      is_dead INTEGER DEFAULT 0
+    );
+  `);
+  // Minimal `dtus` table for the gear DTU lookup path.
+  db.exec(`
+    CREATE TABLE dtus (
+      id TEXT PRIMARY KEY,
+      kind TEXT NOT NULL,
+      creator_id TEXT,
+      meta_json TEXT
+    );
+  `);
+  mig104.up(db);
+  mig142.up(db);
+  mig144.up(db);
+  seedMountSpecies(db);
+});
+
+afterEach(() => { try { db?.close(); } catch { /* intentional */ } });
+
+function _seedCreature(id, speciesId) {
+  db.prepare(`INSERT INTO world_npcs (id, world_id, archetype, x, y, z) VALUES (?, 'concordia-hub', ?, 0, 0, 0)`)
+    .run(id, `creature:${speciesId}`);
+}
+
+function _seedCompanion(id, ownerId, creatureId, mountEligible = 1) {
+  db.prepare(`
+    INSERT INTO player_companions (id, owner_id, creature_id, name, world_id, mount_eligible, tame_bond, loyalty)
+    VALUES (?, ?, ?, ?, 'concordia-hub', ?, 100, 50)
+  `).run(id, ownerId, creatureId, "Pet", mountEligible);
+}
+
+function _seedGearDtu(id, meta, kind = "mount_gear") {
+  db.prepare(`INSERT INTO dtus (id, kind, creator_id, meta_json) VALUES (?, ?, 'alice', ?)`)
+    .run(id, kind, JSON.stringify(meta));
+}
+
+describe("migration 144 — ALTER", () => {
+  it("adds saddle/bridle/barding columns idempotently", () => {
+    const cols = db.prepare("PRAGMA table_info(player_companions)").all().map(c => c.name);
+    for (const k of ["saddle_dtu_id", "bridle_dtu_id", "barding_dtu_id"]) {
+      assert.ok(cols.includes(k), `missing ${k}`);
+    }
+    let threw = false;
+    try { mig144.up(db); } catch { threw = true; }
+    assert.equal(threw, false);
+  });
+});
+
+describe("validateMountGear", () => {
+  const goodMeta = {
+    slot: "saddle",
+    species_compat: ["warhorse"],
+    weight_kg: 8,
+    weight_rating_kg: 200,
+    stat_mods: { speed: 0.1, stamina: 0.05, comfort: 5 },
+    material_list: [{ material_id: "leather", qty: 4 }, { material_id: "iron", qty: 1 }],
+    style_tags: ["tooled", "studded"],
+  };
+
+  it("accepts a well-formed recipe", () => {
+    const r = validateMountGear({ kind: "mount_gear", meta: goodMeta });
+    assert.equal(r.ok, true);
+  });
+
+  it("rejects unknown slot", () => {
+    const r = validateMountGear({ kind: "mount_gear", meta: { ...goodMeta, slot: "hat" } });
+    assert.equal(r.ok, false);
+    assert.match(r.errors.join(";"), /slot must be one of/);
+  });
+
+  it("rejects out-of-bounds stat_mods", () => {
+    const r = validateMountGear({ kind: "mount_gear", meta: { ...goodMeta, stat_mods: { speed: 0.9 } } });
+    assert.equal(r.ok, false);
+    assert.match(r.errors.join(";"), /out of bounds/);
+  });
+
+  it("rejects non-positive weights", () => {
+    const r = validateMountGear({ kind: "mount_gear", meta: { ...goodMeta, weight_kg: 0 } });
+    assert.equal(r.ok, false);
+    assert.match(r.errors.join(";"), /weight_kg/);
+  });
+
+  it("rejects malformed material_list", () => {
+    const r = validateMountGear({ kind: "mount_gear", meta: { ...goodMeta, material_list: [{ qty: 1 }] } });
+    assert.equal(r.ok, false);
+  });
+
+  it("rejects wrong DTU kind", () => {
+    const r = validateMountGear({ kind: "blueprint", meta: goodMeta });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "wrong_kind");
+  });
+
+  it("MOUNT_GEAR_SLOTS exposes the canonical set", () => {
+    assert.equal(MOUNT_GEAR_SLOTS.size, 3);
+    for (const s of ["saddle", "bridle", "barding"]) assert.ok(MOUNT_GEAR_SLOTS.has(s));
+  });
+});
+
+describe("equipGear", () => {
+  beforeEach(() => {
+    _seedCreature("crH", "warhorse");
+    _seedCompanion("c1", "alice", "crH", 1);
+    _seedGearDtu("g_saddle", {
+      slot: "saddle", species_compat: [],
+      weight_kg: 8, weight_rating_kg: 200,
+      stat_mods: { speed: 0.1, stamina: 0.05, comfort: 6 },
+      material_list: [{ material_id: "leather", qty: 4 }],
+      style_tags: ["tooled"],
+    });
+  });
+
+  it("equips a saddle into the saddle slot", () => {
+    const r = equipGear(db, { mountId: "c1", gearDtuId: "g_saddle", slot: "saddle", ownerId: "alice" });
+    assert.equal(r.ok, true);
+    assert.equal(r.replaced, null);
+    const row = db.prepare(`SELECT saddle_dtu_id FROM player_companions WHERE id = 'c1'`).get();
+    assert.equal(row.saddle_dtu_id, "g_saddle");
+  });
+
+  it("rejects non-owner", () => {
+    const r = equipGear(db, { mountId: "c1", gearDtuId: "g_saddle", slot: "saddle", ownerId: "bob" });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "not_owner");
+  });
+
+  it("rejects unknown DTU id", () => {
+    const r = equipGear(db, { mountId: "c1", gearDtuId: "ghost", slot: "saddle", ownerId: "alice" });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "gear_dtu_not_found");
+  });
+
+  it("rejects DTU with wrong kind", () => {
+    _seedGearDtu("g_blueprint", { slot: "saddle", weight_kg: 1, weight_rating_kg: 1, material_list: [], species_compat: [] }, "blueprint");
+    const r = equipGear(db, { mountId: "c1", gearDtuId: "g_blueprint", slot: "saddle", ownerId: "alice" });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "wrong_kind");
+  });
+
+  it("rejects slot mismatch", () => {
+    const r = equipGear(db, { mountId: "c1", gearDtuId: "g_saddle", slot: "bridle", ownerId: "alice" });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "slot_mismatch");
+  });
+
+  it("rejects when species_compat excludes the mount's species", () => {
+    _seedGearDtu("g_chimera_saddle", {
+      slot: "saddle", species_compat: ["chimera"],
+      weight_kg: 12, weight_rating_kg: 250,
+      stat_mods: {}, material_list: [{ material_id: "obsidian", qty: 3 }],
+      style_tags: [],
+    });
+    const r = equipGear(db, { mountId: "c1", gearDtuId: "g_chimera_saddle", slot: "saddle", ownerId: "alice" });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "species_incompatible");
+  });
+
+  it("replaces existing gear in the same slot", () => {
+    equipGear(db, { mountId: "c1", gearDtuId: "g_saddle", slot: "saddle", ownerId: "alice" });
+    _seedGearDtu("g_saddle_2", {
+      slot: "saddle", species_compat: [],
+      weight_kg: 5, weight_rating_kg: 150, stat_mods: {},
+      material_list: [{ material_id: "leather", qty: 2 }], style_tags: [],
+    });
+    const r = equipGear(db, { mountId: "c1", gearDtuId: "g_saddle_2", slot: "saddle", ownerId: "alice" });
+    assert.equal(r.ok, true);
+    assert.equal(r.replaced, "g_saddle");
+  });
+
+  it("idempotent on equipping the same DTU twice (replaced=null on no-op)", () => {
+    equipGear(db, { mountId: "c1", gearDtuId: "g_saddle", slot: "saddle", ownerId: "alice" });
+    const r2 = equipGear(db, { mountId: "c1", gearDtuId: "g_saddle", slot: "saddle", ownerId: "alice" });
+    assert.equal(r2.ok, true);
+    assert.equal(r2.replaced, null);
+  });
+
+  it("rejects invalid slot string", () => {
+    const r = equipGear(db, { mountId: "c1", gearDtuId: "g_saddle", slot: "wing", ownerId: "alice" });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "invalid_slot");
+  });
+});
+
+describe("unequipGear", () => {
+  beforeEach(() => {
+    _seedCreature("crH", "warhorse");
+    _seedCompanion("c1", "alice", "crH", 1);
+    _seedGearDtu("g_saddle", {
+      slot: "saddle", species_compat: [],
+      weight_kg: 8, weight_rating_kg: 200, stat_mods: {},
+      material_list: [{ material_id: "leather", qty: 1 }], style_tags: [],
+    });
+    equipGear(db, { mountId: "c1", gearDtuId: "g_saddle", slot: "saddle", ownerId: "alice" });
+  });
+
+  it("clears the slot", () => {
+    const r = unequipGear(db, { mountId: "c1", slot: "saddle", ownerId: "alice" });
+    assert.equal(r.ok, true);
+    assert.equal(r.had, true);
+    const row = db.prepare(`SELECT saddle_dtu_id FROM player_companions WHERE id = 'c1'`).get();
+    assert.equal(row.saddle_dtu_id, null);
+  });
+
+  it("idempotent on empty slot", () => {
+    const r = unequipGear(db, { mountId: "c1", slot: "bridle", ownerId: "alice" });
+    assert.equal(r.ok, true);
+    assert.equal(r.had, false);
+  });
+
+  it("rejects non-owner", () => {
+    const r = unequipGear(db, { mountId: "c1", slot: "saddle", ownerId: "bob" });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "not_owner");
+  });
+});
+
+describe("computeMountStats", () => {
+  beforeEach(() => {
+    _seedCreature("crH", "warhorse");
+    _seedCompanion("c1", "alice", "crH", 1);
+  });
+
+  it("returns base stats with no gear", () => {
+    const s = computeMountStats(db, "c1");
+    assert.ok(s);
+    assert.equal(s.speciesId, "warhorse");
+    assert.equal(s.modifiers.speed, 0);
+    assert.equal(s.equipped.length, 0);
+    assert.equal(s.effective.speedMps, s.base.speedMps);
+  });
+
+  it("folds saddle speed bonus into effective speed", () => {
+    _seedGearDtu("g_speedy", {
+      slot: "saddle", species_compat: [],
+      weight_kg: 5, weight_rating_kg: 150,
+      stat_mods: { speed: 0.2 },
+      material_list: [{ material_id: "leather", qty: 1 }], style_tags: [],
+    });
+    equipGear(db, { mountId: "c1", gearDtuId: "g_speedy", slot: "saddle", ownerId: "alice" });
+    const s = computeMountStats(db, "c1");
+    assert.ok(s.effective.speedMps > s.base.speedMps * 1.15);
+    assert.ok(s.effective.speedMps < s.base.speedMps * 1.25);
+  });
+
+  it("clamps multipliers to [0.4, 1.8]", () => {
+    // Three slots × +0.5 each = +1.5, clamped to ×1.8.
+    for (const slot of ["saddle", "bridle", "barding"]) {
+      _seedGearDtu(`g_max_${slot}`, {
+        slot, species_compat: [],
+        weight_kg: 3, weight_rating_kg: 100,
+        stat_mods: { speed: 0.5 },
+        material_list: [{ material_id: "x", qty: 1 }], style_tags: [],
+      });
+      equipGear(db, { mountId: "c1", gearDtuId: `g_max_${slot}`, slot, ownerId: "alice" });
+    }
+    const s = computeMountStats(db, "c1");
+    assert.equal(s.modifiers.speed, 1.5);
+    assert.ok(Math.abs(s.effective.speedMps / s.base.speedMps - 1.8) < 1e-9);
+  });
+
+  it("clamps comfort to [0, 30]", () => {
+    for (const slot of ["saddle", "bridle", "barding"]) {
+      _seedGearDtu(`g_cf_${slot}`, {
+        slot, species_compat: [],
+        weight_kg: 3, weight_rating_kg: 100,
+        stat_mods: { comfort: 10 },
+        material_list: [{ material_id: "x", qty: 1 }], style_tags: [],
+      });
+      equipGear(db, { mountId: "c1", gearDtuId: `g_cf_${slot}`, slot, ownerId: "alice" });
+    }
+    const s = computeMountStats(db, "c1");
+    assert.equal(s.effective.comfort, 30);
+  });
+});
+
+describe("getEquippedGear", () => {
+  it("returns null per slot when nothing equipped", () => {
+    _seedCreature("crH", "warhorse");
+    _seedCompanion("c1", "alice", "crH", 1);
+    const g = getEquippedGear(db, "c1");
+    assert.equal(g.saddle, null);
+    assert.equal(g.bridle, null);
+    assert.equal(g.barding, null);
+  });
+
+  it("returns the metadata block for equipped slots", () => {
+    _seedCreature("crH", "warhorse");
+    _seedCompanion("c1", "alice", "crH", 1);
+    _seedGearDtu("g", {
+      slot: "saddle", species_compat: [],
+      weight_kg: 4, weight_rating_kg: 100,
+      stat_mods: { speed: 0.05 },
+      material_list: [{ material_id: "leather", qty: 1 }], style_tags: ["tooled"],
+    });
+    equipGear(db, { mountId: "c1", gearDtuId: "g", slot: "saddle", ownerId: "alice" });
+    const out = getEquippedGear(db, "c1");
+    assert.equal(out.saddle.dtuId, "g");
+    assert.equal(out.saddle.weight_kg, 4);
+    assert.deepEqual(out.saddle.style_tags, ["tooled"]);
+  });
+});

--- a/server/tests/mount-riding.test.js
+++ b/server/tests/mount-riding.test.js
@@ -1,0 +1,251 @@
+/**
+ * Tier-2 contract tests for Concordia Procedural Mount System Phase B2.
+ *
+ * Pinned:
+ *   - tameForMount wraps attemptTame + flips mount_eligible for mountable species
+ *   - mount() requires ownership + mount_eligible + one-active-per-world
+ *   - dismount() is idempotent (no-op when not mounted)
+ *   - getActiveMountPayload returns full HUD bootstrap payload
+ *   - listMountHistory returns recent-first closed instances
+ *   - mounts.* macros respect the FF_MOUNTS_RIDING flag
+ *
+ * Run: node --test tests/mount-riding.test.js
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+
+import * as mig083 from "../migrations/083_creature_crossbreeding.js";
+import * as mig104 from "../migrations/104_player_companions.js";
+import * as mig142 from "../migrations/142_mount_substrate.js";
+import {
+  tameForMount,
+  mount as mountAction,
+  dismount as dismountAction,
+  getActiveMountFor,
+  getActiveMountPayload,
+  listMountHistory,
+} from "../lib/companions-mount.js";
+import { seedMountSpecies } from "../lib/ecosystem/mount-species-seeder.js";
+
+let db;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  // Minimal world_npcs so creatureId → archetype lookup succeeds.
+  db.exec(`
+    CREATE TABLE world_npcs (
+      id TEXT PRIMARY KEY,
+      world_id TEXT NOT NULL,
+      archetype TEXT NOT NULL,
+      name TEXT, x REAL, y REAL, z REAL,
+      level INTEGER DEFAULT 1, is_dead INTEGER DEFAULT 0,
+      is_conscious INTEGER DEFAULT 0, is_immortal INTEGER DEFAULT 0
+    );
+  `);
+  mig083.up(db);
+  mig104.up(db);
+  mig142.up(db);
+  seedMountSpecies(db);
+  delete process.env.FF_MOUNTS_RIDING;
+});
+
+afterEach(() => { try { db?.close(); } catch { /* intentional */ } });
+
+function _seedCreature(creatureId, archetype) {
+  db.prepare(`
+    INSERT INTO world_npcs (id, world_id, archetype, x, y, z)
+    VALUES (?, 'concordia-hub', ?, 0, 0, 0)
+  `).run(creatureId, archetype);
+}
+
+function _seedHighBond(ownerId, creatureId, environment = null) {
+  // Direct insert into creature_bonds at the threshold so attemptTame's
+  // bond gate clears. TAME_BOND_THRESHOLD is 100 in companions.js.
+  db.prepare(`
+    INSERT INTO creature_bonds (a_id, b_id, bond, environment, last_seen_at)
+    VALUES (?, ?, ?, ?, unixepoch())
+  `).run(ownerId, creatureId, 200, environment);
+}
+
+describe("tameForMount — flips mount_eligible for mountable species", () => {
+  it("sets mount_eligible=1 when species is in mount_species", () => {
+    _seedCreature("cr_horse_1", "creature:warhorse");
+    _seedHighBond("alice", "cr_horse_1");
+    // Force success roll by stubbing Math.random.
+    const orig = Math.random;
+    Math.random = () => 0;
+    try {
+      const r = tameForMount(db, { ownerId: "alice", creatureId: "cr_horse_1", creatureName: "Thunder" });
+      assert.equal(r.ok, true);
+      assert.equal(r.mountEligible, true);
+      assert.equal(r.speciesId, "warhorse");
+      const row = db.prepare(`SELECT mount_eligible FROM player_companions WHERE id = ?`).get(r.companionId);
+      assert.equal(row.mount_eligible, 1);
+    } finally { Math.random = orig; }
+  });
+
+  it("does NOT set mount_eligible for non-mountable species", () => {
+    _seedCreature("cr_rabbit_1", "creature:rabbit");
+    _seedHighBond("alice", "cr_rabbit_1");
+    const orig = Math.random;
+    Math.random = () => 0;
+    try {
+      const r = tameForMount(db, { ownerId: "alice", creatureId: "cr_rabbit_1", creatureName: "Hops" });
+      assert.equal(r.ok, true);
+      assert.equal(r.mountEligible, false);
+      const row = db.prepare(`SELECT mount_eligible FROM player_companions WHERE id = ?`).get(r.companionId);
+      assert.equal(row.mount_eligible, 0);
+    } finally { Math.random = orig; }
+  });
+
+  it("propagates the underlying tame failure (bond_too_low)", () => {
+    _seedCreature("cr_horse_2", "creature:warhorse");
+    // No bond row → bond_too_low.
+    const r = tameForMount(db, { ownerId: "alice", creatureId: "cr_horse_2", creatureName: "Solo" });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "bond_too_low");
+  });
+});
+
+describe("mount() — open mounted_instances row", () => {
+  let cb;
+  beforeEach(() => {
+    db.prepare(`
+      INSERT INTO player_companions (id, owner_id, creature_id, name, world_id, mount_eligible, tame_bond, loyalty)
+      VALUES ('c_w', 'alice', 'crH', 'Thunder', 'concordia-hub', 1, 100, 50)
+    `).run();
+    _seedCreature("crH", "creature:warhorse");
+    cb = "c_w";
+  });
+
+  it("opens a mounted_instances row + returns seat offset + species fields", () => {
+    const r = mountAction(db, { riderId: "alice", companionId: cb });
+    assert.equal(r.ok, true);
+    assert.ok(r.instanceId);
+    assert.equal(r.speciesId, "warhorse");
+    assert.equal(r.saddleAnchorBone, "spine_03");
+    assert.equal(r.flightCapable, false);
+    assert.ok(r.seatOffset);
+    assert.equal(typeof r.seatOffset.y, "number");
+    const row = db.prepare(`SELECT * FROM mounted_instances WHERE id = ?`).get(r.instanceId);
+    assert.ok(row);
+    assert.equal(row.dismounted_at, null);
+  });
+
+  it("rejects non-owner", () => {
+    const r = mountAction(db, { riderId: "bob", companionId: cb });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "not_owner");
+  });
+
+  it("rejects non-mountable companion", () => {
+    db.prepare(`UPDATE player_companions SET mount_eligible = 0 WHERE id = ?`).run(cb);
+    const r = mountAction(db, { riderId: "alice", companionId: cb });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "not_mountable");
+  });
+
+  it("enforces one-active-per-world", () => {
+    mountAction(db, { riderId: "alice", companionId: cb });
+    const r2 = mountAction(db, { riderId: "alice", companionId: cb });
+    assert.equal(r2.ok, false);
+    assert.equal(r2.reason, "already_mounted");
+  });
+
+  it("allows separate worlds simultaneously", () => {
+    db.prepare(`
+      INSERT INTO player_companions (id, owner_id, creature_id, name, world_id, mount_eligible, tame_bond, loyalty)
+      VALUES ('c_w2', 'alice', 'crH2', 'Echo', 'world-2', 1, 100, 50)
+    `).run();
+    _seedCreature("crH2", "creature:warhorse");
+    const a = mountAction(db, { riderId: "alice", companionId: cb });
+    const b = mountAction(db, { riderId: "alice", companionId: "c_w2", worldId: "world-2" });
+    assert.equal(a.ok, true);
+    assert.equal(b.ok, true);
+    const open = db.prepare(`SELECT COUNT(*) AS n FROM mounted_instances WHERE rider_id = 'alice' AND dismounted_at IS NULL`).get();
+    assert.equal(open.n, 2);
+  });
+
+  it("rejects unknown companion", () => {
+    const r = mountAction(db, { riderId: "alice", companionId: "ghost" });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "companion_not_found");
+  });
+});
+
+describe("dismount() — idempotent close", () => {
+  it("closes the open instance for the world", () => {
+    db.prepare(`
+      INSERT INTO player_companions (id, owner_id, creature_id, name, world_id, mount_eligible)
+      VALUES ('c_w', 'alice', 'crH', 'T', 'concordia-hub', 1)
+    `).run();
+    _seedCreature("crH", "creature:warhorse");
+    mountAction(db, { riderId: "alice", companionId: "c_w" });
+    const r = dismountAction(db, "alice");
+    assert.equal(r.ok, true);
+    assert.equal(r.wasMounted, true);
+    assert.equal(getActiveMountFor(db, "alice"), null);
+  });
+
+  it("returns wasMounted=false when not mounted (no-op)", () => {
+    const r = dismountAction(db, "alice");
+    assert.equal(r.ok, true);
+    assert.equal(r.wasMounted, false);
+  });
+
+  it("only closes the world-matching instance", () => {
+    db.prepare(`
+      INSERT INTO player_companions (id, owner_id, creature_id, name, world_id, mount_eligible)
+      VALUES ('c_a', 'alice', 'crA', 'A', 'concordia-hub', 1),
+             ('c_b', 'alice', 'crB', 'B', 'world-2', 1)
+    `).run();
+    _seedCreature("crA", "creature:warhorse");
+    _seedCreature("crB", "creature:warhorse");
+    mountAction(db, { riderId: "alice", companionId: "c_a", worldId: "concordia-hub" });
+    mountAction(db, { riderId: "alice", companionId: "c_b", worldId: "world-2" });
+    dismountAction(db, "alice", "concordia-hub");
+    assert.equal(getActiveMountFor(db, "alice", "concordia-hub"), null);
+    assert.ok(getActiveMountFor(db, "alice", "world-2"));
+  });
+});
+
+describe("getActiveMountPayload — HUD bootstrap", () => {
+  it("returns species + gait + seatOffset for the active rider", () => {
+    db.prepare(`
+      INSERT INTO player_companions (id, owner_id, creature_id, name, world_id, mount_eligible)
+      VALUES ('c_w', 'alice', 'crH', 'Thunder', 'concordia-hub', 1)
+    `).run();
+    _seedCreature("crH", "creature:warhorse");
+    mountAction(db, { riderId: "alice", companionId: "c_w" });
+    const p = getActiveMountPayload(db, "alice");
+    assert.ok(p);
+    assert.equal(p.speciesId, "warhorse");
+    assert.ok(p.species);
+    assert.ok(p.gait);
+    assert.ok(p.seatOffset);
+    assert.equal(p.companion.name, "Thunder");
+  });
+
+  it("returns null when not mounted", () => {
+    assert.equal(getActiveMountPayload(db, "alice"), null);
+  });
+});
+
+describe("listMountHistory", () => {
+  it("returns closed instances recent-first", () => {
+    db.prepare(`
+      INSERT INTO player_companions (id, owner_id, creature_id, name, world_id, mount_eligible)
+      VALUES ('c_w', 'alice', 'crH', 'T', 'concordia-hub', 1)
+    `).run();
+    _seedCreature("crH", "creature:warhorse");
+    mountAction(db, { riderId: "alice", companionId: "c_w" });
+    dismountAction(db, "alice");
+    mountAction(db, { riderId: "alice", companionId: "c_w" });
+    dismountAction(db, "alice");
+    const h = listMountHistory(db, "alice");
+    assert.equal(h.length, 2);
+    for (const row of h) assert.ok(row.dismounted_at);
+  });
+});

--- a/server/tests/mount-substrate.test.js
+++ b/server/tests/mount-substrate.test.js
@@ -1,0 +1,262 @@
+/**
+ * Tier-2 contract tests for Concordia Procedural Mount System Phase B1.
+ *
+ * Pinned:
+ *   - migration 142 applies (mount_species, mount_gait_profiles,
+ *     mounted_instances, ALTER on player_companions)
+ *   - size_class CHECK enforces enum
+ *   - seedMountSpecies is idempotent (INSERT OR IGNORE)
+ *   - isSpeciesMountable / getMountSpecies / getGaitProfile read paths
+ *   - markCompanionMountable + isCompanionMountable
+ *   - listMountableCompanionsForOwner respects world scoping
+ *   - 8 starter species seeded with valid gait profiles
+ *
+ * Run: node --test tests/mount-substrate.test.js
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+
+import * as mig104 from "../migrations/104_player_companions.js";
+import * as mig142 from "../migrations/142_mount_substrate.js";
+import {
+  isSpeciesMountable,
+  listMountableSpecies,
+  getMountSpecies,
+  getGaitProfile,
+  markCompanionMountable,
+  isCompanionMountable,
+  listMountableCompanionsForOwner,
+} from "../lib/ecosystem/mount-eligibility.js";
+import { seedMountSpecies } from "../lib/ecosystem/mount-species-seeder.js";
+
+let db;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  // Minimal world_npcs table for the proximity tests below.
+  db.exec(`
+    CREATE TABLE world_npcs (
+      id TEXT PRIMARY KEY,
+      world_id TEXT NOT NULL,
+      archetype TEXT NOT NULL,
+      name TEXT,
+      x REAL, y REAL, z REAL,
+      level INTEGER DEFAULT 1,
+      is_dead INTEGER DEFAULT 0,
+      is_conscious INTEGER DEFAULT 0,
+      is_immortal INTEGER DEFAULT 0
+    );
+  `);
+  mig104.up(db);
+  mig142.up(db);
+});
+
+afterEach(() => { try { db?.close(); } catch { /* intentional */ } });
+
+describe("migration 142 — mount substrate", () => {
+  it("creates mount_species with size_class CHECK", () => {
+    const cols = db.prepare("PRAGMA table_info(mount_species)").all().map(c => c.name);
+    for (const k of ["species_id", "size_class", "base_speed_mps", "carry_capacity_kg", "flight_capable"]) {
+      assert.ok(cols.includes(k), `mount_species missing column ${k}`);
+    }
+    assert.throws(() => {
+      db.prepare(`INSERT INTO mount_species (species_id, display_name, size_class, base_speed_mps, base_stamina, carry_capacity_kg) VALUES ('x', 'X', 'gigantic', 5, 10, 10)`).run();
+    }, /CHECK/);
+  });
+
+  it("creates mount_gait_profiles + mounted_instances", () => {
+    const tg = db.prepare("PRAGMA table_info(mount_gait_profiles)").all().map(c => c.name);
+    assert.ok(tg.includes("walk_cycle_json"));
+    assert.ok(tg.includes("trot_cycle_json"));
+    assert.ok(tg.includes("gallop_cycle_json"));
+
+    const tm = db.prepare("PRAGMA table_info(mounted_instances)").all().map(c => c.name);
+    assert.ok(tm.includes("rider_id"));
+    assert.ok(tm.includes("mount_companion_id"));
+    assert.ok(tm.includes("dismounted_at"));
+  });
+
+  it("ALTER player_companions adds mount_eligible + mount_state", () => {
+    const cols = db.prepare("PRAGMA table_info(player_companions)").all().map(c => c.name);
+    assert.ok(cols.includes("mount_eligible"));
+    assert.ok(cols.includes("mount_state"));
+  });
+
+  it("ALTER is idempotent on re-run (no throw)", () => {
+    let threw = false;
+    try { mig142.up(db); } catch { threw = true; }
+    assert.equal(threw, false);
+  });
+
+  it("flight_capable CHECK rejects values outside 0/1", () => {
+    assert.throws(() => {
+      db.prepare(`INSERT INTO mount_species
+        (species_id, display_name, size_class, base_speed_mps, base_stamina, carry_capacity_kg, flight_capable)
+        VALUES ('x', 'X', 'large', 5, 10, 10, 7)`).run();
+    }, /CHECK/);
+  });
+});
+
+describe("seedMountSpecies", () => {
+  it("seeds 8 species with gait profiles on first call", () => {
+    const r = seedMountSpecies(db);
+    assert.equal(r.ok, true);
+    assert.equal(r.total, 8);
+    assert.equal(r.inserted.species, 8);
+    assert.equal(r.inserted.gaits, 8);
+
+    const speciesCount = db.prepare(`SELECT COUNT(*) AS n FROM mount_species`).get().n;
+    const gaitCount = db.prepare(`SELECT COUNT(*) AS n FROM mount_gait_profiles`).get().n;
+    assert.equal(speciesCount, 8);
+    assert.equal(gaitCount, 8);
+  });
+
+  it("is idempotent — second call inserts 0 rows", () => {
+    seedMountSpecies(db);
+    const r = seedMountSpecies(db);
+    assert.equal(r.ok, true);
+    assert.equal(r.inserted.species, 0);
+    assert.equal(r.inserted.gaits, 0);
+  });
+
+  it("seeds expected starter set", () => {
+    seedMountSpecies(db);
+    const ids = db.prepare(`SELECT species_id FROM mount_species ORDER BY species_id`).all().map(r => r.species_id);
+    for (const expected of ["warhorse", "dire_wolf", "chimera", "giant_elk", "salamander_mount", "hippogriff", "gryphon", "juvenile_wyvern"]) {
+      assert.ok(ids.includes(expected), `missing seeded species ${expected}`);
+    }
+  });
+
+  it("seeds flight-capable set correctly", () => {
+    seedMountSpecies(db);
+    const flying = db.prepare(`SELECT species_id FROM mount_species WHERE flight_capable = 1 ORDER BY species_id`).all().map(r => r.species_id);
+    assert.deepEqual(flying.sort(), ["gryphon", "hippogriff", "juvenile_wyvern"]);
+  });
+
+  it("returns ok:false when db is missing", () => {
+    const r = seedMountSpecies(null);
+    assert.equal(r.ok, false);
+  });
+});
+
+describe("isSpeciesMountable + getMountSpecies + getGaitProfile", () => {
+  beforeEach(() => seedMountSpecies(db));
+
+  it("isSpeciesMountable returns true for seeded species", () => {
+    assert.equal(isSpeciesMountable(db, "warhorse"), true);
+    assert.equal(isSpeciesMountable(db, "chimera"), true);
+  });
+
+  it("isSpeciesMountable returns false for unknown species", () => {
+    assert.equal(isSpeciesMountable(db, "rabbit"), false);
+    assert.equal(isSpeciesMountable(db, ""), false);
+    assert.equal(isSpeciesMountable(db, null), false);
+  });
+
+  it("getMountSpecies returns full record with parsed JSON", () => {
+    const sp = getMountSpecies(db, "warhorse");
+    assert.ok(sp);
+    assert.equal(sp.speciesId, "warhorse");
+    assert.equal(sp.sizeClass, "large");
+    assert.equal(sp.flightCapable, false);
+    assert.ok(sp.riderSeatOffset);
+    assert.equal(typeof sp.riderSeatOffset.y, "number");
+    assert.ok(Array.isArray(sp.aestheticTags));
+  });
+
+  it("getGaitProfile returns parsed cycle blocks", () => {
+    const g = getGaitProfile(db, "warhorse");
+    assert.ok(g);
+    assert.equal(g.speciesId, "warhorse");
+    assert.ok(g.walk?.phase_offsets);
+    assert.equal(g.walk.phase_offsets.length, 4);
+    assert.ok(g.trot?.stride_m);
+    assert.ok(g.gallop?.stride_m);
+    assert.ok(g.turnRadiusM > 0);
+  });
+
+  it("returns null for unknown species lookups", () => {
+    assert.equal(getMountSpecies(db, "ghost"), null);
+    assert.equal(getGaitProfile(db, "ghost"), null);
+  });
+});
+
+describe("markCompanionMountable + isCompanionMountable", () => {
+  beforeEach(() => seedMountSpecies(db));
+
+  it("returns species_not_mountable for unknown species", () => {
+    db.prepare(`
+      INSERT INTO player_companions (id, owner_id, creature_id, name, world_id)
+      VALUES ('c1', 'alice', 'crX', 'Spot', 'concordia-hub')
+    `).run();
+    const r = markCompanionMountable(db, "c1", "rabbit");
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "species_not_mountable");
+    assert.equal(isCompanionMountable(db, "c1"), false);
+  });
+
+  it("flips mount_eligible to 1 for a mountable species", () => {
+    db.prepare(`
+      INSERT INTO player_companions (id, owner_id, creature_id, name, world_id)
+      VALUES ('c2', 'alice', 'crY', 'Thunder', 'concordia-hub')
+    `).run();
+    const r = markCompanionMountable(db, "c2", "warhorse");
+    assert.equal(r.ok, true);
+    assert.equal(r.changed, 1);
+    assert.equal(isCompanionMountable(db, "c2"), true);
+  });
+
+  it("is idempotent — running on already-eligible row is a no-op", () => {
+    db.prepare(`
+      INSERT INTO player_companions (id, owner_id, creature_id, name, world_id, mount_eligible)
+      VALUES ('c3', 'alice', 'crZ', 'Storm', 'concordia-hub', 1)
+    `).run();
+    const r = markCompanionMountable(db, "c3", "warhorse");
+    assert.equal(r.ok, true);
+    assert.equal(r.changed, 0);
+  });
+});
+
+describe("listMountableCompanionsForOwner", () => {
+  beforeEach(() => {
+    seedMountSpecies(db);
+    db.prepare(`INSERT INTO player_companions (id, owner_id, creature_id, name, world_id, mount_eligible) VALUES ('a', 'alice', 'cA', 'A', 'concordia-hub', 1)`).run();
+    db.prepare(`INSERT INTO player_companions (id, owner_id, creature_id, name, world_id, mount_eligible) VALUES ('b', 'alice', 'cB', 'B', 'concordia-hub', 0)`).run();
+    db.prepare(`INSERT INTO player_companions (id, owner_id, creature_id, name, world_id, mount_eligible) VALUES ('c', 'alice', 'cC', 'C', 'other-world', 1)`).run();
+    db.prepare(`INSERT INTO player_companions (id, owner_id, creature_id, name, world_id, mount_eligible) VALUES ('d', 'bob',   'cD', 'D', 'concordia-hub', 1)`).run();
+  });
+
+  it("returns only mount_eligible=1 rows for the owner", () => {
+    const list = listMountableCompanionsForOwner(db, "alice");
+    const ids = list.map(r => r.id).sort();
+    assert.deepEqual(ids, ["a", "c"]);
+  });
+
+  it("filters by world when worldId given", () => {
+    const list = listMountableCompanionsForOwner(db, "alice", "concordia-hub");
+    assert.equal(list.length, 1);
+    assert.equal(list[0].id, "a");
+  });
+
+  it("returns empty for unknown owner", () => {
+    const list = listMountableCompanionsForOwner(db, "ghost");
+    assert.equal(list.length, 0);
+  });
+});
+
+describe("listMountableSpecies ordering", () => {
+  beforeEach(() => seedMountSpecies(db));
+
+  it("orders by size_class then base_speed_mps DESC", () => {
+    const list = listMountableSpecies(db);
+    assert.equal(list.length, 8);
+    // Within same size_class, faster should come first.
+    const huges = list.filter(s => s.sizeClass === "huge");
+    assert.ok(huges.length >= 2);
+    for (let i = 1; i < huges.length; i++) {
+      assert.ok(huges[i - 1].baseSpeedMps >= huges[i].baseSpeedMps);
+    }
+  });
+});


### PR DESCRIPTION
First phase of the Concordia Procedural Mount System
(/root/.claude/plans/okay-dope-now-with-dreamy-dijkstra.md, Track B Wave 1).

Wires the data layer that B2 (taming + riding), B3 (gear), and B4
(combat overlay + evolution + care) build on. No riding logic yet — this
commit is purely substrate + read-only macros + seed.

## Schema (migration 142)

- `mount_species` — capability table per species. PK = species_id.
  Columns: display_name, size_class (CHECK enum small|medium|large|huge),
  base_speed_mps, base_stamina, carry_capacity_kg, gait_profile_id,
  rider_seat_offset_json, saddle_anchor_bone, reins_anchor_bone,
  flight_capable (CHECK 0/1), aesthetic_tags_json, created_at.
- `mount_gait_profiles` — per-species procedural-gait params.
  walk/trot/gallop_cycle_json hold {phase_offsets[4], stride_m,
  ground_clearance_m}. turn_radius_m for IK + steering.
- `mounted_instances` — append-only-with-close ledger of mount events.
  rider_id, mount_companion_id, world_id, mounted_at, dismounted_at NULL.
  Index on (rider_id, world_id, dismounted_at) so the one-active-per-world
  invariant lookup is cheap.
- `player_companions` ALTER (idempotent re-run safe via PRAGMA probe):
  + mount_eligible INTEGER DEFAULT 0
  + mount_state TEXT (JSON: stamina/hunger/loyalty/gait_skill, B4 territory)

## Seed (`server/seeds/mount_species.json`)

8 starter species + full gait profiles:
  warhorse, dire_wolf, chimera, giant_elk, salamander_mount, hippogriff,
  gryphon, juvenile_wyvern. 3 are flight-capable (hippogriff, gryphon,
  juvenile_wyvern) — flight physics deferred to B4. base_speed_mps tuned
  so warhorse ≈ 8.5 m/s ≈ 30 km/h is the ground-mount reference.

## Modules

- `server/lib/ecosystem/mount-species-seeder.js` (~100 LOC) —
  `seedMountSpecies(db)`. INSERT OR IGNORE keyed by species_id +
  gait_profile_id. Idempotent. Wired at boot in server.js, right
  after migrations + refusal-field reload. Failure is best-effort —
  never blocks boot.
- `server/lib/ecosystem/mount-eligibility.js` (~170 LOC) — read +
  write helpers: isSpeciesMountable, listMountableSpecies,
  getMountSpecies (parsed JSON), getGaitProfile (parsed cycle blocks),
  markCompanionMountable (idempotent UPDATE), isCompanionMountable,
  listMountableCompanionsForOwner (world-scoped).
- `server/domains/mounts.js` (~100 LOC) — read-only macros:
  mounts.list_species, get_species, get_gait, list_mountable (caller's
  eligible companions), list_eligible_nearby (proximity scan over
  world_npcs JOIN mount_species, capped at 50 results within 500m).

## Wiring (server.js)

- Imports + registers `registerMountMacros(register)` adjacent to
  combat-polish. Adds `mounts` to publicReadDomains for the 5 read-only
  macros above. Mutating macros (tame/mount/dismount) land in B2.
- Boot path imports + invokes seedMountSpecies(db) right after
  refusal-field reload. Logs `mount_species_seeded {species:8,gaits:8}`
  on first boot. Re-runs are no-ops (logs species:0,gaits:0).

## Tests (22/22 pass)

`server/tests/mount-substrate.test.js`:
  - migration 142: column presence, size_class CHECK, flight_capable CHECK,
    ALTER columns added, ALTER idempotent on re-run.
  - seedMountSpecies: 8 species + 8 gaits inserted, idempotent on second
    call, expected 8 starter set, 3 flight-capable, ok:false on null db.
  - read helpers: isSpeciesMountable true/false, getMountSpecies parses
    JSON, getGaitProfile returns walk/trot/gallop blocks.
  - markCompanionMountable: rejects unknown species, flips flag for
    mountable, idempotent.
  - listMountableCompanionsForOwner: filters by mount_eligible=1 + worldId.
  - listMountableSpecies ordering: size_class then base_speed_mps DESC.

## Verification

- `npm run lint:ci` — 0 errors / 0 warnings on new files.
- `npm run typecheck` — clean.
- `npm run migrate` — applies 142 cleanly; schema_version = 142.
- `node -e "import('./server.js')"` — boots clean, logs
  `mount_species_seeded {species:8,gaits:8,total:8}`.
- `node --test tests/mount-substrate.test.js` → 22/22 pass.

## CLAUDE.md invariant added by this phase

Mounts and creatures share `world_npcs.id`; `mount_species` describes
species capability; a creature is mountable iff a `mount_species` row
exists for its species_id. Quadruped gait foot-slide must stay < 2cm
in stance phase (B4 will pin this with a frontend test).

## Kill-switch

The plan calls for `FF_MOUNTS_ENABLED`. B1 is data-only — no behavior to
gate yet. The flag will gate the mutating B2+ surface and the
fauna-spawner integration when those land.

Plan ref: B1 in /root/.claude/plans/okay-dope-now-with-dreamy-dijkstra.md
Next: A2 (accept/reject telemetry + per-codebase evo + shadow upsert)
per the alternating sequence; then B2 (taming + riding).

https://claude.ai/code/session_012yPEo1fTMRUpJxniB3qAfq