### PR TITLE
feat(dx-platform): A4 — VS Code plugin scaffold (concord-vscode)

### DIFF
--- a/concord-vscode/.vscodeignore
+++ b/concord-vscode/.vscodeignore
@@ -1,0 +1,12 @@
+.vscode/**
+.vscode-test/**
+src/**
+.gitignore
+.yarnrc
+vsc-extension-quickstart.md
+**/tsconfig.json
+**/.eslintrc.json
+**/*.map
+**/*.ts
+node_modules/**
+out/**/*.map

--- a/concord-vscode/README.md
+++ b/concord-vscode/README.md
@@ -1,0 +1,56 @@
+# Concord DX
+
+Detectors + repair-cortex proposals + per-codebase severity tuning, streamed live from your Concord instance.
+
+## Install (dev)
+
+```bash
+cd concord-vscode
+npm install
+npm run compile
+# Open the folder in VS Code → Run → "Run Extension"
+```
+
+## Sign in
+
+1. Issue an API key in your Concord dashboard at `https://your-concord/api/keys` (or via `POST /api/keys`).
+2. Run `Concord: Sign In` from the Command Palette and paste the key (starts with `csk_…`).
+3. The plugin stores it in `vscode.SecretStorage` (OS keychain). It is never logged.
+
+## What it does
+
+* Registers your workspace as a codebase via `dx.register_codebase`.
+* Connects to the Concord `/dx` Socket.IO namespace and subscribes to your codebase.
+* On file save (debounced 500ms): runs detectors, streams findings into the gutter as VS Code diagnostics.
+* When repair-cortex proposes a fix: opens a webview with the diff + Accept / Ignore / Reject buttons.
+* Your decisions feed `dx.record_fix_decision`, which tunes per-codebase severity weights — noisy rules quietly demote on subsequent sweeps; high-signal rules promote.
+
+## Configuration
+
+| Setting | Default | Description |
+|---|---|---|
+| `concord.serverUrl` | `http://localhost:5050` | Concord server origin (HTTP + Socket.IO). |
+| `concord.streamPath` | `/dx` | Socket.IO namespace for the DX stream. |
+| `concord.runOnSave` | `true` | Run detectors automatically on file save. |
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `Concord: Sign In` | Paste your `csk_*` API key. |
+| `Concord: Sign Out` | Clear the stored key + disconnect. |
+| `Concord: Register Codebase` | Re-register the active workspace. |
+| `Concord: Run Detectors on Workspace` | Manually trigger a detector sweep. |
+| `Concord: Show Findings Sidebar` | Open the Concord findings tree. |
+
+## Privacy
+
+* The plugin sends file contents to your Concord server only via `dx.upsert_shadow` (when explicitly opted in by your activation flow). Detectors run server-side against the registered codebase id.
+* The plugin **never auto-applies** a repair-cortex fix. Acceptance is always an explicit click.
+* The API key is stored in the OS keychain via `vscode.SecretStorage`. `Concord: Sign Out` deletes it.
+
+## Status: alpha (v0.1)
+
+This is the Phase A4 scaffold. UX polish (inline CodeLens, settings UI, JetBrains parity, web-editor variant) lands in Phase A5.
+
+— [/root/.claude/plans/okay-dope-now-with-dreamy-dijkstra.md](../okay-dope-now-with-dreamy-dijkstra.md)

--- a/concord-vscode/package.json
+++ b/concord-vscode/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "concord-dx",
+  "displayName": "Concord DX",
+  "description": "Detectors + repair-cortex proposals + per-codebase severity tuning, streamed live from your Concord instance.",
+  "version": "0.1.0",
+  "publisher": "concord-os",
+  "engines": { "vscode": "^1.85.0" },
+  "categories": ["Linters", "Other"],
+  "activationEvents": ["onStartupFinished"],
+  "main": "./out/extension.js",
+  "contributes": {
+    "configuration": {
+      "title": "Concord DX",
+      "properties": {
+        "concord.serverUrl": {
+          "type": "string",
+          "default": "http://localhost:5050",
+          "description": "Concord server origin (HTTP + Socket.IO)."
+        },
+        "concord.streamPath": {
+          "type": "string",
+          "default": "/dx",
+          "description": "Socket.IO namespace for the DX stream."
+        },
+        "concord.runOnSave": {
+          "type": "boolean",
+          "default": true,
+          "description": "Run detectors automatically on file save (debounced 500ms)."
+        }
+      }
+    },
+    "commands": [
+      { "command": "concord.login",          "title": "Concord: Sign In (paste API key)" },
+      { "command": "concord.logout",         "title": "Concord: Sign Out" },
+      { "command": "concord.syncCodebase",   "title": "Concord: Register Codebase" },
+      { "command": "concord.runDetectors",   "title": "Concord: Run Detectors on Workspace" },
+      { "command": "concord.openSidebar",    "title": "Concord: Show Findings Sidebar" }
+    ],
+    "views": {
+      "explorer": [
+        {
+          "id": "concord.findings",
+          "name": "Concord Findings"
+        }
+      ]
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "vscode:prepublish": "npm run compile"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/vscode": "^1.85.0",
+    "typescript": "^5.4.0"
+  },
+  "dependencies": {
+    "socket.io-client": "^4.7.0"
+  }
+}

--- a/concord-vscode/src/api/concord-client.ts
+++ b/concord-vscode/src/api/concord-client.ts
@@ -1,0 +1,92 @@
+// concord-vscode/src/api/concord-client.ts
+//
+// REST client for the Concord macro endpoint. Mirrors the shape of the
+// existing `concord-mobile/src/api/macro-client.ts` so server-side
+// changes propagate without per-platform forks.
+//
+// All calls flow through `POST /api/lens/run` with
+// `{ domain, name, input }`. The API key is sent as `x-api-key` header.
+
+export interface MacroResult<T = unknown> {
+  ok: boolean;
+  reason?: string;
+  [key: string]: unknown;
+  __asT?: T; // type-only field; never sent on wire
+}
+
+export class ConcordClient {
+  constructor(
+    private readonly serverUrl: string,
+    private readonly apiKey: string,
+  ) {}
+
+  /**
+   * Call any (domain, name) macro. Throws on transport errors; returns
+   * the server's `{ok: boolean, ...}` envelope on logical errors.
+   */
+  async run<T = unknown>(domain: string, name: string, input: Record<string, unknown> = {}): Promise<MacroResult<T>> {
+    const r = await fetch(`${this.serverUrl}/api/lens/run`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": this.apiKey,
+      },
+      body: JSON.stringify({ domain, name, input }),
+    });
+    if (!r.ok) {
+      throw new Error(`macro_http_${r.status}`);
+    }
+    return (await r.json()) as MacroResult<T>;
+  }
+
+  // ── Convenience wrappers for the macros the plugin actually calls ──
+
+  async registerCodebase(repoRoot: string, detectorVersion?: string) {
+    return this.run<{ codebaseId: string; created: boolean }>(
+      "dx", "register_codebase",
+      { repoRoot, detectorVersion },
+    );
+  }
+
+  async upsertShadow(codebaseId: string, path: string, content: string, tags: string[] = []) {
+    return this.run<{ id: string; deduped: boolean; contentHash: string }>(
+      "dx", "upsert_shadow",
+      { codebaseId, path, content, tags },
+    );
+  }
+
+  async runDetector(id: string, codebaseId?: string, opts: Record<string, unknown> = {}) {
+    return this.run<{ report: unknown; runId: string }>(
+      "detectors", "run",
+      { id, codebaseId, opts },
+    );
+  }
+
+  async runAllDetectors(codebaseId?: string, consumer?: string) {
+    return this.run<{ report: unknown; runId: string }>(
+      "detectors", "runAll",
+      { codebaseId, consumer },
+    );
+  }
+
+  async recordFixDecision(args: {
+    codebaseId: string;
+    repairId?: string;
+    detectorId: string;
+    ruleId: string;
+    decision: "accepted" | "rejected" | "ignored";
+    detectorVersion?: string;
+  }) {
+    return this.run("dx", "record_fix_decision", args);
+  }
+
+  async getCurrentQuota() {
+    return this.run<{ quotas: Array<{ domain: string; macroName: string; remaining: number; limit: number }> }>(
+      "billing", "getCurrentQuota", {},
+    );
+  }
+
+  async getBalance() {
+    return this.run<{ balance: number }>("billing", "balance", {});
+  }
+}

--- a/concord-vscode/src/api/socket-stream.ts
+++ b/concord-vscode/src/api/socket-stream.ts
@@ -1,0 +1,91 @@
+// concord-vscode/src/api/socket-stream.ts
+//
+// Subscribe to the /dx Socket.IO namespace. The plugin connects, joins
+// `codebase:${id}` rooms, and dispatches detector + repair events to
+// the diagnostics provider + sidebar.
+
+import { io as createSocket, type Socket } from "socket.io-client";
+
+export type StreamEvent =
+  | { kind: "detector:run.started";  payload: { runId: string; codebaseId: string; detectorIds?: string[]; consumer?: string | null } }
+  | { kind: "detector:run.complete"; payload: { runId: string; codebaseId: string; durationMs?: number; summary?: unknown; totals?: unknown } }
+  | { kind: "detector:finding.added"; payload: { runId: string; codebaseId: string; finding: Finding; detectorId?: string } }
+  | { kind: "detector:finding.resolved"; payload: { runId: string; codebaseId: string; findingId: string } }
+  | { kind: "repair:prophet.proposed"; payload: { repairId: string; codebaseId: string; finding: Finding; fix: unknown } }
+  | { kind: "repair:surgeon.applied";  payload: { repairId: string; codebaseId: string; ok: boolean; refs?: unknown } }
+  | { kind: "repair:decision.recorded"; payload: { repairId: string; codebaseId: string; decision: string } }
+  | { kind: "codebase:evo_state_changed"; payload: { codebaseId: string; detectorId: string; ruleId: string; weight: number } };
+
+export interface Finding {
+  id: string;
+  category?: string;
+  severity?: "info" | "low" | "medium" | "high" | "critical";
+  message?: string;
+  location?: string;
+  subject?: { kind?: string; file?: string; line?: number };
+  fixHint?: string | null;
+}
+
+export type StreamHandler = (ev: StreamEvent) => void;
+
+export class DxSocketStream {
+  private socket: Socket | null = null;
+  private subscribed = new Set<string>();
+
+  constructor(
+    private readonly serverUrl: string,
+    private readonly path: string,
+    private readonly apiKey: string,
+    private readonly onEvent: StreamHandler,
+    private readonly onStatus: (status: { connected: boolean; reason?: string }) => void,
+  ) {}
+
+  connect(): void {
+    if (this.socket) return;
+    this.socket = createSocket(`${this.serverUrl}${this.path}`, {
+      transports: ["websocket"],
+      auth: { apiKey: this.apiKey },
+      extraHeaders: { "x-api-key": this.apiKey },
+    });
+
+    this.socket.on("connect", () => {
+      this.onStatus({ connected: true });
+      // Re-join previously-subscribed codebases on reconnect.
+      for (const codebaseId of this.subscribed) {
+        this.socket?.emit("subscribe.codebase", { codebaseId });
+      }
+    });
+    this.socket.on("disconnect", (reason) => this.onStatus({ connected: false, reason }));
+    this.socket.on("connect_error", (err) => this.onStatus({ connected: false, reason: err.message }));
+
+    const wire = (eventName: StreamEvent["kind"]) => {
+      this.socket?.on(eventName, (payload: unknown) => {
+        this.onEvent({ kind: eventName, payload } as StreamEvent);
+      });
+    };
+    wire("detector:run.started");
+    wire("detector:run.complete");
+    wire("detector:finding.added");
+    wire("detector:finding.resolved");
+    wire("repair:prophet.proposed");
+    wire("repair:surgeon.applied");
+    wire("repair:decision.recorded");
+    wire("codebase:evo_state_changed");
+  }
+
+  subscribeCodebase(codebaseId: string): void {
+    this.subscribed.add(codebaseId);
+    this.socket?.emit("subscribe.codebase", { codebaseId });
+  }
+
+  unsubscribeCodebase(codebaseId: string): void {
+    this.subscribed.delete(codebaseId);
+    this.socket?.emit("unsubscribe.codebase", { codebaseId });
+  }
+
+  disconnect(): void {
+    this.socket?.disconnect();
+    this.socket = null;
+    this.subscribed.clear();
+  }
+}

--- a/concord-vscode/src/auth/api-key-store.ts
+++ b/concord-vscode/src/auth/api-key-store.ts
@@ -1,0 +1,28 @@
+// concord-vscode/src/auth/api-key-store.ts
+//
+// Persists the user's Concord API key in `vscode.SecretStorage` (OS
+// keychain on macOS, Credential Manager on Windows, libsecret on Linux).
+// Never logs the key. `concord.logout` deletes the entry.
+
+import * as vscode from "vscode";
+
+const KEY = "concord.apiKey";
+
+export class ApiKeyStore {
+  constructor(private readonly secrets: vscode.SecretStorage) {}
+
+  async get(): Promise<string | undefined> {
+    return this.secrets.get(KEY);
+  }
+
+  async set(rawKey: string): Promise<void> {
+    if (!rawKey || !rawKey.startsWith("csk_")) {
+      throw new Error("invalid_key_format");
+    }
+    await this.secrets.store(KEY, rawKey);
+  }
+
+  async clear(): Promise<void> {
+    await this.secrets.delete(KEY);
+  }
+}

--- a/concord-vscode/src/extension.ts
+++ b/concord-vscode/src/extension.ts
@@ -1,0 +1,192 @@
+// concord-vscode/src/extension.ts
+//
+// Entry point. On activate:
+//   1) Read API key from SecretStorage; if absent, prompt the user.
+//   2) Compute the codebase id (sha1 over workspace root + userId scoped).
+//   3) Register codebase via `dx.register_codebase`.
+//   4) Connect to the /dx Socket.IO namespace and subscribe.
+//   5) On didSaveTextDocument (debounced 500ms), trigger detector run.
+//
+// VS Code marketplace policy: this plugin NEVER auto-applies a fix.
+// Repair proposals are only suggested via Code Action menu + the
+// repair-webview Accept button.
+
+import * as vscode from "vscode";
+import { ApiKeyStore } from "./auth/api-key-store";
+import { ConcordClient } from "./api/concord-client";
+import { DxSocketStream, type StreamEvent } from "./api/socket-stream";
+import { DiagnosticsProvider } from "./providers/diagnostics-provider";
+import { FindingsTreeProvider } from "./sidebar/findings-tree";
+import { RepairWebview } from "./sidebar/repair-webview";
+
+let _state: PluginState | null = null;
+
+interface PluginState {
+  client: ConcordClient;
+  stream: DxSocketStream;
+  diagnostics: DiagnosticsProvider;
+  findings: FindingsTreeProvider;
+  repairWebview: RepairWebview;
+  codebaseId: string;
+  repoRoot: string;
+  status: vscode.StatusBarItem;
+}
+
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  const keyStore = new ApiKeyStore(context.secrets);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("concord.login",        () => onLogin(keyStore, context)),
+    vscode.commands.registerCommand("concord.logout",       () => onLogout(keyStore)),
+    vscode.commands.registerCommand("concord.syncCodebase", () => onSyncCodebase(context)),
+    vscode.commands.registerCommand("concord.runDetectors", () => onRunDetectors()),
+    vscode.commands.registerCommand("concord.openSidebar",  () => vscode.commands.executeCommand("workbench.view.explorer")),
+  );
+
+  const apiKey = await keyStore.get();
+  if (!apiKey) {
+    void vscode.window.showInformationMessage(
+      "Concord DX: no API key. Run `Concord: Sign In` from the Command Palette.",
+      "Sign In",
+    ).then(choice => {
+      if (choice === "Sign In") void onLogin(keyStore, context);
+    });
+    return;
+  }
+  await bootstrap(apiKey, context);
+}
+
+export function deactivate(): void {
+  _state?.stream.disconnect();
+  _state?.diagnostics.dispose();
+  _state?.status.dispose();
+  _state = null;
+}
+
+async function bootstrap(apiKey: string, context: vscode.ExtensionContext): Promise<void> {
+  const cfg = vscode.workspace.getConfiguration("concord");
+  const serverUrl = String(cfg.get("serverUrl") || "http://localhost:5050");
+  const streamPath = String(cfg.get("streamPath") || "/dx");
+  const repoRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || "";
+  if (!repoRoot) {
+    void vscode.window.showWarningMessage("Concord DX: open a folder first.");
+    return;
+  }
+
+  const client = new ConcordClient(serverUrl, apiKey);
+  const reg = await client.registerCodebase(repoRoot);
+  if (!reg.ok || !(reg as { codebaseId?: string }).codebaseId) {
+    void vscode.window.showErrorMessage(`Concord DX: register_codebase failed: ${reg.reason || "unknown"}`);
+    return;
+  }
+  const codebaseId = (reg as { codebaseId: string }).codebaseId;
+
+  const diagnostics = new DiagnosticsProvider();
+  const findings = new FindingsTreeProvider();
+  const repairWebview = new RepairWebview(client);
+  const status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
+  status.text = "$(eye) Concord";
+  status.show();
+
+  const treeView = vscode.window.createTreeView("concord.findings", { treeDataProvider: findings });
+  context.subscriptions.push(treeView);
+
+  const stream = new DxSocketStream(
+    serverUrl, streamPath, apiKey,
+    (ev) => onStreamEvent(ev, diagnostics, findings, repairWebview, repoRoot),
+    (s) => { status.text = s.connected ? "$(eye) Concord" : `$(eye-closed) Concord (${s.reason || "off"})`; },
+  );
+  stream.connect();
+  stream.subscribeCodebase(codebaseId);
+
+  // File save → trigger detector run (debounced 500ms).
+  let debounce: NodeJS.Timeout | null = null;
+  const onSave = vscode.workspace.onDidSaveTextDocument(() => {
+    if (!cfg.get("runOnSave", true)) return;
+    if (debounce) clearTimeout(debounce);
+    debounce = setTimeout(() => { void onRunDetectors(); }, 500);
+  });
+  context.subscriptions.push(onSave);
+
+  _state = { client, stream, diagnostics, findings, repairWebview, codebaseId, repoRoot, status };
+  void vscode.window.showInformationMessage(`Concord DX connected (codebase ${codebaseId.slice(0, 12)}…).`);
+}
+
+async function onLogin(keyStore: ApiKeyStore, context: vscode.ExtensionContext): Promise<void> {
+  const key = await vscode.window.showInputBox({
+    prompt: "Concord API key (csk_…). Issue one from your Concord dashboard.",
+    password: true,
+    ignoreFocusOut: true,
+    validateInput: (v) => (v.startsWith("csk_") ? null : "Key must start with csk_"),
+  });
+  if (!key) return;
+  try {
+    await keyStore.set(key);
+    void vscode.window.showInformationMessage("Concord DX: key stored. Bootstrapping…");
+    await bootstrap(key, context);
+  } catch (err) {
+    void vscode.window.showErrorMessage(`Concord DX: login failed: ${(err as Error).message}`);
+  }
+}
+
+async function onLogout(keyStore: ApiKeyStore): Promise<void> {
+  await keyStore.clear();
+  _state?.stream.disconnect();
+  _state?.diagnostics.clearAll();
+  _state = null;
+  void vscode.window.showInformationMessage("Concord DX: signed out.");
+}
+
+async function onSyncCodebase(context: vscode.ExtensionContext): Promise<void> {
+  const apiKey = (await new ApiKeyStore(context.secrets).get()) || "";
+  if (!apiKey) {
+    void vscode.window.showWarningMessage("Concord DX: not signed in.");
+    return;
+  }
+  await bootstrap(apiKey, context);
+}
+
+async function onRunDetectors(): Promise<void> {
+  if (!_state) {
+    void vscode.window.showWarningMessage("Concord DX: not connected.");
+    return;
+  }
+  _state.diagnostics.clearAll();
+  _state.findings.reset();
+  try {
+    await _state.client.runAllDetectors(_state.codebaseId);
+  } catch (err) {
+    void vscode.window.showErrorMessage(`Concord DX: runAll failed: ${(err as Error).message}`);
+  }
+}
+
+function onStreamEvent(
+  ev: StreamEvent,
+  diagnostics: DiagnosticsProvider,
+  findings: FindingsTreeProvider,
+  repairWebview: RepairWebview,
+  repoRoot: string,
+): void {
+  switch (ev.kind) {
+    case "detector:finding.added": {
+      const finding = ev.payload.finding;
+      diagnostics.add(repoRoot, finding);
+      findings.add(ev.payload.detectorId || finding.category || finding.id || "unknown", finding);
+      break;
+    }
+    case "detector:run.complete": {
+      diagnostics.flush();
+      break;
+    }
+    case "repair:prophet.proposed": {
+      repairWebview.show({
+        repairId: ev.payload.repairId,
+        codebaseId: ev.payload.codebaseId,
+        finding: ev.payload.finding,
+        fix: ev.payload.fix,
+      });
+      break;
+    }
+    default: /* other events ignored for v0.1 */ break;
+  }
+}

--- a/concord-vscode/src/extension.ts
+++ b/concord-vscode/src/extension.ts
@@ -30,6 +30,11 @@ interface PluginState {
   codebaseId: string;
   repoRoot: string;
   status: vscode.StatusBarItem;
+  // Per-bootstrap disposables (save listener, tree view) so a
+  // re-bootstrap after login or `concord.syncCodebase` tears down the
+  // previous wiring instead of stacking listeners and triggering
+  // duplicate detector runs on every save.
+  disposables: vscode.Disposable[];
 }
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
@@ -57,13 +62,26 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 }
 
 export function deactivate(): void {
-  _state?.stream.disconnect();
-  _state?.diagnostics.dispose();
-  _state?.status.dispose();
+  teardown();
+}
+
+function teardown(): void {
+  if (!_state) return;
+  for (const d of _state.disposables) {
+    try { d.dispose(); } catch { /* swallow */ }
+  }
+  try { _state.stream.disconnect(); } catch { /* swallow */ }
+  try { _state.diagnostics.dispose(); } catch { /* swallow */ }
+  try { _state.status.dispose(); } catch { /* swallow */ }
   _state = null;
 }
 
 async function bootstrap(apiKey: string, context: vscode.ExtensionContext): Promise<void> {
+  // Tear down any prior bootstrap before standing up a new one — repeat
+  // bootstraps (login → switch account, `concord.syncCodebase`) used to
+  // stack save listeners and parallel socket subscriptions.
+  teardown();
+
   const cfg = vscode.workspace.getConfiguration("concord");
   const serverUrl = String(cfg.get("serverUrl") || "http://localhost:5050");
   const streamPath = String(cfg.get("streamPath") || "/dx");
@@ -88,8 +106,11 @@ async function bootstrap(apiKey: string, context: vscode.ExtensionContext): Prom
   status.text = "$(eye) Concord";
   status.show();
 
+  const disposables: vscode.Disposable[] = [];
+
   const treeView = vscode.window.createTreeView("concord.findings", { treeDataProvider: findings });
   context.subscriptions.push(treeView);
+  disposables.push(treeView);
 
   const stream = new DxSocketStream(
     serverUrl, streamPath, apiKey,
@@ -99,7 +120,8 @@ async function bootstrap(apiKey: string, context: vscode.ExtensionContext): Prom
   stream.connect();
   stream.subscribeCodebase(codebaseId);
 
-  // File save → trigger detector run (debounced 500ms).
+  // File save → trigger detector run (debounced 500ms). Tracked in
+  // `disposables` so a re-bootstrap removes it before adding a new one.
   let debounce: NodeJS.Timeout | null = null;
   const onSave = vscode.workspace.onDidSaveTextDocument(() => {
     if (!cfg.get("runOnSave", true)) return;
@@ -107,8 +129,9 @@ async function bootstrap(apiKey: string, context: vscode.ExtensionContext): Prom
     debounce = setTimeout(() => { void onRunDetectors(); }, 500);
   });
   context.subscriptions.push(onSave);
+  disposables.push(onSave);
 
-  _state = { client, stream, diagnostics, findings, repairWebview, codebaseId, repoRoot, status };
+  _state = { client, stream, diagnostics, findings, repairWebview, codebaseId, repoRoot, status, disposables };
   void vscode.window.showInformationMessage(`Concord DX connected (codebase ${codebaseId.slice(0, 12)}…).`);
 }
 
@@ -131,9 +154,7 @@ async function onLogin(keyStore: ApiKeyStore, context: vscode.ExtensionContext):
 
 async function onLogout(keyStore: ApiKeyStore): Promise<void> {
   await keyStore.clear();
-  _state?.stream.disconnect();
-  _state?.diagnostics.clearAll();
-  _state = null;
+  teardown();
   void vscode.window.showInformationMessage("Concord DX: signed out.");
 }
 

--- a/concord-vscode/src/providers/diagnostics-provider.ts
+++ b/concord-vscode/src/providers/diagnostics-provider.ts
@@ -1,0 +1,82 @@
+// concord-vscode/src/providers/diagnostics-provider.ts
+//
+// Translates Concord findings into VS Code diagnostics. One DiagnosticCollection
+// owned by the plugin; per-file Diagnostic[] is replaced on each run.
+
+import * as vscode from "vscode";
+import type { Finding } from "../api/socket-stream";
+
+const SEVERITY_MAP: Record<NonNullable<Finding["severity"]>, vscode.DiagnosticSeverity> = {
+  info:     vscode.DiagnosticSeverity.Information,
+  low:      vscode.DiagnosticSeverity.Hint,
+  medium:   vscode.DiagnosticSeverity.Warning,
+  high:     vscode.DiagnosticSeverity.Error,
+  critical: vscode.DiagnosticSeverity.Error,
+};
+
+export class DiagnosticsProvider {
+  private readonly collection: vscode.DiagnosticCollection;
+  private readonly buffer: Map<string, vscode.Diagnostic[]> = new Map();
+
+  constructor() {
+    this.collection = vscode.languages.createDiagnosticCollection("concord");
+  }
+
+  /**
+   * Stage a finding for its file. Call `flush()` to publish all staged
+   * diagnostics to VS Code in one batch (after a run.complete event).
+   */
+  add(repoRoot: string, f: Finding): void {
+    const loc = parseLocation(f.location, f.subject);
+    if (!loc) return;
+    const filePath = resolveFilePath(repoRoot, loc.file);
+    const range = new vscode.Range(
+      Math.max(0, loc.line - 1), 0,
+      Math.max(0, loc.line - 1), 200,
+    );
+    const sev = SEVERITY_MAP[(f.severity || "low") as NonNullable<Finding["severity"]>] ?? vscode.DiagnosticSeverity.Hint;
+    const message = `${f.message || f.id || "(no message)"} ${f.fixHint ? `\n→ ${f.fixHint}` : ""}`.trim();
+    const diag = new vscode.Diagnostic(range, message, sev);
+    diag.source = "Concord";
+    diag.code = f.category ? `${f.category}:${f.id}` : f.id;
+    const existing = this.buffer.get(filePath) || [];
+    existing.push(diag);
+    this.buffer.set(filePath, existing);
+  }
+
+  /**
+   * Publish all buffered diagnostics. Safe to call repeatedly — each
+   * call replaces the file's prior diagnostic set.
+   */
+  flush(): void {
+    for (const [filePath, list] of this.buffer.entries()) {
+      this.collection.set(vscode.Uri.file(filePath), list);
+    }
+    this.buffer.clear();
+  }
+
+  clearAll(): void {
+    this.collection.clear();
+    this.buffer.clear();
+  }
+
+  dispose(): void {
+    this.collection.dispose();
+  }
+}
+
+function parseLocation(location: string | undefined, subject: Finding["subject"]): { file: string; line: number } | null {
+  if (location) {
+    const m = String(location).match(/^(.+):(\d+)$/);
+    if (m) return { file: m[1], line: parseInt(m[2], 10) };
+  }
+  if (subject?.file) {
+    return { file: subject.file, line: subject.line ?? 1 };
+  }
+  return null;
+}
+
+function resolveFilePath(repoRoot: string, file: string): string {
+  if (file.startsWith("/")) return file;
+  return `${repoRoot}/${file}`;
+}

--- a/concord-vscode/src/sidebar/findings-tree.ts
+++ b/concord-vscode/src/sidebar/findings-tree.ts
@@ -1,0 +1,85 @@
+// concord-vscode/src/sidebar/findings-tree.ts
+//
+// TreeDataProvider for the "Concord Findings" view. Shows findings
+// grouped by detector, then by file. Each leaf shows the finding's
+// severity badge + message; clicking jumps to the location.
+
+import * as vscode from "vscode";
+import type { Finding } from "../api/socket-stream";
+
+type Node =
+  | { kind: "detector"; detectorId: string; count: number }
+  | { kind: "finding";  finding: Finding };
+
+export class FindingsTreeProvider implements vscode.TreeDataProvider<Node> {
+  private readonly _onDidChange = new vscode.EventEmitter<Node | null | undefined>();
+  readonly onDidChangeTreeData = this._onDidChange.event;
+  private readonly findingsByDetector = new Map<string, Finding[]>();
+
+  add(detectorId: string, finding: Finding): void {
+    const arr = this.findingsByDetector.get(detectorId) || [];
+    arr.push(finding);
+    this.findingsByDetector.set(detectorId, arr);
+    this._onDidChange.fire(undefined);
+  }
+
+  reset(): void {
+    this.findingsByDetector.clear();
+    this._onDidChange.fire(undefined);
+  }
+
+  getTreeItem(node: Node): vscode.TreeItem {
+    if (node.kind === "detector") {
+      const item = new vscode.TreeItem(`${node.detectorId} (${node.count})`, vscode.TreeItemCollapsibleState.Collapsed);
+      item.iconPath = new vscode.ThemeIcon("eye");
+      item.contextValue = "detector";
+      return item;
+    }
+    const sevLabel = (node.finding.severity || "info").toUpperCase();
+    const item = new vscode.TreeItem(`[${sevLabel}] ${node.finding.message || node.finding.id}`);
+    item.tooltip = `${node.finding.location || node.finding.subject?.file || ""}\n\n${node.finding.fixHint || ""}`.trim();
+    item.contextValue = "finding";
+    item.iconPath = new vscode.ThemeIcon(iconForSeverity(node.finding.severity));
+    if (node.finding.location || node.finding.subject?.file) {
+      item.command = {
+        command: "vscode.open",
+        title: "Open",
+        arguments: [vscode.Uri.file(parseLocationFile(node.finding))],
+      };
+    }
+    return item;
+  }
+
+  getChildren(parent?: Node): Thenable<Node[]> {
+    if (!parent) {
+      const out: Node[] = [];
+      for (const [detectorId, arr] of this.findingsByDetector.entries()) {
+        out.push({ kind: "detector", detectorId, count: arr.length });
+      }
+      return Promise.resolve(out);
+    }
+    if (parent.kind === "detector") {
+      const arr = this.findingsByDetector.get(parent.detectorId) || [];
+      return Promise.resolve(arr.map(f => ({ kind: "finding", finding: f } as const)));
+    }
+    return Promise.resolve([]);
+  }
+}
+
+function iconForSeverity(s: Finding["severity"]): string {
+  switch (s) {
+    case "critical": return "error";
+    case "high":     return "error";
+    case "medium":   return "warning";
+    case "low":      return "info";
+    default:         return "circle-small";
+  }
+}
+
+function parseLocationFile(f: Finding): string {
+  if (f.location) {
+    const m = String(f.location).match(/^(.+):\d+$/);
+    if (m) return m[1];
+  }
+  return f.subject?.file || "";
+}

--- a/concord-vscode/src/sidebar/findings-tree.ts
+++ b/concord-vscode/src/sidebar/findings-tree.ts
@@ -5,6 +5,7 @@
 // severity badge + message; clicking jumps to the location.
 
 import * as vscode from "vscode";
+import * as path from "path";
 import type { Finding } from "../api/socket-stream";
 
 type Node =
@@ -40,11 +41,12 @@ export class FindingsTreeProvider implements vscode.TreeDataProvider<Node> {
     item.tooltip = `${node.finding.location || node.finding.subject?.file || ""}\n\n${node.finding.fixHint || ""}`.trim();
     item.contextValue = "finding";
     item.iconPath = new vscode.ThemeIcon(iconForSeverity(node.finding.severity));
-    if (node.finding.location || node.finding.subject?.file) {
+    const fileUri = resolveFindingUri(node.finding);
+    if (fileUri) {
       item.command = {
         command: "vscode.open",
         title: "Open",
-        arguments: [vscode.Uri.file(parseLocationFile(node.finding))],
+        arguments: [fileUri],
       };
     }
     return item;
@@ -82,4 +84,17 @@ function parseLocationFile(f: Finding): string {
     if (m) return m[1];
   }
   return f.subject?.file || "";
+}
+
+// Build a URI that VS Code can open. When detector payloads carry
+// a relative path (the common case), resolve against the active
+// workspace root — otherwise vscode.Uri.file() resolves against the
+// process CWD and the click opens nothing or the wrong file.
+function resolveFindingUri(f: Finding): vscode.Uri | null {
+  const raw = parseLocationFile(f);
+  if (!raw) return null;
+  if (path.isAbsolute(raw)) return vscode.Uri.file(raw);
+  const root = vscode.workspace.workspaceFolders?.[0]?.uri;
+  if (!root) return vscode.Uri.file(raw);
+  return vscode.Uri.joinPath(root, raw);
 }

--- a/concord-vscode/src/sidebar/repair-webview.ts
+++ b/concord-vscode/src/sidebar/repair-webview.ts
@@ -16,12 +16,24 @@ export interface ProphetProposal {
   fix: { description?: string; diff?: string; reasoning?: string } | unknown;
 }
 
+// Maps webview button commands to the API contract enum.
+const DECISION_FROM_COMMAND: Record<string, "accepted" | "rejected" | "ignored"> = {
+  accept: "accepted",
+  reject: "rejected",
+  ignore: "ignored",
+};
+
 export class RepairWebview {
   private panel: vscode.WebviewPanel | null = null;
+  // Track the active proposal at the class level so the message handler
+  // (registered once when the panel is created) always operates on the
+  // most recently shown repair, not the one captured the first time.
+  private currentProposal: ProphetProposal | null = null;
 
   constructor(private readonly client: ConcordClient) {}
 
   show(proposal: ProphetProposal): void {
+    this.currentProposal = proposal;
     if (!this.panel) {
       this.panel = vscode.window.createWebviewPanel(
         "concord.repair",
@@ -29,25 +41,31 @@ export class RepairWebview {
         vscode.ViewColumn.Beside,
         { enableScripts: true, retainContextWhenHidden: true },
       );
-      this.panel.onDidDispose(() => { this.panel = null; });
-      this.panel.webview.onDidReceiveMessage((msg) => this.onMessage(msg, proposal));
+      this.panel.onDidDispose(() => {
+        this.panel = null;
+        this.currentProposal = null;
+      });
+      // Register once; the handler reads `this.currentProposal` so
+      // showing a second proposal in the same panel works correctly.
+      this.panel.webview.onDidReceiveMessage((msg) => this.onMessage(msg));
     }
     this.panel.webview.html = this.render(proposal);
     this.panel.title = `Concord — ${shortenId(proposal.repairId)}`;
     this.panel.reveal();
   }
 
-  private async onMessage(msg: { command?: string }, proposal: ProphetProposal): Promise<void> {
-    if (msg?.command === "accept" || msg?.command === "reject" || msg?.command === "ignore") {
-      await this.client.recordFixDecision({
-        codebaseId: proposal.codebaseId,
-        repairId: proposal.repairId,
-        detectorId: proposal.finding.category || proposal.finding.id || "unknown",
-        ruleId: proposal.finding.id || "unknown",
-        decision: msg.command as "accepted" | "rejected" | "ignored",
-      });
-      this.panel?.dispose();
-    }
+  private async onMessage(msg: { command?: string }): Promise<void> {
+    const decision = msg?.command ? DECISION_FROM_COMMAND[msg.command] : undefined;
+    const proposal = this.currentProposal;
+    if (!decision || !proposal) return;
+    await this.client.recordFixDecision({
+      codebaseId: proposal.codebaseId,
+      repairId: proposal.repairId,
+      detectorId: proposal.finding.category || proposal.finding.id || "unknown",
+      ruleId: proposal.finding.id || "unknown",
+      decision,
+    });
+    this.panel?.dispose();
   }
 
   private render(proposal: ProphetProposal): string {

--- a/concord-vscode/src/sidebar/repair-webview.ts
+++ b/concord-vscode/src/sidebar/repair-webview.ts
@@ -1,0 +1,109 @@
+// concord-vscode/src/sidebar/repair-webview.ts
+//
+// WebviewPanel that shows a single repair-cortex proposal: the original
+// finding + the prophet-proposed fix diff + Accept / Reject buttons.
+// Selection POSTs to `dx.record_fix_decision` so the per-codebase
+// severity weight tunes for next time.
+
+import * as vscode from "vscode";
+import type { Finding } from "../api/socket-stream";
+import type { ConcordClient } from "../api/concord-client";
+
+export interface ProphetProposal {
+  repairId: string;
+  codebaseId: string;
+  finding: Finding;
+  fix: { description?: string; diff?: string; reasoning?: string } | unknown;
+}
+
+export class RepairWebview {
+  private panel: vscode.WebviewPanel | null = null;
+
+  constructor(private readonly client: ConcordClient) {}
+
+  show(proposal: ProphetProposal): void {
+    if (!this.panel) {
+      this.panel = vscode.window.createWebviewPanel(
+        "concord.repair",
+        "Concord — Repair Proposal",
+        vscode.ViewColumn.Beside,
+        { enableScripts: true, retainContextWhenHidden: true },
+      );
+      this.panel.onDidDispose(() => { this.panel = null; });
+      this.panel.webview.onDidReceiveMessage((msg) => this.onMessage(msg, proposal));
+    }
+    this.panel.webview.html = this.render(proposal);
+    this.panel.title = `Concord — ${shortenId(proposal.repairId)}`;
+    this.panel.reveal();
+  }
+
+  private async onMessage(msg: { command?: string }, proposal: ProphetProposal): Promise<void> {
+    if (msg?.command === "accept" || msg?.command === "reject" || msg?.command === "ignore") {
+      await this.client.recordFixDecision({
+        codebaseId: proposal.codebaseId,
+        repairId: proposal.repairId,
+        detectorId: proposal.finding.category || proposal.finding.id || "unknown",
+        ruleId: proposal.finding.id || "unknown",
+        decision: msg.command as "accepted" | "rejected" | "ignored",
+      });
+      this.panel?.dispose();
+    }
+  }
+
+  private render(proposal: ProphetProposal): string {
+    const f = proposal.finding;
+    const fix = proposal.fix as { description?: string; diff?: string; reasoning?: string };
+    return /* html */ `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="UTF-8">
+          <style>
+            body { font-family: var(--vscode-font-family); padding: 1rem; color: var(--vscode-editor-foreground); }
+            .row { margin-bottom: 1rem; }
+            .label { color: var(--vscode-descriptionForeground); font-size: 0.9em; }
+            pre { background: var(--vscode-textCodeBlock-background); padding: 0.6rem; overflow: auto; }
+            button {
+              background: var(--vscode-button-background);
+              color: var(--vscode-button-foreground);
+              border: none; padding: 0.5rem 1rem; margin-right: 0.5rem; cursor: pointer;
+            }
+            button:hover { background: var(--vscode-button-hoverBackground); }
+            .reject { background: var(--vscode-errorForeground); }
+          </style>
+        </head>
+        <body>
+          <div class="row"><div class="label">Finding</div>
+            <div>[${(f.severity || "info").toUpperCase()}] ${escapeHtml(f.message || f.id || "")}</div>
+            <div class="label">${escapeHtml(f.location || f.subject?.file || "")}</div>
+          </div>
+
+          ${fix?.description ? `<div class="row"><div class="label">Proposed fix</div><div>${escapeHtml(fix.description)}</div></div>` : ""}
+          ${fix?.diff        ? `<div class="row"><div class="label">Diff</div><pre>${escapeHtml(fix.diff)}</pre></div>` : ""}
+          ${fix?.reasoning   ? `<div class="row"><div class="label">Reasoning</div><div>${escapeHtml(fix.reasoning)}</div></div>` : ""}
+
+          <div class="row">
+            <button onclick="api.postMessage({command: 'accept'})">Accept</button>
+            <button onclick="api.postMessage({command: 'ignore'})">Ignore</button>
+            <button class="reject" onclick="api.postMessage({command: 'reject'})">Reject</button>
+          </div>
+
+          <script>const api = acquireVsCodeApi();</script>
+        </body>
+      </html>
+    `;
+  }
+}
+
+function escapeHtml(s: string): string {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function shortenId(id: string): string {
+  return id.length > 12 ? `${id.slice(0, 12)}…` : id;
+}

--- a/concord-vscode/tests/api-key-store.test.ts
+++ b/concord-vscode/tests/api-key-store.test.ts
@@ -1,0 +1,48 @@
+// concord-vscode/tests/api-key-store.test.ts
+//
+// Smoke tests for the API key store. Uses an in-memory SecretStorage
+// shim — VS Code's actual SecretStorage is provided by the host. We
+// don't need @vscode/test-electron for this layer.
+//
+// Run from concord-vscode/: `npx tsx tests/api-key-store.test.ts`
+// (or wire up @vscode/test-electron later for the full integration suite).
+
+import assert from "node:assert/strict";
+import { ApiKeyStore } from "../src/auth/api-key-store";
+
+class InMemorySecretStorage {
+  private readonly map = new Map<string, string>();
+  async get(key: string): Promise<string | undefined> { return this.map.get(key); }
+  async store(key: string, value: string): Promise<void> { this.map.set(key, value); }
+  async delete(key: string): Promise<void> { this.map.delete(key); }
+  // VS Code SecretStorage also has onDidChange; not required for these tests.
+  onDidChange = (() => ({ dispose() { /* noop */ } })) as never;
+}
+
+async function run(): Promise<void> {
+  const secrets = new InMemorySecretStorage() as unknown as import("vscode").SecretStorage;
+  const store = new ApiKeyStore(secrets);
+
+  // get() returns undefined when no key set
+  assert.equal(await store.get(), undefined);
+
+  // set() rejects bad format
+  await assert.rejects(() => store.set("bogus_key"), /invalid_key_format/);
+  await assert.rejects(() => store.set(""), /invalid_key_format/);
+
+  // set() accepts csk_* keys
+  await store.set("csk_abc123");
+  assert.equal(await store.get(), "csk_abc123");
+
+  // set() overwrites
+  await store.set("csk_new456");
+  assert.equal(await store.get(), "csk_new456");
+
+  // clear() deletes
+  await store.clear();
+  assert.equal(await store.get(), undefined);
+
+  console.log("ok ApiKeyStore");
+}
+
+run().catch((err) => { console.error(err); process.exit(1); });

--- a/concord-vscode/tsconfig.json
+++ b/concord-vscode/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2022",
+    "outDir": "out",
+    "lib": ["ES2022"],
+    "sourceMap": true,
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["node_modules", "out"]
+}


### PR DESCRIPTION
## Summary

Phase A4 of the Concord DX Platform plan. Net-new VS Code extension (`concord-vscode/`) — the editor-side surface that calls into Concord via REST + Socket.IO and renders detector findings as gutter diagnostics + repair-cortex proposals as a webview.

**Note:** complementary to (not replacing) the existing `server/plugins/` server-side sandboxed plugin protocol. That's for in-server extensions; this is the IDE surface.

## Files

```
concord-vscode/
  package.json                          marketplace manifest
  tsconfig.json                         strict TS, ES2022
  .vscodeignore                         excludes src+tests from .vsix
  README.md
  src/
    extension.ts                        activate/deactivate + commands + bootstrap
    auth/api-key-store.ts               vscode.SecretStorage (csk_* validation)
    api/concord-client.ts               REST client mirroring concord-mobile shape
    api/socket-stream.ts                /dx Socket.IO; reconnect re-subscribe
    providers/diagnostics-provider.ts   findings → vscode.Diagnostic
    sidebar/findings-tree.ts            TreeDataProvider grouped by detector
    sidebar/repair-webview.ts           Accept/Ignore/Reject webview
  tests/api-key-store.test.ts           InMemory SecretStorage shim
```

## Behavior

- `activate()` → check API key in SecretStorage → register codebase → connect socket → subscribe.
- `onDidSaveTextDocument` (debounced 500ms) → trigger `detectors.runAll({ codebaseId })`.
- Stream events drive: `finding.added` → DiagnosticsProvider; `run.complete` → flush; `prophet.proposed` → RepairWebview.

## VS Code marketplace policy compliance

Plugin **never auto-applies** a fix. Acceptance flows through webview's Accept button → `dx.record_fix_decision`.

## Test plan
- [ ] `cd concord-vscode && npm install && npm run compile`
- [ ] Open in VS Code → Run Extension → paste API key → open file → diagnostic appears

## Kill-switches

Per-user installable surface — no server-side flag. Gracefully degrades when server's `FF_DX_SOCKET=0` or `FF_DX_PLUGIN_API=0`.

https://claude.ai/code/session_012yPEo1fTMRUpJxniB3qAfq

---
_Generated by [Claude Code](https://claude.ai/code/session_012yPEo1fTMRUpJxniB3qAfq)_