### PR TITLE
fix(ci): replace literal ESC byte breaking ci.yml YAML validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -829,7 +829,7 @@ jobs:
               for (const x of (s.suites || [])) walk(x);
               for (const t of (s.specs || [])) {
                 if (!t.ok) {
-                  const errs = (t.tests || []).flatMap(tt => (tt.results || []).flatMap(rr => (rr.errors || []).map(e => (e.message || e.value || '').toString().replace(/\[[0-9;]*m/g, '').slice(0, 300))));
+                  const errs = (t.tests || []).flatMap(tt => (tt.results || []).flatMap(rr => (rr.errors || []).map(e => (e.message || e.value || '').toString().replace(/\x1b\[[0-9;]*m/g, '').slice(0, 300))));
                   fails.push({ title: t.title, file: t.file, line: t.line, error: errs[0] || '(no msg)' });
                 }
               }

--- a/.github/workflows/dx-extension.yml
+++ b/.github/workflows/dx-extension.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+          cache-dependency-path: concord-lsp/package-lock.json
 
       - name: Install LSP dependencies + compile
         working-directory: ./concord-lsp
@@ -40,7 +41,11 @@ jobs:
 
       - name: Install extension dependencies
         working-directory: ./concord-vscode
-        run: npm ci
+        # No package-lock.json checked in for concord-vscode (only 6 direct
+        # deps, all pinned in package.json with ^). `npm install` resolves
+        # at build time. Generate + commit a lock if vsce build time becomes
+        # a concern.
+        run: npm install
 
       - name: Compile extension
         working-directory: ./concord-vscode


### PR DESCRIPTION
## Summary

`ci.yml` has been failing workflow-file validation for every push since the E2E-Core PR-comment digest landed. The block reason is buried at file-validation time — no jobs run, no logs surface, and the failure label in the runs list just says "Failure" without indicating it never started.

## Root cause

Line 832 contains a raw `0x1B` (ESC) byte where the author intended the 4-character JavaScript escape sequence `\x1b` (used inside a regex to strip ANSI color codes from Playwright error messages before they're posted as a PR comment). YAML parsers reject `0x1B` as an unprintable special character → `Invalid workflow file: .github/workflows/ci.yml#L1 - YAML syntax error` → the entire workflow refuses to start.

Runs 1367–1370 (i.e. every push since the embed) failed the workflow-file gate before *any* job could fire. That's why `ci.yml` was "red" even though every gate it would have run (lint, typecheck, check-deps, auth-bypass grep, route-auth, cartograph drift, validate-lens-quality, validate-production-grade) passes locally.

## Fix

Byte-precise: replace the lone `0x1B` byte with the literal 4-character `\x1b`. The regex `replace(/\x1b\[[0-9;]*m/g, '')` now compiles correctly at runtime AND the YAML file is valid.

```bash
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
# (no output — valid)
```

## Also fixed: dx-extension cache path

Bundled in this PR because you pasted it as a concurrent failure. `setup-node@v4` with `cache: 'npm'` was looking for a root `package-lock.json` and failing because the lock files live under `concord-lsp/` and `concord-vscode/`. Plus `concord-vscode/` has no checked-in lock file, so `npm ci` would have failed in that step anyway.

Two-line fix:
- Pin `cache-dependency-path: concord-lsp/package-lock.json` (the only lock in scope for the dx pipeline).
- Switch the `concord-vscode` install from `npm ci` to `npm install` (6 direct deps, all pinned with `^` in `package.json`).

## Test plan

- [x] `yaml.safe_load` of both files succeeds
- [x] Local run of every `lint-and-test` gate (lint:ci, typecheck, check-deps, frontend lint + type-check, validate-lens-quality, validate-production-grade, cartograph drift, auth-bypass grep, route-auth) → all green
- [ ] CI on this PR: `ci.yml` actually runs jobs instead of failing file-validation
- [ ] dx-extension job reaches the install step instead of erroring at `setup-node`

https://claude.ai/code/session_0143LVhbrKR9563RtvxzjVL5

---
_Generated by [Claude Code](https://claude.ai/code/session_0143LVhbrKR9563RtvxzjVL5)_