### PR TITLE
fix(cleanup): codex P1s for mounts (×2) + dx-platform LensShell + manifest + 1 lint

### DIFF
--- a/concord-frontend/app/lenses/dx-platform/billing/page.tsx
+++ b/concord-frontend/app/lenses/dx-platform/billing/page.tsx
@@ -13,6 +13,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { LensShell } from "@/components/lens/LensShell";
 
 interface UsageRow {
   ts_day: number;
@@ -97,6 +98,7 @@ export default function BillingDashboardPage() {
     .slice(0, 12);
 
   return (
+    <LensShell lensId="dx-platform" asMain={false}>
     <div className="p-6 space-y-6 text-sm">
       <header className="flex items-baseline justify-between">
         <h1 className="text-2xl font-semibold">DX Platform — Billing</h1>
@@ -211,6 +213,7 @@ export default function BillingDashboardPage() {
         </div>
       </section>
     </div>
+    </LensShell>
   );
 }
 

--- a/concord-frontend/app/lenses/dx-platform/page.tsx
+++ b/concord-frontend/app/lenses/dx-platform/page.tsx
@@ -5,9 +5,11 @@
 "use client";
 
 import Link from "next/link";
+import { LensShell } from "@/components/lens/LensShell";
 
 export default function DxPlatformPage() {
   return (
+    <LensShell lensId="dx-platform" asMain={false}>
     <div className="p-8 max-w-4xl mx-auto space-y-8">
       <header>
         <h1 className="text-3xl font-semibold">Concord DX Platform</h1>
@@ -51,6 +53,7 @@ export default function DxPlatformPage() {
         </ol>
       </section>
     </div>
+    </LensShell>
   );
 }
 

--- a/concord-frontend/app/lenses/dx-platform/web-editor/page.tsx
+++ b/concord-frontend/app/lenses/dx-platform/web-editor/page.tsx
@@ -12,6 +12,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { LensShell } from "@/components/lens/LensShell";
 
 const MONACO_VERSION = "0.45.0";
 
@@ -142,6 +143,7 @@ export default function WebEditorPage() {
   };
 
   return (
+    <LensShell lensId="dx-platform" asMain={false}>
     <div className="grid grid-rows-[auto_1fr_auto] h-screen text-sm">
       <header className="flex items-center justify-between p-3 border-b border-zinc-800">
         <h1 className="text-base font-medium">Concord DX — Web editor (demo)</h1>
@@ -170,6 +172,7 @@ export default function WebEditorPage() {
         </ul>
       </footer>
     </div>
+    </LensShell>
   );
 }
 

--- a/concord-frontend/lib/concordia/mounts/mount-state-machine.ts
+++ b/concord-frontend/lib/concordia/mounts/mount-state-machine.ts
@@ -85,6 +85,13 @@ export function stepTowards(current: MountedState, target: MountedState): Mounte
   if (current === "mounted_combat" && target !== "mounted_combat") {
     return "mounted_idle";
   }
+  // Symmetric entry bridge: gait → mounted_combat is illegal directly,
+  // but reachable via mounted_idle. Without this the state machine
+  // returns `current` indefinitely when gaitForSpeed(...inCombat=true)
+  // targets combat at a higher gait.
+  if (target === "mounted_combat" && current !== "mounted_idle" && isMounted(current)) {
+    return "mounted_idle";
+  }
   // mounting/dismounting are one-step states; the caller drives them.
   return current;
 }

--- a/concord-frontend/lib/lenses/manifest.ts
+++ b/concord-frontend/lib/lenses/manifest.ts
@@ -2037,6 +2037,15 @@ export const LENS_MANIFESTS: LensManifest[] = [
     actions: ['create_scenario', 'run_simulation', 'view_forecast', 'compare_counterfactuals'],
     category: 'system',
   },
+  {
+    domain: 'dx-platform',
+    label: 'DX Platform',
+    artifacts: ['codebase', 'finding', 'repair_proposal', 'usage_row', 'quota'],
+    macros: { list: 'lens.dx-platform.list', get: 'lens.dx-platform.get', run: 'lens.dx-platform.run', export: 'lens.dx-platform.export' },
+    exports: ['json', 'csv'],
+    actions: ['register_codebase', 'run_detectors', 'view_billing', 'top_up_wallet', 'web_editor_demo', 'record_fix_decision'],
+    category: 'system',
+  },
 ];
 
 // ---- Sub-lens auto-registration ----

--- a/concord-lsp/package-lock.json
+++ b/concord-lsp/package-lock.json
@@ -1,0 +1,209 @@
+{
+  "name": "concord-lsp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "concord-lsp",
+      "version": "0.1.0",
+      "dependencies": {
+        "socket.io-client": "^4.7.0",
+        "vscode-languageserver": "^9.0.0",
+        "vscode-languageserver-textdocument": "^1.0.0"
+      },
+      "bin": {
+        "concord-lsp": "out/server.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    }
+  }
+}

--- a/server/lib/companions-mount.js
+++ b/server/lib/companions-mount.js
@@ -98,6 +98,10 @@ export function mount(db, args) {
   if (!comp) return { ok: false, reason: "companion_not_found" };
   if (comp.owner_id !== riderId) return { ok: false, reason: "not_owner" };
   if (!comp.mount_eligible) return { ok: false, reason: "not_mountable" };
+  // Companion must live in the world we're mounting into — otherwise a
+  // single companion could open `mounted_instances` rows in multiple
+  // worlds simultaneously, breaking world consistency.
+  if (comp.world_id !== worldId) return { ok: false, reason: "wrong_world" };
 
   // One active per world.
   const existing = getActiveMountFor(db, riderId, worldId);

--- a/server/server.js
+++ b/server/server.js
@@ -33289,7 +33289,7 @@ register("marketplace", "purchaseWithRoyalties", async (ctx, input) => {
     // Server-side balance check — never trust client balance
     const buyerId = ctx?.actor?.userId || ctx?.actor?.id;
     if (!buyerId) return { ok: false, error: "authentication_required" };
-    try { ensureEconomicState(); } catch {}
+    try { ensureEconomicState(); } catch { /* idempotent — best-effort init */ }
     const buyerWallet = STATE.economic?.wallets?.get(buyerId);
     const buyerBalance = buyerWallet?.balance || 0;
     if (buyerBalance < price) {


### PR DESCRIPTION
## Summary

Bundles four follow-up fixes that became necessary after the #306 + #307 + #308 merge burst — three real bugs in newly-landed feature code that codex flagged but weren't addressed before merge, plus the dx-platform manifest wiring and one orphan lint regression.

### 1. `server/lib/companions-mount.js` — wrong-world mount slip (codex P1 on #306)
`mount()` read `comp.world_id` but never compared it to `args.worldId`. A player could mount their world-A companion into world B by passing `worldId: 'B'`, opening parallel `mounted_instances` rows for the same companion across worlds — broke world consistency, allowed cross-world mount duplication.

**Fix:** added `if (comp.world_id !== worldId) return { ok: false, reason: "wrong_world" };` after the eligibility check.

### 2. `concord-frontend/lib/concordia/mounts/mount-state-machine.ts` — `mounted_combat` unreachable from gait states (codex P1 on #306)
`stepTowards()` had a one-way "combat → idle" bridge but no symmetric "gait → combat" entry path. Since `mounted_combat` isn't in the `order` array, `ti=-1` made the function return `current` indefinitely when `gaitForSpeed(...inCombat=true)` targeted combat at higher gait.

**Fix:** symmetric entry bridge — gait → idle → combat in two steps.

### 3. `concord-frontend/app/lenses/dx-platform/{page,billing/page,web-editor/page}.tsx` — missing `<LensShell>` mounts (#307 Lint & Test failure)
Three new lens pages added in #307 (A5) skipped the substrate-required `<LensShell>` wrapper, tripping `lensManifest/lens-page-uses-shell`.

### 4. `concord-frontend/lib/lenses/manifest.ts` — `dx-platform` manifest entry
With the three pages mounting `<LensShell lensId="dx-platform">`, the `lensManifest/lens-id-is-known` rule needs the entry. Added with proper artifacts (codebase, finding, repair_proposal, usage_row, quota), macros (list/get/run/export), and the 6 actions the pages exercise.

### 5. `server/server.js:33292` — empty catch block lint error
Pre-existing `try { ensureEconomicState(); } catch {}` tripped `no-empty` after the merge cascade. Added an intent comment.

### 6. `concord-lsp/package-lock.json` — generated lockfile so `npm ci` works in CI
`concord-lsp/` was added in #307 without a lockfile.

## Test plan

- [x] `cd server && npm run lint` → 0 errors, 0 warnings
- [x] `cd concord-frontend && npm run lint` → 0 errors, 0 warnings
- [x] `cd concord-frontend && npm run type-check` → 0 errors
- [x] `cd server && node --test tests/companions.test.js tests/mount-*.test.js` → 75/75 pass
- [x] `cd concord-frontend && npx vitest run tests/concordia` → 127/127 pass

https://claude.ai/code/session_01CbqwYzjS2TNfz6zqt9oiRp

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbqwYzjS2TNfz6zqt9oiRp)_