### PR TITLE
fix(ci): Trivy SARIF upload step survives GitHub Actions 429s

### DIFF
--- a/.github/workflows/platinum-security.yml
+++ b/.github/workflows/platinum-security.yml
@@ -209,8 +209,21 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
+          # `exit-code: 1` keeps THIS step the actual CVE gate — if
+          # Trivy finds a CRITICAL or HIGH-severity CVE this fails the
+          # job. The SARIF upload step below is informational only.
           exit-code: '1'
       - name: Upload Trivy SARIF
+        # `continue-on-error: true` because this step downloads
+        # `github/codeql-action/upload-sarif@v3` from GitHub's CDN,
+        # which occasionally returns HTTP 429 (Too Many Requests) and
+        # fails the entire job during "Set up job" phase — before any
+        # of our scan logic runs. That's transient GitHub Actions
+        # infrastructure noise, not a CVE finding. The Trivy scan step
+        # above is the actual blocking CVE check; this step only
+        # uploads results to GitHub's Security dashboard for
+        # visualization, so a 429 here shouldn't gate merges.
+        continue-on-error: true
         if: always() && steps.dockerfile_check.outputs.present == 'true'
         uses: github/codeql-action/upload-sarif@v3
         with:


### PR DESCRIPTION
## Summary

Post-#337 main run failed on **Container — Trivy image scan**, but the actual root cause was **GitHub Actions infrastructure noise**, not anything in our code or any CVE finding:

```
Failed to download archive...after 3 attempts
HTTP 429 (Too Many Requests)
```

The runner couldn't download `github/codeql-action/upload-sarif@v3` from GitHub's own CDN during the **"Set up job"** phase — before any of our scan steps ran. Pure transient infrastructure rate-limiting, not a real issue.

## The fix

Added `continue-on-error: true` to **just the SARIF upload step**:

```yaml
- name: Upload Trivy SARIF
  continue-on-error: true  # ← new
  if: always() && steps.dockerfile_check.outputs.present == 'true'
  uses: github/codeql-action/upload-sarif@v3
```

The Trivy scan step itself still has `exit-code: 1`, so it remains the actual blocking CVE gate. A real CRITICAL or HIGH-severity CVE still fails the build.

## What changes / doesn't change

| | Before | After |
|---|---|---|
| Real CVE in image | ❌ fails build | ❌ fails build (unchanged) |
| GitHub CDN 429 on SARIF upload | ❌ fails build | ⚠️ best-effort, build continues |
| Trivy scan errors (image pull, etc) | ❌ fails build | ❌ fails build (unchanged) |
| SARIF dashboard data | always uploaded | uploaded when CDN healthy |

## What we lose

SARIF dashboard data may occasionally not appear in GitHub's "Security" tab during a CDN-rate-limited window. Next successful run refreshes it. No permanent data loss.

## What we gain

The merge gate doesn't go red on GitHub-side infrastructure flake. Same architectural pattern as:
- PR #336's `baseline_check` guard (visual regression auto-skips on missing baselines)
- PR #337's `continue-on-error` on ZAP (transient scan-execution failures don't gate)

**Actual gate stays strict; transient infrastructure is best-effort.**

## Test plan

- [x] YAML parses
- [ ] CI on this PR runs Trivy scan step (still blocks on real CVEs)
- [ ] Merge → next main push survives 429s on SARIF upload

---
_Generated by [Claude Code](https://claude.ai/code/session_0143LVhbrKR9563RtvxzjVL5)_