### PR TITLE
fix(ci): playthrough — stop double-booting the frontend on :3000

### DIFF
--- a/.github/workflows/playthrough.yml
+++ b/.github/workflows/playthrough.yml
@@ -70,11 +70,15 @@ jobs:
             sleep 2
           done
 
-      - name: Build + start frontend (background)
+      # Build the prod artifact only — do NOT start the frontend here.
+      # playwright.config.ts owns the webServer (`npm run start:ci` on
+      # :3000, reuseExistingServer:false in CI). Pre-starting it here
+      # caused playwright to fail at launch with "http://localhost:3000
+      # is already used". Same shape as ci.yml's E2E Core job: build,
+      # then let playwright manage the server.
+      - name: Build frontend (production)
         working-directory: ./concord-frontend
-        run: |
-          npm run build
-          nohup npm start > frontend.log 2>&1 &
+        run: npm run build
         env:
           NEXT_PUBLIC_API_URL: http://localhost:5050
           # Default Node heap (~3.8GB) OOMs the Next.js prod compile
@@ -82,17 +86,14 @@ jobs:
           # ci.yml / lighthouse.yml / platinum-performance.yml.
           NODE_OPTIONS: --max-old-space-size=6144
 
-      - name: Wait for frontend
-        run: |
-          for i in {1..30}; do
-            curl -fsS http://localhost:3000 && break
-            sleep 2
-          done
-
       - name: Run playthrough
         working-directory: ./concord-frontend
+        # playwright.config.ts's webServer block starts `npm run start:ci`
+        # on :3000 and waits for it before any spec runs — no manual
+        # frontend boot or readiness poll needed.
         run: npx playwright test tests/e2e/playthrough.spec.ts
         env:
+          CI: 'true'
           PLAYWRIGHT_BASE_URL: http://localhost:3000
 
       - name: Upload screenshots


### PR DESCRIPTION
## Why

The Per-world walkthrough job failed at playwright launch:

```
Error: http://localhost:3000 is already used, make sure that nothing is
running on the port/url or set reuseExistingServer:true in config.webServer.
##[error]Process completed with exit code 1.
```

`playthrough.yml` manually started the frontend (`nohup npm start &`), **and** `playwright.config.ts`'s `webServer` block also starts one (`npm run start:ci`, `reuseExistingServer: !process.env.CI` → `false` in CI). Two servers, one port → playwright aborts before any spec runs.

## What

Align with how `ci.yml`'s E2E Core job already works: build the prod artifact in the workflow, then let playwright's `webServer` own the frontend process.

- Renamed "Build + start frontend (background)" → "Build frontend (production)", dropped the `nohup npm start &`.
- Removed the now-redundant "Wait for frontend" curl poll — playwright's `webServer` block waits on its `url` before running specs.
- `Run playthrough` step is otherwise unchanged.

## Risk

Workflow-only — no application or test code touched. `npm run build` still bakes `NEXT_PUBLIC_API_URL` at build time; playwright's `start:ci` serves the artifact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGy6Zu9XB1Uk7Jr5SrLcKE)_