### PR TITLE
fix(detector): lens-health domain discovery — parse register() instead of filenames

### DIFF
--- a/audit/detectors/BASELINE.json
+++ b/audit/detectors/BASELINE.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "generatedAt": "2026-05-12T16:50:12.052Z",
+  "generatedAt": "2026-05-12T17:53:14.965Z",
   "totals": {
     "critical": 0,
-    "high": 8,
+    "high": 0,
     "medium": 867,
     "low": 1131,
     "info": 399,
-    "total": 2405
+    "total": 2397
   },
   "detectorCount": 18,
   "fingerprints": {
@@ -4529,71 +4529,7 @@
       "severity": "info",
       "kind": "static",
       "location": null,
-      "message": "Scanned 227 lenses · 8 issues found"
-    },
-    "893044afd03891f4": {
-      "detector": "lens-health",
-      "id": "lens_unknown_domain",
-      "severity": "high",
-      "kind": "static",
-      "location": "concord-frontend/app/lenses/code/page.tsx:958",
-      "message": "Lens code calls domain \"llm\" but no server/domains/llm.js exists"
-    },
-    "f92f5daf6bd50cb6": {
-      "detector": "lens-health",
-      "id": "lens_unknown_domain",
-      "severity": "high",
-      "kind": "static",
-      "location": "concord-frontend/app/lenses/code/page.tsx:1032",
-      "message": "Lens code calls domain \"llm\" but no server/domains/llm.js exists"
-    },
-    "f23a03eb25f36784": {
-      "detector": "lens-health",
-      "id": "lens_unknown_domain",
-      "severity": "high",
-      "kind": "static",
-      "location": "concord-frontend/app/lenses/deities/page.tsx:38",
-      "message": "Lens deities calls domain \"deity\" but no server/domains/deity.js exists"
-    },
-    "5fe60c62b8532637": {
-      "detector": "lens-health",
-      "id": "lens_unknown_domain",
-      "severity": "high",
-      "kind": "static",
-      "location": "concord-frontend/app/lenses/deities/page.tsx:52",
-      "message": "Lens deities calls domain \"deity\" but no server/domains/deity.js exists"
-    },
-    "d664b83cc1c8f1c9": {
-      "detector": "lens-health",
-      "id": "lens_unknown_domain",
-      "severity": "high",
-      "kind": "static",
-      "location": "concord-frontend/app/lenses/deities/page.tsx:160",
-      "message": "Lens deities calls domain \"deity\" but no server/domains/deity.js exists"
-    },
-    "4b319bda911eb211": {
-      "detector": "lens-health",
-      "id": "lens_unknown_domain",
-      "severity": "high",
-      "kind": "static",
-      "location": "concord-frontend/app/lenses/event-timeline/page.tsx:109",
-      "message": "Lens event-timeline calls domain \"event_timeline\" but no server/domains/event_timeline.js exists"
-    },
-    "53bb45b25af0cf05": {
-      "detector": "lens-health",
-      "id": "lens_unknown_domain",
-      "severity": "high",
-      "kind": "static",
-      "location": "concord-frontend/app/lenses/event-timeline/page.tsx:116",
-      "message": "Lens event-timeline calls domain \"event_timeline\" but no server/domains/event_timeline.js exists"
-    },
-    "38fedf3baf8f7ad4": {
-      "detector": "lens-health",
-      "id": "lens_unknown_domain",
-      "severity": "high",
-      "kind": "static",
-      "location": "concord-frontend/app/lenses/expert-mode/page.tsx:119",
-      "message": "Lens expert-mode calls domain \"expert_mode\" but no server/domains/expert_mode.js exists"
+      "message": "Scanned 227 lenses · 0 issues found"
     },
     "2f600c033f853e95": {
       "detector": "lens-decorative-state",
@@ -4641,7 +4577,7 @@
       "severity": "info",
       "kind": "static",
       "location": null,
-      "message": "Scanned 3314 files; flagged 0"
+      "message": "Scanned 3315 files; flagged 0"
     },
     "6954d635fa3b8074": {
       "detector": "performance-hotspot",

--- a/audit/detectors/runtime-history.jsonl
+++ b/audit/detectors/runtime-history.jsonl
@@ -153,3 +153,6 @@
 {"generatedAt":"2026-05-12T16:49:35.505Z","tableRows":{},"heapMb":6,"heapLimitMb":null}
 {"generatedAt":"2026-05-12T16:50:12.265Z","tableRows":{},"heapMb":6,"heapLimitMb":null}
 {"generatedAt":"2026-05-12T16:51:54.161Z","tableRows":{},"heapMb":6,"heapLimitMb":null}
+{"generatedAt":"2026-05-12T17:51:51.719Z","tableRows":{},"heapMb":6,"heapLimitMb":null}
+{"generatedAt":"2026-05-12T17:52:36.733Z","tableRows":{},"heapMb":6,"heapLimitMb":null}
+{"generatedAt":"2026-05-12T17:53:57.484Z","tableRows":{},"heapMb":23,"heapLimitMb":null}

--- a/server/lib/detectors/lens-health-detector.js
+++ b/server/lib/detectors/lens-health-detector.js
@@ -14,6 +14,14 @@ import { walk, readSafe, existsSafe, makeReport, makeError, lineOf, relPath } fr
 
 const LENS_RUN_RE = /\/api\/lens\/run/;
 const DOMAIN_REF_RE = /domain\s*:\s*['"`]([a-zA-Z0-9_-]+)['"`]/g;
+// Backend macros are declared as `register("domain", "name", handler)`. The
+// domain name in the lens call must match the FIRST argument here — not the
+// filename. Filenames in server/domains/ are kebab-case (`event-timeline.js`)
+// while the registered domain is often snake_case (`event_timeline`), and
+// many domains (`llm`, `dtu`, `chat`) register inline in server.js with no
+// dedicated file at all. Pre-fix the detector matched on filename and produced
+// 8 HIGH false-positives; the real source of truth is the register() call.
+const REGISTER_DOMAIN_RE = /\bregister\(\s*['"`]([a-zA-Z0-9_-]+)['"`]\s*,\s*['"`][a-zA-Z0-9_-]+['"`]/g;
 
 export async function runLensHealthDetector({ root, opts = {} } = {}) {
   const t0 = Date.now();
@@ -34,15 +42,46 @@ export async function runLensHealthDetector({ root, opts = {} } = {}) {
       .map(e => e.name)
       .filter(n => !n.startsWith("[") && !n.startsWith("("));
 
-    // Collect known backend domains
+    // Collect known backend domains by parsing register("domain", "name", ...)
+    // and registerLensAction("domain", "name", ...) calls across server.js,
+    // server/domains/, server/routes/, server/emergent/, and server/lib/.
+    // Filename matching produces false positives because (a) filenames are
+    // kebab-case while many domains register snake_case names, and (b) many
+    // domains (`llm`, `dtu`, `chat`) register inline in server.js with no
+    // dedicated file. The register() call is the source of truth.
     const knownDomains = new Set();
-    try {
-      for (const e of await readdir(domainsDir, { withFileTypes: true })) {
-        if (e.isFile() && e.name.endsWith(".js")) {
-          knownDomains.add(e.name.replace(/\.js$/, ""));
+    const serverDir = path.join(root, "server");
+    const scanRoots = [
+      path.join(serverDir, "server.js"),
+      path.join(serverDir, "domains"),
+      path.join(serverDir, "lib"),
+      path.join(serverDir, "routes"),
+      path.join(serverDir, "emergent"),
+    ];
+    const filesToScan = [];
+    for (const p of scanRoots) {
+      if (!(await existsSafe(p))) continue;
+      const s = p.endsWith(".js") ? [p] : await walk(p, [".js"]);
+      filesToScan.push(...s);
+    }
+    for (const f of filesToScan) {
+      const c = await readSafe(f);
+      if (!c) continue;
+      if (c.includes("register(")) {
+        REGISTER_DOMAIN_RE.lastIndex = 0;
+        let m;
+        while ((m = REGISTER_DOMAIN_RE.exec(c)) != null) {
+          knownDomains.add(m[1]);
         }
       }
-    } catch { /* tolerate missing dir */ }
+      if (c.includes("registerLensAction(")) {
+        const lensActionRe = /\bregisterLensAction\(\s*['"`]([a-zA-Z0-9_-]+)['"`]\s*,/g;
+        let m;
+        while ((m = lensActionRe.exec(c)) != null) {
+          knownDomains.add(m[1]);
+        }
+      }
+    }
 
     const findings = [];
 
@@ -123,13 +162,23 @@ export async function runLensHealthDetector({ root, opts = {} } = {}) {
         while ((m = DOMAIN_REF_RE.exec(c)) != null) {
           const dom = m[1];
           if (!knownDomains.has(dom) && dom !== "lens") {
+            // Unknown domains are NOT broken at runtime: server.js#/api/lens/run
+            // (the route that handles these calls) has an AI catch-all that
+            // routes unregistered domain.action calls to the utility brain
+            // (utilityCall(action, domain, rest)). The lens still works — it
+            // gets LLM-generated content instead of a deterministic handler.
+            //
+            // This is reported as `info` (not `high`) so the lens-unknown-domain
+            // surface tracks "places where a dedicated handler would beat the
+            // LLM fallback" rather than "broken lenses." The previous `high`
+            // severity produced 8 false-positive blockers in CI.
             findings.push({
               id: "lens_unknown_domain",
-              severity: "high",
+              severity: "info",
               kind: "lens-health",
-              message: `Lens ${lensName} calls domain "${dom}" but no server/domains/${dom}.js exists`,
+              message: `Lens ${lensName} calls domain "${dom}" — no dedicated handler registered; runtime routes via utility-brain AI catch-all. Adding a register("${dom}", ...) handler would give deterministic behavior.`,
               location: `${relPath(root, pagePath)}:${lineOf(c, m.index)}`,
-              evidence: { domain: dom },
+              evidence: { domain: dom, runtimeFallback: "utility-brain" },
             });
           }
         }

--- a/server/tests/lens-health-detector.test.js
+++ b/server/tests/lens-health-detector.test.js
@@ -1,0 +1,104 @@
+/**
+ * Tier-2 contract tests for LensHealthDetector.
+ *
+ * Pins the post-fix behavior:
+ *
+ *   - knownDomains is collected by parsing register() AND registerLensAction()
+ *     calls across server.js, server/domains/, server/lib/, server/routes/,
+ *     and server/emergent/ — NOT by reading filenames in server/domains/.
+ *     (Pre-fix, filename heuristic produced 8 HIGH false-positives because
+ *     filenames are kebab-case while many domains register snake_case names,
+ *     and many domains register inline in server.js with no dedicated file.)
+ *
+ *   - When a lens calls a domain that has no register() / registerLensAction()
+ *     anywhere in the tree, the finding is `info` severity (not `high`),
+ *     because the /api/lens/run route falls through to a utility-brain AI
+ *     catch-all — the lens still works, it just gets LLM-generated content
+ *     instead of a deterministic handler.
+ *
+ * Run: node --test server/tests/lens-health-detector.test.js
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { runLensHealthDetector } from "../lib/detectors/lens-health-detector.js";
+
+function withFixture(layout) {
+  const dir = path.join(tmpdir(), `lens-health-${Math.random().toString(36).slice(2)}`);
+  for (const [relPath, content] of Object.entries(layout)) {
+    const full = path.join(dir, relPath);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return dir;
+}
+function teardown(d) { try { rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ } }
+
+describe("lens-health-detector — domain discovery", () => {
+  it("treats register() inline in server.js as a known domain", async () => {
+    const root = withFixture({
+      "server/server.js": `register("widget", "list", () => {}); register("widget", "create", () => {});`,
+      "server/domains/.gitkeep": "",
+      "concord-frontend/app/lenses/widget/page.tsx":
+        `export default function P() { return <div onClick={() => api.post('/api/lens/run', { domain: 'widget', action: 'list' })}/>; }`,
+    });
+    try {
+      const r = await runLensHealthDetector({ root });
+      const unknown = r.findings.filter(f => f.id === "lens_unknown_domain");
+      assert.equal(unknown.length, 0, "inline register() in server.js must count as a known domain");
+    } finally { teardown(root); }
+  });
+
+  it("treats registerLensAction() as a known domain", async () => {
+    const root = withFixture({
+      "server/server.js": "",
+      "server/domains/healthcare.js":
+        `export default function fn(registerLensAction) { registerLensAction("healthcare", "vision", () => {}); }`,
+      "concord-frontend/app/lenses/healthcare/page.tsx":
+        `export default function P() { return <div onClick={() => api.post('/api/lens/run', { domain: 'healthcare', action: 'generate' })}/>; }`,
+    });
+    try {
+      const r = await runLensHealthDetector({ root });
+      const unknown = r.findings.filter(f => f.id === "lens_unknown_domain");
+      // Lens calls action 'generate' which doesn't exist, but the DOMAIN
+      // 'healthcare' is registered (via registerLensAction). The detector
+      // checks domain existence; action-level mismatch falls through to AI
+      // catch-all at runtime.
+      assert.equal(unknown.length, 0, "registerLensAction must count as a known domain");
+    } finally { teardown(root); }
+  });
+
+  it("handles kebab-case filename / snake_case domain mismatch", async () => {
+    const root = withFixture({
+      "server/server.js": "",
+      "server/domains/event-timeline.js":
+        `export default function fn(register) { register("event_timeline", "recent", () => {}); }`,
+      "concord-frontend/app/lenses/event-timeline/page.tsx":
+        `export default function P() { return <div onClick={() => api.post('/api/lens/run', { domain: 'event_timeline', action: 'recent' })}/>; }`,
+    });
+    try {
+      const r = await runLensHealthDetector({ root });
+      const unknown = r.findings.filter(f => f.id === "lens_unknown_domain");
+      assert.equal(unknown.length, 0, "domain name (snake_case) is the source of truth, not filename (kebab-case)");
+    } finally { teardown(root); }
+  });
+
+  it("reports unknown domains as info severity (not high), citing the AI catch-all", async () => {
+    const root = withFixture({
+      "server/server.js": "",
+      "server/domains/.gitkeep": "",
+      "concord-frontend/app/lenses/exotic/page.tsx":
+        `export default function P() { return <div onClick={() => api.post('/api/lens/run', { domain: 'exotic', action: 'do_thing' })}/>; }`,
+    });
+    try {
+      const r = await runLensHealthDetector({ root });
+      const unknown = r.findings.filter(f => f.id === "lens_unknown_domain");
+      assert.equal(unknown.length, 1, "unknown domain must still be reported");
+      assert.equal(unknown[0].severity, "info", "unknown domains route via AI catch-all — info, not high");
+      assert.match(unknown[0].message, /utility-brain|catch-all/i, "message should cite the runtime fallback");
+    } finally { teardown(root); }
+  });
+});


### PR DESCRIPTION
## Summary

Closes the 8 lens-health HIGH false-positives that PR #341 documented as
"deliberate future work." Detector now tells the truth about domain
registrations; lens-health budget can drop to 0 highs going forward.

## Root cause

The detector at `server/lib/detectors/lens-health-detector.js:38-45` built
its known-domains set by listing **filenames** in `server/domains/`:

```js
for (const e of await readdir(domainsDir, ...)) {
  knownDomains.add(e.name.replace(/\.js$/, ""));
}
```

Then looked up the snake_case `domain:` string from the lens call:

```js
if (!knownDomains.has(dom) && dom !== "lens") { /* HIGH */ }
```

Two miss classes:
1. **kebab-case filename, snake_case domain** — `event-timeline.js`
   registers `"event_timeline"`. Filename ≠ registered name.
2. **inline registration in `server.js`** — `llm`, `dtu`, `chat`,
   `studio`, `law` all register directly in `server.js:32300` etc.
   No dedicated file, never in the set.

All 8 baseline HIGHs were one of these classes. The lenses worked at
runtime; the detector was lying.

## Fix

Replace the filename heuristic with parsing actual registration calls:

- `register("domain", "name", handler)` across server.js + server/domains/
  + server/lib/ + server/routes/ + server/emergent/
- `registerLensAction("domain", "name", handler)` across the same tree

The register() / registerLensAction() call is the source of truth.

## Bonus: unknown-domain reclassified `high → info`

`server.js:36018` already has an AI catch-all for unregistered
`domain.action` calls — they fall through to `utilityCall(action, domain, rest)`
which routes to the utility brain. The lens still works; it just gets
LLM-generated content instead of a deterministic handler.

Pre-fix: detector said HIGH (CI-blocking) on a lens that worked fine.
Post-fix: detector says INFO with a message that cites the runtime
fallback so a maintainer knows it's "improvement opportunity," not "broken."

Real breakage signals (`lens_no_page`, `lens_no_default_export`,
`lens_manifest_duplicate_number`) remain HIGH.

## Verification

- Local: `node scripts/run-detectors.js --ci` → CI check **PASSED**
  with `added: 0 high, removed: 8`.
- 4 new contract tests in `server/tests/lens-health-detector.test.js` pin:
  - Inline `register()` in `server.js` counts as a known domain
  - `registerLensAction()` counts as a known domain
  - Kebab-case filename / snake_case domain normalizes correctly
  - Truly-unknown domains report at INFO severity with catch-all citation
- BASELINE.json refreshed to current post-fix state (2392 fingerprints,
  0 high, 0 critical).

## Test plan

- [x] 4/4 new detector tests pass locally
- [x] `--ci` exits PASSED with 8 highs removed, 0 added
- [ ] CI on this PR: lint, detectors, every gate green
- [ ] Merge → lens-health budget tightens to 0 in BUDGET.json (follow-up)

https://claude.ai/code/session_0143LVhbrKR9563RtvxzjVL5

---
_Generated by [Claude Code](https://claude.ai/code/session_0143LVhbrKR9563RtvxzjVL5)_