### PR TITLE
fix(realtime): alias __CONCORD_REALTIME__ to _concordREALTIME at the source

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -6909,6 +6909,10 @@ async function tryInitWebSockets(server) {
   REALTIME.io = io;
   REALTIME.ready = true;
   globalThis._concordREALTIME = REALTIME;
+  // Alias for legacy consumers using the all-caps double-underscore form
+  // (combat-polish, lattice-quest-cycle, personal-beat-scheduler, procgen-regions,
+  // seasons, embodied/signals). Both names point at the same REALTIME object.
+  globalThis.__CONCORD_REALTIME__ = REALTIME;
 
   // Horizontal scaling: attach Redis pub/sub adapter when REDIS_URL is set
   if (process.env.REDIS_URL) {


### PR DESCRIPTION
Six production modules consume `globalThis.__CONCORD_REALTIME__` (double
underscores both ends), but server.js only set `globalThis._concordREALTIME`
(single underscore, mixed case). The 6 emit sites silently no-op'd in
production — try/catch + optional-chain hid the failure, and tests passed
because they stub `__CONCORD_REALTIME__` directly.

Affected events that were quietly never reaching the client:
- world:sonic-pulse        (PR #317, embodied/signals.js)
- combat:polish            (combat-polish.js)
- world:region-spawned     (procgen-regions.js)
- world:season-transition  (seasons.js)
- quest:lattice-born       (emergent/lattice-quest-cycle.js)
- beat:offered             (emergent/personal-beat-scheduler.js)

Aliasing both globals at the single assignment point heals all 6 consumers
without touching their files (so I don't conflict with PRs #316 / #317
in flight) and without leaving a dual-API surface that future code can
pick wrong from — both names point at the same REALTIME object reference.

https://claude.ai/code/session_01Qv6jkrxxSB8Tv6zv65MXkB