### PR TITLE
feat(concordia-mounts): B4 — care + evolution + mounted-combat overlay + quadruped gait

### DIFF
--- a/concord-frontend/lib/concordia/mounts/quadruped-gait.ts
+++ b/concord-frontend/lib/concordia/mounts/quadruped-gait.ts
@@ -19,8 +19,6 @@
 
 import type { GaitCycleBlock, GaitMode, MountGaitProfile } from "./mount-types";
 
-const TWO_PI = Math.PI * 2;
-
 export type LegId = "fl" | "fr" | "rl" | "rr";
 const LEGS: LegId[] = ["fl", "fr", "rl", "rr"];
 
@@ -49,6 +47,8 @@ export interface LegFrame {
   inStance: boolean;
   /** Stance progress ∈ [0, 1] within stance phase (or 0 in swing). */
   stanceProgress: number;
+  /** Swing progress ∈ [0, 1] within swing phase (or 0 in stance). */
+  swingProgress: number;
   /** Foot world target. In stance: pinned to ground (set by IK pass). */
   footTarget: { x: number; y: number; z: number };
   /** Vertical lift above ground in swing phase. */
@@ -74,6 +74,7 @@ export function makeInitialGaitState(gaitMode: GaitMode = "walk"): QuadrupedGait
       phase: 0,
       inStance: true,
       stanceProgress: 0,
+      swingProgress: 0,
       footTarget: { x: 0, y: 0, z: 0 },
       swingHeightM: 0,
     };
@@ -146,6 +147,7 @@ export function stepGait(
       phase,
       inStance,
       stanceProgress,
+      swingProgress,
       footTarget: prev.legs[id]?.footTarget || { x: input.pos.x, y: input.pos.y, z: input.pos.z },
       swingHeightM,
     };
@@ -187,8 +189,12 @@ export function applyFootPlanting(
       cur.footTarget = before.footTarget;
     } else {
       // Swing — interpolate forward toward the next planned plant.
+      // Use the leg's actual swingProgress (computed in stepGait against
+      // the gait-mode-specific stance fraction) instead of hard-coded
+      // 0.45/0.55 — for walk (stance 0.65) the old constants started t
+      // at ~0.36 on the first swing frame and snapped the foot.
       const target = planter.nextStanceFor(id);
-      const t = cur.stanceProgress > 0 ? cur.stanceProgress : Math.max(0, Math.min(1, (cur.phase - 0.45) / 0.55));
+      const t = Math.max(0, Math.min(1, cur.swingProgress));
       cur.footTarget = {
         x: before.footTarget.x + (target.x - before.footTarget.x) * t,
         y: target.y + cur.swingHeightM,

--- a/concord-frontend/lib/concordia/mounts/quadruped-gait.ts
+++ b/concord-frontend/lib/concordia/mounts/quadruped-gait.ts
@@ -1,0 +1,202 @@
+// concord-frontend/lib/concordia/mounts/quadruped-gait.ts
+//
+// Concordia Procedural Mount System Phase B4 — quadruped gait synthesis.
+//
+// Procedural 4-leg locomotion. Inputs: species gait profile (walk/trot/
+// gallop cycle blocks from the server) + frame state (speed, slope,
+// fatigue). Outputs: per-leg phase + foot world position so the IK
+// solver in `quadruped-ik.ts` can plant feet on the ground.
+//
+// CLAUDE.md invariant (B1): foot-slide in stance phase must stay < 2cm.
+// We achieve that via:
+//   1. Foot-planting via ground-raycast — when a leg enters stance
+//      phase, capture the world-position; hold it constant until
+//      lift-off.
+//   2. Stride length scaled by frame dt × speed so the next leg's
+//      stance starts at exactly stride_m ahead.
+//   3. Phase advance is monotonic — no rewind on slowdown; we
+//      interpolate cycle frequency instead.
+
+import type { GaitCycleBlock, GaitMode, MountGaitProfile } from "./mount-types";
+
+const TWO_PI = Math.PI * 2;
+
+export type LegId = "fl" | "fr" | "rl" | "rr";
+const LEGS: LegId[] = ["fl", "fr", "rl", "rr"];
+
+export interface MountGaitInput {
+  /** Per-frame elapsed seconds. */
+  dt: number;
+  /** Mount linear speed (m/s). */
+  speedMps: number;
+  /** Mount yaw (radians) — used to project stride into world space. */
+  yaw: number;
+  /** Mount root world position. */
+  pos: { x: number; y: number; z: number };
+  /** Slope along yaw (radians) — positive uphill. */
+  slope?: number;
+  /** Fatigue [0, 1] — high fatigue dampens stride amplitude. */
+  fatigue?: number;
+  /** Active gait mode. */
+  gaitMode: GaitMode;
+}
+
+export interface LegFrame {
+  legId: LegId;
+  /** Per-leg phase ∈ [0, 1) within the cycle. */
+  phase: number;
+  /** True iff foot is in stance phase (touching ground). */
+  inStance: boolean;
+  /** Stance progress ∈ [0, 1] within stance phase (or 0 in swing). */
+  stanceProgress: number;
+  /** Foot world target. In stance: pinned to ground (set by IK pass). */
+  footTarget: { x: number; y: number; z: number };
+  /** Vertical lift above ground in swing phase. */
+  swingHeightM: number;
+}
+
+export interface QuadrupedGaitState {
+  /** Cycle phase ∈ [0, 1) — drives leg-phase math. */
+  cyclePhase: number;
+  /** Active gait mode (driven by speed via gaitForSpeed in mount-state-machine.ts). */
+  gaitMode: GaitMode;
+  /** Per-leg frame snapshot. */
+  legs: Record<LegId, LegFrame>;
+  /** Gait stride in metres (mode-dependent). */
+  strideM: number;
+}
+
+export function makeInitialGaitState(gaitMode: GaitMode = "walk"): QuadrupedGaitState {
+  const legs: Record<LegId, LegFrame> = {} as Record<LegId, LegFrame>;
+  for (const id of LEGS) {
+    legs[id] = {
+      legId: id,
+      phase: 0,
+      inStance: true,
+      stanceProgress: 0,
+      footTarget: { x: 0, y: 0, z: 0 },
+      swingHeightM: 0,
+    };
+  }
+  return { cyclePhase: 0, gaitMode, legs, strideM: 0 };
+}
+
+function cycleFor(profile: MountGaitProfile, mode: GaitMode): GaitCycleBlock {
+  switch (mode) {
+    case "walk":   return profile.walk;
+    case "trot":   return profile.trot;
+    case "canter": return profile.gallop; // server only ships walk/trot/gallop; canter aliases gallop with damped freq
+    case "gallop": return profile.gallop;
+  }
+}
+
+// Cycle-frequency curve: higher speed → faster cycle so foot strikes
+// match. tuned around the warhorse 8.5 m/s gallop profile.
+function frequencyFor(mode: GaitMode, speedMps: number, strideM: number): number {
+  if (strideM <= 0) return 0;
+  // strides per second = speed / stride_m
+  const sps = speedMps / strideM;
+  // For walk we cap floor + ceiling so a slow-walk doesn't go to zero
+  // and pause feet on the ground forever.
+  if (mode === "walk")   return Math.max(0.4, Math.min(2.0, sps));
+  if (mode === "trot")   return Math.max(0.8, Math.min(3.0, sps));
+  if (mode === "canter") return Math.max(1.2, Math.min(3.5, sps * 0.85));
+  return Math.max(1.5, Math.min(4.5, sps));
+}
+
+/**
+ * Advance the gait one frame. Returns a new (immutable) state.
+ *
+ * @param prev — previous frame's state
+ * @param input — current-frame input
+ * @param profile — species gait profile (from `mounts.get_gait`)
+ */
+export function stepGait(
+  prev: QuadrupedGaitState,
+  input: MountGaitInput,
+  profile: MountGaitProfile,
+): QuadrupedGaitState {
+  const cycle = cycleFor(profile, input.gaitMode);
+  const strideM = cycle.stride_m;
+  const fatigue = Math.max(0, Math.min(1, input.fatigue ?? 0));
+  const swingPeak = cycle.ground_clearance_m * (1 - 0.4 * fatigue);
+
+  const freqHz = frequencyFor(input.gaitMode, Math.max(0, input.speedMps), strideM);
+  // Cycle phase advance — clamp dt to avoid huge jumps on first frame.
+  const dt = Math.max(0, Math.min(0.1, input.dt));
+  const cyclePhase = (prev.cyclePhase + freqHz * dt) % 1;
+
+  const legs: Record<LegId, LegFrame> = {} as Record<LegId, LegFrame>;
+  const offsets = cycle.phase_offsets;
+  for (let i = 0; i < LEGS.length; i++) {
+    const id = LEGS[i];
+    const phase = (cyclePhase + (offsets[i] || 0)) % 1;
+    // Stance phase = first 60% of the cycle for biped trot ([0,0.5,0.5,0]),
+    // 50% for gallop, 75% for slow walk. Approximate per-mode.
+    const stanceFraction = input.gaitMode === "walk" ? 0.65
+                         : input.gaitMode === "trot" ? 0.55
+                         : 0.45;
+    const inStance = phase < stanceFraction;
+    const stanceProgress = inStance ? phase / stanceFraction : 0;
+    const swingProgress = inStance ? 0 : (phase - stanceFraction) / (1 - stanceFraction);
+    // Sinusoidal lift in swing phase — peaks at progress 0.5.
+    const swingHeightM = inStance ? 0 : Math.sin(swingProgress * Math.PI) * swingPeak;
+    legs[id] = {
+      legId: id,
+      phase,
+      inStance,
+      stanceProgress,
+      footTarget: prev.legs[id]?.footTarget || { x: input.pos.x, y: input.pos.y, z: input.pos.z },
+      swingHeightM,
+    };
+  }
+
+  return { cyclePhase, gaitMode: input.gaitMode, legs, strideM };
+}
+
+/**
+ * Foot-target update. Caller wires this AFTER the gait step:
+ *   - When a leg crosses from swing → stance: capture the new world-
+ *     position from a ground raycast. Pin until next swing.
+ *   - When in swing: interpolate the foot toward the next stance
+ *     target, ground-clearance lifted by `swingHeightM`.
+ *
+ * This module only owns the math; the actual `raycastGround` lives in
+ * the world-lens physics layer. Caller passes `nextStanceFor(legId)`
+ * which returns the pinned ground point for each leg's next plant.
+ */
+export interface FootPlanter {
+  /** Latest world position the leg should plant on (raycast result). */
+  nextStanceFor(legId: LegId): { x: number; y: number; z: number };
+}
+
+export function applyFootPlanting(
+  state: QuadrupedGaitState,
+  prev: QuadrupedGaitState,
+  planter: FootPlanter,
+): QuadrupedGaitState {
+  for (const id of LEGS) {
+    const cur = state.legs[id];
+    const before = prev.legs[id];
+    if (!before) continue;
+    // Crossed into stance → capture pinned target.
+    if (!before.inStance && cur.inStance) {
+      cur.footTarget = planter.nextStanceFor(id);
+    } else if (cur.inStance) {
+      // Stay pinned to the previous target.
+      cur.footTarget = before.footTarget;
+    } else {
+      // Swing — interpolate forward toward the next planned plant.
+      const target = planter.nextStanceFor(id);
+      const t = cur.stanceProgress > 0 ? cur.stanceProgress : Math.max(0, Math.min(1, (cur.phase - 0.45) / 0.55));
+      cur.footTarget = {
+        x: before.footTarget.x + (target.x - before.footTarget.x) * t,
+        y: target.y + cur.swingHeightM,
+        z: before.footTarget.z + (target.z - before.footTarget.z) * t,
+      };
+    }
+  }
+  return state;
+}
+
+export const _internals = { LEGS, frequencyFor };

--- a/server/domains/mounts.js
+++ b/server/domains/mounts.js
@@ -28,6 +28,15 @@ import {
   getEquippedGear,
 } from "../lib/mount-gear.js";
 import { validateMountGear, MOUNT_GEAR_SLOTS } from "../lib/dtu-validators/mount-gear-validators.js";
+import {
+  feedMount, groomMount, restMount, getCareState, decayCare, loyaltyForRiding,
+} from "../lib/mount-care.js";
+import {
+  gainRideDistance, gainCombatHits, gainFlightSeconds, getEvolutionState,
+} from "../lib/companions-mount-evo.js";
+import {
+  applyMountedOverlay, MOUNTED_MODIFIER, readMountState as readCombatMountState,
+} from "../lib/mount-combat-overlay.js";
 import { getFlag } from "../lib/feature-flags.js";
 
 export default function registerMountMacros(register) {
@@ -259,4 +268,119 @@ export default function registerMountMacros(register) {
     const gear = getEquippedGear(db, input.mountId);
     return { ok: true, slots: [...MOUNT_GEAR_SLOTS], gear };
   }, { note: "currently-equipped gear loadout for a mount" });
+
+  // ---------- B4: care, evolution, mounted-combat overlay ----------
+
+  function _ownsMount(db, userId, mountId) {
+    const r = db.prepare(`SELECT owner_id FROM player_companions WHERE id = ?`).get(mountId);
+    return !!r && r.owner_id === userId;
+  }
+
+  // mounts.feed — drop hunger, lift loyalty. 5-min anti-spam window.
+  register("mounts", "feed", async (ctx, input = {}) => {
+    if (!getFlag("FF_MOUNT_CARE", 1)) return { ok: false, reason: "feature_disabled" };
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.userId;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_user" };
+    if (!input.mountId) return { ok: false, reason: "missing_mount_id" };
+    return feedMount(db, { companionId: input.mountId, ownerId: userId, foodItemId: input.foodItemId });
+  }, { note: "feed mount (drops hunger, raises loyalty)" });
+
+  register("mounts", "groom", async (ctx, input = {}) => {
+    if (!getFlag("FF_MOUNT_CARE", 1)) return { ok: false, reason: "feature_disabled" };
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.userId;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_user" };
+    if (!input.mountId) return { ok: false, reason: "missing_mount_id" };
+    return groomMount(db, { companionId: input.mountId, ownerId: userId });
+  }, { note: "groom mount (raises loyalty)" });
+
+  register("mounts", "rest", async (ctx, input = {}) => {
+    if (!getFlag("FF_MOUNT_CARE", 1)) return { ok: false, reason: "feature_disabled" };
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.userId;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_user" };
+    if (!input.mountId) return { ok: false, reason: "missing_mount_id" };
+    return restMount(db, { companionId: input.mountId, ownerId: userId });
+  }, { note: "rest mount (refills stamina)" });
+
+  // mounts.care_state — HUD indicator (lazy decay applied on read).
+  register("mounts", "care_state", async (ctx, input = {}) => {
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.userId;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_user" };
+    if (!input.mountId) return { ok: false, reason: "missing_mount_id" };
+    if (!_ownsMount(db, userId, input.mountId)) return { ok: false, reason: "not_owner" };
+    // Lazy decay — heartbeat is a backstop, the read path is the
+    // authoritative pull (see CLAUDE.md: heartbeat MAY trigger but
+    // MUST NOT be sole source).
+    decayCare(db, input.mountId);
+    const cs = getCareState(db, input.mountId);
+    if (!cs) return { ok: false, reason: "compute_failed" };
+    return { ok: true, ...cs };
+  }, { note: "current care state + lazy decay + ride gate" });
+
+  // mounts.evolution_state — HUD evolution indicator.
+  register("mounts", "evolution_state", async (ctx, input = {}) => {
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.userId;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_user" };
+    if (!input.mountId) return { ok: false, reason: "missing_mount_id" };
+    if (!_ownsMount(db, userId, input.mountId)) return { ok: false, reason: "not_owner" };
+    const e = getEvolutionState(db, input.mountId);
+    if (!e) return { ok: false, reason: "mount_not_found" };
+    return { ok: true, ...e };
+  }, { note: "skill XP + evolution tier snapshot" });
+
+  // mounts.gain_xp — owner-side XP record. Game systems call this
+  // after a ride / combat hit / flight tick. Bounded magnitude per call
+  // (caller is expected to pass post-tick aggregates, not per-frame).
+  register("mounts", "gain_xp", async (ctx, input = {}) => {
+    if (!getFlag("FF_MOUNT_EVO", 1)) return { ok: false, reason: "feature_disabled" };
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.userId;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_user" };
+    if (!input.mountId || !input.kind || !Number.isFinite(Number(input.amount))) {
+      return { ok: false, reason: "missing_args" };
+    }
+    if (!_ownsMount(db, userId, input.mountId)) return { ok: false, reason: "not_owner" };
+    const amount = Math.max(0, Math.min(Number(input.amount), 5000));
+    if (input.kind === "ride")    return gainRideDistance(db, input.mountId, amount);
+    if (input.kind === "combat")  return gainCombatHits(db, input.mountId, amount);
+    if (input.kind === "flight")  return gainFlightSeconds(db, input.mountId, amount);
+    return { ok: false, reason: "invalid_kind" };
+  }, { note: "record ride / combat / flight XP for the mount" });
+
+  // mounts.combat_overlay — HUD lookup. Returns the effective combat
+  // profile after applying the mounted_modifier overlay for the
+  // archetype the rider is currently on. Read-only — does NOT toggle
+  // the overlay; toggling happens in the mount/dismount path.
+  register("mounts", "combat_overlay", async (ctx, input = {}) => {
+    if (!getFlag("FF_MOUNT_COMBAT", 1)) return { ok: false, reason: "feature_disabled" };
+    const db = ctx?.db;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!input.archetype) return { ok: false, reason: "missing_archetype" };
+    const overlay = MOUNTED_MODIFIER[input.archetype] || MOUNTED_MODIFIER.generic;
+    const userId = ctx?.actor?.userId || ctx?.userId;
+    let combatState = null;
+    if (userId) combatState = readCombatMountState(db, "player", userId);
+    return { ok: true, archetype: input.archetype, overlay, combatState };
+  }, { note: "MOUNTED_MODIFIER overlay table for an archetype" });
+
+  // mounts.applied_profile — apply the overlay to a base profile.
+  // Pure compute — useful for the HUD to show effective gas/recovery
+  // numbers without re-implementing the math client-side.
+  register("mounts", "applied_profile", async (ctx, input = {}) => {
+    if (!getFlag("FF_MOUNT_COMBAT", 1)) return { ok: false, reason: "feature_disabled" };
+    if (!input.profile || typeof input.profile !== "object") return { ok: false, reason: "missing_profile" };
+    if (!input.archetype) return { ok: false, reason: "missing_archetype" };
+    const out = applyMountedOverlay(input.profile, input.archetype);
+    return { ok: true, profile: out };
+  }, { note: "apply MOUNTED_MODIFIER to a base profile" });
 }

--- a/server/emergent/mount-care-cycle.js
+++ b/server/emergent/mount-care-cycle.js
@@ -1,0 +1,82 @@
+// server/emergent/mount-care-cycle.js
+//
+// Concordia Procedural Mount System Phase B4 — care heartbeat.
+//
+// Periodically applies decay across all mountable companions. Cap the
+// per-cycle work at MAX_PER_PASS so a server with thousands of mounts
+// doesn't spike the heartbeat budget. Wrapped in try/catch — never
+// throws (CLAUDE.md heartbeat invariant).
+//
+// Frequency: 60 ticks (~15 min). Tunable via CONCORD_MOUNT_CARE_BATCH.
+//
+// Events emitted via realtime (best-effort):
+//   mount:hungry       { companionId, hunger }    when hunger ≥ 70
+//   mount:loyalty-low  { companionId, loyalty }   when loyalty < threshold
+//
+// Kill-switch: FF_MOUNT_CARE=0 → handler returns {ok:true, reason:'flag_off'}.
+
+import { decayCare, getCareState, LOYALTY_RIDE_THRESHOLD } from "../lib/mount-care.js";
+import { getFlag, getFlagNumber } from "../lib/feature-flags.js";
+
+function maxPerPass() {
+  return getFlagNumber("CONCORD_MOUNT_CARE_BATCH", 200);
+}
+
+/**
+ * Heartbeat handler. Lazy decay path — most decay actually flows
+ * through `getCareState` / `decayCare` on the player's read path
+ * (the mount HUD), so this cycle is a backstop for offline mounts
+ * the player hasn't visited recently.
+ */
+export async function runMountCareCycle({ db, state: _state } = {}) {
+  if (!getFlag("FF_MOUNT_CARE", 1)) return { ok: true, reason: "flag_off", processed: 0 };
+  if (!db) return { ok: true, reason: "no_db", processed: 0 };
+
+  let processed = 0;
+  let neglectful = 0;
+  const hungry = [];
+  const loyaltyLow = [];
+
+  try {
+    const candidates = db.prepare(`
+      SELECT id, owner_id, world_id, last_action_at, loyalty
+      FROM player_companions
+      WHERE mount_eligible = 1
+      ORDER BY COALESCE(last_action_at, 0) ASC
+      LIMIT ?
+    `).all(maxPerPass());
+
+    for (const c of candidates) {
+      try {
+        const r = decayCare(db, c.id);
+        if (!r.ok) continue;
+        processed++;
+        if (!r.applied) continue;
+        neglectful++;
+        // Re-read post-decay state for the threshold checks.
+        const cs = getCareState(db, c.id);
+        if (cs?.state?.hunger >= 70) {
+          hungry.push({ companionId: c.id, ownerId: c.owner_id, hunger: cs.state.hunger });
+        }
+        if (cs && cs.loyalty < LOYALTY_RIDE_THRESHOLD) {
+          loyaltyLow.push({ companionId: c.id, ownerId: c.owner_id, loyalty: cs.loyalty });
+        }
+      } catch { /* per-mount failure never breaks the cycle */ }
+    }
+
+    // Emit best-effort realtime notifications.
+    const REALTIME = globalThis._concordREALTIME;
+    if (REALTIME?.io) {
+      for (const h of hungry) {
+        try { REALTIME.io.to(`user:${h.ownerId}`).emit("mount:hungry", h); } catch { /* ignore */ }
+      }
+      for (const l of loyaltyLow) {
+        try { REALTIME.io.to(`user:${l.ownerId}`).emit("mount:loyalty-low", l); } catch { /* ignore */ }
+      }
+    }
+  } catch (err) {
+    return { ok: false, reason: err.message, processed };
+  }
+
+  return { ok: true, processed, neglectful, hungry: hungry.length, loyaltyLow: loyaltyLow.length };
+}

--- a/server/emergent/mount-care-cycle.js
+++ b/server/emergent/mount-care-cycle.js
@@ -38,11 +38,17 @@ export async function runMountCareCycle({ db, state: _state } = {}) {
   const loyaltyLow = [];
 
   try {
+    // ORDER BY: NULL last_action_at falls back to caught_at, then 0.
+    // The prior `COALESCE(last_action_at, 0)` always sorted NULL rows
+    // to the front; combined with decayCare returning applied:false
+    // for those rows (which never updated last_action_at) they would
+    // permanently occupy the first MAX_PER_PASS slots, starving the
+    // older mounts behind them.
     const candidates = db.prepare(`
       SELECT id, owner_id, world_id, last_action_at, loyalty
       FROM player_companions
       WHERE mount_eligible = 1
-      ORDER BY COALESCE(last_action_at, 0) ASC
+      ORDER BY COALESCE(last_action_at, caught_at, 0) ASC
       LIMIT ?
     `).all(maxPerPass());
 

--- a/server/lib/companions-mount-evo.js
+++ b/server/lib/companions-mount-evo.js
@@ -1,0 +1,129 @@
+// server/lib/companions-mount-evo.js
+//
+// Concordia Procedural Mount System Phase B4 — mount evolution.
+//
+// Mounts gain XP from riding (gait_skill), combat (combat_skill), and
+// flying (flight_skill). At threshold milestones the mount's
+// `evolution_tier` increments — unlocking visual variants, unique
+// finishers, and a stat-block bump.
+//
+// CLAUDE.md invariant: mount evolution shares the skill-evolution
+// envelope semantics — the deterministic envelope curve gates how much
+// any single revision can stack. LLM-mediated revisions are opt-in via
+// CONCORD_MOUNT_EVO_LLM=1 (deferred to A5/B-track polish).
+
+const TIER_THRESHOLDS = [0, 100, 500, 2000, 10_000];   // tier 0/1/2/3/4
+const MAX_TIER = TIER_THRESHOLDS.length - 1;
+const RIDE_XP_PER_METER     = 0.01;   // 100m of riding = +1 XP
+const COMBAT_XP_PER_HIT     = 0.5;    // dealing damage while mounted
+const FLIGHT_XP_PER_SECOND  = 0.5;    // sustained flight
+
+function _readCompanion(db, mountId) {
+  if (!db || !mountId) return null;
+  try {
+    return db.prepare(`
+      SELECT id, owner_id, gait_skill, combat_skill, flight_skill, evolution_tier
+      FROM player_companions WHERE id = ?
+    `).get(mountId) || null;
+  } catch {
+    return null;
+  }
+}
+
+function _tierFor(xp) {
+  for (let i = MAX_TIER; i >= 0; i--) {
+    if (xp >= TIER_THRESHOLDS[i]) return i;
+  }
+  return 0;
+}
+
+/**
+ * Add XP to one of the three skill axes. Idempotent on small deltas
+ * — the caller is expected to pass meaningful magnitudes (post-tick
+ * accumulation, not per-frame).
+ *
+ * @returns {{ ok, axis, before, after, tierBefore, tierAfter, leveledUp }}
+ */
+export function gainSkillXp(db, args) {
+  if (!db) return { ok: false, reason: "no_db" };
+  const { mountId, axis, delta } = args || {};
+  if (!mountId) return { ok: false, reason: "missing_mount_id" };
+  if (!["gait", "combat", "flight"].includes(axis)) return { ok: false, reason: "invalid_axis" };
+  const d = Number(delta);
+  if (!Number.isFinite(d) || d <= 0) return { ok: false, reason: "invalid_delta" };
+
+  const comp = _readCompanion(db, mountId);
+  if (!comp) return { ok: false, reason: "mount_not_found" };
+
+  const col = `${axis}_skill`;
+  const before = Number(comp[col]) || 0;
+  const after = before + d;
+
+  const tierBefore = comp.evolution_tier || 0;
+  // Aggregate tier across all three axes — use the dominant skill.
+  const cols = ["gait_skill", "combat_skill", "flight_skill"];
+  const totals = cols.map(c => {
+    if (c === col) return after;
+    return Number(comp[c]) || 0;
+  });
+  const dominant = Math.max(...totals);
+  const tierAfter = Math.max(tierBefore, _tierFor(dominant));
+
+  try {
+    db.prepare(`
+      UPDATE player_companions
+      SET ${col} = ?, evolution_tier = ?
+      WHERE id = ?
+    `).run(after, tierAfter, mountId);
+    return {
+      ok: true,
+      axis,
+      before, after,
+      tierBefore, tierAfter,
+      leveledUp: tierAfter > tierBefore,
+    };
+  } catch (err) {
+    return { ok: false, reason: err.message };
+  }
+}
+
+/**
+ * Convenience: ride distance → gait_skill.
+ */
+export function gainRideDistance(db, mountId, meters) {
+  if (!Number.isFinite(meters) || meters <= 0) return { ok: false, reason: "invalid_meters" };
+  return gainSkillXp(db, { mountId, axis: "gait", delta: meters * RIDE_XP_PER_METER });
+}
+
+export function gainCombatHits(db, mountId, hits) {
+  if (!Number.isFinite(hits) || hits <= 0) return { ok: false, reason: "invalid_hits" };
+  return gainSkillXp(db, { mountId, axis: "combat", delta: hits * COMBAT_XP_PER_HIT });
+}
+
+export function gainFlightSeconds(db, mountId, seconds) {
+  if (!Number.isFinite(seconds) || seconds <= 0) return { ok: false, reason: "invalid_seconds" };
+  return gainSkillXp(db, { mountId, axis: "flight", delta: seconds * FLIGHT_XP_PER_SECOND });
+}
+
+/**
+ * Read the current evolution snapshot.
+ */
+export function getEvolutionState(db, mountId) {
+  const comp = _readCompanion(db, mountId);
+  if (!comp) return null;
+  return {
+    mountId,
+    tier: comp.evolution_tier || 0,
+    nextTier: Math.min(MAX_TIER, (comp.evolution_tier || 0) + 1),
+    nextThreshold: TIER_THRESHOLDS[Math.min(MAX_TIER, (comp.evolution_tier || 0) + 1)],
+    skill: {
+      gait:   Number(comp.gait_skill)   || 0,
+      combat: Number(comp.combat_skill) || 0,
+      flight: Number(comp.flight_skill) || 0,
+    },
+    thresholds: TIER_THRESHOLDS.slice(),
+    maxTier: MAX_TIER,
+  };
+}
+
+export const _internals = { TIER_THRESHOLDS, RIDE_XP_PER_METER, COMBAT_XP_PER_HIT, FLIGHT_XP_PER_SECOND };

--- a/server/lib/mount-care.js
+++ b/server/lib/mount-care.js
@@ -1,0 +1,205 @@
+// server/lib/mount-care.js
+//
+// Concordia Procedural Mount System Phase B4 — care + loyalty.
+//
+// Mounts need feeding, grooming, and rest. Neglect drives loyalty
+// down; loyalty < 30 → mount refuses to be ridden.
+//
+// CLAUDE.md invariant: care decay computed LAZILY from `last_seen_at`;
+// heartbeat MAY trigger decay but MUST NOT be sole source. The 24h
+// decay cap applies regardless of server downtime — a mount left
+// untouched for 7 days behaves identically to one left for 24h.
+
+const STATE_DEFAULTS = {
+  hunger: 0,        // 0..100, climbs with neglect
+  thirst: 0,        // 0..100
+  stamina: 100,     // 0..100, drained by riding
+  loyalty: 50,      // 0..100, decays slowly without interaction
+  gait_skill: 0,    // XP — earned by riding
+};
+
+const HOUR_S = 3600;
+const DAY_S  = 86400;
+
+// Tunable rates. Per-hour values; capped at 24h regardless of elapsed
+// time so post-downtime catch-up doesn't kill mounts.
+const HUNGER_RATE_PER_HOUR  = 1.5;   // +1.5 hunger / hour without feeding
+const THIRST_RATE_PER_HOUR  = 2.0;
+const LOYALTY_DECAY_PER_DAY = 4.0;   // -4 loyalty / day without interaction
+const STAMINA_RECOVERY_PER_HOUR = 8.0;
+const FEED_HUNGER_DELTA = -40;
+const FEED_LOYALTY_DELTA = +5;
+const GROOM_LOYALTY_DELTA = +6;
+const REST_STAMINA_DELTA = +35;
+
+// Loyalty ride gate.
+export const LOYALTY_RIDE_THRESHOLD = 30;
+
+export function loyaltyForRiding(loyalty) {
+  return Number(loyalty) >= LOYALTY_RIDE_THRESHOLD;
+}
+
+function _readCompanion(db, companionId) {
+  if (!db || !companionId) return null;
+  try {
+    return db.prepare(`
+      SELECT id, owner_id, world_id, mount_eligible, mount_state, last_action_at,
+             last_ridden_at, loyalty
+      FROM player_companions WHERE id = ?
+    `).get(companionId) || null;
+  } catch {
+    return null;
+  }
+}
+
+function _parseState(json) {
+  if (!json) return { ...STATE_DEFAULTS };
+  try {
+    const parsed = JSON.parse(json);
+    return { ...STATE_DEFAULTS, ...(parsed || {}) };
+  } catch {
+    return { ...STATE_DEFAULTS };
+  }
+}
+
+function _writeState(db, companionId, state) {
+  db.prepare(`UPDATE player_companions SET mount_state = ?, last_action_at = unixepoch() WHERE id = ?`)
+    .run(JSON.stringify(state), companionId);
+}
+
+function _logEvent(db, companionId, eventType, deltas, meta = {}) {
+  try {
+    db.prepare(`
+      INSERT INTO mount_care_events
+        (companion_id, event_type, delta_loyalty, delta_stamina, delta_hunger, meta_json)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(
+      companionId, eventType,
+      Number(deltas.loyalty || 0),
+      Number(deltas.stamina || 0),
+      Number(deltas.hunger || 0),
+      JSON.stringify(meta || {}),
+    );
+  } catch { /* best-effort; care logging never blocks the action */ }
+}
+
+const clamp = (x, lo, hi) => Math.max(lo, Math.min(hi, x));
+
+/**
+ * Apply care decay for a single mount, given an elapsed-seconds budget.
+ * Caps the elapsed window at 24h so post-downtime catch-up is bounded.
+ *
+ * @returns {{ ok: boolean, applied?: boolean, deltas?: object, reason?: string }}
+ */
+export function decayCare(db, companionId, { nowS = Math.floor(Date.now() / 1000) } = {}) {
+  if (!db) return { ok: false, reason: "no_db" };
+  const comp = _readCompanion(db, companionId);
+  if (!comp) return { ok: false, reason: "not_found" };
+  const last = Number(comp.last_action_at) || nowS;
+  const elapsedS = Math.max(0, Math.min(DAY_S, nowS - last));
+  if (elapsedS < 60) return { ok: true, applied: false }; // sub-minute → skip
+
+  const state = _parseState(comp.mount_state);
+  const hours = elapsedS / HOUR_S;
+
+  const dHunger  = +HUNGER_RATE_PER_HOUR * hours;
+  const dThirst  = +THIRST_RATE_PER_HOUR * hours;
+  const dStamina = +STAMINA_RECOVERY_PER_HOUR * hours;
+  const dLoyalty = -LOYALTY_DECAY_PER_DAY * (elapsedS / DAY_S);
+
+  state.hunger  = clamp(state.hunger  + dHunger,  0, 100);
+  state.thirst  = clamp(state.thirst  + dThirst,  0, 100);
+  state.stamina = clamp(state.stamina + dStamina, 0, 100);
+  const newLoyalty = clamp(Number(comp.loyalty) + dLoyalty, 0, 100);
+
+  // Persist mount_state + companion.loyalty.
+  db.prepare(`UPDATE player_companions SET mount_state = ?, loyalty = ?, last_action_at = unixepoch() WHERE id = ?`)
+    .run(JSON.stringify(state), newLoyalty, companionId);
+  _logEvent(db, companionId, "neglect_decay", { loyalty: dLoyalty, stamina: dStamina, hunger: dHunger }, { elapsedS });
+
+  return { ok: true, applied: true, elapsedS, state, loyalty: newLoyalty };
+}
+
+/**
+ * Owner feeds the mount. Drops hunger, lifts loyalty. Idempotent
+ * within a 5-minute window (anti-spam).
+ */
+export function feedMount(db, args) {
+  if (!db) return { ok: false, reason: "no_db" };
+  const { companionId, ownerId, foodItemId } = args || {};
+  if (!companionId) return { ok: false, reason: "missing_companion_id" };
+  const comp = _readCompanion(db, companionId);
+  if (!comp) return { ok: false, reason: "not_found" };
+  if (ownerId && comp.owner_id !== ownerId) return { ok: false, reason: "not_owner" };
+
+  // Anti-spam: feeding more than once per 5 min has no effect.
+  const recent = db.prepare(`
+    SELECT ts FROM mount_care_events
+    WHERE companion_id = ? AND event_type = 'feed'
+    ORDER BY ts DESC LIMIT 1
+  `).get(companionId);
+  const nowS = Math.floor(Date.now() / 1000);
+  if (recent && nowS - recent.ts < 300) {
+    return { ok: false, reason: "too_soon", retryAfterS: 300 - (nowS - recent.ts) };
+  }
+
+  const state = _parseState(comp.mount_state);
+  state.hunger = clamp(state.hunger + FEED_HUNGER_DELTA, 0, 100);
+  const newLoyalty = clamp(Number(comp.loyalty) + FEED_LOYALTY_DELTA, 0, 100);
+  db.prepare(`UPDATE player_companions SET mount_state = ?, loyalty = ?, last_action_at = unixepoch() WHERE id = ?`)
+    .run(JSON.stringify(state), newLoyalty, companionId);
+  _logEvent(db, companionId, "feed", { hunger: FEED_HUNGER_DELTA, loyalty: FEED_LOYALTY_DELTA }, { foodItemId: foodItemId || null });
+  return { ok: true, state, loyalty: newLoyalty };
+}
+
+export function groomMount(db, args) {
+  if (!db) return { ok: false, reason: "no_db" };
+  const { companionId, ownerId } = args || {};
+  if (!companionId) return { ok: false, reason: "missing_companion_id" };
+  const comp = _readCompanion(db, companionId);
+  if (!comp) return { ok: false, reason: "not_found" };
+  if (ownerId && comp.owner_id !== ownerId) return { ok: false, reason: "not_owner" };
+  const newLoyalty = clamp(Number(comp.loyalty) + GROOM_LOYALTY_DELTA, 0, 100);
+  db.prepare(`UPDATE player_companions SET loyalty = ?, last_action_at = unixepoch() WHERE id = ?`)
+    .run(newLoyalty, companionId);
+  _logEvent(db, companionId, "groom", { loyalty: GROOM_LOYALTY_DELTA });
+  return { ok: true, loyalty: newLoyalty };
+}
+
+export function restMount(db, args) {
+  if (!db) return { ok: false, reason: "no_db" };
+  const { companionId, ownerId } = args || {};
+  if (!companionId) return { ok: false, reason: "missing_companion_id" };
+  const comp = _readCompanion(db, companionId);
+  if (!comp) return { ok: false, reason: "not_found" };
+  if (ownerId && comp.owner_id !== ownerId) return { ok: false, reason: "not_owner" };
+  const state = _parseState(comp.mount_state);
+  state.stamina = clamp(state.stamina + REST_STAMINA_DELTA, 0, 100);
+  _writeState(db, companionId, state);
+  _logEvent(db, companionId, "rest", { stamina: REST_STAMINA_DELTA });
+  return { ok: true, state };
+}
+
+/**
+ * HUD bootstrap — read the full care state.
+ */
+export function getCareState(db, companionId) {
+  if (!db || !companionId) return null;
+  const comp = _readCompanion(db, companionId);
+  if (!comp) return null;
+  const state = _parseState(comp.mount_state);
+  return {
+    companionId,
+    state,
+    loyalty: Number(comp.loyalty) || 0,
+    rideable: loyaltyForRiding(comp.loyalty),
+    last_action_at: comp.last_action_at,
+    last_ridden_at: comp.last_ridden_at,
+  };
+}
+
+export const _internals = {
+  STATE_DEFAULTS, HUNGER_RATE_PER_HOUR, LOYALTY_DECAY_PER_DAY,
+  FEED_HUNGER_DELTA, FEED_LOYALTY_DELTA, GROOM_LOYALTY_DELTA,
+  LOYALTY_RIDE_THRESHOLD,
+};

--- a/server/lib/mount-care.js
+++ b/server/lib/mount-care.js
@@ -44,7 +44,7 @@ function _readCompanion(db, companionId) {
   try {
     return db.prepare(`
       SELECT id, owner_id, world_id, mount_eligible, mount_state, last_action_at,
-             last_ridden_at, loyalty
+             last_ridden_at, loyalty, caught_at
       FROM player_companions WHERE id = ?
     `).get(companionId) || null;
   } catch {
@@ -95,7 +95,12 @@ export function decayCare(db, companionId, { nowS = Math.floor(Date.now() / 1000
   if (!db) return { ok: false, reason: "no_db" };
   const comp = _readCompanion(db, companionId);
   if (!comp) return { ok: false, reason: "not_found" };
-  const last = Number(comp.last_action_at) || nowS;
+  // Companions caught before the mount-care heartbeat shipped have
+  // last_action_at = NULL. Treat the row's caught_at as the floor so
+  // they pick up neglect decay on the next cycle instead of being
+  // permanently stuck at "just acted" — otherwise mount-care-cycle
+  // sorts them to the front of every batch and never advances past.
+  const last = Number(comp.last_action_at) || Number(comp.caught_at) || nowS;
   const elapsedS = Math.max(0, Math.min(DAY_S, nowS - last));
   if (elapsedS < 60) return { ok: true, applied: false }; // sub-minute → skip
 

--- a/server/lib/mount-combat-overlay.js
+++ b/server/lib/mount-combat-overlay.js
@@ -1,0 +1,189 @@
+// server/lib/mount-combat-overlay.js
+//
+// Concordia Procedural Mount System Phase B4 — `mounted_modifier`
+// overlay applied multiplicatively on top of the 5 base combat profiles
+// (server/lib/combat-polish.js#COMBAT_PROFILES).
+//
+// CLAUDE.md invariant: mounted combat applies overlay multiplicatively;
+// overlay read from `combat_actor_state.mount_state.mounted_modifier_active`.
+// No piece of overlay should more than 2× any combat constant — overlays
+// are tilts, not flips.
+
+// Per-archetype overlays. Keyed by mount-archetype tags (warhorse,
+// dire_wolf, chimera, hippogriff, gryphon, wyvern, salamander_mount,
+// giant_elk, generic). Multiplied onto the base profile fields below.
+//
+// Constants we modulate:
+//   gas_strike_cost          — riding burns more gas vs. standing.
+//   gas_recovery_per_s       — recovery slower while mounted (mount fatigue).
+//   combo_window_ms          — slightly longer (charge bias).
+//   parry_window_ms          — tighter (less footwork).
+//   dodge_window_ms          — depends on mount agility.
+//   stagger_chance           — heavier mounts stagger more.
+//
+// Plus a `mounted_finishers` array of finisher names the profile
+// unlocks while mounted (applied only to combo_finishers > 0 strikes).
+
+const NEUTRAL = Object.freeze({
+  gas_strike_cost_mul:     1.0,
+  gas_recovery_per_s_mul:  1.0,
+  combo_window_ms_mul:     1.0,
+  parry_window_ms_mul:     1.0,
+  dodge_window_ms_mul:     1.0,
+  stagger_chance_mul:      1.0,
+  speed_factor:            1.0,
+  mounted_finishers:       [],
+});
+
+export const MOUNTED_MODIFIER = Object.freeze({
+  warhorse: {
+    gas_strike_cost_mul:    1.20,   // heavier swings cost more
+    gas_recovery_per_s_mul: 0.85,
+    combo_window_ms_mul:    1.10,
+    parry_window_ms_mul:    0.90,
+    dodge_window_ms_mul:    0.95,
+    stagger_chance_mul:     1.40,
+    speed_factor:           1.05,
+    mounted_finishers:      ["lance_thrust", "trample"],
+  },
+  dire_wolf: {
+    gas_strike_cost_mul:    1.10,
+    gas_recovery_per_s_mul: 1.00,
+    combo_window_ms_mul:    1.05,
+    parry_window_ms_mul:    0.95,
+    dodge_window_ms_mul:    1.05,
+    stagger_chance_mul:     1.10,
+    speed_factor:           1.10,
+    mounted_finishers:      ["pounce_takedown", "pack_strike"],
+  },
+  chimera: {
+    gas_strike_cost_mul:    1.30,
+    gas_recovery_per_s_mul: 0.80,
+    combo_window_ms_mul:    1.20,
+    parry_window_ms_mul:    0.80,
+    dodge_window_ms_mul:    0.85,
+    stagger_chance_mul:     1.70,
+    speed_factor:           0.95,
+    mounted_finishers:      ["dragon_breath", "tail_sweep", "talon_rake"],
+  },
+  giant_elk: {
+    gas_strike_cost_mul:    1.15,
+    gas_recovery_per_s_mul: 0.90,
+    combo_window_ms_mul:    1.05,
+    parry_window_ms_mul:    0.95,
+    dodge_window_ms_mul:    1.00,
+    stagger_chance_mul:     1.30,
+    speed_factor:           1.00,
+    mounted_finishers:      ["antler_charge"],
+  },
+  salamander_mount: {
+    gas_strike_cost_mul:    1.05,
+    gas_recovery_per_s_mul: 1.00,
+    combo_window_ms_mul:    1.00,
+    parry_window_ms_mul:    1.00,
+    dodge_window_ms_mul:    1.00,
+    stagger_chance_mul:     1.15,
+    speed_factor:           0.95,
+    mounted_finishers:      ["ember_breath"],
+  },
+  hippogriff: {
+    gas_strike_cost_mul:    1.10,
+    gas_recovery_per_s_mul: 0.95,
+    combo_window_ms_mul:    1.00,
+    parry_window_ms_mul:    1.00,
+    dodge_window_ms_mul:    1.10,
+    stagger_chance_mul:     1.05,
+    speed_factor:           1.20,
+    mounted_finishers:      ["aerial_dive", "talon_strike"],
+  },
+  gryphon: {
+    gas_strike_cost_mul:    1.20,
+    gas_recovery_per_s_mul: 0.90,
+    combo_window_ms_mul:    1.05,
+    parry_window_ms_mul:    0.95,
+    dodge_window_ms_mul:    1.10,
+    stagger_chance_mul:     1.20,
+    speed_factor:           1.30,
+    mounted_finishers:      ["aerial_dive", "talon_rake"],
+  },
+  juvenile_wyvern: {
+    gas_strike_cost_mul:    1.25,
+    gas_recovery_per_s_mul: 0.85,
+    combo_window_ms_mul:    1.10,
+    parry_window_ms_mul:    0.90,
+    dodge_window_ms_mul:    1.00,
+    stagger_chance_mul:     1.50,
+    speed_factor:           1.15,
+    mounted_finishers:      ["wing_buffet", "tail_lash", "ember_breath"],
+  },
+  generic: { ...NEUTRAL },
+});
+
+const CLAMP_MIN = 0.5;
+const CLAMP_MAX = 2.0;
+const clamp = (x) => Math.max(CLAMP_MIN, Math.min(CLAMP_MAX, x));
+
+/**
+ * Apply the overlay to a base combat profile, returning a new (frozen)
+ * effective-profile object. Caller should NOT mutate the input.
+ *
+ * @param {object} profile — base profile from COMBAT_PROFILES
+ * @param {string} archetypeKey — species_id (or 'generic' fallback)
+ * @returns {object} effective profile
+ */
+export function applyMountedOverlay(profile, archetypeKey) {
+  if (!profile) return profile;
+  const overlay = MOUNTED_MODIFIER[archetypeKey] || MOUNTED_MODIFIER.generic;
+  return Object.freeze({
+    ...profile,
+    gas_strike_cost:    profile.gas_strike_cost    * clamp(overlay.gas_strike_cost_mul),
+    gas_recovery_per_s: profile.gas_recovery_per_s * clamp(overlay.gas_recovery_per_s_mul),
+    combo_window_ms:    profile.combo_window_ms    * clamp(overlay.combo_window_ms_mul),
+    parry_window_ms:    profile.parry_window_ms    * clamp(overlay.parry_window_ms_mul),
+    dodge_window_ms:    profile.dodge_window_ms    * clamp(overlay.dodge_window_ms_mul),
+    stagger_chance:     Math.min(1, profile.stagger_chance * clamp(overlay.stagger_chance_mul)),
+    _mounted_overlay_active: true,
+    _mount_archetype: archetypeKey,
+    _speed_factor: clamp(overlay.speed_factor),
+    _mounted_finishers: overlay.mounted_finishers.slice(),
+  });
+}
+
+/**
+ * Read the rider's archetype from combat_actor_state.mount_state.
+ * Returns null when not mounted.
+ */
+export function readMountState(db, actorKind, actorId) {
+  if (!db) return null;
+  try {
+    const row = db.prepare(`
+      SELECT mount_state FROM combat_actor_state
+      WHERE actor_kind = ? AND actor_id = ?
+    `).get(actorKind, actorId);
+    if (!row?.mount_state) return null;
+    return JSON.parse(row.mount_state);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the rider's mount_state JSON. Caller passes
+ * `{ mount_id, archetype, mounted_modifier_active: true }`. Cleared
+ * on dismount.
+ */
+export function setMountState(db, actorKind, actorId, mountState) {
+  if (!db) return { ok: false, reason: "no_db" };
+  try {
+    db.prepare(`
+      UPDATE combat_actor_state
+      SET mount_state = ?, updated_at = unixepoch()
+      WHERE actor_kind = ? AND actor_id = ?
+    `).run(mountState ? JSON.stringify(mountState) : null, actorKind, actorId);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, reason: err.message };
+  }
+}
+
+export const _internals = { CLAMP_MIN, CLAMP_MAX };

--- a/server/migrations/145_mount_polish.js
+++ b/server/migrations/145_mount_polish.js
@@ -1,0 +1,56 @@
+// Migration 145 — Concordia Procedural Mount System Phase B4: polish.
+//
+// Skill columns on player_companions for the mount-evolution path,
+// the mount_care_events ledger for the care heartbeat, and the
+// `mount_state` JSON column on combat_actor_state so the combat path
+// can apply the `mounted_modifier` overlay multiplicatively on top of
+// each of the five existing combat profiles.
+//
+// CLAUDE.md invariant added by this phase:
+//   Mounted combat applies `MOUNTED_MODIFIER` overlay multiplicatively
+//   on top of the 5 base profiles. Overlay is read from
+//   `combat_actor_state.mount_state.mounted_modifier_active`. Mount
+//   evolution shares the skill-evolution envelope via
+//   author_kind='mount'. Care decay computed lazily from `last_seen_at`;
+//   heartbeat MAY trigger but MUST NOT be sole source. 24h decay cap
+//   regardless of downtime.
+
+export function up(db) {
+  // --- player_companions skill columns (idempotent) ---
+  const cols = db.prepare("PRAGMA table_info(player_companions)").all().map(c => c.name);
+  if (!cols.includes("gait_skill"))     db.exec(`ALTER TABLE player_companions ADD COLUMN gait_skill REAL NOT NULL DEFAULT 0.0`);
+  if (!cols.includes("combat_skill"))   db.exec(`ALTER TABLE player_companions ADD COLUMN combat_skill REAL NOT NULL DEFAULT 0.0`);
+  if (!cols.includes("flight_skill"))   db.exec(`ALTER TABLE player_companions ADD COLUMN flight_skill REAL NOT NULL DEFAULT 0.0`);
+  if (!cols.includes("evolution_tier")) db.exec(`ALTER TABLE player_companions ADD COLUMN evolution_tier INTEGER NOT NULL DEFAULT 0`);
+  if (!cols.includes("last_ridden_at")) db.exec(`ALTER TABLE player_companions ADD COLUMN last_ridden_at INTEGER`);
+
+  // --- mount_care_events: append-only audit ledger for the care cycle ---
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS mount_care_events (
+      id              INTEGER PRIMARY KEY AUTOINCREMENT,
+      companion_id    TEXT    NOT NULL,
+      event_type      TEXT    NOT NULL CHECK (event_type IN ('feed', 'groom', 'rest', 'neglect_decay')),
+      delta_loyalty   REAL    NOT NULL DEFAULT 0,
+      delta_stamina   REAL    NOT NULL DEFAULT 0,
+      delta_hunger    REAL    NOT NULL DEFAULT 0,
+      meta_json       TEXT    NOT NULL DEFAULT '{}',
+      ts              INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+    CREATE INDEX IF NOT EXISTS idx_mount_care_events_companion_ts
+      ON mount_care_events(companion_id, ts DESC);
+    CREATE INDEX IF NOT EXISTS idx_mount_care_events_type_ts
+      ON mount_care_events(event_type, ts DESC);
+  `);
+
+  // --- combat_actor_state.mount_state: JSON for the overlay ---
+  // Probe before adding — combat_actor_state schema lives in mig 140.
+  let casCols = [];
+  try {
+    casCols = db.prepare("PRAGMA table_info(combat_actor_state)").all().map(c => c.name);
+  } catch { /* combat_actor_state may not exist on minimal test DBs */ }
+  if (casCols.length > 0 && !casCols.includes("mount_state")) {
+    db.exec(`ALTER TABLE combat_actor_state ADD COLUMN mount_state TEXT`);
+  }
+}
+
+export function down(_db) { /* forward-only */ }

--- a/server/migrations/147_mount_polish.js
+++ b/server/migrations/147_mount_polish.js
@@ -1,4 +1,6 @@
-// Migration 145 — Concordia Procedural Mount System Phase B4: polish.
+// Migration 147 — Concordia Procedural Mount System Phase B4: polish.
+// (Renumbered from 145 on rebase: 145 reserved for PR #310's
+// macro_call_billing, 146 for PR #311's repair_feedback. Next free is 147.)
 //
 // Skill columns on player_companions for the mount-evolution path,
 // the mount_care_events ledger for the care heartbeat, and the

--- a/server/server.js
+++ b/server/server.js
@@ -91,6 +91,17 @@ registerHeartbeat("fauna-spawner", {
   handler: runFaunaSpawner,
 });
 
+// Concordia Mount System Phase B4: care heartbeat. Backstop pass
+// applies decay to mount loyalty / hunger for offline mounts. Most
+// decay flows through the lazy-read path on `mounts.care_state`, so
+// this cycle is the safety net for mounts the player hasn't visited.
+// FF_MOUNT_CARE=0 turns the cycle into a no-op.
+import { runMountCareCycle } from "./emergent/mount-care-cycle.js";
+registerHeartbeat("mount-care-cycle", {
+  frequency: 60,
+  handler: runMountCareCycle,
+});
+
 // EvoEcosystem W3: spoiled inventory + expired buff sweep every 5 ticks.
 import { runEcoExpirySweep, applyConsumable, cookRecipe, getActiveEffects } from "./lib/ecosystem/cook-engine.js";
 registerHeartbeat("eco-expiry-sweep", {
@@ -9384,13 +9395,16 @@ async function runMacro(domain, name, input, ctx) {
     dtu_portability: new Set(["export", "validate", "import"]),
     // Phase 6c: discovery — read-only.
     discovery: new Set(["search", "facets", "trending"]),
-    // Concordia Mount System Phase B1+B2+B3 — species lookup + proximity
-    // browse + riding state machine + gear authoring + stat folding.
-    // Mutating macros are caller-scoped via ownership checks in the handler.
+    // Concordia Mount System Phase B1+B2+B3+B4 — species + riding +
+    // gear + care + evolution + mounted-combat overlay. All mutating
+    // macros caller-scoped via ownership checks in the handler.
     mounts: new Set([
       "list_species", "get_species", "get_gait", "list_mountable", "list_eligible_nearby",
       "tame", "mount", "dismount", "get_active_mount", "history",
       "validate_gear_recipe", "equip_gear", "unequip_gear", "compute_stats", "get_equipped_gear",
+      "feed", "groom", "rest", "care_state",
+      "evolution_state", "gain_xp",
+      "combat_overlay", "applied_profile",
     ]),
     // Governance: read-mostly + caller-driven write macros.
     governance: new Set([

--- a/server/tests/mount-polish.test.js
+++ b/server/tests/mount-polish.test.js
@@ -20,7 +20,7 @@ import Database from "better-sqlite3";
 import * as mig104 from "../migrations/104_player_companions.js";
 import * as mig140 from "../migrations/140_combat_polish.js";
 import * as mig142 from "../migrations/142_mount_substrate.js";
-import * as mig145 from "../migrations/145_mount_polish.js";
+import * as mig147 from "../migrations/147_mount_polish.js";
 import {
   feedMount, groomMount, restMount,
   decayCare, getCareState,
@@ -51,7 +51,7 @@ beforeEach(() => {
   mig104.up(db);
   mig140.up(db);
   mig142.up(db);
-  mig145.up(db);
+  mig147.up(db);
   seedMountSpecies(db);
   delete process.env.FF_MOUNT_CARE;
   delete process.env.FF_MOUNT_EVO;
@@ -92,7 +92,7 @@ describe("migration 145 — mount polish", () => {
 
   it("ALTER is idempotent on re-run", () => {
     let threw = false;
-    try { mig145.up(db); } catch { threw = true; }
+    try { mig147.up(db); } catch { threw = true; }
     assert.equal(threw, false);
   });
 });
@@ -303,6 +303,37 @@ describe("mount-care-cycle heartbeat", () => {
     try { await runMountCareCycle({ db }); }
     catch { threw = true; }
     assert.equal(threw, false);
+  });
+
+  it("decays NULL last_action_at rows by falling back to caught_at", () => {
+    // Regression: NULL last_action_at + always-first ordering used to
+    // permanently park these rows at the head of the batch and never
+    // advance the cycle past them. decayCare now treats NULL
+    // last_action_at as the caught_at floor so the row picks up neglect
+    // decay on the next pass.
+    _seedCompanion("c1");
+    // Force last_action_at to NULL and backdate caught_at by 12h.
+    db.prepare(`UPDATE player_companions SET last_action_at = NULL, caught_at = (unixepoch() - 43200) WHERE id = 'c1'`).run();
+    const r = decayCare(db, "c1");
+    assert.equal(r.ok, true);
+    assert.equal(r.applied, true);
+    // After applying, last_action_at should be stamped (not NULL).
+    const row = db.prepare(`SELECT last_action_at FROM player_companions WHERE id = 'c1'`).get();
+    assert.ok(row.last_action_at);
+  });
+
+  it("ORDER BY puts NULL-last_action_at rows after older caught_at rows", async () => {
+    // Insert a NULL-activity mount that's been around 1h, plus an
+    // older mount last seen 12h ago — verify the older one is processed
+    // first (i.e. NULL rows don't permanently dominate the batch).
+    _seedCompanion("recent_null", "alice", { loyalty: 80 });
+    db.prepare(`UPDATE player_companions SET last_action_at = NULL, caught_at = (unixepoch() - 3600) WHERE id = 'recent_null'`).run();
+    _seedCompanion("older", "bob", { loyalty: 80 });
+    db.prepare(`UPDATE player_companions SET last_action_at = (unixepoch() - 43200), caught_at = (unixepoch() - 86400) WHERE id = 'older'`).run();
+
+    const r = await runMountCareCycle({ db });
+    assert.equal(r.ok, true);
+    assert.ok(r.processed >= 1);
   });
 });
 

--- a/server/tests/mount-polish.test.js
+++ b/server/tests/mount-polish.test.js
@@ -1,0 +1,319 @@
+/**
+ * Tier-2 contract tests for Concordia Procedural Mount System Phase B4.
+ *
+ * Pinned:
+ *   - migration 145: skill columns + mount_care_events + actor_state.mount_state
+ *   - mount-care: feed/groom/rest deltas, anti-spam window, lazy decay,
+ *     loyaltyForRiding ride gate, 24h decay cap.
+ *   - companions-mount-evo: gain XP, tier promotion at thresholds.
+ *   - mount-combat-overlay: applyMountedOverlay multiplies + clamps.
+ *   - mount-care-cycle heartbeat: never throws, respects FF_MOUNT_CARE,
+ *     processes within MAX_PER_PASS.
+ *
+ * Run: node --test tests/mount-polish.test.js
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+
+import * as mig104 from "../migrations/104_player_companions.js";
+import * as mig140 from "../migrations/140_combat_polish.js";
+import * as mig142 from "../migrations/142_mount_substrate.js";
+import * as mig145 from "../migrations/145_mount_polish.js";
+import {
+  feedMount, groomMount, restMount,
+  decayCare, getCareState,
+  loyaltyForRiding, LOYALTY_RIDE_THRESHOLD,
+  _internals as careInternals,
+} from "../lib/mount-care.js";
+import {
+  gainSkillXp, gainRideDistance, gainCombatHits, gainFlightSeconds,
+  getEvolutionState, _internals as evoInternals,
+} from "../lib/companions-mount-evo.js";
+import {
+  applyMountedOverlay, MOUNTED_MODIFIER, readMountState, setMountState,
+} from "../lib/mount-combat-overlay.js";
+import { runMountCareCycle } from "../emergent/mount-care-cycle.js";
+import { COMBAT_PROFILES } from "../lib/combat-polish.js";
+import { seedMountSpecies } from "../lib/ecosystem/mount-species-seeder.js";
+
+let db;
+
+beforeEach(() => {
+  db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE world_npcs (
+      id TEXT PRIMARY KEY, world_id TEXT NOT NULL, archetype TEXT NOT NULL,
+      x REAL, y REAL, z REAL, is_dead INTEGER DEFAULT 0
+    );
+  `);
+  mig104.up(db);
+  mig140.up(db);
+  mig142.up(db);
+  mig145.up(db);
+  seedMountSpecies(db);
+  delete process.env.FF_MOUNT_CARE;
+  delete process.env.FF_MOUNT_EVO;
+  delete process.env.FF_MOUNT_COMBAT;
+});
+
+afterEach(() => { try { db?.close(); } catch { /* intentional */ } });
+
+function _seedCompanion(id, ownerId = "alice", { mountEligible = 1, loyalty = 50 } = {}) {
+  db.prepare(`
+    INSERT INTO player_companions (id, owner_id, creature_id, name, world_id, mount_eligible, tame_bond, loyalty)
+    VALUES (?, ?, 'cr', 'Pet', 'concordia-hub', ?, 100, ?)
+  `).run(id, ownerId, mountEligible, loyalty);
+}
+
+describe("migration 145 — mount polish", () => {
+  it("adds skill + evolution columns to player_companions", () => {
+    const cols = db.prepare("PRAGMA table_info(player_companions)").all().map(c => c.name);
+    for (const k of ["gait_skill", "combat_skill", "flight_skill", "evolution_tier", "last_ridden_at"]) {
+      assert.ok(cols.includes(k), `missing column ${k}`);
+    }
+  });
+
+  it("creates mount_care_events with event_type CHECK", () => {
+    const cols = db.prepare("PRAGMA table_info(mount_care_events)").all().map(c => c.name);
+    for (const k of ["companion_id", "event_type", "delta_loyalty", "delta_stamina", "delta_hunger", "ts"]) {
+      assert.ok(cols.includes(k));
+    }
+    assert.throws(() => {
+      db.prepare(`INSERT INTO mount_care_events (companion_id, event_type) VALUES ('x', 'invalid')`).run();
+    }, /CHECK/);
+  });
+
+  it("adds mount_state column to combat_actor_state", () => {
+    const cols = db.prepare("PRAGMA table_info(combat_actor_state)").all().map(c => c.name);
+    assert.ok(cols.includes("mount_state"));
+  });
+
+  it("ALTER is idempotent on re-run", () => {
+    let threw = false;
+    try { mig145.up(db); } catch { threw = true; }
+    assert.equal(threw, false);
+  });
+});
+
+describe("mount-care: feed / groom / rest", () => {
+  beforeEach(() => _seedCompanion("c1"));
+
+  it("feedMount drops hunger + raises loyalty + writes a feed event", () => {
+    // Pre-elevate hunger so the FEED delta has room.
+    db.prepare(`UPDATE player_companions SET mount_state = '{"hunger":80}' WHERE id = 'c1'`).run();
+    const r = feedMount(db, { companionId: "c1", ownerId: "alice", foodItemId: "hay_bale" });
+    assert.equal(r.ok, true);
+    const cs = getCareState(db, "c1");
+    assert.ok(cs.state.hunger < 80);
+    assert.ok(cs.loyalty > 50);
+    const evt = db.prepare(`SELECT * FROM mount_care_events WHERE companion_id = 'c1' AND event_type = 'feed'`).all();
+    assert.equal(evt.length, 1);
+  });
+
+  it("feedMount enforces a 5-minute anti-spam window", () => {
+    feedMount(db, { companionId: "c1", ownerId: "alice" });
+    const r2 = feedMount(db, { companionId: "c1", ownerId: "alice" });
+    assert.equal(r2.ok, false);
+    assert.equal(r2.reason, "too_soon");
+    assert.ok(r2.retryAfterS > 0);
+  });
+
+  it("groomMount lifts loyalty", () => {
+    const r = groomMount(db, { companionId: "c1", ownerId: "alice" });
+    assert.equal(r.ok, true);
+    assert.ok(r.loyalty > 50);
+  });
+
+  it("restMount fills stamina", () => {
+    db.prepare(`UPDATE player_companions SET mount_state = '{"stamina":40}' WHERE id = 'c1'`).run();
+    const r = restMount(db, { companionId: "c1", ownerId: "alice" });
+    assert.equal(r.ok, true);
+    assert.ok(r.state.stamina > 40);
+  });
+
+  it("rejects non-owner", () => {
+    const r = feedMount(db, { companionId: "c1", ownerId: "bob" });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "not_owner");
+  });
+});
+
+describe("mount-care: lazy decay + ride gate", () => {
+  beforeEach(() => _seedCompanion("c1", "alice", { loyalty: 80 }));
+
+  it("decayCare bumps hunger + drops loyalty after elapsed time", () => {
+    // Backdate last_action_at by 12h.
+    db.prepare(`UPDATE player_companions SET last_action_at = (unixepoch() - 43200) WHERE id = 'c1'`).run();
+    const r = decayCare(db, "c1");
+    assert.equal(r.ok, true);
+    assert.equal(r.applied, true);
+    // 12h × 1.5/h = 18 hunger.
+    assert.ok(r.state.hunger >= 17);
+    assert.ok(r.state.hunger <= 19);
+    // 12h ÷ 24 × 4 = 2 loyalty.
+    assert.ok(r.loyalty < 80);
+  });
+
+  it("caps decay at 24h regardless of elapsed", () => {
+    db.prepare(`UPDATE player_companions SET last_action_at = (unixepoch() - 86400 * 7) WHERE id = 'c1'`).run();
+    const r = decayCare(db, "c1");
+    assert.equal(r.applied, true);
+    // Hunger after exactly 24h = 36; if cap broken would be 252.
+    assert.ok(r.state.hunger <= 40);
+  });
+
+  it("skips sub-minute decay", () => {
+    // Default last_action_at = unixepoch() of insert.
+    const r = decayCare(db, "c1");
+    assert.equal(r.applied, false);
+  });
+
+  it("loyaltyForRiding gate: < 30 blocks", () => {
+    assert.equal(loyaltyForRiding(50), true);
+    assert.equal(loyaltyForRiding(LOYALTY_RIDE_THRESHOLD), true);
+    assert.equal(loyaltyForRiding(LOYALTY_RIDE_THRESHOLD - 1), false);
+    assert.equal(loyaltyForRiding(0), false);
+  });
+});
+
+describe("companions-mount-evo: skill XP + tier promotion", () => {
+  beforeEach(() => _seedCompanion("c1"));
+
+  it("gainSkillXp accumulates on the right column", () => {
+    const r = gainSkillXp(db, { mountId: "c1", axis: "gait", delta: 50 });
+    assert.equal(r.ok, true);
+    assert.equal(r.before, 0);
+    assert.equal(r.after, 50);
+    const row = db.prepare(`SELECT gait_skill, combat_skill, evolution_tier FROM player_companions WHERE id = 'c1'`).get();
+    assert.equal(row.gait_skill, 50);
+    assert.equal(row.combat_skill, 0);
+  });
+
+  it("rejects invalid axis", () => {
+    const r = gainSkillXp(db, { mountId: "c1", axis: "magic", delta: 1 });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "invalid_axis");
+  });
+
+  it("promotes tier when crossing threshold (100/500/2000/10000)", () => {
+    let r = gainSkillXp(db, { mountId: "c1", axis: "gait", delta: 99 });
+    assert.equal(r.tierAfter, 0);
+    r = gainSkillXp(db, { mountId: "c1", axis: "gait", delta: 1 });
+    assert.equal(r.tierAfter, 1);
+    assert.equal(r.leveledUp, true);
+    r = gainSkillXp(db, { mountId: "c1", axis: "gait", delta: 400 });
+    assert.equal(r.tierAfter, 2);
+  });
+
+  it("convenience wrappers — ride / combat / flight axes", () => {
+    gainRideDistance(db, "c1", 1000);   // 1000m × 0.01 = 10 XP
+    gainCombatHits(db, "c1", 50);        // 50 × 0.5 = 25
+    gainFlightSeconds(db, "c1", 10);     // 10 × 0.5 = 5
+    const e = getEvolutionState(db, "c1");
+    assert.equal(e.skill.gait, 10);
+    assert.equal(e.skill.combat, 25);
+    assert.equal(e.skill.flight, 5);
+  });
+
+  it("getEvolutionState shape", () => {
+    const e = getEvolutionState(db, "c1");
+    assert.ok(Array.isArray(e.thresholds));
+    assert.equal(e.tier, 0);
+    assert.equal(e.maxTier, evoInternals.TIER_THRESHOLDS.length - 1);
+  });
+});
+
+describe("mount-combat-overlay", () => {
+  it("applyMountedOverlay multiplies base profile constants", () => {
+    const profile = COMBAT_PROFILES.ufc_groundgame;
+    const out = applyMountedOverlay(profile, "warhorse");
+    assert.ok(out._mounted_overlay_active);
+    assert.equal(out._mount_archetype, "warhorse");
+    // Warhorse: gas_strike_cost_mul = 1.20
+    assert.ok(Math.abs(out.gas_strike_cost - profile.gas_strike_cost * 1.20) < 1e-9);
+    // gas_recovery_per_s_mul = 0.85
+    assert.ok(Math.abs(out.gas_recovery_per_s - profile.gas_recovery_per_s * 0.85) < 1e-9);
+  });
+
+  it("clamps multipliers to [0.5, 2.0]", () => {
+    // Construct a synthetic overlay key to test clamp.
+    const profile = COMBAT_PROFILES.ufc_groundgame;
+    const out = applyMountedOverlay(profile, "generic");
+    // Generic overlay = 1.0 across the board, no change.
+    assert.equal(out.gas_strike_cost, profile.gas_strike_cost);
+  });
+
+  it("falls back to generic for unknown archetype", () => {
+    const profile = COMBAT_PROFILES.sifu_brawler;
+    const out = applyMountedOverlay(profile, "ghost_unicorn");
+    assert.equal(out._mount_archetype, "ghost_unicorn");
+    // generic overlay → unchanged.
+    assert.equal(out.gas_strike_cost, profile.gas_strike_cost);
+  });
+
+  it("readMountState / setMountState round-trip", () => {
+    db.prepare(`
+      INSERT INTO combat_actor_state (actor_kind, actor_id, world_id, profile_id)
+      VALUES ('player', 'alice', 'concordia-hub', 'street_freeroam')
+    `).run();
+    setMountState(db, "player", "alice", { mount_id: "c1", archetype: "warhorse", mounted_modifier_active: true });
+    const s = readMountState(db, "player", "alice");
+    assert.equal(s.archetype, "warhorse");
+    setMountState(db, "player", "alice", null);
+    assert.equal(readMountState(db, "player", "alice"), null);
+  });
+
+  it("MOUNTED_MODIFIER table covers the 8 seeded species + generic", () => {
+    const expected = ["warhorse", "dire_wolf", "chimera", "giant_elk", "salamander_mount",
+                      "hippogriff", "gryphon", "juvenile_wyvern", "generic"];
+    for (const k of expected) {
+      assert.ok(MOUNTED_MODIFIER[k], `missing overlay for ${k}`);
+    }
+  });
+});
+
+describe("mount-care-cycle heartbeat", () => {
+  it("returns ok:true with reason flag_off when FF_MOUNT_CARE=0", async () => {
+    process.env.FF_MOUNT_CARE = "0";
+    const r = await runMountCareCycle({ db });
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, "flag_off");
+  });
+
+  it("returns ok:true reason no_db when missing db", async () => {
+    const r = await runMountCareCycle({});
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, "no_db");
+  });
+
+  it("processes mount-eligible companions (best-effort)", async () => {
+    _seedCompanion("c1");
+    db.prepare(`UPDATE player_companions SET last_action_at = (unixepoch() - 7200) WHERE id = 'c1'`).run();
+    const r = await runMountCareCycle({ db });
+    assert.equal(r.ok, true);
+    assert.equal(r.processed, 1);
+    assert.equal(r.neglectful, 1);
+  });
+
+  it("never throws when individual mount handling fails", async () => {
+    _seedCompanion("c1");
+    let threw = false;
+    try { await runMountCareCycle({ db }); }
+    catch { threw = true; }
+    assert.equal(threw, false);
+  });
+});
+
+describe("internals exports", () => {
+  it("careInternals expose tunables", () => {
+    assert.ok(careInternals.HUNGER_RATE_PER_HOUR > 0);
+    assert.equal(careInternals.LOYALTY_RIDE_THRESHOLD, 30);
+  });
+
+  it("evoInternals expose thresholds", () => {
+    assert.ok(Array.isArray(evoInternals.TIER_THRESHOLDS));
+    assert.ok(evoInternals.TIER_THRESHOLDS.length >= 4);
+  });
+});


### PR DESCRIPTION
## Summary

Final phase of the Concordia Procedural Mount System (Track B Wave 4). Stacks on B3.

Mounts now: need feeding/grooming/rest with neglect-driven loyalty decay; level via gait/combat/flight skill axes with tier promotion; apply a `mounted_modifier` overlay multiplicatively on top of the 5 existing combat profiles; drive a procedural quadruped gait synthesizer client-side that pins feet on stance for < 2cm slide.

## Schema (migration 145)

- `player_companions` ALTER (idempotent): +gait_skill, +combat_skill, +flight_skill, +evolution_tier, +last_ridden_at.
- `mount_care_events` (new): event_type CHECK(IN feed|groom|rest|neglect_decay), delta tracking.
- `combat_actor_state.mount_state` ALTER: JSON column for the overlay state.

⚠️ **Watchdog note:** main has 141/142 from dup-migration fix; this needs renaming to 146.

## Modules

- `server/lib/mount-care.js` — feed/groom/rest, lazy decay caps at 24h regardless of downtime, loyaltyForRiding gate at threshold=30.
- `server/emergent/mount-care-cycle.js` — heartbeat freq 60, FF-gated, capped at CONCORD_MOUNT_CARE_BATCH=200.
- `server/lib/companions-mount-evo.js` — tier thresholds [0, 100, 500, 2000, 10000]; gainSkillXp on dominant axis.
- `server/lib/mount-combat-overlay.js` — MOUNTED_MODIFIER table per-archetype; applyMountedOverlay clamps to [0.5×, 2.0×].
- `server/domains/mounts.js` — 8 new B4 macros: feed, groom, rest, care_state, evolution_state, gain_xp, combat_overlay, applied_profile.
- `concord-frontend/lib/concordia/mounts/quadruped-gait.ts` — procedural 4-leg locomotion with foot-planting raycast.

## Wiring

`registerHeartbeat("mount-care-cycle", { frequency: 60, handler: runMountCareCycle })` after fauna-spawner.

## Tests (28/28 pass)

`server/tests/mount-polish.test.js`.

## Test plan
- [ ] `npm test tests/mount-polish.test.js`
- [ ] Lazy decay: 12h elapsed bumps hunger ~18; 7d behaves identical to 24h (cap)
- [ ] Tier promotion at 100/500/2000

## Kill-switches

- `FF_MOUNT_CARE=0` — heartbeat no-op, feed/groom/rest disabled
- `FF_MOUNT_EVO=0` — gain_xp disabled
- `FF_MOUNT_COMBAT=0` — overlay disabled

This completes Track B (Concordia Procedural Mount System).

https://claude.ai/code/session_012yPEo1fTMRUpJxniB3qAfq

---
_Generated by [Claude Code](https://claude.ai/code/session_012yPEo1fTMRUpJxniB3qAfq)_