### PR TITLE
fix(e2e): harden playwright auth setup against the localhost IPv6 hang

### DIFF
--- a/concord-frontend/tests/e2e-infra/auth.setup.ts
+++ b/concord-frontend/tests/e2e-infra/auth.setup.ts
@@ -1,4 +1,4 @@
-import { test as setup, expect } from '@playwright/test';
+import { test as setup, expect, type APIResponse } from '@playwright/test';
 import fs from 'node:fs';
 import path from 'node:path';
 import { AUTH_STATE_FILE } from './_helpers';
@@ -25,18 +25,71 @@ import { AUTH_STATE_FILE } from './_helpers';
  * Runs as its own `setup` project; the `chromium` project depends on it.
  */
 setup('authenticate against the e2e-infra backend', async ({ request, context, page }) => {
-  const apiBase = (process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5050').replace(/\/$/, '');
+  // Resolve the backend base. CI passes NEXT_PUBLIC_API_URL=http://localhost:5050,
+  // but playwright's `request` fixture (undici) resolving `localhost` on a
+  // GitHub runner can pick the IPv6 `::1` address. The server's
+  // `app.listen(PORT)` opens a dual-stack socket, but the runner's IPv6
+  // path is frequently broken — so the connection HANGS to the full
+  // actionTimeout (60s) instead of failing fast. Force IPv4 `127.0.0.1`
+  // to remove the ambiguity. _helpers.ts already gives the SPECS a
+  // "degrade cleanly, never 60s-hang" contract; the setup project — which
+  // every other infra spec depends on — needs the same resilience.
+  const apiBase = (process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5050')
+    .replace(/\/$/, '')
+    .replace('//localhost:', '//127.0.0.1:');
   const username = process.env.CONCORD_E2E_USERNAME || 'admin';
   const password = process.env.ADMIN_PASSWORD || 'testpassword123';
 
-  // Log in for real. /api/auth/login is CSRF-exempt — no token round-trip
-  // needed. The standalone `request` fixture's User-Agent is not
-  // bot-flagged (the backend botGuard 403s curl/wget/etc on /api/ paths;
-  // playthrough.spec.ts proves this fixture clears it).
-  const loginRes = await request.post(`${apiBase}/api/auth/login`, {
-    headers: { 'content-type': 'application/json' },
-    data: { username, password },
-  });
+  // Pre-flight: confirm the backend is actually answering before the login
+  // POST. ci.yml's "Wait for server" step polls /health with curl (which
+  // happily falls back across address families); this re-checks from the
+  // SAME client that will do the login, with a short per-probe timeout, so
+  // a crashed / unresponsive backend surfaces as a fast, clear failure
+  // instead of a silent 60s hang inside request.post.
+  let healthy = false;
+  for (let i = 1; i <= 12 && !healthy; i++) {
+    try {
+      const h = await request.get(`${apiBase}/health`, { timeout: 5_000 });
+      if (h.ok()) { healthy = true; break; }
+    } catch { /* not ready — retry */ }
+    await new Promise((r) => setTimeout(r, 2_500));
+  }
+  if (!healthy) {
+    throw new Error(
+      `e2e-infra backend at ${apiBase} never answered /health within ~30s — ` +
+        `the server process likely crashed or is unresponsive. Check the ` +
+        `"Start server" step's server.log.`,
+    );
+  }
+
+  // Log in for real, with bounded retries. /api/auth/login is CSRF-exempt —
+  // no token round-trip needed. The standalone `request` fixture's
+  // User-Agent is not bot-flagged (the backend botGuard 403s curl/wget on
+  // /api/ paths; this fixture clears it). A single unbounded request.post
+  // would burn the full 60s actionTimeout on one transient hiccup; instead
+  // try up to 3 times with a 20s per-attempt cap and a short backoff.
+  let loginRes: APIResponse | null = null;
+  let lastErr: unknown = null;
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      loginRes = await request.post(`${apiBase}/api/auth/login`, {
+        headers: { 'content-type': 'application/json' },
+        data: { username, password },
+        timeout: 20_000,
+      });
+      break;
+    } catch (err) {
+      lastErr = err;
+      await new Promise((r) => setTimeout(r, 2_000 * attempt));
+    }
+  }
+  if (!loginRes) {
+    throw new Error(
+      `e2e-infra login POST to ${apiBase}/api/auth/login failed after 3 ` +
+        `attempts (last error: ${String(lastErr)}). The backend answered ` +
+        `/health but not the login route — likely resource-starved.`,
+    );
+  }
   expect(
     loginRes.ok(),
     `e2e-infra login failed (HTTP ${loginRes.status()}). This suite needs the ` +

--- a/concord-frontend/tests/e2e/playthrough.spec.ts
+++ b/concord-frontend/tests/e2e/playthrough.spec.ts
@@ -27,7 +27,36 @@ import * as path from 'node:path';
 test.use({ browserName: 'chromium' });
 test.describe.configure({ mode: 'serial' });
 
-const BACKEND = process.env.CONCORD_API_BASE || 'http://localhost:5050';
+// Force IPv4. playwright's `request` (undici) can resolve `localhost` to
+// the IPv6 `::1` on a GitHub runner; the server's dual-stack listen
+// socket is reachable in theory, but the runner's IPv6 path is flaky and
+// the connection then HANGS to the action timeout instead of failing
+// fast. `127.0.0.1` removes the ambiguity. (Same fix as
+// tests/e2e-infra/auth.setup.ts.)
+const BACKEND = (process.env.CONCORD_API_BASE || 'http://localhost:5050')
+  .replace(/\/$/, '')
+  .replace('//localhost:', '//127.0.0.1:');
+
+/** POST with bounded retries — a single unbounded request.post burns the
+ *  whole action timeout on one transient hang; 3 attempts at 20s each
+ *  with a short backoff recovers from a momentary hiccup and fails fast
+ *  with a clear error otherwise. */
+async function postWithRetry(
+  request: APIRequestContext,
+  url: string,
+  opts: Parameters<APIRequestContext['post']>[1],
+) {
+  let lastErr: unknown = null;
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      return await request.post(url, { timeout: 20_000, ...opts });
+    } catch (err) {
+      lastErr = err;
+      await new Promise((r) => setTimeout(r, 2_000 * attempt));
+    }
+  }
+  throw new Error(`POST ${url} failed after 3 attempts: ${String(lastErr)}`);
+}
 
 /** Register + log in a fresh test user, return a cookie header value
  *  the page context can replay. The frontend's middleware checks
@@ -39,11 +68,11 @@ async function makeTestSession(request: APIRequestContext): Promise<{ cookies: {
   const password = 'PlaywrightSmoke!9912';
   const loadedAt = Date.now() - 3_500; // satisfy the 2s timing check.
 
-  await request.post(`${BACKEND}/api/auth/register`, {
+  await postWithRetry(request, `${BACKEND}/api/auth/register`, {
     data: { username: uniq, email, password, _t: loadedAt },
     headers: { 'content-type': 'application/json' },
   });
-  const loginRes = await request.post(`${BACKEND}/api/auth/login`, {
+  const loginRes = await postWithRetry(request, `${BACKEND}/api/auth/login`, {
     data: { email, password },
     headers: { 'content-type': 'application/json' },
   });


### PR DESCRIPTION
## Why

The E2E Infra job's `auth.setup.ts` chronically failed with a 60s `TimeoutError` on `POST /api/auth/login`. Root cause: playwright's `request` fixture (undici) resolving `localhost` on a GitHub runner can pick the IPv6 `::1` address. The server's `app.listen(PORT)` opens a dual-stack socket, but the runner's IPv6 path is frequently broken — so the connection **hangs** to the full 60s `actionTimeout` instead of failing fast. `auth.setup.ts` had zero resilience: one unbounded `request.post`, and a hang there fails the whole `setup` project → every dependent infra spec dies.

## What

Mirrors the "degrade cleanly, never 60s-hang" contract `tests/e2e-infra/_helpers.ts` already gives the *specs* — the setup project never got it.

**`auth.setup.ts`**
- Normalize the API base to IPv4 `127.0.0.1` (removes the `localhost`/`::1` ambiguity outright; production URLs untouched).
- Pre-flight `/health` poll from the same client that does the login, short per-probe timeout — a crashed/unresponsive backend now surfaces as a fast, clear error instead of a silent hang.
- Login POST wrapped in 3 bounded-retry attempts (20s cap each, short backoff).

**`playthrough.spec.ts`** (`makeTestSession` — identical fragility)
- Same `127.0.0.1` normalization.
- New `postWithRetry()` helper: register + login both go through 3 bounded-retry attempts at 20s each.

Cookie objects keep `domain: 'localhost'` — they're applied to the browser context visiting the `:3000` frontend, which is correct; only the direct API calls move to `127.0.0.1`.

## Risk

Near-zero. Touches 2 playwright test-client files only — no server/runtime code. Both affected CI jobs (E2E Infra, Per-world walkthrough) are `continue-on-error`, so this was never blocking — it just makes the informational gate actually green.

## Test plan

- [x] `tsc --noEmit` clean on both files
- [x] `eslint` clean on both files
- [x] normalization unit-checked: `localhost`→`127.0.0.1`, trailing-slash strip, idempotent on already-IPv4, production hostnames untouched
- [ ] Live-server repro was blocked by the sandbox process watchdog — CI is the real check

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGy6Zu9XB1Uk7Jr5SrLcKE)_