### PR TITLE
fix(useLensCommand): re-register only on shape change, not action identity

### DIFF
--- a/concord-frontend/hooks/useLensCommand.ts
+++ b/concord-frontend/hooks/useLensCommand.ts
@@ -57,7 +57,7 @@ export function useLensCommand(commands: LensCommand[], options: UseLensCommandO
   );
 
   // Reconcile on shape changes only, not on every action identity tick.
-  // Extracted from the dep array so the static dep-checker can see it.
+  // Extracted to its own useMemo so the static dep-checker can see it.
   const commandShapeKey = useMemo(
     () =>
       namespacedCommands
@@ -66,13 +66,27 @@ export function useLensCommand(commands: LensCommand[], options: UseLensCommandO
     [namespacedCommands]
   );
 
+  // Refs to access the latest namespacedCommands + keyboard hooks inside
+  // the registration effect WITHOUT pulling them into the dep array. The
+  // contract: re-register only when shape changes; action identity must
+  // not trigger re-registration (covered by tests/hooks/useLensCommand.test.tsx).
+  const commandsRef = useRef(namespacedCommands);
+  commandsRef.current = namespacedCommands;
+  const registerRef = useRef(registerShortcut);
+  registerRef.current = registerShortcut;
+  const unregisterRef = useRef(unregisterShortcut);
+  unregisterRef.current = unregisterShortcut;
+
   useEffect(() => {
-    // Capture the ref-Map at effect-run time so the cleanup closes over
-    // the same Map instance even if the ref is reassigned later.
+    // Snapshot the live-actions Map so the cleanup closes over the same
+    // instance even if the ref were reassigned later.
     const liveMap = liveActions.current;
-    namespacedCommands.forEach((cmd) => {
+    const cmds = commandsRef.current;
+    const register = registerRef.current;
+    const unregister = unregisterRef.current;
+    cmds.forEach((cmd) => {
       liveMap.set(cmd.namespacedId, cmd.action);
-      registerShortcut({
+      register({
         id: cmd.namespacedId,
         keys: cmd.keys,
         description: cmd.description,
@@ -84,14 +98,14 @@ export function useLensCommand(commands: LensCommand[], options: UseLensCommandO
       });
     });
 
-    const registeredIds = namespacedCommands.map((c) => c.namespacedId);
+    const registeredIds = cmds.map((c) => c.namespacedId);
     return () => {
       registeredIds.forEach((id) => {
         liveMap.delete(id);
-        unregisterShortcut(id);
+        unregister(id);
       });
     };
-  }, [lensId, commandShapeKey, namespacedCommands, registerShortcut, unregisterShortcut]);
+  }, [lensId, commandShapeKey]);
 
   // Keep liveActions in sync without re-registering.
   useEffect(() => {


### PR DESCRIPTION
## Summary

Self-inflicted regression caught by #306's Lint & Test (run 25601578615). My earlier refactor in `521252a1` (PR #305) added `namespacedCommands` + `registerShortcut` + `unregisterShortcut` to the registration `useEffect`'s dep array to silence `react-hooks/exhaustive-deps`. That broke the contract pinned by `concord-frontend/tests/hooks/useLensCommand.test.tsx:100`:

> When only a command's `action` changes, `registerShortcut` MUST NOT be called again — the shape (id/keys/description/enabled/global) hasn't changed, and action identity is plumbed through `liveActions.current` indirection.

Pulling `namespacedCommands` into the deps turned every action swap into a full re-register.

## Fix

Keep the `commandShapeKey` `useMemo` extraction (linter-friendly) but move `namespacedCommands` + `registerShortcut` + `unregisterShortcut` access to refs that update on every render. The effect now depends only on `[lensId, commandShapeKey]` — no `eslint-disable` needed because ref reads aren't lint-flagged.

## Test plan

- [x] `npx vitest run tests/hooks/useLensCommand.test.tsx` → 4/4 pass
- [x] `npm run lint` (frontend) → 0 errors, 0 warnings

https://claude.ai/code/session_01CbqwYzjS2TNfz6zqt9oiRp

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbqwYzjS2TNfz6zqt9oiRp)_