### PR TITLE
fix(quests): repair getActiveQuests SQL — pq.user_id AS accepted_by

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,17 @@
 
+# Environment / secrets — never commit. .env.runpod and .env.example
+# stay tracked as templates; .env (the active local-config file) and
+# any deployment-specific overrides do not.
+.env
+.env.local
+.env.production
+.env.development
+.env.test
+server/.env
+server/.env.local
+concord-frontend/.env
+concord-frontend/.env.local
+
 # Dependencies
 node_modules/
 

--- a/audit/detectors/runtime-history.jsonl
+++ b/audit/detectors/runtime-history.jsonl
@@ -242,3 +242,4 @@
 {"generatedAt":"2026-05-12T23:00:11.145Z","tableRows":{},"heapMb":6,"heapLimitMb":null}
 {"generatedAt":"2026-05-12T23:01:00.728Z","tableRows":{},"heapMb":6,"heapLimitMb":null}
 {"generatedAt":"2026-05-12T23:01:38.154Z","tableRows":{},"heapMb":6,"heapLimitMb":null}
+{"generatedAt":"2026-05-12T23:29:41.577Z","tableRows":{},"heapMb":6,"heapLimitMb":null}

--- a/server/lib/quests/quest-engine.js
+++ b/server/lib/quests/quest-engine.js
@@ -8,8 +8,11 @@ import { gainSkillXP } from '../skills/skill-engine.js';
  * Return all active quests for a player in a world, with objectives and rewards attached.
  */
 export function getActiveQuests(db, userId, worldId) {
+  // pq.user_id IS the "accepted by" field — `user_id` was the column name
+  // chosen at migration 068; the original query asked for a non-existent
+  // `accepted_by` column and 500'd every /api/worlds/:id/quests/active hit.
   const rows = db.prepare(`
-    SELECT q.*, pq.accepted_by, pq.status, pq.completed_at
+    SELECT q.*, pq.user_id AS accepted_by, pq.status, pq.completed_at
     FROM world_quests q
     JOIN player_quests pq ON pq.quest_id = q.id
     WHERE pq.user_id = ? AND pq.world_id = ? AND (pq.status IS NULL OR pq.status = 'active')


### PR DESCRIPTION
## Summary

Found while smoke-testing dev mode end-to-end. The QuestTracker HUD polls `/api/worlds/:id/quests/active` — that endpoint was 500'ing on every hit with:

```
{"ok": false, "error": "no such column: pq.accepted_by"}
```

The query in `getActiveQuests` asked for `pq.accepted_by` but the `player_quests` table (migration 068) only has `pq.user_id` + `pq.accepted_at`. Without this fix, **players never see active quests in the HUD** — Kael's torchlight onboarding quest (the first-win guidance step) silently doesn't surface.

## Fix

```sql
-- Before
SELECT q.*, pq.accepted_by, pq.status, pq.completed_at FROM ...

-- After
SELECT q.*, pq.user_id AS accepted_by, pq.status, pq.completed_at FROM ...
```

`pq.user_id` IS the "accepted by" identity — aliased it as `accepted_by` so any caller still using the column name keeps working.

## Test plan

- [x] Local: registered fresh user → `/api/worlds/concordia-hub/quests/active` returns `{"ok": true, "quests": []}` (was 500)
- [x] No other callers reference `accepted_by` column directly (grep confirms)
- [x] Server lint + typecheck clean

https://claude.ai/code/session_0143LVhbrKR9563RtvxzjVL5

---
_Generated by [Claude Code](https://claude.ai/code/session_0143LVhbrKR9563RtvxzjVL5)_