### PR TITLE
feat(foundry): Phase 1 — System Registry

### DIFF
--- a/concord-frontend/app/lenses/foundry/page.tsx
+++ b/concord-frontend/app/lenses/foundry/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Foundry Lens (#66) — no-code game-builder.
+ * Foundry Lens (#125) — no-code game-builder.
  *
  * Build complete, persistent, cross-world games by composing Concord's
  * existing systems as configurable building blocks. This page is the

--- a/concord-frontend/app/lenses/foundry/page.tsx
+++ b/concord-frontend/app/lenses/foundry/page.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+/**
+ * Foundry Lens (#66) — no-code game-builder.
+ *
+ * Build complete, persistent, cross-world games by composing Concord's
+ * existing systems as configurable building blocks. This page is the
+ * LensShell wrapper; the build/configure/validate/save/publish loop
+ * lives in <FoundryCanvas>.
+ *
+ * Distinct from /lenses/forge (the polyglot single-file *app*
+ * generator) — different domain namespace (foundry.* macros),
+ * different product.
+ */
+
+import dynamic from 'next/dynamic';
+import { LensShell } from '@/components/lens/LensShell';
+import { ManifestActionBar } from '@/components/lens/ManifestActionBar';
+import { Boxes, Loader2 } from 'lucide-react';
+
+// Drag-drop + the catalog fetch are browser-only — load client-side.
+const FoundryCanvas = dynamic(() => import('@/components/foundry/FoundryCanvas'), {
+  ssr: false,
+  loading: () => (
+    <div className="flex items-center justify-center gap-2 py-24 text-sm text-slate-400">
+      <Loader2 className="h-4 w-4 animate-spin" /> Loading Foundry…
+    </div>
+  ),
+});
+
+export default function FoundryLensPage() {
+  return (
+    <LensShell lensId="foundry" asMain={false}>
+      <ManifestActionBar />
+      <main className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-950 to-sky-950/10 text-slate-100">
+        <header className="border-b border-sky-500/20 bg-slate-950/70 px-4 py-2.5 backdrop-blur sm:px-6">
+          <div className="mx-auto flex max-w-screen-2xl items-center gap-3">
+            <div className="rounded-lg border border-sky-500/40 bg-sky-500/10 p-2">
+              <Boxes className="h-5 w-5 text-sky-400" aria-hidden="true" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <h1 className="text-base font-semibold tracking-tight sm:text-lg">
+                Foundry — Build Games from Concord&apos;s Systems
+              </h1>
+              <p className="mt-0.5 hidden truncate text-xs text-slate-400 sm:block">
+                Compose terrain, living NPCs, combat, economies and more into a persistent,
+                cross-world game. No code, no infrastructure.
+              </p>
+            </div>
+            <span className="hidden rounded-full border border-sky-500/30 bg-sky-500/10 px-2.5 py-1 text-[11px] font-medium text-sky-300 sm:inline">
+              Beta
+            </span>
+          </div>
+        </header>
+
+        <section className="mx-auto max-w-screen-2xl">
+          <FoundryCanvas />
+        </section>
+      </main>
+    </LensShell>
+  );
+}

--- a/concord-frontend/components/foundry/ComponentPalette.tsx
+++ b/concord-frontend/components/foundry/ComponentPalette.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+/**
+ * Foundry — ComponentPalette.
+ *
+ * The left rail: every composable system from the registry, grouped by
+ * category. Each system is a card you can drag onto the canvas (native
+ * HTML5 DnD) or add with a click/Enter — keyboard-accessible by design.
+ * Systems already on the canvas are dimmed + disabled. Stub systems
+ * (the Phase 7 net-new set) carry a "soon" badge but are still
+ * selectable, since they persist in the worldspec and activate later.
+ */
+
+import { useMemo, useState } from 'react';
+import type { SystemEntry, CategoryGroup, SystemCategory } from '@/lib/foundry/api';
+import { ChevronDown, ChevronRight, Plus, Search } from 'lucide-react';
+
+interface ComponentPaletteProps {
+  categories: Record<SystemCategory, CategoryGroup>;
+  selectedIds: Set<string>;
+  onAdd: (systemId: string) => void;
+}
+
+const CATEGORY_ORDER: SystemCategory[] = ['world', 'character', 'combat', 'npc', 'economy', 'social'];
+
+export function ComponentPalette({ categories, selectedIds, onAdd }: ComponentPaletteProps) {
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const [query, setQuery] = useState('');
+
+  const toggle = (cat: string) =>
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(cat)) next.delete(cat); else next.add(cat);
+      return next;
+    });
+
+  const q = query.trim().toLowerCase();
+  const filtered = useMemo(() => {
+    const out: Array<{ cat: SystemCategory; group: CategoryGroup; systems: SystemEntry[] }> = [];
+    for (const cat of CATEGORY_ORDER) {
+      const group = categories[cat];
+      if (!group) continue;
+      const systems = q
+        ? group.systems.filter(
+            (s) => s.displayName.toLowerCase().includes(q) || s.description.toLowerCase().includes(q),
+          )
+        : group.systems;
+      if (systems.length) out.push({ cat, group, systems });
+    }
+    return out;
+  }, [categories, q]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="border-b border-slate-800 px-3 py-2.5">
+        <h2 className="text-sm font-semibold text-slate-200">Components</h2>
+        <div className="relative mt-2">
+          <Search className="pointer-events-none absolute left-2 top-1.5 h-3.5 w-3.5 text-slate-500" />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search systems…"
+            className="w-full rounded-md border border-slate-700 bg-slate-900 py-1 pl-7 pr-2 text-xs text-slate-100 placeholder:text-slate-600 focus:outline-none focus:ring-2 focus:ring-sky-500"
+          />
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-2 py-2">
+        {filtered.length === 0 && (
+          <p className="px-1 py-4 text-center text-xs text-slate-500">No systems match “{query}”.</p>
+        )}
+        {filtered.map(({ cat, group, systems }) => {
+          const isCollapsed = collapsed.has(cat);
+          return (
+            <div key={cat} className="mb-1">
+              <button
+                type="button"
+                onClick={() => toggle(cat)}
+                className="flex w-full items-center gap-1 rounded px-1 py-1 text-left text-[11px] font-semibold uppercase tracking-wide text-slate-400 hover:text-slate-200 focus:outline-none focus:ring-2 focus:ring-sky-500"
+              >
+                {isCollapsed ? <ChevronRight className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+                {group.label}
+                <span className="ml-auto font-mono text-slate-600">{systems.length}</span>
+              </button>
+              {!isCollapsed && (
+                <div className="space-y-1 py-1">
+                  {systems.map((sys) => {
+                    const added = selectedIds.has(sys.id);
+                    return (
+                      <div
+                        key={sys.id}
+                        draggable={!added}
+                        onDragStart={(e) => {
+                          e.dataTransfer.setData('application/x-foundry-system', sys.id);
+                          e.dataTransfer.effectAllowed = 'copy';
+                        }}
+                        className={`group rounded-md border px-2 py-1.5 transition-colors ${
+                          added
+                            ? 'cursor-default border-slate-800 bg-slate-900/40 opacity-50'
+                            : 'cursor-grab border-slate-700 bg-slate-900 hover:border-sky-600/60 hover:bg-slate-800/80'
+                        }`}
+                      >
+                        <div className="flex items-start gap-1.5">
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-center gap-1.5">
+                              <span className="truncate text-xs font-medium text-slate-200">
+                                {sys.displayName}
+                              </span>
+                              {sys.status === 'stub' && (
+                                <span className="shrink-0 rounded-full border border-amber-600/40 bg-amber-500/10 px-1 py-px text-[9px] font-medium text-amber-300">
+                                  soon
+                                </span>
+                              )}
+                            </div>
+                            <p className="mt-0.5 line-clamp-2 text-[10px] leading-snug text-slate-500">
+                              {sys.description}
+                            </p>
+                          </div>
+                          <button
+                            type="button"
+                            disabled={added}
+                            onClick={() => !added && onAdd(sys.id)}
+                            aria-label={`Add ${sys.displayName}`}
+                            className="shrink-0 rounded p-0.5 text-slate-500 hover:bg-sky-600/20 hover:text-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-500 disabled:opacity-30"
+                          >
+                            <Plus className="h-3.5 w-3.5" />
+                          </button>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default ComponentPalette;

--- a/concord-frontend/components/foundry/ConfigPanel.tsx
+++ b/concord-frontend/components/foundry/ConfigPanel.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+/**
+ * Foundry — ConfigPanel.
+ *
+ * Renders a registry-schema-driven config form for one selected
+ * system. Every field type in the System Registry's configSchema
+ * (enum / number / bool / text / range) maps to a control here. The
+ * panel is fully driven by the schema the backend hands back — adding
+ * a config field to a system server-side makes it appear here with no
+ * frontend change.
+ */
+
+import type { SystemEntry, ConfigField } from '@/lib/foundry/api';
+import { AlertTriangle, Link2, Ban } from 'lucide-react';
+
+interface ConfigPanelProps {
+  system: SystemEntry;
+  config: Record<string, unknown>;
+  onChange: (field: string, value: unknown) => void;
+}
+
+function FieldControl({
+  field,
+  desc,
+  value,
+  onChange,
+}: {
+  field: string;
+  desc: ConfigField;
+  value: unknown;
+  onChange: (v: unknown) => void;
+}) {
+  const id = `cfg-${field}`;
+  switch (desc.type) {
+    case 'enum':
+      return (
+        <select
+          id={id}
+          value={String(value ?? desc.default)}
+          onChange={(e) => onChange(e.target.value)}
+          className="w-full rounded-md border border-slate-700 bg-slate-900 px-2 py-1.5 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500"
+        >
+          {(desc.options ?? []).map((opt) => (
+            <option key={opt} value={opt}>{opt}</option>
+          ))}
+        </select>
+      );
+    case 'number':
+      return (
+        <div className="flex items-center gap-2">
+          <input
+            id={id}
+            type="range"
+            min={desc.min}
+            max={desc.max}
+            step={desc.step ?? 1}
+            value={Number(value ?? desc.default)}
+            onChange={(e) => onChange(Number(e.target.value))}
+            className="flex-1 accent-sky-500"
+          />
+          <span className="w-14 shrink-0 text-right font-mono text-xs text-sky-300">
+            {Number(value ?? desc.default)}
+          </span>
+        </div>
+      );
+    case 'bool':
+      return (
+        <button
+          id={id}
+          type="button"
+          role="switch"
+          aria-checked={Boolean(value)}
+          onClick={() => onChange(!value)}
+          className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500 ${
+            value ? 'bg-sky-500' : 'bg-slate-700'
+          }`}
+        >
+          <span
+            className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${
+              value ? 'translate-x-4' : 'translate-x-1'
+            }`}
+          />
+        </button>
+      );
+    case 'text':
+      return (
+        <input
+          id={id}
+          type="text"
+          value={String(value ?? desc.default ?? '')}
+          maxLength={desc.maxLength}
+          onChange={(e) => onChange(e.target.value)}
+          className="w-full rounded-md border border-slate-700 bg-slate-900 px-2 py-1.5 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500"
+        />
+      );
+    case 'range': {
+      const [lo, hi] = Array.isArray(value) ? (value as number[]) : (desc.default as number[]);
+      return (
+        <div className="flex items-center gap-2">
+          <input
+            type="number" min={desc.min} max={desc.max} value={lo}
+            onChange={(e) => onChange([Number(e.target.value), hi])}
+            className="w-16 rounded-md border border-slate-700 bg-slate-900 px-1.5 py-1 text-xs text-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500"
+          />
+          <span className="text-xs text-slate-500">to</span>
+          <input
+            type="number" min={desc.min} max={desc.max} value={hi}
+            onChange={(e) => onChange([lo, Number(e.target.value)])}
+            className="w-16 rounded-md border border-slate-700 bg-slate-900 px-1.5 py-1 text-xs text-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500"
+          />
+        </div>
+      );
+    }
+    default:
+      return null;
+  }
+}
+
+export function ConfigPanel({ system, config, onChange }: ConfigPanelProps) {
+  const fields = Object.entries(system.configSchema);
+  return (
+    <div className="flex h-full flex-col">
+      <div className="border-b border-slate-800 px-3 py-2.5">
+        <div className="flex items-center gap-2">
+          <h3 className="flex-1 text-sm font-semibold text-slate-100">{system.displayName}</h3>
+          {system.status === 'stub' && (
+            <span className="rounded-full border border-amber-600/40 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium text-amber-300">
+              coming soon
+            </span>
+          )}
+        </div>
+        <p className="mt-1 text-xs leading-relaxed text-slate-400">{system.description}</p>
+        <div className="mt-1.5 flex flex-wrap gap-1.5 text-[10px]">
+          <span className="rounded bg-slate-800 px-1.5 py-0.5 text-slate-400">
+            scope: {system.worldScope}
+          </span>
+          {system.dependsOn.map((d) => (
+            <span key={d} className="flex items-center gap-0.5 rounded bg-sky-950/60 px-1.5 py-0.5 text-sky-300">
+              <Link2 className="h-2.5 w-2.5" /> needs {d}
+            </span>
+          ))}
+          {system.conflictsWith.map((c) => (
+            <span key={c} className="flex items-center gap-0.5 rounded bg-red-950/60 px-1.5 py-0.5 text-red-300">
+              <Ban className="h-2.5 w-2.5" /> conflicts {c}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex-1 space-y-3 overflow-y-auto px-3 py-3">
+        {system.status === 'stub' && (
+          <div className="flex items-start gap-2 rounded-md border border-amber-700/40 bg-amber-950/30 px-2.5 py-2 text-xs text-amber-200">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>
+              This system isn&apos;t built yet — it stays in your worldspec and starts working
+              automatically once it ships. Configure it now; it just won&apos;t activate on publish.
+            </span>
+          </div>
+        )}
+        {fields.length === 0 && (
+          <p className="text-xs text-slate-500">This system has no configuration.</p>
+        )}
+        {fields.map(([field, desc]) => (
+          <div key={field}>
+            <label htmlFor={`cfg-${field}`} className="mb-1 block text-xs font-medium text-slate-300">
+              {desc.label}
+            </label>
+            <FieldControl
+              field={field}
+              desc={desc}
+              value={config[field]}
+              onChange={(v) => onChange(field, v)}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ConfigPanel;

--- a/concord-frontend/components/foundry/FoundryCanvas.tsx
+++ b/concord-frontend/components/foundry/FoundryCanvas.tsx
@@ -16,13 +16,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   fetchSystems, listWorlds, createWorld, updateWorld, getWorld,
-  publishWorld, unpublishWorld, validateWorld, defaultConfig,
+  publishWorld, unpublishWorld, validateWorld, defaultConfig, fetchTemplates,
   type SystemEntry, type CategoryGroup, type SystemCategory,
   type WorldspecSystem, type Worldspec, type FoundryWorld, type ValidationResult,
+  type FoundryRule, type TemplateSummary,
 } from '@/lib/foundry/api';
 import dynamic from 'next/dynamic';
 import { ComponentPalette } from './ComponentPalette';
 import { ConfigPanel } from './ConfigPanel';
+import { FoundryRulesPanel } from './FoundryRulesPanel';
 import {
   Loader2, Save, Rocket, Trash2, X, CheckCircle2, AlertTriangle,
   Circle, FileStack, Undo2, Eye,
@@ -48,6 +50,8 @@ export function FoundryCanvas() {
   const [worldDescription, setWorldDescription] = useState('');
   const [universeType, setUniverseType] = useState('fantasy');
   const [selected, setSelected] = useState<WorldspecSystem[]>([]);
+  const [rules, setRules] = useState<FoundryRule[]>([]);
+  const [templates, setTemplates] = useState<TemplateSummary[]>([]);
   const [activeConfigId, setActiveConfigId] = useState<string | null>(null);
 
   // Persistence + lifecycle
@@ -80,6 +84,10 @@ export function FoundryCanvas() {
         const w = await listWorlds();
         if (alive && w.ok) setMyWorlds(w.worlds);
       } catch { /* my-worlds strip is best-effort */ }
+      try {
+        const t = await fetchTemplates();
+        if (alive && t.ok) setTemplates(t.templates);
+      } catch { /* template picker is best-effort */ }
     })();
     return () => { alive = false; };
   }, []);
@@ -90,8 +98,8 @@ export function FoundryCanvas() {
     template: null,
     theme: { universeType, displayName: worldName, palette: null },
     systems: selected,
-    rules: [],
-  }), [universeType, worldName, selected]);
+    rules,
+  }), [universeType, worldName, selected, rules]);
 
   // ── Live validation (debounced) ────────────────────────────────────────────
   const validateTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -153,7 +161,7 @@ export function FoundryCanvas() {
         if (!r.ok) { flash('err', `Save failed: ${r.reason}`); return; }
         flash('ok', 'Saved.');
       } else {
-        const r = await createWorld(worldName, worldDescription, ws);
+        const r = await createWorld(worldName, worldDescription, { worldspec: ws });
         if (!r.ok || !r.world) { flash('err', `Save failed: ${r.reason}`); return; }
         setCurrentWorldId(r.world.id);
         setWorldStatus(r.world.status);
@@ -229,6 +237,7 @@ export function FoundryCanvas() {
       setWorldDescription(w.description);
       setUniverseType(w.worldspec.theme.universeType);
       setSelected(w.worldspec.systems);
+      setRules((w.worldspec.rules as FoundryRule[]) ?? []);
       setWorldStatus(w.status);
       setActiveConfigId(w.worldspec.systems[0]?.id ?? null);
     } catch {
@@ -238,12 +247,33 @@ export function FoundryCanvas() {
     }
   }, []);
 
+  // Start a fresh draft from a template — created server-side so the
+  // template's curated worldspec is normalized + validated on the way in.
+  const createFromTemplate = useCallback(async (templateId: string) => {
+    if (!templateId) return;
+    setBusy(true);
+    try {
+      const tpl = templates.find((t) => t.id === templateId);
+      const r = await createWorld(tpl?.name ?? 'New Game', '', { templateId });
+      if (!r.ok || !r.world) { flash('err', `Template start failed: ${r.reason}`); return; }
+      await loadWorld(r.world.id);
+      const w = await listWorlds();
+      if (w.ok) setMyWorlds(w.worlds);
+      flash('ok', `Started from “${tpl?.name ?? templateId}”.`);
+    } catch {
+      flash('err', 'Template start failed — could not reach the backend.');
+    } finally {
+      setBusy(false);
+    }
+  }, [templates, loadWorld]);
+
   const newWorld = useCallback(() => {
     setCurrentWorldId(null);
     setWorldName('Untitled Game');
     setWorldDescription('');
     setUniverseType('fantasy');
     setSelected([]);
+    setRules([]);
     setActiveConfigId(null);
     setWorldStatus(null);
     setValidation(null);
@@ -310,6 +340,20 @@ export function FoundryCanvas() {
           </span>
         )}
 
+        {templates.length > 0 && (
+          <select
+            value=""
+            onChange={(e) => { if (e.target.value) createFromTemplate(e.target.value); }}
+            disabled={busy}
+            aria-label="Start from a template"
+            className="rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-xs text-slate-300 focus:outline-none focus:ring-2 focus:ring-sky-500 disabled:opacity-40"
+          >
+            <option value="">Start from template…</option>
+            {templates.map((t) => (
+              <option key={t.id} value={t.id}>{t.name} ({t.systemCount})</option>
+            ))}
+          </select>
+        )}
         <button
           type="button" onClick={newWorld} disabled={busy}
           className="rounded-md border border-slate-700 px-2 py-1 text-xs text-slate-300 hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-sky-500 disabled:opacity-40"
@@ -433,6 +477,15 @@ export function FoundryCanvas() {
                 );
               })}
             </div>
+          )}
+
+          {/* Rules — natural-language game logic (Phase 6) */}
+          {selected.length > 0 && (
+            <FoundryRulesPanel
+              foundryWorldId={currentWorldId}
+              rules={rules}
+              onRulesChange={setRules}
+            />
           )}
 
           {/* My worlds strip */}

--- a/concord-frontend/components/foundry/FoundryCanvas.tsx
+++ b/concord-frontend/components/foundry/FoundryCanvas.tsx
@@ -1,0 +1,457 @@
+'use client';
+
+/**
+ * Foundry — FoundryCanvas.
+ *
+ * The composer surface: three panes — ComponentPalette (left),
+ * the canvas (center: the systems you've added, drag-drop target),
+ * ConfigPanel (right: the active system's config). Header carries the
+ * world name, universe type, validation status, and the Save / Publish
+ * actions. "My worlds" strip lets you reload a saved draft.
+ *
+ * Live 3D preview is Phase 5 — this phase ships the full build +
+ * configure + validate + save + publish loop.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  fetchSystems, listWorlds, createWorld, updateWorld, getWorld,
+  publishWorld, unpublishWorld, validateWorld, defaultConfig,
+  type SystemEntry, type CategoryGroup, type SystemCategory,
+  type WorldspecSystem, type Worldspec, type FoundryWorld, type ValidationResult,
+} from '@/lib/foundry/api';
+import { ComponentPalette } from './ComponentPalette';
+import { ConfigPanel } from './ConfigPanel';
+import {
+  Loader2, Save, Rocket, Trash2, X, CheckCircle2, AlertTriangle,
+  Circle, FileStack, Undo2,
+} from 'lucide-react';
+
+const UNIVERSE_TYPES = [
+  'fantasy', 'scifi', 'noir', 'cyber', 'post-apocalyptic',
+  'historical', 'surreal', 'slice-of-life', 'horror', 'mythic',
+];
+
+export function FoundryCanvas() {
+  // Catalog
+  const [categories, setCategories] = useState<Record<SystemCategory, CategoryGroup> | null>(null);
+  const [systemsById, setSystemsById] = useState<Map<string, SystemEntry>>(new Map());
+  const [catalogError, setCatalogError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // The worldspec under construction
+  const [worldName, setWorldName] = useState('Untitled Game');
+  const [worldDescription, setWorldDescription] = useState('');
+  const [universeType, setUniverseType] = useState('fantasy');
+  const [selected, setSelected] = useState<WorldspecSystem[]>([]);
+  const [activeConfigId, setActiveConfigId] = useState<string | null>(null);
+
+  // Persistence + lifecycle
+  const [currentWorldId, setCurrentWorldId] = useState<string | null>(null);
+  const [worldStatus, setWorldStatus] = useState<'draft' | 'published' | null>(null);
+  const [myWorlds, setMyWorlds] = useState<FoundryWorld[]>([]);
+  const [validation, setValidation] = useState<ValidationResult | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState<{ kind: 'ok' | 'err'; msg: string } | null>(null);
+
+  const selectedIds = useMemo(() => new Set(selected.map((s) => s.id)), [selected]);
+
+  // ── Load catalog + my worlds ───────────────────────────────────────────────
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const cat = await fetchSystems();
+        if (!alive) return;
+        if (!cat.ok) { setCatalogError('Failed to load the system catalog.'); return; }
+        setCategories(cat.categories);
+        setSystemsById(new Map(cat.systems.map((s) => [s.id, s])));
+      } catch {
+        if (alive) setCatalogError('Could not reach the Foundry catalog. Is the backend up?');
+      } finally {
+        if (alive) setLoading(false);
+      }
+      try {
+        const w = await listWorlds();
+        if (alive && w.ok) setMyWorlds(w.worlds);
+      } catch { /* my-worlds strip is best-effort */ }
+    })();
+    return () => { alive = false; };
+  }, []);
+
+  // ── Build the worldspec from current state ─────────────────────────────────
+  const buildWorldspec = useCallback((): Worldspec => ({
+    version: 1,
+    template: null,
+    theme: { universeType, displayName: worldName, palette: null },
+    systems: selected,
+    rules: [],
+  }), [universeType, worldName, selected]);
+
+  // ── Live validation (debounced) ────────────────────────────────────────────
+  const validateTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (validateTimer.current) clearTimeout(validateTimer.current);
+    if (selected.length === 0) { setValidation(null); return; }
+    validateTimer.current = setTimeout(async () => {
+      try {
+        const v = await validateWorld({ worldspec: buildWorldspec() });
+        setValidation(v);
+      } catch { /* validation is advisory — a failed call just leaves it stale */ }
+    }, 400);
+    return () => { if (validateTimer.current) clearTimeout(validateTimer.current); };
+  }, [selected, buildWorldspec]);
+
+  // ── System add / remove / configure ────────────────────────────────────────
+  const addSystem = useCallback((id: string) => {
+    setSelected((prev) => {
+      if (prev.some((s) => s.id === id)) return prev;
+      const sys = systemsById.get(id);
+      if (!sys) return prev;
+      return [...prev, { id, config: defaultConfig(sys.configSchema) }];
+    });
+    setActiveConfigId(id);
+  }, [systemsById]);
+
+  const removeSystem = useCallback((id: string) => {
+    setSelected((prev) => prev.filter((s) => s.id !== id));
+    setActiveConfigId((cur) => (cur === id ? null : cur));
+  }, []);
+
+  const updateConfig = useCallback((id: string, field: string, value: unknown) => {
+    setSelected((prev) =>
+      prev.map((s) => (s.id === id ? { ...s, config: { ...s.config, [field]: value } } : s)),
+    );
+  }, []);
+
+  // ── Drag-drop onto the canvas ──────────────────────────────────────────────
+  const [dragOver, setDragOver] = useState(false);
+  const onDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragOver(false);
+    const id = e.dataTransfer.getData('application/x-foundry-system');
+    if (id) addSystem(id);
+  };
+
+  // ── Save / publish / load ──────────────────────────────────────────────────
+  const flash = (kind: 'ok' | 'err', msg: string) => {
+    setNotice({ kind, msg });
+    setTimeout(() => setNotice(null), 4000);
+  };
+
+  const save = useCallback(async () => {
+    setBusy(true);
+    try {
+      const ws = buildWorldspec();
+      if (currentWorldId) {
+        const r = await updateWorld(currentWorldId, { name: worldName, description: worldDescription, worldspec: ws });
+        if (!r.ok) { flash('err', `Save failed: ${r.reason}`); return; }
+        flash('ok', 'Saved.');
+      } else {
+        const r = await createWorld(worldName, worldDescription, ws);
+        if (!r.ok || !r.world) { flash('err', `Save failed: ${r.reason}`); return; }
+        setCurrentWorldId(r.world.id);
+        setWorldStatus(r.world.status);
+        flash('ok', 'Created.');
+      }
+      const w = await listWorlds();
+      if (w.ok) setMyWorlds(w.worlds);
+    } catch {
+      flash('err', 'Save failed — could not reach the backend.');
+    } finally {
+      setBusy(false);
+    }
+  }, [buildWorldspec, currentWorldId, worldName, worldDescription]);
+
+  const doPublish = useCallback(async () => {
+    if (!currentWorldId) { flash('err', 'Save before publishing.'); return; }
+    setBusy(true);
+    try {
+      // Persist the latest edits first so publish compiles what's on screen.
+      await updateWorld(currentWorldId, { name: worldName, description: worldDescription, worldspec: buildWorldspec() });
+      const r = await publishWorld(currentWorldId);
+      if (!r.ok) {
+        flash('err', r.errors?.length ? `Can't publish: ${r.errors[0]}` : `Publish failed: ${r.reason}`);
+        return;
+      }
+      setWorldStatus('published');
+      const stubNote = r.skippedStubs?.length ? ` (${r.skippedStubs.length} system(s) pending Phase 7)` : '';
+      flash('ok', `Published as a live world${stubNote}.`);
+    } catch {
+      flash('err', 'Publish failed — could not reach the backend.');
+    } finally {
+      setBusy(false);
+    }
+  }, [currentWorldId, worldName, worldDescription, buildWorldspec]);
+
+  const doUnpublish = useCallback(async () => {
+    if (!currentWorldId) return;
+    setBusy(true);
+    try {
+      const r = await unpublishWorld(currentWorldId);
+      if (!r.ok) { flash('err', `Unpublish failed: ${r.reason}`); return; }
+      setWorldStatus('draft');
+      flash('ok', `Back to draft (world ${r.disposition}).`);
+    } catch {
+      flash('err', 'Unpublish failed — could not reach the backend.');
+    } finally {
+      setBusy(false);
+    }
+  }, [currentWorldId]);
+
+  const loadWorld = useCallback(async (id: string) => {
+    setBusy(true);
+    try {
+      const r = await getWorld(id);
+      if (!r.ok || !r.world) { flash('err', `Load failed: ${r.reason}`); return; }
+      const w = r.world;
+      setCurrentWorldId(w.id);
+      setWorldName(w.name);
+      setWorldDescription(w.description);
+      setUniverseType(w.worldspec.theme.universeType);
+      setSelected(w.worldspec.systems);
+      setWorldStatus(w.status);
+      setActiveConfigId(w.worldspec.systems[0]?.id ?? null);
+    } catch {
+      flash('err', 'Load failed — could not reach the backend.');
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const newWorld = useCallback(() => {
+    setCurrentWorldId(null);
+    setWorldName('Untitled Game');
+    setWorldDescription('');
+    setUniverseType('fantasy');
+    setSelected([]);
+    setActiveConfigId(null);
+    setWorldStatus(null);
+    setValidation(null);
+  }, []);
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center gap-2 py-24 text-sm text-slate-400">
+        <Loader2 className="h-4 w-4 animate-spin" /> Loading the Foundry catalog…
+      </div>
+    );
+  }
+  if (catalogError || !categories) {
+    return (
+      <div className="mx-auto max-w-md py-24 text-center">
+        <AlertTriangle className="mx-auto h-6 w-6 text-amber-400" />
+        <p className="mt-2 text-sm text-slate-300">{catalogError ?? 'Catalog unavailable.'}</p>
+      </div>
+    );
+  }
+
+  const activeSystem = activeConfigId ? systemsById.get(activeConfigId) : null;
+  const activeConfig = activeConfigId ? selected.find((s) => s.id === activeConfigId)?.config ?? {} : {};
+  const canPublish = selected.length > 0 && (validation?.ok ?? false);
+
+  return (
+    <div className="flex h-[calc(100vh-7rem)] flex-col">
+      {/* Header */}
+      <div className="flex flex-wrap items-center gap-2 border-b border-slate-800 bg-slate-950/60 px-3 py-2">
+        <input
+          value={worldName}
+          onChange={(e) => setWorldName(e.target.value)}
+          className="min-w-0 flex-1 rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-sm font-medium text-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500"
+          placeholder="Game name"
+        />
+        <select
+          value={universeType}
+          onChange={(e) => setUniverseType(e.target.value)}
+          className="rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-xs text-slate-200 focus:outline-none focus:ring-2 focus:ring-sky-500"
+        >
+          {UNIVERSE_TYPES.map((u) => <option key={u} value={u}>{u}</option>)}
+        </select>
+
+        {/* Validation badge */}
+        {validation && (
+          <span
+            className={`flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium ${
+              validation.ok
+                ? 'border border-emerald-600/40 bg-emerald-500/10 text-emerald-300'
+                : 'border border-red-600/40 bg-red-500/10 text-red-300'
+            }`}
+            title={(validation.ok ? validation.warnings : validation.errors).join('\n')}
+          >
+            {validation.ok ? <CheckCircle2 className="h-3 w-3" /> : <AlertTriangle className="h-3 w-3" />}
+            {validation.ok
+              ? `valid${validation.warnings.length ? ` · ${validation.warnings.length} note(s)` : ''}`
+              : `${validation.errors.length} issue(s)`}
+          </span>
+        )}
+        {worldStatus === 'published' && (
+          <span className="flex items-center gap-1 rounded-full border border-sky-600/40 bg-sky-500/10 px-2 py-0.5 text-[11px] font-medium text-sky-300">
+            <Circle className="h-2 w-2 fill-sky-400" /> live
+          </span>
+        )}
+
+        <button
+          type="button" onClick={newWorld} disabled={busy}
+          className="rounded-md border border-slate-700 px-2 py-1 text-xs text-slate-300 hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-sky-500 disabled:opacity-40"
+        >
+          New
+        </button>
+        <button
+          type="button" onClick={save} disabled={busy}
+          className="flex items-center gap-1 rounded-md border border-slate-700 bg-slate-800 px-2.5 py-1 text-xs text-slate-100 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-sky-500 disabled:opacity-40"
+        >
+          {busy ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />} Save
+        </button>
+        {worldStatus === 'published' ? (
+          <button
+            type="button" onClick={doUnpublish} disabled={busy}
+            className="flex items-center gap-1 rounded-md border border-amber-700/50 bg-amber-900/30 px-2.5 py-1 text-xs text-amber-200 hover:bg-amber-900/50 focus:outline-none focus:ring-2 focus:ring-amber-500 disabled:opacity-40"
+          >
+            <Undo2 className="h-3 w-3" /> Unpublish
+          </button>
+        ) : (
+          <button
+            type="button" onClick={doPublish} disabled={busy || !canPublish}
+            title={!canPublish ? 'Add at least one system and resolve validation issues' : 'Publish as a live world'}
+            className="flex items-center gap-1 rounded-md border border-sky-600/50 bg-sky-600/20 px-2.5 py-1 text-xs font-medium text-sky-200 hover:bg-sky-600/40 focus:outline-none focus:ring-2 focus:ring-sky-500 disabled:opacity-40"
+          >
+            <Rocket className="h-3 w-3" /> Publish
+          </button>
+        )}
+      </div>
+
+      {/* Notice */}
+      {notice && (
+        <div
+          role="status"
+          className={`px-3 py-1.5 text-xs ${
+            notice.kind === 'ok' ? 'bg-emerald-950/50 text-emerald-200' : 'bg-red-950/50 text-red-200'
+          }`}
+        >
+          {notice.msg}
+        </div>
+      )}
+
+      {/* 3-pane body */}
+      <div className="grid flex-1 grid-cols-[16rem_1fr_18rem] overflow-hidden">
+        {/* Palette */}
+        <aside className="overflow-hidden border-r border-slate-800 bg-slate-950/40">
+          <ComponentPalette categories={categories} selectedIds={selectedIds} onAdd={addSystem} />
+        </aside>
+
+        {/* Canvas */}
+        <main
+          onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+          onDragLeave={() => setDragOver(false)}
+          onDrop={onDrop}
+          className={`overflow-y-auto p-4 transition-colors ${
+            dragOver ? 'bg-sky-950/20' : 'bg-slate-950/20'
+          }`}
+        >
+          {selected.length === 0 ? (
+            <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-slate-500">
+              <FileStack className="h-8 w-8 text-slate-700" />
+              <p className="text-sm">Drag systems from the left, or click <span className="text-slate-300">+</span> to add them.</p>
+              <p className="max-w-xs text-xs text-slate-600">
+                Every system you add is configured per-world and travels with the lattice once published.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {validation && !validation.ok && (
+                <div className="rounded-md border border-red-700/40 bg-red-950/30 px-3 py-2 text-xs text-red-200">
+                  <strong>Resolve before publishing:</strong>
+                  <ul className="mt-1 list-disc pl-4">
+                    {validation.errors.slice(0, 6).map((e, i) => <li key={i}>{e}</li>)}
+                  </ul>
+                </div>
+              )}
+              {selected.map((s) => {
+                const sys = systemsById.get(s.id);
+                if (!sys) return null;
+                const isActive = activeConfigId === s.id;
+                return (
+                  <div
+                    key={s.id}
+                    className={`rounded-lg border px-3 py-2 transition-colors ${
+                      isActive ? 'border-sky-600/60 bg-sky-950/30' : 'border-slate-800 bg-slate-900/60 hover:border-slate-700'
+                    }`}
+                  >
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setActiveConfigId(isActive ? null : s.id)}
+                        className="min-w-0 flex-1 text-left focus:outline-none"
+                      >
+                        <div className="flex items-center gap-1.5">
+                          <span className="truncate text-sm font-medium text-slate-100">{sys.displayName}</span>
+                          {sys.status === 'stub' && (
+                            <span className="rounded-full border border-amber-600/40 bg-amber-500/10 px-1 py-px text-[9px] font-medium text-amber-300">
+                              soon
+                            </span>
+                          )}
+                          <span className="rounded bg-slate-800 px-1 py-px text-[9px] text-slate-500">{sys.category}</span>
+                        </div>
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => removeSystem(s.id)}
+                        aria-label={`Remove ${sys.displayName}`}
+                        className="rounded p-1 text-slate-500 hover:bg-red-600/20 hover:text-red-300 focus:outline-none focus:ring-2 focus:ring-red-500"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* My worlds strip */}
+          {myWorlds.length > 0 && (
+            <div className="mt-6 border-t border-slate-800 pt-3">
+              <h3 className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-slate-500">My worlds</h3>
+              <div className="flex flex-wrap gap-1.5">
+                {myWorlds.map((w) => (
+                  <button
+                    key={w.id}
+                    type="button"
+                    onClick={() => loadWorld(w.id)}
+                    className={`flex items-center gap-1 rounded-md border px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-sky-500 ${
+                      w.id === currentWorldId
+                        ? 'border-sky-600/60 bg-sky-950/40 text-sky-200'
+                        : 'border-slate-700 bg-slate-900 text-slate-300 hover:bg-slate-800'
+                    }`}
+                  >
+                    {w.status === 'published' && <Circle className="h-1.5 w-1.5 fill-sky-400 text-sky-400" />}
+                    {w.name}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </main>
+
+        {/* Config */}
+        <aside className="overflow-hidden border-l border-slate-800 bg-slate-950/40">
+          {activeSystem ? (
+            <ConfigPanel
+              system={activeSystem}
+              config={activeConfig}
+              onChange={(field, value) => updateConfig(activeSystem.id, field, value)}
+            />
+          ) : (
+            <div className="flex h-full flex-col items-center justify-center gap-2 px-4 text-center text-slate-600">
+              <X className="h-5 w-5" />
+              <p className="text-xs">Select a system on the canvas to configure it.</p>
+            </div>
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+export default FoundryCanvas;

--- a/concord-frontend/components/foundry/FoundryCanvas.tsx
+++ b/concord-frontend/components/foundry/FoundryCanvas.tsx
@@ -20,12 +20,16 @@ import {
   type SystemEntry, type CategoryGroup, type SystemCategory,
   type WorldspecSystem, type Worldspec, type FoundryWorld, type ValidationResult,
 } from '@/lib/foundry/api';
+import dynamic from 'next/dynamic';
 import { ComponentPalette } from './ComponentPalette';
 import { ConfigPanel } from './ConfigPanel';
 import {
   Loader2, Save, Rocket, Trash2, X, CheckCircle2, AlertTriangle,
-  Circle, FileStack, Undo2,
+  Circle, FileStack, Undo2, Eye,
 } from 'lucide-react';
+
+// Preview pulls in ConcordiaScene (Three.js) — load it only when opened.
+const FoundryPreview = dynamic(() => import('./FoundryPreview'), { ssr: false });
 
 const UNIVERSE_TYPES = [
   'fantasy', 'scifi', 'noir', 'cyber', 'post-apocalyptic',
@@ -52,6 +56,7 @@ export function FoundryCanvas() {
   const [myWorlds, setMyWorlds] = useState<FoundryWorld[]>([]);
   const [validation, setValidation] = useState<ValidationResult | null>(null);
   const [busy, setBusy] = useState(false);
+  const [showPreview, setShowPreview] = useState(false);
   const [notice, setNotice] = useState<{ kind: 'ok' | 'err'; msg: string } | null>(null);
 
   const selectedIds = useMemo(() => new Set(selected.map((s) => s.id)), [selected]);
@@ -184,6 +189,20 @@ export function FoundryCanvas() {
     }
   }, [currentWorldId, worldName, worldDescription, buildWorldspec]);
 
+  const doPreview = useCallback(async () => {
+    if (!currentWorldId) { flash('err', 'Save before previewing.'); return; }
+    setBusy(true);
+    try {
+      // Persist the latest edits so the preview renders what's on screen.
+      await updateWorld(currentWorldId, { name: worldName, description: worldDescription, worldspec: buildWorldspec() });
+      setShowPreview(true);
+    } catch {
+      flash('err', 'Could not save before preview — backend unreachable.');
+    } finally {
+      setBusy(false);
+    }
+  }, [currentWorldId, worldName, worldDescription, buildWorldspec]);
+
   const doUnpublish = useCallback(async () => {
     if (!currentWorldId) return;
     setBusy(true);
@@ -302,6 +321,13 @@ export function FoundryCanvas() {
           className="flex items-center gap-1 rounded-md border border-slate-700 bg-slate-800 px-2.5 py-1 text-xs text-slate-100 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-sky-500 disabled:opacity-40"
         >
           {busy ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />} Save
+        </button>
+        <button
+          type="button" onClick={doPreview} disabled={busy || !currentWorldId || selected.length === 0}
+          title={!currentWorldId ? 'Save first to preview' : selected.length === 0 ? 'Add a system to preview' : 'Render this world in 3D'}
+          className="flex items-center gap-1 rounded-md border border-slate-700 bg-slate-800 px-2.5 py-1 text-xs text-slate-100 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-sky-500 disabled:opacity-40"
+        >
+          <Eye className="h-3 w-3" /> Preview
         </button>
         {worldStatus === 'published' ? (
           <button
@@ -450,6 +476,15 @@ export function FoundryCanvas() {
           )}
         </aside>
       </div>
+
+      {/* Live 3D preview — full-screen overlay (Phase 5) */}
+      {showPreview && currentWorldId && (
+        <FoundryPreview
+          foundryWorldId={currentWorldId}
+          worldName={worldName}
+          onClose={() => setShowPreview(false)}
+        />
+      )}
     </div>
   );
 }

--- a/concord-frontend/components/foundry/FoundryPreview.tsx
+++ b/concord-frontend/components/foundry/FoundryPreview.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+/**
+ * Foundry — FoundryPreview.
+ *
+ * A slide-over panel that renders the world being built, live, in the
+ * real 3D engine. ConcordiaScene is hardwired to load a world by id,
+ * so the preview IS a real (transient) `worlds` row: foundry.preview
+ * compiles the current draft into a status='preview' world and hands
+ * back its id; we mount ConcordiaScene against it. foundry.preview_end
+ * tears it down on close (and the foundry-preview-cleanup heartbeat
+ * sweeps any orphan).
+ *
+ * The caller saves the draft before opening this, so the preview
+ * reflects exactly what's on the canvas.
+ */
+
+import { useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
+import { previewWorld, endPreview } from '@/lib/foundry/api';
+import { Loader2, X, AlertTriangle, Eye } from 'lucide-react';
+
+const ConcordiaScene = dynamic(
+  () => import('@/components/world-lens/ConcordiaScene'),
+  { ssr: false, loading: () => null },
+);
+
+interface FoundryPreviewProps {
+  foundryWorldId: string;
+  worldName: string;
+  onClose: () => void;
+}
+
+export function FoundryPreview({ foundryWorldId, worldName, onClose }: FoundryPreviewProps) {
+  const [previewWorldId, setPreviewWorldId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [skippedStubs, setSkippedStubs] = useState<string[]>([]);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const r = await previewWorld(foundryWorldId);
+        if (!alive) return;
+        if (!r.ok || !r.previewWorldId) {
+          setError(r.reason === 'no_systems'
+            ? 'Add at least one system before previewing.'
+            : `Preview failed: ${r.reason ?? 'unknown'}`);
+          return;
+        }
+        setPreviewWorldId(r.previewWorldId);
+        setSkippedStubs(r.skippedStubs ?? []);
+      } catch {
+        if (alive) setError('Could not reach the backend to build the preview.');
+      }
+    })();
+    // Tear the transient world down on close. Fire-and-forget — the
+    // cleanup heartbeat is the backstop if this never lands.
+    return () => {
+      alive = false;
+      endPreview(foundryWorldId).catch(() => {});
+    };
+  }, [foundryWorldId]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex flex-col bg-slate-950"
+      role="dialog"
+      aria-label={`Live preview of ${worldName}`}
+    >
+      <div className="flex items-center gap-2 border-b border-slate-800 bg-slate-950/90 px-3 py-2">
+        <Eye className="h-4 w-4 text-sky-400" />
+        <span className="flex-1 truncate text-sm font-medium text-slate-100">
+          Live preview — {worldName}
+        </span>
+        {skippedStubs.length > 0 && (
+          <span className="rounded-full border border-amber-600/40 bg-amber-500/10 px-2 py-0.5 text-[11px] text-amber-300">
+            {skippedStubs.length} system(s) not yet built — not shown
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={onClose}
+          className="flex items-center gap-1 rounded-md border border-slate-700 px-2 py-1 text-xs text-slate-200 hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-sky-500"
+        >
+          <X className="h-3.5 w-3.5" /> Close
+        </button>
+      </div>
+
+      <div className="relative flex-1 overflow-hidden">
+        {error ? (
+          <div className="flex h-full flex-col items-center justify-center gap-2 text-center">
+            <AlertTriangle className="h-6 w-6 text-amber-400" />
+            <p className="text-sm text-slate-300">{error}</p>
+          </div>
+        ) : !previewWorldId ? (
+          <div className="flex h-full items-center justify-center gap-2 text-sm text-slate-400">
+            <Loader2 className="h-4 w-4 animate-spin" /> Compiling your world…
+          </div>
+        ) : (
+          <ConcordiaScene districtId={previewWorldId} cameraMode="free" quality="medium" />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default FoundryPreview;

--- a/concord-frontend/components/foundry/FoundryRulesPanel.tsx
+++ b/concord-frontend/components/foundry/FoundryRulesPanel.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+/**
+ * Foundry — FoundryRulesPanel.
+ *
+ * Author game rules in plain language. Each line ("when a player
+ * enters the boss arena, lock the doors") goes to foundry.compose_rule,
+ * which translates it into a structured rule via the conscious brain —
+ * or, if no brain is reachable, a deterministic keyword parse. Either
+ * way you get a usable rule back; the composedBy badge says which path
+ * produced it. Composed rules persist into the worldspec.
+ */
+
+import { useState } from 'react';
+import { composeRule, type FoundryRule } from '@/lib/foundry/api';
+import { Loader2, Plus, Wand2, Trash2 } from 'lucide-react';
+
+interface FoundryRulesPanelProps {
+  foundryWorldId: string | null;
+  rules: FoundryRule[];
+  onRulesChange: (rules: FoundryRule[]) => void;
+}
+
+export function FoundryRulesPanel({ foundryWorldId, rules, onRulesChange }: FoundryRulesPanelProps) {
+  const [draft, setDraft] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const add = async () => {
+    const nl = draft.trim();
+    if (!nl) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      // Pass the world id when saved so the rule persists server-side;
+      // otherwise it's held locally until the next Save.
+      const r = await composeRule(nl, foundryWorldId ?? undefined);
+      if (!r.ok || !r.rule) {
+        setErr(r.reason === 'rule_too_long' ? 'Keep the rule under 500 characters.' : `Couldn't compose that rule (${r.reason ?? 'unknown'}).`);
+        return;
+      }
+      onRulesChange([...rules, r.rule]);
+      setDraft('');
+    } catch {
+      setErr('Could not reach the backend to compose the rule.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = (id: string) => onRulesChange(rules.filter((r) => r.id !== id));
+
+  return (
+    <div className="mt-6 border-t border-slate-800 pt-3">
+      <h3 className="mb-1.5 flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+        <Wand2 className="h-3 w-3" /> Rules
+      </h3>
+
+      <div className="flex gap-1.5">
+        <input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter' && !busy) add(); }}
+          placeholder="e.g. when a player enters the boss arena, lock the doors"
+          maxLength={500}
+          className="min-w-0 flex-1 rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-xs text-slate-100 placeholder:text-slate-600 focus:outline-none focus:ring-2 focus:ring-sky-500"
+        />
+        <button
+          type="button"
+          onClick={add}
+          disabled={busy || !draft.trim()}
+          className="flex items-center gap-1 rounded-md border border-slate-700 bg-slate-800 px-2 py-1 text-xs text-slate-100 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-sky-500 disabled:opacity-40"
+        >
+          {busy ? <Loader2 className="h-3 w-3 animate-spin" /> : <Plus className="h-3 w-3" />} Add
+        </button>
+      </div>
+      {err && <p className="mt-1 text-[11px] text-red-300">{err}</p>}
+
+      {rules.length > 0 && (
+        <ul className="mt-2 space-y-1">
+          {rules.map((rule) => (
+            <li
+              key={rule.id}
+              className="flex items-start gap-2 rounded-md border border-slate-800 bg-slate-900/60 px-2 py-1.5"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-xs text-slate-200">{rule.source}</p>
+                <p className="mt-0.5 text-[10px] text-slate-500">
+                  <span className="text-sky-400">{rule.trigger.kind}</span>
+                  {rule.trigger.target ? ` (${rule.trigger.target})` : ''}
+                  {' → '}
+                  <span className="text-emerald-400">{rule.effect.kind}</span>
+                  {rule.effect.target ? ` (${rule.effect.target})` : ''}
+                  <span className="ml-1.5 rounded bg-slate-800 px-1 py-px">
+                    {rule.composedBy === 'llm' ? 'AI' : 'keyword'}
+                  </span>
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => remove(rule.id)}
+                aria-label="Remove rule"
+                className="rounded p-0.5 text-slate-500 hover:bg-red-600/20 hover:text-red-300 focus:outline-none focus:ring-2 focus:ring-red-500"
+              >
+                <Trash2 className="h-3 w-3" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default FoundryRulesPanel;

--- a/concord-frontend/lib/foundry/api.ts
+++ b/concord-frontend/lib/foundry/api.ts
@@ -112,9 +112,13 @@ export function validateSystems(systems: WorldspecSystem[]) {
 
 // ── Phase 2 — worldspec persistence ─────────────────────────────────────────
 
-export function createWorld(name: string, description?: string, worldspec?: Partial<Worldspec>) {
+export function createWorld(
+  name: string,
+  description?: string,
+  opts?: { worldspec?: Partial<Worldspec>; templateId?: string },
+) {
   return foundryCall<{ ok: boolean; world?: FoundryWorld; reason?: string }>('create', {
-    name, description, worldspec,
+    name, description, worldspec: opts?.worldspec, templateId: opts?.templateId,
   });
 }
 export function updateWorld(
@@ -162,6 +166,34 @@ export function previewWorld(id: string) {
 }
 export function endPreview(id: string) {
   return foundryCall<{ ok: boolean; reason?: string }>('preview_end', { id });
+}
+
+// ── Phase 6 — templates + NL rules ──────────────────────────────────────────
+
+export interface TemplateSummary {
+  id: string;
+  name: string;
+  description: string;
+  universeType: string;
+  systemCount: number;
+}
+export interface FoundryRule {
+  id: string;
+  source: string;
+  trigger: { kind: string; target: string | null };
+  effect: { kind: string; target: string | null; value: unknown };
+  confidence: number;
+  composedBy: 'llm' | 'deterministic';
+}
+
+export function fetchTemplates() {
+  return foundryCall<{ ok: boolean; count: number; templates: TemplateSummary[] }>('templates', {});
+}
+export function composeRule(naturalLanguage: string, id?: string) {
+  return foundryCall<{
+    ok: boolean; reason?: string; rule?: FoundryRule;
+    composedBy?: string; warnings?: string[]; saved?: boolean;
+  }>('compose_rule', { naturalLanguage, id });
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────

--- a/concord-frontend/lib/foundry/api.ts
+++ b/concord-frontend/lib/foundry/api.ts
@@ -152,6 +152,18 @@ export function unpublishWorld(id: string) {
   }>('unpublish', { id });
 }
 
+// ── Phase 5 — live 3D preview ───────────────────────────────────────────────
+
+export function previewWorld(id: string) {
+  return foundryCall<{
+    ok: boolean; reason?: string; previewWorldId?: string;
+    universeType?: string; activatedSystems?: string[]; skippedStubs?: string[];
+  }>('preview', { id });
+}
+export function endPreview(id: string) {
+  return foundryCall<{ ok: boolean; reason?: string }>('preview_end', { id });
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 /** A blank worldspec — mirror of server emptyWorldspec(). */

--- a/concord-frontend/lib/foundry/api.ts
+++ b/concord-frontend/lib/foundry/api.ts
@@ -1,0 +1,173 @@
+// concord-frontend/lib/foundry/api.ts
+//
+// Foundry lens — typed client for the foundry.* macro surface.
+// Every call goes through POST /api/lens/run { domain:'foundry', name, input }.
+// Mirrors server/lib/foundry/{system-registry,worldspec,compiler}.js +
+// server/domains/foundry.js.
+
+import { api } from '@/lib/api/client';
+
+// ── Registry types (mirror server/lib/foundry/system-registry.js) ───────────
+
+export type SystemCategory = 'world' | 'character' | 'combat' | 'npc' | 'economy' | 'social';
+export type WorldScope = 'world' | 'global' | 'player';
+export type SystemStatus = 'available' | 'stub';
+
+export interface ConfigField {
+  type: 'enum' | 'number' | 'bool' | 'text' | 'range';
+  label: string;
+  default: unknown;
+  options?: string[];
+  min?: number;
+  max?: number;
+  step?: number;
+  maxLength?: number;
+}
+export type ConfigSchema = Record<string, ConfigField>;
+
+export interface SystemEntry {
+  id: string;
+  category: SystemCategory;
+  displayName: string;
+  description: string;
+  worldScope: WorldScope;
+  status: SystemStatus;
+  activation: { kind: string; key?: string };
+  dependsOn: string[];
+  conflictsWith: string[];
+  configSchema: ConfigSchema;
+}
+
+export interface CategoryGroup {
+  label: string;
+  systems: SystemEntry[];
+}
+
+// ── Worldspec types (mirror server/lib/foundry/worldspec.js) ────────────────
+
+export interface WorldspecSystem {
+  id: string;
+  config: Record<string, unknown>;
+}
+export interface Worldspec {
+  version: number;
+  template: string | null;
+  theme: { universeType: string; displayName: string; palette: Record<string, unknown> | null };
+  systems: WorldspecSystem[];
+  rules: unknown[];
+}
+export interface FoundryWorld {
+  id: string;
+  creatorId: string;
+  name: string;
+  description: string;
+  worldspec: Worldspec;
+  status: 'draft' | 'published';
+  publishedWorldId: string | null;
+  previewWorldId: string | null;
+  promoted: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  normalized?: Worldspec;
+  resolved?: WorldspecSystem[];
+}
+
+// ── Macro caller ────────────────────────────────────────────────────────────
+
+async function foundryCall<T = Record<string, unknown>>(
+  name: string,
+  input: Record<string, unknown> = {},
+): Promise<T> {
+  const { data } = await api.post('/api/lens/run', { domain: 'foundry', name, input });
+  // /api/lens/run returns either { ok, result } (lens-action) or the
+  // macro's own object directly (canonical macro path — foundry's case).
+  const payload = (data && typeof data === 'object' && 'result' in data && data.result)
+    ? data.result
+    : data;
+  return payload as T;
+}
+
+// ── Phase 1 — registry ──────────────────────────────────────────────────────
+
+export function fetchSystems(category?: SystemCategory) {
+  return foundryCall<{
+    ok: boolean; count: number; total: number;
+    categories: Record<SystemCategory, CategoryGroup>; systems: SystemEntry[];
+  }>('systems', category ? { category } : {});
+}
+
+export function fetchSystemSchema(id: string) {
+  return foundryCall<{ ok: boolean } & Partial<SystemEntry>>('system_schema', { id });
+}
+
+export function validateSystems(systems: WorldspecSystem[]) {
+  return foundryCall<ValidationResult>('validate_systems', { systems });
+}
+
+// ── Phase 2 — worldspec persistence ─────────────────────────────────────────
+
+export function createWorld(name: string, description?: string, worldspec?: Partial<Worldspec>) {
+  return foundryCall<{ ok: boolean; world?: FoundryWorld; reason?: string }>('create', {
+    name, description, worldspec,
+  });
+}
+export function updateWorld(
+  id: string,
+  patch: { name?: string; description?: string; worldspec?: Partial<Worldspec> },
+) {
+  return foundryCall<{ ok: boolean; world?: FoundryWorld; reason?: string }>('update', { id, ...patch });
+}
+export function getWorld(id: string) {
+  return foundryCall<{ ok: boolean; world?: FoundryWorld; reason?: string }>('get', { id });
+}
+export function listWorlds(limit = 50) {
+  return foundryCall<{ ok: boolean; count: number; worlds: FoundryWorld[] }>('list', { limit });
+}
+export function deleteWorld(id: string) {
+  return foundryCall<{ ok: boolean; deleted?: string; reason?: string }>('delete', { id });
+}
+export function validateWorld(arg: { id: string } | { worldspec: Partial<Worldspec> }) {
+  return foundryCall<ValidationResult>('validate', arg as Record<string, unknown>);
+}
+
+// ── Phase 3 — publish pipeline ──────────────────────────────────────────────
+
+export function publishWorld(id: string) {
+  return foundryCall<{
+    ok: boolean; reason?: string; publishedWorldId?: string;
+    world?: FoundryWorld; activatedSystems?: string[]; skippedStubs?: string[];
+    contentSeeds?: string[]; errors?: string[];
+  }>('publish', { id });
+}
+export function unpublishWorld(id: string) {
+  return foundryCall<{
+    ok: boolean; reason?: string; disposition?: string;
+    formerWorldId?: string; world?: FoundryWorld;
+  }>('unpublish', { id });
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** A blank worldspec — mirror of server emptyWorldspec(). */
+export function emptyWorldspec(): Worldspec {
+  return {
+    version: 1,
+    template: null,
+    theme: { universeType: 'fantasy', displayName: '', palette: null },
+    systems: [],
+    rules: [],
+  };
+}
+
+/** Build a default config object from a system's schema. */
+export function defaultConfig(schema: ConfigSchema): Record<string, unknown> {
+  const cfg: Record<string, unknown> = {};
+  for (const [field, desc] of Object.entries(schema)) cfg[field] = desc.default;
+  return cfg;
+}

--- a/concord-frontend/lib/lenses/manifest.ts
+++ b/concord-frontend/lib/lenses/manifest.ts
@@ -1919,6 +1919,15 @@ export const LENS_MANIFESTS: LensManifest[] = [
     category: 'creative',
   },
   {
+    domain: 'foundry',
+    label: 'Foundry',
+    artifacts: ['foundry_world', 'worldspec', 'system_registry'],
+    macros: { list: 'foundry.list', get: 'foundry.get', create: 'foundry.create', update: 'foundry.update', delete: 'foundry.delete', run: 'foundry.publish' },
+    exports: [],
+    actions: ['systems', 'system_schema', 'validate_systems', 'create', 'update', 'get', 'list', 'delete', 'validate', 'publish', 'unpublish'],
+    category: 'creative',
+  },
+  {
     domain: 'kingdoms',
     label: 'Kingdoms',
     artifacts: ['kingdom', 'decree', 'contest', 'region'],

--- a/content/foundry-templates/arena-clash.json
+++ b/content/foundry-templates/arena-clash.json
@@ -1,0 +1,18 @@
+{
+  "id": "arena-clash",
+  "name": "Arena Clash",
+  "description": "A fast cyber PvP arena — tuned physics, the full combat motor with elements and equipment, scripted boss phases, aerial and mounted combat, live spectating, and spectator betting on every match.",
+  "universeType": "cyber",
+  "systems": [
+    { "id": "physics-modifiers", "config": { "gravity": 90, "jumpHeight": 160 } },
+    { "id": "combat-motor", "config": { "lethality": "hardcore", "friendlyFire": true } },
+    { "id": "armor-weapon-reflex", "config": {} },
+    { "id": "elemental-status-effects", "config": { "enabledElements": "extended-six" } },
+    { "id": "boss-phases", "config": { "maxPhases": 4 } },
+    { "id": "aerial-mount-combat", "config": {} },
+    { "id": "realtime-coop-pvp", "config": { "mode": "pvp", "maxConcurrent": 32 } },
+    { "id": "live-spectator", "config": {} },
+    { "id": "marketplace-spectator-betting", "config": { "spectatorBetting": true, "bettingCurrency": "sparks" } }
+  ],
+  "rules": []
+}

--- a/content/foundry-templates/social-hub.json
+++ b/content/foundry-templates/social-hub.json
@@ -1,0 +1,18 @@
+{
+  "id": "social-hub",
+  "name": "Social Hub",
+  "description": "A low-stakes slice-of-life gathering world — gentle terrain, expressive NPCs with their own voices and routines, proximity voice chat, co-op presence, a marketplace, and player-run guilds. No combat.",
+  "universeType": "slice-of-life",
+  "systems": [
+    { "id": "terrain-biomes", "config": { "biomeSet": "temperate", "ruggedness": 20 } },
+    { "id": "weather-ecology", "config": { "baseClimate": "temperate", "weatherVolatility": 20 } },
+    { "id": "llm-npcs", "config": { "npcCount": 24, "dreamsEnabled": true } },
+    { "id": "npc-schedules", "config": {} },
+    { "id": "npc-voice-idiolect", "config": { "voiceVariety": "per-npc" } },
+    { "id": "voice-chat-proximity", "config": { "voiceMode": "proximity" } },
+    { "id": "realtime-coop-pvp", "config": { "mode": "coop" } },
+    { "id": "marketplace-spectator-betting", "config": { "spectatorBetting": false } },
+    { "id": "player-orgs", "config": { "orgTypes": "guilds-only", "kingdomsEnabled": false } }
+  ],
+  "rules": []
+}

--- a/content/foundry-templates/starter-rpg.json
+++ b/content/foundry-templates/starter-rpg.json
@@ -1,0 +1,18 @@
+{
+  "id": "starter-rpg",
+  "name": "Starter RPG",
+  "description": "A classic fantasy RPG world — terrain and weather, living NPCs with daily lives, melee combat with equipment, persistent factions, and cross-world travel. The friendliest place to start.",
+  "universeType": "fantasy",
+  "systems": [
+    { "id": "terrain-biomes", "config": { "biomeSet": "temperate", "ruggedness": 45 } },
+    { "id": "weather-ecology", "config": { "baseClimate": "temperate" } },
+    { "id": "llm-npcs", "config": { "npcCount": 30, "grudgesEnabled": true } },
+    { "id": "npc-schedules", "config": {} },
+    { "id": "combat-motor", "config": { "lethality": "standard" } },
+    { "id": "armor-weapon-reflex", "config": {} },
+    { "id": "persistent-inventory", "config": {} },
+    { "id": "factions-politics", "config": { "factionCount": 4 } },
+    { "id": "concord-link", "config": { "travelMode": "portal" } }
+  ],
+  "rules": []
+}

--- a/content/foundry-templates/survival-frontier.json
+++ b/content/foundry-templates/survival-frontier.json
@@ -1,0 +1,18 @@
+{
+  "id": "survival-frontier",
+  "name": "Survival Frontier",
+  "description": "A harsh post-apocalyptic survival world — volatile weather, predatory fauna, a six-season year, low gravity, crafting and construction economies, and tameable mounts to cross the wastes.",
+  "universeType": "post-apocalyptic",
+  "systems": [
+    { "id": "terrain-biomes", "config": { "biomeSet": "arid", "ruggedness": 70 } },
+    { "id": "weather-ecology", "config": { "baseClimate": "storm-locked", "weatherVolatility": 80 } },
+    { "id": "fauna-flocks", "config": { "density": "abundant", "predators": true } },
+    { "id": "seasons", "config": { "startingSeason": "deep-winter" } },
+    { "id": "physics-modifiers", "config": { "gravity": 80 } },
+    { "id": "combat-motor", "config": { "lethality": "hardcore" } },
+    { "id": "recipe-authoring", "config": {} },
+    { "id": "insurance-construction", "config": {} },
+    { "id": "mount-system", "config": { "wildMounts": true } }
+  ],
+  "rules": []
+}

--- a/server/domains/foundry-systems.js
+++ b/server/domains/foundry-systems.js
@@ -1,0 +1,181 @@
+// server/domains/foundry-systems.js
+//
+// Foundry Phase 7 — macro surface for the four net-new gameplay
+// systems built this phase: Size Scaling, per-player Skill Affinity,
+// Status Window, and Isekai Reincarnation.
+//
+// These are gameplay operations (not Foundry-builder operations, which
+// live in domains/foundry.js). Each is world-scoped: the per-world
+// config comes from the published world's rule_modulators, written by
+// the Foundry compiler when the world's worldspec enables the system.
+
+import {
+  setPlayerScale, getPlayerScale, scaleEffects, scaledCombatProfile,
+} from "../lib/foundry/size-scaling.js";
+import {
+  recordSkillUse, getPlayerAffinity, effectiveAffinity,
+} from "../lib/foundry/skill-affinity.js";
+import {
+  awardTitle, listTitles, composeStatusWindow,
+} from "../lib/foundry/status-window.js";
+import { reincarnate, getLives } from "../lib/foundry/reincarnation.js";
+
+/** Pull a world's per-system config out of its rule_modulators. */
+function worldSystemConfig(db, worldId, key) {
+  if (!db || !worldId) return {};
+  const row = db.prepare(`SELECT rule_modulators FROM worlds WHERE id = ?`).get(worldId);
+  if (!row) return {};
+  try {
+    const mods = JSON.parse(row.rule_modulators || "{}");
+    return (mods && typeof mods[key] === "object" && mods[key]) || {};
+  } catch {
+    return {};
+  }
+}
+
+export default function registerFoundrySystemsMacros(register) {
+  // ===== Size Scaling ========================================================
+
+  /** size.get — a player's current scale + its gameplay effects. */
+  register("size", "get", (ctx, input = {}) => {
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.actor?.id;
+    const worldId = String((input && input.worldId) || "");
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_actor" };
+    if (!worldId) return { ok: false, reason: "missing_world_id" };
+    const config = worldSystemConfig(db, worldId, "size_scaling");
+    const scale = getPlayerScale(db, userId, worldId);
+    return { ok: true, scale, effects: scaleEffects(scale, config) };
+  });
+
+  /** size.set — set a player's scale; returns resolved scale + the
+   *  change cost the caller debits (free/stamina/cooldown/item). */
+  register("size", "set", (ctx, input = {}) => {
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.actor?.id;
+    const worldId = String((input && input.worldId) || "");
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_actor" };
+    if (!worldId) return { ok: false, reason: "missing_world_id" };
+    const config = worldSystemConfig(db, worldId, "size_scaling");
+    return setPlayerScale(db, userId, worldId, input.scale, config);
+  });
+
+  /** size.combat_profile — the size-scaled-combat damage model for the
+   *  player's current scale. */
+  register("size", "combat_profile", (ctx, input = {}) => {
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.actor?.id;
+    const worldId = String((input && input.worldId) || "");
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_actor" };
+    if (!worldId) return { ok: false, reason: "missing_world_id" };
+    const config = worldSystemConfig(db, worldId, "size_scaling");
+    const scale = getPlayerScale(db, userId, worldId);
+    return { ok: true, profile: scaledCombatProfile(scale, config) };
+  });
+
+  // ===== Per-player Skill Affinity ===========================================
+
+  /** skill_affinity.record — register a skill use; grows personal affinity. */
+  register("skill_affinity", "record", (ctx, input = {}) => {
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.actor?.id;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_actor" };
+    const skillId = String((input && input.skillId) || "");
+    if (!skillId) return { ok: false, reason: "missing_skill_id" };
+    const config = input.worldId
+      ? worldSystemConfig(db, String(input.worldId), "skill-affinity-player")
+      : {};
+    return recordSkillUse(db, userId, skillId, config);
+  });
+
+  /** skill_affinity.get — a player's effective affinity for a skill,
+   *  optionally combined with a world's per-domain modulator. */
+  register("skill_affinity", "get", (ctx, input = {}) => {
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.actor?.id;
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_actor" };
+    const skillId = String((input && input.skillId) || "");
+    if (!skillId) return { ok: false, reason: "missing_skill_id" };
+    const config = input.worldId
+      ? worldSystemConfig(db, String(input.worldId), "skill-affinity-player")
+      : {};
+    const playerAffinity = getPlayerAffinity(db, userId, skillId, config);
+    const worldAffinityPct = Number(input.worldAffinityPct);
+    return {
+      ok: true,
+      skillId,
+      playerAffinity,
+      effective: effectiveAffinity(playerAffinity, Number.isFinite(worldAffinityPct) ? worldAffinityPct : 100),
+    };
+  });
+
+  // ===== Status Window =======================================================
+
+  /** status.window — compose a player's world-adaptive status panel. */
+  register("status", "window", (ctx, input = {}) => {
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.actor?.id;
+    const worldId = String((input && input.worldId) || "");
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_actor" };
+    if (!worldId) return { ok: false, reason: "missing_world_id" };
+    const config = worldSystemConfig(db, worldId, "status_window");
+    // `sources` (stats/skills/effects) is caller-supplied — the macro
+    // composes titles + style; richer stat panels enrich it client-side.
+    return composeStatusWindow(db, userId, worldId, config, input.sources || {});
+  });
+
+  /** status.award_title — grant a player a world-scoped title. */
+  register("status", "award_title", (ctx, input = {}) => {
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.actor?.id;
+    const worldId = String((input && input.worldId) || "");
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_actor" };
+    if (!worldId) return { ok: false, reason: "missing_world_id" };
+    return awardTitle(db, userId, worldId, input.title);
+  });
+
+  /** status.titles — a player's earned titles in a world. */
+  register("status", "titles", (ctx, input = {}) => {
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.actor?.id;
+    const worldId = String((input && input.worldId) || "");
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_actor" };
+    if (!worldId) return { ok: false, reason: "missing_world_id" };
+    return { ok: true, titles: listTitles(db, userId, worldId) };
+  });
+
+  // ===== Isekai Reincarnation ================================================
+
+  /** reincarnation.reincarnate — start a new life, carrying an
+   *  inherited boon from the prior one. The caller's death handler
+   *  invokes this with the dying character's state. */
+  register("reincarnation", "reincarnate", (ctx, input = {}) => {
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.actor?.id;
+    const worldId = String((input && input.worldId) || "");
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_actor" };
+    if (!worldId) return { ok: false, reason: "missing_world_id" };
+    const config = worldSystemConfig(db, worldId, "reincarnation");
+    return reincarnate(db, userId, worldId, input.priorState || {}, config);
+  });
+
+  /** reincarnation.lives — a player's life ledger in a world. */
+  register("reincarnation", "lives", (ctx, input = {}) => {
+    const db = ctx?.db;
+    const userId = ctx?.actor?.userId || ctx?.actor?.id;
+    const worldId = String((input && input.worldId) || "");
+    if (!db) return { ok: false, reason: "no_db" };
+    if (!userId) return { ok: false, reason: "no_actor" };
+    if (!worldId) return { ok: false, reason: "missing_world_id" };
+    return { ok: true, lives: getLives(db, userId, worldId) };
+  });
+}

--- a/server/domains/foundry.js
+++ b/server/domains/foundry.js
@@ -2,14 +2,15 @@
 //
 // Foundry — no-code game-builder lens (#66). Macro surface.
 //
-// Phase 1 (this commit): the System Registry read surface — the
-// Foundry canvas pulls the catalog + per-system config schemas from
-// here to render the component palette and config panels.
+// Phase 1 — System Registry read surface (foundry.systems /
+//   system_schema / validate_systems).
+// Phase 2 — Worldspec persistence: foundry.{create,update,get,list,
+//   delete,validate} backed by the foundry_worlds table (migration 191).
 //
-// Later phases extend this file: Phase 2 adds foundry.{create,update,
-// get,list,delete,validate} (worldspec persistence), Phase 3 adds
-// foundry.publish, Phase 5 adds foundry.preview, Phase 6 adds
-// foundry.compose_rule.
+// Later phases extend this file: Phase 3 adds foundry.publish, Phase 5
+// adds foundry.preview, Phase 6 adds foundry.compose_rule.
+
+import { randomUUID } from "node:crypto";
 
 import {
   SYSTEM_REGISTRY,
@@ -20,15 +21,40 @@ import {
   getConfigSchema,
   validateSystemSelection,
 } from "../lib/foundry/system-registry.js";
+import {
+  emptyWorldspec,
+  normalizeWorldspec,
+  validateWorldspec,
+} from "../lib/foundry/worldspec.js";
+
+// ── Row <-> API shape ───────────────────────────────────────────────────────
+function rowToWorld(row) {
+  if (!row) return null;
+  let worldspec;
+  try { worldspec = JSON.parse(row.worldspec_json); }
+  catch { worldspec = emptyWorldspec(); }
+  return {
+    id: row.id,
+    creatorId: row.creator_id,
+    name: row.name,
+    description: row.description || "",
+    worldspec,
+    status: row.status,
+    publishedWorldId: row.published_world_id || null,
+    previewWorldId: row.preview_world_id || null,
+    promoted: !!row.promoted,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
 
 export default function registerFoundryMacros(register) {
+  // ===== Phase 1 — System Registry read surface ==============================
+
   /**
    * foundry.systems — the full composable-system catalog. The Foundry
    * canvas renders its palette straight off this.
-   * input: { category? } — optional category filter (world|character|
-   *         combat|npc|economy|social)
-   * output: { ok, count, categories, systems } — `systems` is flat,
-   *         `categories` is the grouped+labelled view.
+   * input: { category? } — optional category filter
    */
   register("foundry", "systems", (_ctx, input = {}) => {
     const category = input && input.category ? String(input.category) : null;
@@ -46,9 +72,7 @@ export default function registerFoundryMacros(register) {
   });
 
   /**
-   * foundry.system_schema — the config schema for one system (the shape
-   * the ConfigPanel renders). Also returns the system's metadata so the
-   * panel can show deps/conflicts/status inline.
+   * foundry.system_schema — the config schema + metadata for one system.
    * input: { id }
    */
   register("foundry", "system_schema", (_ctx, input = {}) => {
@@ -72,16 +96,191 @@ export default function registerFoundryMacros(register) {
   });
 
   /**
-   * foundry.validate_systems — dependency + conflict + config check on a
-   * system selection, without persisting anything. The canvas calls this
-   * live as the user adds/removes components; Phase 2's foundry.validate
-   * wraps it for the full worldspec.
+   * foundry.validate_systems — dependency/conflict/config check on a bare
+   * system selection (no worldspec envelope). The canvas calls this live.
    * input: { systems: [{ id, config? }] }
-   * output: { ok, errors, warnings, resolved }
    */
   register("foundry", "validate_systems", (_ctx, input = {}) => {
     const systems = (input && input.systems) || [];
     const result = validateSystemSelection(systems);
     return { ok: result.ok, errors: result.errors, warnings: result.warnings, resolved: result.resolved };
+  });
+
+  // ===== Phase 2 — Worldspec persistence =====================================
+
+  /**
+   * foundry.create — start a new draft game/world.
+   * input: { name, description?, worldspec? }
+   * The worldspec is normalized (defaults filled, unknown keys dropped);
+   * validation is advisory at create time and hard-gated at publish.
+   */
+  register("foundry", "create", (ctx, input = {}) => {
+    const db = ctx?.db;
+    if (!db) return { ok: false, reason: "no_db" };
+    const creatorId = ctx?.actor?.userId || ctx?.actor?.id;
+    if (!creatorId) return { ok: false, reason: "no_actor" };
+
+    const name = String((input && input.name) || "").trim();
+    if (!name) return { ok: false, reason: "missing_name" };
+    if (name.length > 200) return { ok: false, reason: "name_too_long" };
+    const description = String((input && input.description) || "").slice(0, 2000);
+
+    const worldspec = input && input.worldspec
+      ? normalizeWorldspec(input.worldspec)
+      : emptyWorldspec();
+
+    const id = `fw_${randomUUID().replace(/-/g, "").slice(0, 20)}`;
+    const now = Date.now();
+    try {
+      db.prepare(`
+        INSERT INTO foundry_worlds
+          (id, creator_id, name, description, worldspec_json, status, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, 'draft', ?, ?)
+      `).run(id, creatorId, name, description, JSON.stringify(worldspec), now, now);
+    } catch (e) {
+      return { ok: false, reason: "create_failed", error: String(e?.message || e) };
+    }
+    const row = db.prepare(`SELECT * FROM foundry_worlds WHERE id = ?`).get(id);
+    return { ok: true, world: rowToWorld(row) };
+  });
+
+  /**
+   * foundry.update — patch a draft/published world's name, description,
+   * or worldspec. Creator-scoped. Publishing is a separate macro (Phase
+   * 3) — updating the worldspec of a published world does NOT re-publish
+   * it; the live world keeps its current config until republish.
+   * input: { id, name?, description?, worldspec? }
+   */
+  register("foundry", "update", (ctx, input = {}) => {
+    const db = ctx?.db;
+    if (!db) return { ok: false, reason: "no_db" };
+    const creatorId = ctx?.actor?.userId || ctx?.actor?.id;
+    if (!creatorId) return { ok: false, reason: "no_actor" };
+    const id = String((input && input.id) || "");
+    if (!id) return { ok: false, reason: "missing_id" };
+
+    const row = db.prepare(`SELECT * FROM foundry_worlds WHERE id = ?`).get(id);
+    if (!row) return { ok: false, reason: "not_found" };
+    if (row.creator_id !== creatorId) return { ok: false, reason: "not_owner" };
+
+    const sets = [];
+    const params = [];
+    if (input.name !== undefined) {
+      const name = String(input.name).trim();
+      if (!name) return { ok: false, reason: "missing_name" };
+      if (name.length > 200) return { ok: false, reason: "name_too_long" };
+      sets.push("name = ?"); params.push(name);
+    }
+    if (input.description !== undefined) {
+      sets.push("description = ?"); params.push(String(input.description).slice(0, 2000));
+    }
+    if (input.worldspec !== undefined) {
+      sets.push("worldspec_json = ?"); params.push(JSON.stringify(normalizeWorldspec(input.worldspec)));
+    }
+    if (sets.length === 0) return { ok: false, reason: "nothing_to_update" };
+
+    sets.push("updated_at = ?"); params.push(Date.now());
+    params.push(id);
+    try {
+      db.prepare(`UPDATE foundry_worlds SET ${sets.join(", ")} WHERE id = ?`).run(...params);
+    } catch (e) {
+      return { ok: false, reason: "update_failed", error: String(e?.message || e) };
+    }
+    const updated = db.prepare(`SELECT * FROM foundry_worlds WHERE id = ?`).get(id);
+    return { ok: true, world: rowToWorld(updated) };
+  });
+
+  /**
+   * foundry.get — load one foundry world. Creator-scoped for now;
+   * published-world discovery for non-creators lands with the publish
+   * pipeline.
+   * input: { id }
+   */
+  register("foundry", "get", (ctx, input = {}) => {
+    const db = ctx?.db;
+    if (!db) return { ok: false, reason: "no_db" };
+    const creatorId = ctx?.actor?.userId || ctx?.actor?.id;
+    if (!creatorId) return { ok: false, reason: "no_actor" };
+    const id = String((input && input.id) || "");
+    if (!id) return { ok: false, reason: "missing_id" };
+
+    const row = db.prepare(`SELECT * FROM foundry_worlds WHERE id = ?`).get(id);
+    if (!row) return { ok: false, reason: "not_found" };
+    if (row.creator_id !== creatorId) return { ok: false, reason: "not_owner" };
+    return { ok: true, world: rowToWorld(row) };
+  });
+
+  /**
+   * foundry.list — the caller's foundry worlds, newest-updated first.
+   * input: { limit? }
+   */
+  register("foundry", "list", (ctx, input = {}) => {
+    const db = ctx?.db;
+    if (!db) return { ok: false, reason: "no_db" };
+    const creatorId = ctx?.actor?.userId || ctx?.actor?.id;
+    if (!creatorId) return { ok: false, reason: "no_actor" };
+    const limit = Math.min(Math.max(Number(input && input.limit) || 50, 1), 200);
+
+    const rows = db.prepare(`
+      SELECT * FROM foundry_worlds WHERE creator_id = ?
+      ORDER BY updated_at DESC LIMIT ?
+    `).all(creatorId, limit);
+    return { ok: true, count: rows.length, worlds: rows.map(rowToWorld) };
+  });
+
+  /**
+   * foundry.delete — remove a foundry world. Creator-scoped. Published
+   * worlds are blocked: deleting one would orphan the live `worlds` row.
+   * Unpublish (Phase 3) before delete.
+   * input: { id }
+   */
+  register("foundry", "delete", (ctx, input = {}) => {
+    const db = ctx?.db;
+    if (!db) return { ok: false, reason: "no_db" };
+    const creatorId = ctx?.actor?.userId || ctx?.actor?.id;
+    if (!creatorId) return { ok: false, reason: "no_actor" };
+    const id = String((input && input.id) || "");
+    if (!id) return { ok: false, reason: "missing_id" };
+
+    const row = db.prepare(`SELECT * FROM foundry_worlds WHERE id = ?`).get(id);
+    if (!row) return { ok: false, reason: "not_found" };
+    if (row.creator_id !== creatorId) return { ok: false, reason: "not_owner" };
+    if (row.status === "published" && row.published_world_id) {
+      return { ok: false, reason: "world_published", hint: "unpublish before deleting" };
+    }
+    db.prepare(`DELETE FROM foundry_worlds WHERE id = ?`).run(id);
+    return { ok: true, deleted: id };
+  });
+
+  /**
+   * foundry.validate — full worldspec validation: envelope shape +
+   * system dependency/conflict/config graph. Accepts either a stored
+   * world ({ id }) or a bare worldspec ({ worldspec }). The Foundry
+   * canvas calls this before enabling the Publish button.
+   * input: { id } | { worldspec }
+   * output: { ok, errors, warnings, normalized }
+   */
+  register("foundry", "validate", (ctx, input = {}) => {
+    const db = ctx?.db;
+    let worldspec = input && input.worldspec;
+    if (!worldspec && input && input.id) {
+      if (!db) return { ok: false, reason: "no_db" };
+      const creatorId = ctx?.actor?.userId || ctx?.actor?.id;
+      if (!creatorId) return { ok: false, reason: "no_actor" };
+      const row = db.prepare(`SELECT * FROM foundry_worlds WHERE id = ?`).get(String(input.id));
+      if (!row) return { ok: false, reason: "not_found" };
+      if (row.creator_id !== creatorId) return { ok: false, reason: "not_owner" };
+      try { worldspec = JSON.parse(row.worldspec_json); }
+      catch { worldspec = emptyWorldspec(); }
+    }
+    if (!worldspec) return { ok: false, reason: "missing_worldspec_or_id" };
+
+    const result = validateWorldspec(worldspec);
+    return {
+      ok: result.ok,
+      errors: result.errors,
+      warnings: result.warnings,
+      normalized: result.normalized,
+    };
   });
 }

--- a/server/domains/foundry.js
+++ b/server/domains/foundry.js
@@ -1,0 +1,87 @@
+// server/domains/foundry.js
+//
+// Foundry — no-code game-builder lens (#66). Macro surface.
+//
+// Phase 1 (this commit): the System Registry read surface — the
+// Foundry canvas pulls the catalog + per-system config schemas from
+// here to render the component palette and config panels.
+//
+// Later phases extend this file: Phase 2 adds foundry.{create,update,
+// get,list,delete,validate} (worldspec persistence), Phase 3 adds
+// foundry.publish, Phase 5 adds foundry.preview, Phase 6 adds
+// foundry.compose_rule.
+
+import {
+  SYSTEM_REGISTRY,
+  CATEGORY_LABELS,
+  getSystem,
+  listSystems,
+  systemsByCategory,
+  getConfigSchema,
+  validateSystemSelection,
+} from "../lib/foundry/system-registry.js";
+
+export default function registerFoundryMacros(register) {
+  /**
+   * foundry.systems — the full composable-system catalog. The Foundry
+   * canvas renders its palette straight off this.
+   * input: { category? } — optional category filter (world|character|
+   *         combat|npc|economy|social)
+   * output: { ok, count, categories, systems } — `systems` is flat,
+   *         `categories` is the grouped+labelled view.
+   */
+  register("foundry", "systems", (_ctx, input = {}) => {
+    const category = input && input.category ? String(input.category) : null;
+    if (category && !CATEGORY_LABELS[category]) {
+      return { ok: false, reason: "unknown_category", category };
+    }
+    const systems = listSystems(category ? { category } : {});
+    return {
+      ok: true,
+      count: systems.length,
+      total: SYSTEM_REGISTRY.length,
+      categories: systemsByCategory(),
+      systems,
+    };
+  });
+
+  /**
+   * foundry.system_schema — the config schema for one system (the shape
+   * the ConfigPanel renders). Also returns the system's metadata so the
+   * panel can show deps/conflicts/status inline.
+   * input: { id }
+   */
+  register("foundry", "system_schema", (_ctx, input = {}) => {
+    const id = input && input.id ? String(input.id) : null;
+    if (!id) return { ok: false, reason: "missing_id" };
+    const sys = getSystem(id);
+    if (!sys) return { ok: false, reason: "unknown_system", id };
+    return {
+      ok: true,
+      id,
+      displayName: sys.displayName,
+      description: sys.description,
+      category: sys.category,
+      worldScope: sys.worldScope,
+      status: sys.status,
+      activation: sys.activation,
+      dependsOn: sys.dependsOn,
+      conflictsWith: sys.conflictsWith,
+      configSchema: getConfigSchema(id),
+    };
+  });
+
+  /**
+   * foundry.validate_systems — dependency + conflict + config check on a
+   * system selection, without persisting anything. The canvas calls this
+   * live as the user adds/removes components; Phase 2's foundry.validate
+   * wraps it for the full worldspec.
+   * input: { systems: [{ id, config? }] }
+   * output: { ok, errors, warnings, resolved }
+   */
+  register("foundry", "validate_systems", (_ctx, input = {}) => {
+    const systems = (input && input.systems) || [];
+    const result = validateSystemSelection(systems);
+    return { ok: result.ok, errors: result.errors, warnings: result.warnings, resolved: result.resolved };
+  });
+}

--- a/server/domains/foundry.js
+++ b/server/domains/foundry.js
@@ -432,4 +432,113 @@ export default function registerFoundryMacros(register) {
     const updated = db.prepare(`SELECT * FROM foundry_worlds WHERE id = ?`).get(id);
     return { ok: true, disposition, formerWorldId: worldId, world: rowToWorld(updated) };
   });
+
+  // ===== Phase 5 — Live 3D preview ===========================================
+
+  /**
+   * foundry.preview — compile the current draft into a throwaway
+   * `worlds` row (status='preview') the 3D renderer can load by id.
+   * ConcordiaScene is hardwired to load-a-world-by-id, so the preview
+   * IS a real (transient) world. Reuses an existing preview row when
+   * one is already attached — never accumulates more than one per
+   * foundry world. The foundry-preview-cleanup heartbeat sweeps any
+   * that go stale (~2h).
+   *
+   * Forgiving by design: unlike publish this does NOT hard-gate on
+   * validation — the compiler skips unknown/stub systems gracefully,
+   * so you can preview a half-built world. Only an empty selection is
+   * rejected (nothing to render).
+   * input: { id }
+   * output: { ok, previewWorldId, universeType, activatedSystems }
+   */
+  register("foundry", "preview", (ctx, input = {}) => {
+    const db = ctx?.db;
+    if (!db) return { ok: false, reason: "no_db" };
+    const creatorId = ctx?.actor?.userId || ctx?.actor?.id;
+    if (!creatorId) return { ok: false, reason: "no_actor" };
+    const id = String((input && input.id) || "");
+    if (!id) return { ok: false, reason: "missing_id" };
+
+    const row = db.prepare(`SELECT * FROM foundry_worlds WHERE id = ?`).get(id);
+    if (!row) return { ok: false, reason: "not_found" };
+    if (row.creator_id !== creatorId) return { ok: false, reason: "not_owner" };
+
+    let rawSpec;
+    try { rawSpec = JSON.parse(row.worldspec_json); }
+    catch { rawSpec = emptyWorldspec(); }
+    const worldspec = normalizeWorldspec(rawSpec);
+    if (worldspec.systems.length === 0) {
+      return { ok: false, reason: "no_systems", hint: "add a system before previewing" };
+    }
+
+    const compiled = compileWorldspec(worldspec);
+    const nowSec = Math.floor(Date.now() / 1000);
+    const physJson = JSON.stringify(compiled.physics_modulators);
+    const ruleJson = JSON.stringify(compiled.rule_modulators);
+    const previewName = `${row.name} (preview)`;
+
+    // Reuse an attached preview row if it still exists; else mint one.
+    let previewWorldId = row.preview_world_id;
+    const existing = previewWorldId
+      ? db.prepare(`SELECT id FROM worlds WHERE id = ? AND status = 'preview'`).get(previewWorldId)
+      : null;
+
+    try {
+      if (existing) {
+        db.prepare(`
+          UPDATE worlds
+          SET name = ?, universe_type = ?, physics_modulators = ?, rule_modulators = ?, created_at = ?
+          WHERE id = ?
+        `).run(previewName, worldspec.theme.universeType, physJson, ruleJson, nowSec, previewWorldId);
+      } else {
+        previewWorldId = `preview-${randomUUID()}`;
+        db.prepare(`
+          INSERT INTO worlds
+            (id, name, universe_type, description, physics_modulators, rule_modulators, created_by, status, created_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, 'preview', ?)
+        `).run(
+          previewWorldId, previewName, worldspec.theme.universeType,
+          `Foundry live preview of ${row.name}.`, physJson, ruleJson, creatorId, nowSec,
+        );
+        db.prepare(`UPDATE foundry_worlds SET preview_world_id = ? WHERE id = ?`).run(previewWorldId, id);
+      }
+    } catch (e) {
+      return { ok: false, reason: "preview_failed", error: String(e?.message || e) };
+    }
+
+    return {
+      ok: true,
+      previewWorldId,
+      universeType: worldspec.theme.universeType,
+      activatedSystems: compiled.activatedSystems,
+      skippedStubs: compiled.skippedStubs,
+    };
+  });
+
+  /**
+   * foundry.preview_end — tear down a foundry world's preview row.
+   * Called when the builder closes the preview panel. Idempotent.
+   * input: { id }
+   */
+  register("foundry", "preview_end", (ctx, input = {}) => {
+    const db = ctx?.db;
+    if (!db) return { ok: false, reason: "no_db" };
+    const creatorId = ctx?.actor?.userId || ctx?.actor?.id;
+    if (!creatorId) return { ok: false, reason: "no_actor" };
+    const id = String((input && input.id) || "");
+    if (!id) return { ok: false, reason: "missing_id" };
+
+    const row = db.prepare(`SELECT * FROM foundry_worlds WHERE id = ?`).get(id);
+    if (!row) return { ok: false, reason: "not_found" };
+    if (row.creator_id !== creatorId) return { ok: false, reason: "not_owner" };
+    if (!row.preview_world_id) return { ok: true, alreadyClear: true };
+
+    try {
+      db.prepare(`DELETE FROM worlds WHERE id = ? AND status = 'preview'`).run(row.preview_world_id);
+      db.prepare(`UPDATE foundry_worlds SET preview_world_id = NULL WHERE id = ?`).run(id);
+    } catch (e) {
+      return { ok: false, reason: "preview_end_failed", error: String(e?.message || e) };
+    }
+    return { ok: true };
+  });
 }

--- a/server/domains/foundry.js
+++ b/server/domains/foundry.js
@@ -26,6 +26,7 @@ import {
   normalizeWorldspec,
   validateWorldspec,
 } from "../lib/foundry/worldspec.js";
+import { compileWorldspec, buildConcordLinkAnchor } from "../lib/foundry/compiler.js";
 
 // ── Row <-> API shape ───────────────────────────────────────────────────────
 function rowToWorld(row) {
@@ -282,5 +283,153 @@ export default function registerFoundryMacros(register) {
       warnings: result.warnings,
       normalized: result.normalized,
     };
+  });
+
+  // ===== Phase 3 — Publish pipeline (overlay model) ==========================
+
+  /**
+   * foundry.publish — compile a draft worldspec into a real `worlds`
+   * row. The hybrid model's "overlay" half: the published game IS a
+   * first-class worlds row, driven by compiled rule_modulators /
+   * physics_modulators rather than an authored content directory.
+   *
+   * Hard-gated: the worldspec must validate (errors block) and have at
+   * least one non-stub system. Stub systems persist in the spec but
+   * don't activate until Phase 7 flips their status.
+   *
+   * input: { id }
+   * output: { ok, publishedWorldId, world, activatedSystems, skippedStubs, contentSeeds }
+   */
+  register("foundry", "publish", (ctx, input = {}) => {
+    const db = ctx?.db;
+    if (!db) return { ok: false, reason: "no_db" };
+    const creatorId = ctx?.actor?.userId || ctx?.actor?.id;
+    if (!creatorId) return { ok: false, reason: "no_actor" };
+    const id = String((input && input.id) || "");
+    if (!id) return { ok: false, reason: "missing_id" };
+
+    const row = db.prepare(`SELECT * FROM foundry_worlds WHERE id = ?`).get(id);
+    if (!row) return { ok: false, reason: "not_found" };
+    if (row.creator_id !== creatorId) return { ok: false, reason: "not_owner" };
+    if (row.status === "published" && row.published_world_id) {
+      return { ok: false, reason: "already_published", publishedWorldId: row.published_world_id };
+    }
+
+    let rawSpec;
+    try { rawSpec = JSON.parse(row.worldspec_json); }
+    catch { rawSpec = emptyWorldspec(); }
+    const validation = validateWorldspec(rawSpec);
+    if (!validation.ok) {
+      return { ok: false, reason: "worldspec_invalid", errors: validation.errors, warnings: validation.warnings };
+    }
+    const worldspec = validation.normalized;
+    if (worldspec.systems.length === 0) {
+      return { ok: false, reason: "no_systems", hint: "select at least one system before publishing" };
+    }
+
+    const compiled = compileWorldspec(worldspec);
+    const worldId = `world-${randomUUID()}`;
+    const now = Date.now();
+
+    const publishTx = db.transaction(() => {
+      db.prepare(`
+        INSERT INTO worlds
+          (id, name, universe_type, description, physics_modulators, rule_modulators, created_by, status)
+        VALUES (?, ?, ?, ?, ?, ?, ?, 'active')
+      `).run(
+        worldId,
+        row.name,
+        worldspec.theme.universeType,
+        row.description || worldspec.theme.displayName || "",
+        JSON.stringify(compiled.physics_modulators),
+        JSON.stringify(compiled.rule_modulators),
+        creatorId,
+      );
+
+      // Concord Link anchor — best-effort; a missing table must not
+      // abort the publish (the world is still valid without an anchor).
+      if (compiled.concordLinkAnchor) {
+        try {
+          const a = buildConcordLinkAnchor(worldId, row.name, compiled.concordLinkAnchor);
+          db.prepare(`
+            INSERT INTO concord_link_anchors
+              (id, world_id, name, access_method, description, location, controlled_by_faction, stability)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET access_method = excluded.access_method, stability = excluded.stability
+          `).run(a.id, a.world_id, a.name, a.access_method, a.description, a.location, a.controlled_by_faction, a.stability);
+        } catch (_e) { /* anchor table optional in some contexts */ }
+      }
+
+      db.prepare(`
+        UPDATE foundry_worlds
+        SET status = 'published', published_world_id = ?, updated_at = ?
+        WHERE id = ?
+      `).run(worldId, now, id);
+    });
+
+    try { publishTx(); }
+    catch (e) { return { ok: false, reason: "publish_failed", error: String(e?.message || e) }; }
+
+    const updated = db.prepare(`SELECT * FROM foundry_worlds WHERE id = ?`).get(id);
+    return {
+      ok: true,
+      publishedWorldId: worldId,
+      world: rowToWorld(updated),
+      activatedSystems: compiled.activatedSystems,
+      skippedStubs: compiled.skippedStubs, // stub systems — activate once Phase 7 ships
+      contentSeeds: compiled.contentSeeds.map((c) => c.key), // declared; deep seeding is promote-tier
+    };
+  });
+
+  /**
+   * foundry.unpublish — take a published Foundry world back to draft.
+   * The overlay `worlds` row is deleted if nobody has visited it, or
+   * archived (status='archived') if it has visits — so live worlds
+   * people have used are never silently destroyed. The Concord Link
+   * anchor is removed best-effort.
+   * input: { id }
+   */
+  register("foundry", "unpublish", (ctx, input = {}) => {
+    const db = ctx?.db;
+    if (!db) return { ok: false, reason: "no_db" };
+    const creatorId = ctx?.actor?.userId || ctx?.actor?.id;
+    if (!creatorId) return { ok: false, reason: "no_actor" };
+    const id = String((input && input.id) || "");
+    if (!id) return { ok: false, reason: "missing_id" };
+
+    const row = db.prepare(`SELECT * FROM foundry_worlds WHERE id = ?`).get(id);
+    if (!row) return { ok: false, reason: "not_found" };
+    if (row.creator_id !== creatorId) return { ok: false, reason: "not_owner" };
+    if (row.status !== "published" || !row.published_world_id) {
+      return { ok: false, reason: "not_published" };
+    }
+
+    const worldId = row.published_world_id;
+    let disposition = "deleted";
+    const unpublishTx = db.transaction(() => {
+      const w = db.prepare(`SELECT total_visits FROM worlds WHERE id = ?`).get(worldId);
+      if (w && Number(w.total_visits) > 0) {
+        db.prepare(`UPDATE worlds SET status = 'archived' WHERE id = ?`).run(worldId);
+        disposition = "archived";
+      } else if (w) {
+        db.prepare(`DELETE FROM worlds WHERE id = ?`).run(worldId);
+        disposition = "deleted";
+      } else {
+        disposition = "world_already_gone";
+      }
+      try { db.prepare(`DELETE FROM concord_link_anchors WHERE world_id = ?`).run(worldId); }
+      catch (_e) { /* anchor table optional */ }
+      db.prepare(`
+        UPDATE foundry_worlds
+        SET status = 'draft', published_world_id = NULL, updated_at = ?
+        WHERE id = ?
+      `).run(Date.now(), id);
+    });
+
+    try { unpublishTx(); }
+    catch (e) { return { ok: false, reason: "unpublish_failed", error: String(e?.message || e) }; }
+
+    const updated = db.prepare(`SELECT * FROM foundry_worlds WHERE id = ?`).get(id);
+    return { ok: true, disposition, formerWorldId: worldId, world: rowToWorld(updated) };
   });
 }

--- a/server/domains/foundry.js
+++ b/server/domains/foundry.js
@@ -27,6 +27,10 @@ import {
   validateWorldspec,
 } from "../lib/foundry/worldspec.js";
 import { compileWorldspec, buildConcordLinkAnchor } from "../lib/foundry/compiler.js";
+import { listTemplates, getTemplate } from "../lib/foundry/templates.js";
+import {
+  composeRuleDeterministic, validateRule, buildRulePrompt, parseRuleFromLLM,
+} from "../lib/foundry/rules.js";
 
 // ── Row <-> API shape ───────────────────────────────────────────────────────
 function rowToWorld(row) {
@@ -126,9 +130,20 @@ export default function registerFoundryMacros(register) {
     if (name.length > 200) return { ok: false, reason: "name_too_long" };
     const description = String((input && input.description) || "").slice(0, 2000);
 
-    const worldspec = input && input.worldspec
-      ? normalizeWorldspec(input.worldspec)
-      : emptyWorldspec();
+    // Worldspec source priority: an explicit worldspec, then a
+    // templateId (Phase 6), then a blank slate. Templates are
+    // normalized like any other spec so a stale template can't
+    // corrupt anything.
+    let worldspec;
+    if (input && input.worldspec) {
+      worldspec = normalizeWorldspec(input.worldspec);
+    } else if (input && input.templateId) {
+      const tpl = getTemplate(input.templateId);
+      if (!tpl) return { ok: false, reason: "unknown_template", templateId: input.templateId };
+      worldspec = normalizeWorldspec(tpl.worldspec);
+    } else {
+      worldspec = emptyWorldspec();
+    }
 
     const id = `fw_${randomUUID().replace(/-/g, "").slice(0, 20)}`;
     const now = Date.now();
@@ -513,6 +528,83 @@ export default function registerFoundryMacros(register) {
       activatedSystems: compiled.activatedSystems,
       skippedStubs: compiled.skippedStubs,
     };
+  });
+
+  // ===== Phase 6 — templates + NL rules ======================================
+
+  /**
+   * foundry.templates — the game-template catalog. Each is a pre-filled
+   * worldspec; foundry.create accepts a templateId to start from one.
+   * input: {} — no args
+   */
+  register("foundry", "templates", () => {
+    const templates = listTemplates();
+    return { ok: true, count: templates.length, templates };
+  });
+
+  /**
+   * foundry.compose_rule — translate a natural-language game rule into a
+   * structured rule. Tries the conscious brain first; on any failure or
+   * unparseable output it falls back to a deterministic keyword parse —
+   * the macro ALWAYS returns a usable rule (brain-offline is not an
+   * error here, same posture as the dream/forward-sim engines).
+   *
+   * If `id` is given, the composed rule is appended to that foundry
+   * world's worldspec.rules[] and persisted. Otherwise the rule is just
+   * returned for the canvas to hold client-side.
+   * input: { naturalLanguage, id? }
+   * output: { ok, rule, composedBy, warnings, saved? }
+   */
+  register("foundry", "compose_rule", async (ctx, input = {}) => {
+    const nl = String((input && input.naturalLanguage) || "").trim();
+    if (!nl) return { ok: false, reason: "missing_natural_language" };
+    if (nl.length > 500) return { ok: false, reason: "rule_too_long" };
+
+    // Try the LLM path; fall back to deterministic on any hiccup.
+    let rule = null;
+    try {
+      if (ctx?.llm?.enabled && typeof ctx.llm.chat === "function") {
+        const r = await ctx.llm.chat({
+          system: "You convert plain-language game rules into strict JSON. Reply with JSON only.",
+          messages: [{ role: "user", content: buildRulePrompt(nl) }],
+          temperature: 0.2,
+          maxTokens: 300,
+          timeoutMs: 20000,
+        });
+        const text = r && (r.content || r.message?.content || r.text);
+        if (r && r.ok !== false && text) rule = parseRuleFromLLM(nl, text);
+      }
+    } catch {
+      rule = null; // deterministic fallback below
+    }
+    if (!rule) rule = composeRuleDeterministic(nl);
+
+    const validated = validateRule(rule);
+    if (!validated.ok) return { ok: false, reason: "rule_invalid", warnings: validated.warnings };
+    rule = validated.rule;
+
+    // Optionally persist onto a stored foundry world.
+    let saved = false;
+    const id = input && input.id ? String(input.id) : null;
+    if (id) {
+      const db = ctx?.db;
+      const creatorId = ctx?.actor?.userId || ctx?.actor?.id;
+      if (db && creatorId) {
+        const row = db.prepare(`SELECT * FROM foundry_worlds WHERE id = ?`).get(id);
+        if (!row) return { ok: false, reason: "not_found" };
+        if (row.creator_id !== creatorId) return { ok: false, reason: "not_owner" };
+        let spec;
+        try { spec = JSON.parse(row.worldspec_json); }
+        catch { spec = emptyWorldspec(); }
+        const normalized = normalizeWorldspec(spec);
+        normalized.rules = [...normalized.rules, rule].slice(-200);
+        db.prepare(`UPDATE foundry_worlds SET worldspec_json = ?, updated_at = ? WHERE id = ?`)
+          .run(JSON.stringify(normalized), Date.now(), id);
+        saved = true;
+      }
+    }
+
+    return { ok: true, rule, composedBy: rule.composedBy, warnings: validated.warnings, saved };
   });
 
   /**

--- a/server/domains/foundry.js
+++ b/server/domains/foundry.js
@@ -1,6 +1,6 @@
 // server/domains/foundry.js
 //
-// Foundry — no-code game-builder lens (#66). Macro surface.
+// Foundry — no-code game-builder lens (#125). Macro surface.
 //
 // Phase 1 — System Registry read surface (foundry.systems /
 //   system_schema / validate_systems).

--- a/server/emergent/foundry-preview-cleanup.js
+++ b/server/emergent/foundry-preview-cleanup.js
@@ -1,0 +1,62 @@
+// server/emergent/foundry-preview-cleanup.js
+//
+// Foundry — preview-world cleanup heartbeat (Phase 5).
+//
+// foundry.preview mints throwaway `worlds` rows (status='preview') so
+// ConcordiaScene can render a draft live. foundry.preview_end tears
+// them down when the builder closes the panel — but a closed tab, a
+// crash, or a lost connection leaves an orphan. This heartbeat sweeps
+// preview rows whose created_at (refreshed on every foundry.preview
+// call) is older than the TTL, and clears any dangling
+// foundry_worlds.preview_world_id pointers.
+//
+// Registered in server.js via registerHeartbeat. Frequency is low
+// (~1h) — preview rows are tiny and a short-lived orphan is harmless;
+// this is housekeeping, not a hot path. Heartbeat-safe: always returns
+// a plain { ok } object, never throws.
+
+const PREVIEW_TTL_SECONDS = 2 * 60 * 60; // 2h — well past any real editing session
+
+/**
+ * @param {{ db: object }} ctx
+ * @returns {{ ok: boolean, swept?: number, danglingCleared?: number, reason?: string }}
+ */
+export function runFoundryPreviewCleanup(ctx = {}) {
+  const db = ctx && ctx.db;
+  if (!db) return { ok: true, reason: "no_db" };
+
+  try {
+    const cutoff = Math.floor(Date.now() / 1000) - PREVIEW_TTL_SECONDS;
+
+    // Sweep stale preview worlds.
+    const stale = db.prepare(
+      `SELECT id FROM worlds WHERE status = 'preview' AND created_at < ?`,
+    ).all(cutoff);
+    let swept = 0;
+    if (stale.length) {
+      const del = db.prepare(`DELETE FROM worlds WHERE id = ?`);
+      for (const row of stale) { del.run(row.id); swept += 1; }
+    }
+
+    // Clear foundry_worlds.preview_world_id pointers that no longer
+    // resolve to a live preview row (swept above, or gone any other way).
+    let danglingCleared = 0;
+    try {
+      const r = db.prepare(`
+        UPDATE foundry_worlds
+        SET preview_world_id = NULL
+        WHERE preview_world_id IS NOT NULL
+          AND preview_world_id NOT IN (SELECT id FROM worlds WHERE status = 'preview')
+      `).run();
+      danglingCleared = r.changes || 0;
+    } catch (_e) {
+      // foundry_worlds may not exist in some minimal contexts — non-fatal.
+    }
+
+    return { ok: true, swept, danglingCleared };
+  } catch (e) {
+    return { ok: false, reason: "cleanup_failed", error: String(e?.message || e) };
+  }
+}
+
+export const FOUNDRY_PREVIEW_CLEANUP_INTERNALS = Object.freeze({ PREVIEW_TTL_SECONDS });

--- a/server/lib/foundry/compiler.js
+++ b/server/lib/foundry/compiler.js
@@ -93,13 +93,18 @@ export function compileWorldspec(worldspec) {
   }
 
   // Provenance marker — lets the runtime + a future "promote" step
-  // recognise a Foundry-built world and know what it was assembled from.
+  // recognise a Foundry-built world and know what it was assembled
+  // from. The authored rules ride along here too: this is the stable
+  // place a runtime rule-evaluator reads them from once that layer
+  // lands (Phase 6 ships composition + persistence; the evaluator
+  // that fires rules against live world events is a later layer).
   rule_modulators.foundry = {
     worldspecVersion: worldspec?.version || 1,
     template: worldspec?.template || null,
     systems: activatedSystems,
     stubs: skippedStubs,
     contentSeeds: contentSeeds.map((c) => c.key),
+    rules: Array.isArray(worldspec?.rules) ? worldspec.rules : [],
   };
 
   return {

--- a/server/lib/foundry/compiler.js
+++ b/server/lib/foundry/compiler.js
@@ -1,0 +1,132 @@
+// server/lib/foundry/compiler.js
+//
+// Foundry — the Worldspec compiler (Phase 3).
+//
+// Turns a validated worldspec into the concrete artifacts a real
+// `worlds` row needs: physics_modulators, rule_modulators, the
+// content-seed declarations, and a Concord Link anchor spec.
+//
+// This is the "overlay" half of the hybrid publish model: a published
+// Foundry game IS a real `worlds` row, but its behaviour is driven by
+// modulators rather than an authored content/world/<id>/ directory.
+// "Promotion" to a full first-class world node (persisted seed
+// content) is a later flag — the compiler output is the same; only
+// the seeding depth changes.
+//
+// How a system activates is declared on its registry entry's
+// `activation`:
+//   physics_modulator — config -> physics_modulators[key]
+//   rule_modulator    — config -> rule_modulators[key]
+//   heartbeat_optin   — config -> rule_modulators[key] + an explicit
+//                       rule_modulators.foundry_heartbeats[key] = true
+//                       marker (the per-world heartbeats already run;
+//                       the marker lets future wiring gate them)
+//   content_seed      — collected into contentSeeds[]; concord-link is
+//                       special-cased into a concordLinkAnchor spec
+//   always_on         — substrate/player-level; no per-world write
+//
+// Stub systems (status:'stub' — the Phase 7 net-new set) are SKIPPED:
+// they're selectable + persist in the worldspec, but don't activate
+// until Phase 7 flips their status. No compiler change needed then.
+
+import { getSystem } from "./system-registry.js";
+
+/**
+ * Compile a (validated, normalized) worldspec into world artifacts.
+ *
+ * @param {object} worldspec
+ * @returns {{
+ *   physics_modulators: object,
+ *   rule_modulators: object,
+ *   contentSeeds: Array<{system,key,config}>,
+ *   concordLinkAnchor: object|null,
+ *   activatedSystems: string[],
+ *   skippedStubs: string[],
+ * }}
+ */
+export function compileWorldspec(worldspec) {
+  const physics_modulators = {};
+  const rule_modulators = {};
+  const contentSeeds = [];
+  let concordLinkAnchor = null;
+  const activatedSystems = [];
+  const skippedStubs = [];
+
+  const systems = Array.isArray(worldspec?.systems) ? worldspec.systems : [];
+
+  for (const entry of systems) {
+    const sys = getSystem(entry && entry.id);
+    if (!sys) continue; // unknown id — validation should have caught it
+    if (sys.status === "stub") {
+      skippedStubs.push(entry.id);
+      continue; // not built yet — activates once Phase 7 ships
+    }
+    const config = entry.config && typeof entry.config === "object" ? entry.config : {};
+    const { activation } = sys;
+    activatedSystems.push(entry.id);
+
+    switch (activation.kind) {
+      case "physics_modulator":
+        physics_modulators[activation.key] = config;
+        break;
+      case "rule_modulator":
+        rule_modulators[activation.key] = config;
+        break;
+      case "heartbeat_optin":
+        rule_modulators[activation.key] = config;
+        (rule_modulators.foundry_heartbeats ||= {})[activation.key] = true;
+        break;
+      case "content_seed":
+        contentSeeds.push({ system: entry.id, key: activation.key, config });
+        if (entry.id === "concord-link") {
+          concordLinkAnchor = {
+            travelMode: config.travelMode || "portal",
+            inboundOpen: config.inboundOpen !== false,
+            outboundOpen: config.outboundOpen !== false,
+          };
+        }
+        break;
+      case "always_on":
+      default:
+        break; // substrate/player-level — nothing per-world to write
+    }
+  }
+
+  // Provenance marker — lets the runtime + a future "promote" step
+  // recognise a Foundry-built world and know what it was assembled from.
+  rule_modulators.foundry = {
+    worldspecVersion: worldspec?.version || 1,
+    template: worldspec?.template || null,
+    systems: activatedSystems,
+    stubs: skippedStubs,
+    contentSeeds: contentSeeds.map((c) => c.key),
+  };
+
+  return {
+    physics_modulators,
+    rule_modulators,
+    contentSeeds,
+    concordLinkAnchor,
+    activatedSystems,
+    skippedStubs,
+  };
+}
+
+/**
+ * Build the Concord Link anchor row spec for a freshly-published world.
+ * Returns null when concord-link wasn't selected. The shape matches
+ * what `concord_link_anchors` expects (see seedAnchorsFromWorldMeta).
+ */
+export function buildConcordLinkAnchor(worldId, worldName, anchorCfg) {
+  if (!anchorCfg) return null;
+  return {
+    id: `anchor-${worldId}`,
+    world_id: worldId,
+    name: `${worldName} Gateway`,
+    access_method: anchorCfg.travelMode || "portal",
+    description: `Concord Link arrival point for ${worldName}, built in Foundry.`,
+    location: null,
+    controlled_by_faction: null,
+    stability: 1.0,
+  };
+}

--- a/server/lib/foundry/reincarnation.js
+++ b/server/lib/foundry/reincarnation.js
@@ -1,0 +1,119 @@
+// server/lib/foundry/reincarnation.js
+//
+// Foundry Phase 7 — Isekai Reincarnation.
+//
+// On death in a world that enables this system, a character can be
+// reincarnated rather than simply ending — carrying a fraction of
+// their prior progress forward as an inherited boon, optionally with a
+// rerolled appearance and fragmentary past-life memories.
+//
+// The world's isekai-reincarnation config carries enabled /
+// inheritedFraction / rerollAppearance / memoryFragments. This module
+// owns the per-world life ledger + the inheritance math + the
+// reincarnate flow. Hooking it onto the actual death event is the
+// caller's job (a world's death handler invokes reincarnate()).
+
+import { randomUUID } from "node:crypto";
+
+const DEFAULT_CONFIG = Object.freeze({
+  enabled: true,
+  inheritedFraction: 20,   // % of prior progress carried forward
+  rerollAppearance: true,
+  memoryFragments: true,
+});
+
+function cfg(c) {
+  return { ...DEFAULT_CONFIG, ...(c && typeof c === "object" ? c : {}) };
+}
+
+/**
+ * Compute the inherited boon from a prior life's state. Numeric
+ * progress fields (xp, level, currency, skill totals) carry forward at
+ * inheritedFraction; everything else is dropped — reincarnation is a
+ * fresh start with an echo, not a save-load.
+ */
+export function computeInheritance(priorState, worldConfig) {
+  const c = cfg(worldConfig);
+  const frac = Math.min(0.75, Math.max(0, c.inheritedFraction / 100));
+  const prior = priorState && typeof priorState === "object" ? priorState : {};
+  const inherited = {};
+  for (const key of ["xp", "level", "currency", "skillPoints", "renown"]) {
+    const v = Number(prior[key]);
+    if (Number.isFinite(v) && v > 0) {
+      // level carries as a floor (you don't lose a level to a fraction
+      // of 1); the rest carry proportionally.
+      inherited[key] = key === "level"
+        ? Math.max(1, Math.floor(v * frac))
+        : Number((v * frac).toFixed(2));
+    }
+  }
+  return { fraction: frac, inherited };
+}
+
+/**
+ * Reincarnate a player in a world. Records a new life in the ledger
+ * and returns the starting state for the new life.
+ * @returns {{ ok, lifeNumber, inherited, rerollAppearance, memoryFragments }}
+ */
+export function reincarnate(db, userId, worldId, priorState, worldConfig) {
+  if (!db) return { ok: false, reason: "no_db" };
+  if (!userId || !worldId) return { ok: false, reason: "missing_args" };
+  const c = cfg(worldConfig);
+  if (c.enabled === false) return { ok: false, reason: "reincarnation_disabled" };
+
+  const prevLives = db.prepare(
+    `SELECT COUNT(*) AS n FROM reincarnations WHERE user_id = ? AND world_id = ?`,
+  ).get(userId, worldId).n;
+  const lifeNumber = prevLives + 2; // life 1 was the original; first reincarnation is life 2
+
+  const { fraction, inherited } = computeInheritance(priorState, worldConfig);
+  const inheritedRecord = {
+    fraction,
+    ...inherited,
+    memoryFragments: c.memoryFragments
+      ? `Fragments of life ${lifeNumber - 1} linger.`
+      : null,
+  };
+
+  db.prepare(`
+    INSERT INTO reincarnations (id, user_id, world_id, life_number, prior_avatar_id, inherited_json, reincarnated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    `rein_${randomUUID().replace(/-/g, "").slice(0, 18)}`,
+    userId, worldId, lifeNumber,
+    priorState && priorState.avatarId ? String(priorState.avatarId) : null,
+    JSON.stringify(inheritedRecord),
+    Date.now(),
+  );
+
+  return {
+    ok: true,
+    lifeNumber,
+    inherited: inheritedRecord,
+    rerollAppearance: c.rerollAppearance !== false,
+    memoryFragments: c.memoryFragments !== false,
+  };
+}
+
+/** The full life ledger for a player in a world, newest life first. */
+export function getLives(db, userId, worldId) {
+  if (!db || !userId || !worldId) return [];
+  const rows = db.prepare(`
+    SELECT id, life_number, prior_avatar_id, inherited_json, reincarnated_at
+    FROM reincarnations WHERE user_id = ? AND world_id = ?
+    ORDER BY life_number DESC
+  `).all(userId, worldId);
+  return rows.map((r) => {
+    let inherited;
+    try { inherited = JSON.parse(r.inherited_json); } catch { inherited = {}; }
+    return {
+      id: r.id,
+      lifeNumber: r.life_number,
+      priorAvatarId: r.prior_avatar_id,
+      inherited,
+      reincarnatedAt: r.reincarnated_at,
+    };
+  });
+}
+
+export const REINCARNATION_INTERNALS = Object.freeze({ DEFAULT_CONFIG });

--- a/server/lib/foundry/rules.js
+++ b/server/lib/foundry/rules.js
@@ -1,0 +1,199 @@
+// server/lib/foundry/rules.js
+//
+// Foundry — natural-language rule composition (Phase 6).
+//
+// A "rule" is an authored bit of game logic: "when a player enters the
+// boss arena, lock the doors". foundry.compose_rule translates the
+// natural-language sentence into this structured shape, which lands in
+// the worldspec's rules[] array and is compiled into
+// rule_modulators.foundry.rules on publish — a stable place a future
+// runtime rule-evaluator reads from. (The evaluator that *fires* these
+// against live world events is its own layer; Phase 6 ships the
+// composition + persistence + the schema it consumes.)
+//
+// Two composition paths:
+//   - LLM: the utility brain translates NL -> structured rule (best
+//     fidelity). Used when a brain is reachable.
+//   - deterministic: a keyword/grammar fallback that runs with no LLM
+//     at all. Lower confidence, but a rule with composedBy:'deterministic'
+//     still carries the author's intent and is fully persisted.
+// The macro always returns a usable rule — it never hard-fails on a
+// brain being offline (same posture as the dream/forward-sim engines).
+
+import { randomUUID } from "node:crypto";
+
+// ── Vocabulary ──────────────────────────────────────────────────────────────
+export const RULE_TRIGGERS = Object.freeze([
+  "player_enters",   // a player enters a named region/structure
+  "player_leaves",   // a player leaves one
+  "on_time",         // a time interval / schedule
+  "on_combat",       // combat starts / a hit lands
+  "on_death",        // an entity dies
+  "on_gather",       // a resource node is harvested
+  "world_state",     // a world-state condition is met
+  "unknown",         // couldn't classify — still stored
+]);
+
+export const RULE_EFFECTS = Object.freeze([
+  "lock",       // seal a region / structure / exit
+  "unlock",     // open one
+  "spawn",      // spawn an entity / encounter
+  "announce",   // surface a message to players
+  "reward",     // grant currency / items / xp
+  "modifier",   // apply a temporary world/skill modifier
+  "despawn",    // remove an entity
+  "unknown",
+]);
+
+const TRIGGER_KEYWORDS = [
+  [/\b(enters?|arriv\w+|steps? into|walks? into)\b/i, "player_enters"],
+  [/\b(leaves?|exits?|steps? out|walks? out)\b/i, "player_leaves"],
+  [/\b(every|each|after \d|per (minute|hour|day)|on a timer)\b/i, "on_time"],
+  [/\b(fights?|attacks?|combat|battle|strikes?)\b/i, "on_combat"],
+  [/\b(dies?|death|killed|defeated|falls?)\b/i, "on_death"],
+  [/\b(gathers?|harvests?|mines?|collects?)\b/i, "on_gather"],
+];
+
+const EFFECT_KEYWORDS = [
+  [/\b(unlocks?|opens?|reveals?)\b/i, "unlock"], // before "lock" so "unlock" wins
+  [/\b(locks?|seals?|closes?|bars?)\b/i, "lock"],
+  [/\b(spawns?|summons?|appears?|emerges?)\b/i, "spawn"],
+  [/\b(despawns?|removes?|vanish\w*|disappears?)\b/i, "despawn"],
+  [/\b(announces?|messages?|tells?|warns?|notif\w+|broadcasts?)\b/i, "announce"],
+  [/\b(rewards?|grants?|gives?|awards?|drops?)\b/i, "reward"],
+  [/\b(boosts?|buffs?|debuffs?|modif\w+|increases?|decreases?|slows?|hastens?)\b/i, "modifier"],
+];
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+// Words that shouldn't start (or sit inside) a target noun phrase —
+// trims the deterministic extractor from drifting into the verb clause.
+const TARGET_STOPWORDS = new Set([
+  "player", "players", "enters", "leaves", "arrives", "exits", "fights",
+  "attacks", "dies", "gathers", "harvests", "spawns", "locks", "unlocks",
+  "opens", "closes", "and", "then", "when", "will", "gets", "get",
+]);
+
+/**
+ * Grab a short target phrase — up to 3 words after "the" (target noun
+ * phrases overwhelmingly use the definite article), stopping at the
+ * first stopword. Best-effort: this is the no-LLM fallback's extractor,
+ * and the rule it feeds is explicitly low-confidence.
+ */
+function extractTarget(text) {
+  const m = text.match(/\bthe\s+([a-z][a-z'-]*(?:\s+[a-z][a-z'-]*){0,2})/i);
+  if (!m) return null;
+  const words = m[1].toLowerCase().split(/\s+/);
+  const kept = [];
+  for (const w of words) {
+    if (TARGET_STOPWORDS.has(w)) break;
+    kept.push(w);
+  }
+  return kept.length ? kept.join(" ") : null;
+}
+
+/**
+ * Deterministic NL -> rule. No LLM. Keyword classification + a
+ * best-effort target extraction. Confidence is intentionally modest.
+ */
+export function composeRuleDeterministic(naturalLanguage) {
+  const nl = String(naturalLanguage || "").trim();
+  let triggerKind = "unknown";
+  for (const [re, kind] of TRIGGER_KEYWORDS) { if (re.test(nl)) { triggerKind = kind; break; } }
+  let effectKind = "unknown";
+  for (const [re, kind] of EFFECT_KEYWORDS) { if (re.test(nl)) { effectKind = kind; break; } }
+
+  const target = extractTarget(nl);
+  // Confidence: 0.55 if we classified both halves, 0.35 if one, 0.2 if neither.
+  const classified = (triggerKind !== "unknown" ? 1 : 0) + (effectKind !== "unknown" ? 1 : 0);
+  const confidence = classified === 2 ? 0.55 : classified === 1 ? 0.35 : 0.2;
+
+  return {
+    id: `rule_${randomUUID().replace(/-/g, "").slice(0, 16)}`,
+    source: nl.slice(0, 500),
+    trigger: { kind: triggerKind, target },
+    effect: { kind: effectKind, target, value: null },
+    confidence,
+    composedBy: "deterministic",
+  };
+}
+
+/**
+ * Validate + normalize a rule object (whatever produced it — LLM or
+ * deterministic or hand-written). Unknown trigger/effect kinds are
+ * coerced to 'unknown' rather than rejected: a rule the system can't
+ * fully classify is still authored intent worth keeping.
+ * @returns {{ ok, rule, warnings }}
+ */
+export function validateRule(raw) {
+  const warnings = [];
+  if (!raw || typeof raw !== "object") {
+    return { ok: false, rule: null, warnings: ["rule must be an object"] };
+  }
+  const source = String(raw.source || "").slice(0, 500);
+  if (!source) return { ok: false, rule: null, warnings: ["rule has no source text"] };
+
+  const t = raw.trigger && typeof raw.trigger === "object" ? raw.trigger : {};
+  const e = raw.effect && typeof raw.effect === "object" ? raw.effect : {};
+  let triggerKind = String(t.kind || "unknown");
+  let effectKind = String(e.kind || "unknown");
+  if (!RULE_TRIGGERS.includes(triggerKind)) { warnings.push(`trigger '${triggerKind}' -> unknown`); triggerKind = "unknown"; }
+  if (!RULE_EFFECTS.includes(effectKind)) { warnings.push(`effect '${effectKind}' -> unknown`); effectKind = "unknown"; }
+
+  const conf = Number(raw.confidence);
+  const rule = {
+    id: typeof raw.id === "string" && raw.id ? raw.id : `rule_${randomUUID().replace(/-/g, "").slice(0, 16)}`,
+    source,
+    trigger: {
+      kind: triggerKind,
+      target: t.target ? String(t.target).slice(0, 80) : null,
+    },
+    effect: {
+      kind: effectKind,
+      target: e.target ? String(e.target).slice(0, 80) : null,
+      value: e.value ?? null,
+    },
+    confidence: Number.isFinite(conf) ? Math.min(1, Math.max(0, conf)) : 0.3,
+    composedBy: raw.composedBy === "llm" ? "llm" : "deterministic",
+  };
+  return { ok: true, rule, warnings };
+}
+
+/**
+ * The prompt used when an LLM is available. Kept here so the macro and
+ * any test can share the exact contract.
+ */
+export function buildRulePrompt(naturalLanguage) {
+  return [
+    "Translate a game rule written in plain language into a strict JSON object.",
+    `Triggers (pick one): ${RULE_TRIGGERS.join(", ")}`,
+    `Effects (pick one): ${RULE_EFFECTS.join(", ")}`,
+    'Respond with ONLY this JSON shape, no prose:',
+    '{"trigger":{"kind":"...","target":"..."},"effect":{"kind":"...","target":"...","value":null}}',
+    "target is a short lowercase noun phrase or null. value is a number/string or null.",
+    `Rule: ${String(naturalLanguage || "").slice(0, 500)}`,
+  ].join("\n");
+}
+
+/**
+ * Parse an LLM response into a rule. Returns null if the model didn't
+ * produce usable JSON — the caller then falls back to deterministic.
+ */
+export function parseRuleFromLLM(naturalLanguage, llmText) {
+  if (!llmText || typeof llmText !== "string") return null;
+  const match = llmText.match(/\{[\s\S]*\}/);
+  if (!match) return null;
+  let parsed;
+  try { parsed = JSON.parse(match[0]); } catch { return null; }
+  const candidate = {
+    source: naturalLanguage,
+    trigger: parsed.trigger,
+    effect: parsed.effect,
+    confidence: 0.8,
+    composedBy: "llm",
+  };
+  const { ok, rule } = validateRule(candidate);
+  return ok ? rule : null;
+}
+
+export const RULES_INTERNALS = Object.freeze({ TRIGGER_KEYWORDS, EFFECT_KEYWORDS, extractTarget });

--- a/server/lib/foundry/size-scaling.js
+++ b/server/lib/foundry/size-scaling.js
@@ -1,0 +1,113 @@
+// server/lib/foundry/size-scaling.js
+//
+// Foundry Phase 7 — Size Scaling (Ant-Man / Giant).
+//
+// Player size as a core loop. A Foundry world enables it via the
+// size-scaling system; rule_modulators.size_scaling carries the
+// per-world config (minScale / maxScale / smallGrantsFlight /
+// largeGrantsDestruction / scaleChangeCost). This module owns the
+// per-player size STATE + the gameplay-effect derivation. The 3D
+// renderer scaling the avatar mesh is a frontend concern that reads
+// size.get; the substrate — state, clamping, cost, effects — is here.
+
+const DEFAULT_CONFIG = Object.freeze({
+  minScale: 15, maxScale: 800,
+  smallGrantsFlight: true, largeGrantsDestruction: true,
+  scaleChangeCost: "stamina",
+});
+
+// Thresholds (as a % of normal size) where the small/large effects engage.
+const SMALL_THRESHOLD = 60;  // <=60% counts as "small"
+const LARGE_THRESHOLD = 160; // >=160% counts as "large"
+
+function cfg(worldConfig) {
+  return { ...DEFAULT_CONFIG, ...(worldConfig && typeof worldConfig === "object" ? worldConfig : {}) };
+}
+
+/** Clamp a requested scale (a percentage) into the world's bounds. */
+export function clampScale(requestedPct, worldConfig) {
+  const c = cfg(worldConfig);
+  const n = Number(requestedPct);
+  if (!Number.isFinite(n)) return 100;
+  return Math.min(c.maxScale, Math.max(c.minScale, n));
+}
+
+/**
+ * Derive the gameplay effects of a given scale under a world's config.
+ * @returns {{ band, multiplier, canFly, canDestroy, stealthBonus, reachBonus }}
+ */
+export function scaleEffects(scalePct, worldConfig) {
+  const c = cfg(worldConfig);
+  const scale = clampScale(scalePct, worldConfig);
+  const multiplier = scale / 100; // 1.0 = normal
+  const band = scale <= SMALL_THRESHOLD ? "small" : scale >= LARGE_THRESHOLD ? "large" : "normal";
+  return {
+    band,
+    scale,
+    multiplier,
+    // Small unlocks flight (if the world allows) + a stealth edge that
+    // grows the smaller you are; large unlocks structural destruction +
+    // reach that grows with size.
+    canFly: band === "small" && c.smallGrantsFlight !== false,
+    canDestroy: band === "large" && c.largeGrantsDestruction !== false,
+    stealthBonus: band === "small" ? Number((1 - multiplier).toFixed(2)) : 0,
+    reachBonus: band === "large" ? Number((multiplier - 1).toFixed(2)) : 0,
+  };
+}
+
+/**
+ * Combat profile at a given scale — feeds the size-scaled-combat
+ * system. Small = precision/evasion; large = AoE/knockback. Damage and
+ * incoming-damage scale gently with size (not linearly — a giant
+ * isn't 8x tougher).
+ */
+export function scaledCombatProfile(scalePct, worldConfig) {
+  const { band, multiplier } = scaleEffects(scalePct, worldConfig);
+  if (band === "small") {
+    return { band, damageMult: 0.7, incomingMult: 1.3, model: "precision", evasion: 0.35 };
+  }
+  if (band === "large") {
+    return {
+      band,
+      damageMult: Number((1 + (multiplier - 1) * 0.4).toFixed(2)),
+      incomingMult: Number((1 - Math.min(0.4, (multiplier - 1) * 0.15)).toFixed(2)),
+      model: "aoe",
+      knockback: Number(Math.min(2.0, multiplier * 0.5).toFixed(2)),
+    };
+  }
+  return { band, damageMult: 1.0, incomingMult: 1.0, model: "balanced" };
+}
+
+/** Read a player's current scale in a world (defaults to 100%). */
+export function getPlayerScale(db, userId, worldId) {
+  if (!db || !userId || !worldId) return 100;
+  const row = db.prepare(`SELECT scale FROM player_size WHERE user_id = ? AND world_id = ?`).get(userId, worldId);
+  return row ? row.scale : 100;
+}
+
+/**
+ * Set a player's scale in a world. Clamps to the world's bounds and
+ * returns the resolved scale + its effects + the change cost the
+ * caller should debit.
+ * @returns {{ ok, scale, effects, cost }}
+ */
+export function setPlayerScale(db, userId, worldId, requestedPct, worldConfig) {
+  if (!db) return { ok: false, reason: "no_db" };
+  if (!userId || !worldId) return { ok: false, reason: "missing_args" };
+  const c = cfg(worldConfig);
+  const scale = clampScale(requestedPct, worldConfig);
+  const now = Date.now();
+  db.prepare(`
+    INSERT INTO player_size (user_id, world_id, scale, changed_at)
+    VALUES (?, ?, ?, ?)
+    ON CONFLICT(user_id, world_id) DO UPDATE SET scale = excluded.scale, changed_at = excluded.changed_at
+  `).run(userId, worldId, scale, now);
+  return {
+    ok: true,
+    scale,
+    effects: scaleEffects(scale, worldConfig),
+    cost: c.scaleChangeCost, // 'free' | 'stamina' | 'cooldown' | 'item' — caller debits
+  };
+}
+
+export const SIZE_SCALING_INTERNALS = Object.freeze({ DEFAULT_CONFIG, SMALL_THRESHOLD, LARGE_THRESHOLD });

--- a/server/lib/foundry/skill-affinity.js
+++ b/server/lib/foundry/skill-affinity.js
@@ -1,0 +1,91 @@
+// server/lib/foundry/skill-affinity.js
+//
+// Foundry Phase 7 — per-player skill learning.
+//
+// Distinct from the existing per-WORLD skill_affinity modulator (a
+// world saying "magic is 1.5x potent here"). This is per-PLAYER: a
+// skill you use heavily grows YOUR personal affinity with it, and that
+// affinity travels with you across worlds. It decays when unused.
+//
+// The world's skill-affinity-player system config carries learnRate /
+// decayWhenUnused / crossWorldCarry. Effective potency is the product
+// of the per-player affinity and the per-world modulator.
+
+const DEFAULT_CONFIG = Object.freeze({
+  learnRate: 100,        // % — 100 = baseline gain per use
+  decayWhenUnused: true,
+  crossWorldCarry: true,
+});
+
+const BASE_GAIN_PER_USE = 0.015;   // affinity points per use at 100% learnRate
+const MAX_AFFINITY = 3.0;          // 3x personal potency ceiling
+const MIN_AFFINITY = 0.5;          // never decays below half
+const DECAY_PER_DAY = 0.02;        // idle decay, applied lazily on read
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function cfg(c) {
+  return { ...DEFAULT_CONFIG, ...(c && typeof c === "object" ? c : {}) };
+}
+
+/**
+ * Record a use of a skill by a player — grows their personal affinity.
+ * @returns {{ ok, skillId, affinity, uses }}
+ */
+export function recordSkillUse(db, userId, skillId, worldConfig) {
+  if (!db) return { ok: false, reason: "no_db" };
+  if (!userId || !skillId) return { ok: false, reason: "missing_args" };
+  const c = cfg(worldConfig);
+  const now = Date.now();
+  const row = db.prepare(`SELECT affinity, uses FROM player_skill_affinity WHERE user_id = ? AND skill_id = ?`)
+    .get(userId, skillId);
+
+  const gain = BASE_GAIN_PER_USE * (c.learnRate / 100);
+  const prior = row ? row.affinity : 1.0;
+  const affinity = Math.min(MAX_AFFINITY, prior + gain);
+  const uses = (row ? row.uses : 0) + 1;
+
+  db.prepare(`
+    INSERT INTO player_skill_affinity (user_id, skill_id, affinity, uses, last_used_at)
+    VALUES (?, ?, ?, ?, ?)
+    ON CONFLICT(user_id, skill_id) DO UPDATE SET
+      affinity = excluded.affinity, uses = excluded.uses, last_used_at = excluded.last_used_at
+  `).run(userId, skillId, affinity, uses, now);
+
+  return { ok: true, skillId, affinity: Number(affinity.toFixed(4)), uses };
+}
+
+/**
+ * Read a player's current affinity for a skill, applying lazy idle
+ * decay (when the world's config has decayWhenUnused on). Returns 1.0
+ * for a skill the player has never used.
+ */
+export function getPlayerAffinity(db, userId, skillId, worldConfig, now = Date.now()) {
+  if (!db || !userId || !skillId) return 1.0;
+  const row = db.prepare(`SELECT affinity, last_used_at FROM player_skill_affinity WHERE user_id = ? AND skill_id = ?`)
+    .get(userId, skillId);
+  if (!row) return 1.0;
+  const c = cfg(worldConfig);
+  if (!c.decayWhenUnused) return Number(row.affinity.toFixed(4));
+  const idleDays = Math.max(0, (now - row.last_used_at) / DAY_MS);
+  const decayed = Math.max(MIN_AFFINITY, row.affinity - idleDays * DECAY_PER_DAY);
+  return Number(decayed.toFixed(4));
+}
+
+/**
+ * Effective potency multiplier for a skill cast: the player's personal
+ * affinity combined with the per-world skill_affinity modulator. This
+ * is what a combat / cast path multiplies raw skill output by.
+ *
+ * @param {number} playerAffinity   — from getPlayerAffinity (1.0 = none)
+ * @param {number} worldAffinityPct — rule_modulators.skill_affinity[domain]
+ *                                    as a percent (100 = neutral)
+ */
+export function effectiveAffinity(playerAffinity, worldAffinityPct = 100) {
+  const player = Number.isFinite(playerAffinity) ? playerAffinity : 1.0;
+  const world = Number.isFinite(worldAffinityPct) ? worldAffinityPct / 100 : 1.0;
+  return Number((player * world).toFixed(4));
+}
+
+export const SKILL_AFFINITY_INTERNALS = Object.freeze({
+  DEFAULT_CONFIG, BASE_GAIN_PER_USE, MAX_AFFINITY, MIN_AFFINITY, DECAY_PER_DAY,
+});

--- a/server/lib/foundry/status-window.js
+++ b/server/lib/foundry/status-window.js
@@ -1,0 +1,98 @@
+// server/lib/foundry/status-window.js
+//
+// Foundry Phase 7 — Status Window (isekai-style).
+//
+// A world-adaptive character status panel. The world's status-window
+// config carries style (classic-rpg / minimal / ornate / sci-fi-hud),
+// showHiddenStats, and titleSystem.
+//
+// This module owns the earnable-titles substrate (player_titles) and
+// the composition that assembles a status object the frontend renders.
+// It does NOT hard-depend on every player-stat table existing — the
+// caller passes already-fetched stats/skills/effects in via `sources`,
+// so the lib stays testable and decoupled from schema drift. Titles,
+// which Phase 7 owns, are queried directly.
+
+import { randomUUID } from "node:crypto";
+
+const VALID_STYLES = ["classic-rpg", "minimal", "ornate", "sci-fi-hud"];
+
+const DEFAULT_CONFIG = Object.freeze({
+  style: "classic-rpg",
+  showHiddenStats: false,
+  titleSystem: true,
+});
+
+function cfg(c) {
+  const merged = { ...DEFAULT_CONFIG, ...(c && typeof c === "object" ? c : {}) };
+  if (!VALID_STYLES.includes(merged.style)) merged.style = DEFAULT_CONFIG.style;
+  return merged;
+}
+
+/**
+ * Award a title to a player in a world. Idempotent — the unique index
+ * on (user_id, world_id, title) means re-awarding is a no-op.
+ * @returns {{ ok, awarded }}  awarded=false if they already had it
+ */
+export function awardTitle(db, userId, worldId, title) {
+  if (!db) return { ok: false, reason: "no_db" };
+  if (!userId || !worldId || !title) return { ok: false, reason: "missing_args" };
+  const clean = String(title).trim().slice(0, 80);
+  if (!clean) return { ok: false, reason: "empty_title" };
+  try {
+    const r = db.prepare(`
+      INSERT INTO player_titles (id, user_id, world_id, title, earned_at)
+      VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT (user_id, world_id, title) DO NOTHING
+    `).run(`title_${randomUUID().replace(/-/g, "").slice(0, 16)}`, userId, worldId, clean, Date.now());
+    return { ok: true, awarded: r.changes > 0, title: clean };
+  } catch (e) {
+    return { ok: false, reason: "award_failed", error: String(e?.message || e) };
+  }
+}
+
+/** A player's earned titles in a world, newest first. */
+export function listTitles(db, userId, worldId) {
+  if (!db || !userId || !worldId) return [];
+  return db.prepare(`
+    SELECT title, earned_at FROM player_titles
+    WHERE user_id = ? AND world_id = ? ORDER BY earned_at DESC
+  `).all(userId, worldId).map((r) => ({ title: r.title, earnedAt: r.earned_at }));
+}
+
+/**
+ * Compose the world-adaptive status window for a player.
+ *
+ * @param {object} db
+ * @param {string} userId
+ * @param {string} worldId
+ * @param {object} worldConfig  — rule_modulators.status_window
+ * @param {object} [sources]    — caller-supplied stat data, all optional:
+ *   { stats: {hp,stamina,...}, skills: [{id,level}], effects: [...],
+ *     inventoryCount: n, hiddenStats: {...} }
+ * @returns {{ ok, window }}
+ */
+export function composeStatusWindow(db, userId, worldId, worldConfig, sources = {}) {
+  const c = cfg(worldConfig);
+  const titles = c.titleSystem ? listTitles(db, userId, worldId) : [];
+  const s = sources && typeof sources === "object" ? sources : {};
+
+  const window = {
+    style: c.style,
+    userId,
+    worldId,
+    titles: titles.map((t) => t.title),
+    activeTitle: titles[0]?.title ?? null,
+    stats: s.stats && typeof s.stats === "object" ? s.stats : {},
+    skills: Array.isArray(s.skills) ? s.skills : [],
+    effects: Array.isArray(s.effects) ? s.effects : [],
+    inventoryCount: Number.isFinite(s.inventoryCount) ? s.inventoryCount : 0,
+  };
+  // Hidden stats only surface when the world opts in.
+  if (c.showHiddenStats && s.hiddenStats && typeof s.hiddenStats === "object") {
+    window.hiddenStats = s.hiddenStats;
+  }
+  return { ok: true, window };
+}
+
+export const STATUS_WINDOW_INTERNALS = Object.freeze({ DEFAULT_CONFIG, VALID_STYLES });

--- a/server/lib/foundry/system-registry.js
+++ b/server/lib/foundry/system-registry.js
@@ -162,7 +162,7 @@ export const SYSTEM_REGISTRY = Object.freeze([
     displayName: 'Size Scaling (Ant-Man / Giant)',
     description: 'Player size as a core loop — shrink for stealth/flight access, grow for destruction/reach. Render scale + physics scale + combat scale.',
     worldScope: 'world',
-    status: 'stub', // Phase 7 — does not exist yet
+    status: 'available', // Phase 7 — built: server/lib/foundry/size-scaling.js
     activation: { kind: 'rule_modulator', key: 'size_scaling' },
     configSchema: {
       minScale: f.number('Minimum scale (%)', 5, 100, 15),
@@ -214,7 +214,7 @@ export const SYSTEM_REGISTRY = Object.freeze([
     displayName: 'Status Window (Isekai-Style)',
     description: 'World-adaptive character status panel — stats, titles, skills surfaced as a diegetic isekai-style overlay.',
     worldScope: 'world',
-    status: 'stub', // Phase 7
+    status: 'available', // Phase 7 — built
     activation: { kind: 'rule_modulator', key: 'status_window' },
     configSchema: {
       style: f.enum('Window style', ['classic-rpg', 'minimal', 'ornate', 'sci-fi-hud'], 'classic-rpg'),
@@ -248,7 +248,7 @@ export const SYSTEM_REGISTRY = Object.freeze([
     displayName: 'Per-Player Skill Learning',
     description: 'Skills a player uses heavily grow personal affinity that travels with them — distinct from the per-world multipliers.',
     worldScope: 'player',
-    status: 'stub', // Phase 7
+    status: 'available', // Phase 7 — built
     activation: { kind: 'always_on' },
     configSchema: {
       learnRate: f.number('Learn rate (%)', 25, 400, 100),
@@ -264,7 +264,7 @@ export const SYSTEM_REGISTRY = Object.freeze([
     displayName: 'Isekai Reincarnation',
     description: 'On death, a character can reincarnate into the world — carrying a fraction of prior progress as an inherited boon.',
     worldScope: 'world',
-    status: 'stub', // Phase 7
+    status: 'available', // Phase 7 — built
     activation: { kind: 'rule_modulator', key: 'reincarnation' },
     configSchema: {
       enabled: f.bool('Reincarnation enabled', true),
@@ -391,7 +391,7 @@ export const SYSTEM_REGISTRY = Object.freeze([
     displayName: 'Size-Scaled Combat',
     description: 'Combat mechanics that change with player scale — small = precision/evasion, large = AoE/knockback.',
     worldScope: 'world',
-    status: 'stub', // Phase 7 — rides on size-scaling
+    status: 'available', // Phase 7 — built: scaledCombatProfile in size-scaling.js
     activation: { kind: 'rule_modulator', key: 'size_combat' },
     configSchema: {
       smallDamageModel: f.enum('Small-scale damage', ['precision', 'evasion', 'swarm'], 'precision'),

--- a/server/lib/foundry/system-registry.js
+++ b/server/lib/foundry/system-registry.js
@@ -1,0 +1,769 @@
+// server/lib/foundry/system-registry.js
+//
+// Foundry — System Registry (Phase 1).
+//
+// The declarative catalog that turns Concord's ~40 already-built
+// systems into composable building blocks. Foundry's whole premise is
+// that the systems already exist (terrain, weather, LLM NPCs, combat
+// motor, royalty cascade, ...) — what was missing is a description of
+// each one *as a part*: what it is, what config it takes, how it
+// activates on a world, what it depends on, what it conflicts with.
+//
+// This file is that description. The Foundry canvas (Phase 4) renders
+// the palette + config panels straight off these entries; the publish
+// pipeline (Phase 3) reads `activation` to know how to apply each
+// system to the target world.
+//
+// worldScope (from the substrate audit):
+//   'world'  — already per-world configurable (the heartbeats iterate
+//              per-world; config rides on worlds.rule_modulators /
+//              worlds.physics_modulators). The easy majority.
+//   'global' — runs once across the whole lattice, not per-world.
+//              Still selectable, but the config is advisory + the
+//              publish pipeline flags it as a shared system.
+//   'player' — attached to players, not worlds; behaviour may be
+//              world-aware but ownership is per-player.
+//
+// status:
+//   'available' — exists in the codebase today, wired.
+//   'stub'      — does NOT exist yet; built in Phase 7. Shows in the
+//                 palette flagged "coming soon" so the catalog is the
+//                 single source of truth and Phase 7 just flips the flag.
+//
+// activation.kind — how the publish pipeline applies the system:
+//   'rule_modulator'     — writes config under worlds.rule_modulators[key]
+//   'physics_modulator'  — writes config under worlds.physics_modulators[key]
+//   'content_seed'       — emits authored content into the world's seed set
+//   'heartbeat_optin'    — toggles a per-world heartbeat participation flag
+//   'always_on'          — substrate-level, no per-world activation needed
+
+export const CATEGORIES = Object.freeze({
+  WORLD: 'world',
+  CHARACTER: 'character',
+  COMBAT: 'combat',
+  NPC: 'npc',
+  ECONOMY: 'economy',
+  SOCIAL: 'social',
+});
+
+export const CATEGORY_LABELS = Object.freeze({
+  world: 'World Systems',
+  character: 'Character & Progression',
+  combat: 'Combat & Action',
+  npc: 'NPC & AI Intelligence',
+  economy: 'Economy & Creation',
+  social: 'Social & Multiplayer',
+});
+
+// ── Config-field shorthand ──────────────────────────────────────────────────
+// Each system's configSchema is a flat map of field-name -> descriptor.
+// Descriptor shape: { type, label, default, ...constraints }
+//   type 'enum'   — { options: [...], default }
+//   type 'number' — { min, max, step, default }
+//   type 'bool'   — { default }
+//   type 'text'   — { maxLength, default }
+//   type 'range'  — { min, max, default: [lo, hi] }
+const f = {
+  enum: (label, options, def) => ({ type: 'enum', label, options, default: def ?? options[0] }),
+  number: (label, min, max, def, step = 1) => ({ type: 'number', label, min, max, default: def, step }),
+  bool: (label, def = false) => ({ type: 'bool', label, default: def }),
+  text: (label, maxLength, def = '') => ({ type: 'text', label, maxLength, default: def }),
+  range: (label, min, max, def) => ({ type: 'range', label, min, max, default: def }),
+};
+
+// ── The catalog ─────────────────────────────────────────────────────────────
+export const SYSTEM_REGISTRY = Object.freeze([
+  // ===== WORLD SYSTEMS =========================================================
+  {
+    id: 'terrain-biomes',
+    category: CATEGORIES.WORLD,
+    displayName: 'Procedural Terrain & Biomes',
+    description: 'Seeded heightfield terrain with biome distribution. The 3D renderer reads the terrain config to draw the world.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'physics_modulator', key: 'terrain' },
+    configSchema: {
+      biomeSet: f.enum('Biome set', ['temperate', 'arid', 'frozen', 'tropical', 'volcanic', 'mixed'], 'mixed'),
+      seaLevel: f.number('Sea level', 0, 100, 30),
+      ruggedness: f.number('Terrain ruggedness', 0, 100, 50),
+      seed: f.text('Terrain seed (blank = random)', 64),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+  {
+    id: 'weather-ecology',
+    category: CATEGORIES.WORLD,
+    displayName: 'Dynamic Weather & Ecology',
+    description: 'The environment-sensor heartbeat writes per-cell climate signals; weather shifts over time and feeds skill/combat env coupling.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'rule_modulator', key: 'climate' },
+    configSchema: {
+      baseClimate: f.enum('Base climate', ['temperate', 'desert', 'tundra', 'rainforest', 'storm-locked'], 'temperate'),
+      weatherVolatility: f.number('Weather volatility', 0, 100, 40),
+      dayNightCycle: f.bool('Day/night cycle', true),
+    },
+    dependsOn: ['terrain-biomes'],
+    conflictsWith: [],
+  },
+  {
+    id: 'fauna-flocks',
+    category: CATEGORIES.WORLD,
+    displayName: 'Fauna & Creature Flocks',
+    description: 'The creature-flock-cycle heartbeat spawns and flocks fauna per world with separation/alignment/cohesion + flee-from-player.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'heartbeat_optin', key: 'fauna' },
+    configSchema: {
+      density: f.enum('Fauna density', ['sparse', 'moderate', 'abundant'], 'moderate'),
+      predators: f.bool('Predator species', true),
+      flockingIntensity: f.number('Flocking intensity', 0, 100, 60),
+    },
+    dependsOn: ['terrain-biomes'],
+    conflictsWith: [],
+  },
+  {
+    id: 'seasons',
+    category: CATEGORIES.WORLD,
+    displayName: 'Seasons & Long-Cycle Time',
+    description: 'Six-season 42-day world year with per-season temperature/yield bias. The season-cycle heartbeat advances it.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'heartbeat_optin', key: 'seasons' },
+    configSchema: {
+      yearLengthDays: f.number('World-year length (days)', 6, 120, 42),
+      startingSeason: f.enum('Starting season', ['spring', 'high-summer', 'harvest', 'fade', 'deep-winter', 'thaw'], 'spring'),
+    },
+    dependsOn: ['weather-ecology'],
+    conflictsWith: [],
+  },
+  {
+    id: 'physics-modifiers',
+    category: CATEGORIES.WORLD,
+    displayName: 'Per-World Physics',
+    description: 'Gravity, water density, and movement tuning. Written to physics_modulators and consumed by the Rapier physics world.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'physics_modulator', key: 'movement' },
+    configSchema: {
+      gravity: f.number('Gravity (% of Earth)', 10, 300, 100),
+      waterDensity: f.number('Water density', 50, 200, 100),
+      jumpHeight: f.number('Jump height (%)', 25, 400, 100),
+      glideEnabled: f.bool('Gliding enabled', true),
+      swimEnabled: f.bool('Swimming enabled', true),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+  {
+    id: 'size-scaling',
+    category: CATEGORIES.WORLD,
+    displayName: 'Size Scaling (Ant-Man / Giant)',
+    description: 'Player size as a core loop — shrink for stealth/flight access, grow for destruction/reach. Render scale + physics scale + combat scale.',
+    worldScope: 'world',
+    status: 'stub', // Phase 7 — does not exist yet
+    activation: { kind: 'rule_modulator', key: 'size_scaling' },
+    configSchema: {
+      minScale: f.number('Minimum scale (%)', 5, 100, 15),
+      maxScale: f.number('Maximum scale (%)', 100, 2000, 800),
+      smallGrantsFlight: f.bool('Small size grants flight access', true),
+      largeGrantsDestruction: f.bool('Large size grants structure destruction', true),
+      scaleChangeCost: f.enum('Scale-change cost', ['free', 'stamina', 'cooldown', 'item'], 'stamina'),
+    },
+    dependsOn: ['physics-modifiers'],
+    conflictsWith: [],
+  },
+  {
+    id: 'mount-system',
+    category: CATEGORIES.WORLD,
+    displayName: 'Mounts & MountDesigner',
+    description: 'Player-owned mounts with coat generation, care, gear, and a behavior heartbeat (wander/flee/feed). Behavior is world-aware.',
+    worldScope: 'player',
+    status: 'available',
+    activation: { kind: 'rule_modulator', key: 'mounts' },
+    configSchema: {
+      allowMounts: f.bool('Mounts allowed', true),
+      mountCombat: f.bool('Mounted combat', true),
+      wildMounts: f.bool('Tameable wild mounts', false),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+  {
+    id: 'concord-link',
+    category: CATEGORIES.WORLD,
+    displayName: 'Concord Link (Cross-World Travel)',
+    description: 'Registers the world as a travelable node in the lattice. Characters, skills, and inventory carry across the link.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'content_seed', key: 'concord_link_anchor' },
+    configSchema: {
+      travelMode: f.enum('Arrival mode', ['portal', 'walker-escort', 'open'], 'portal'),
+      inboundOpen: f.bool('Open to inbound travelers', true),
+      outboundOpen: f.bool('Travelers may leave', true),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+
+  // ===== CHARACTER & PROGRESSION ===============================================
+  {
+    id: 'status-window',
+    category: CATEGORIES.CHARACTER,
+    displayName: 'Status Window (Isekai-Style)',
+    description: 'World-adaptive character status panel — stats, titles, skills surfaced as a diegetic isekai-style overlay.',
+    worldScope: 'world',
+    status: 'stub', // Phase 7
+    activation: { kind: 'rule_modulator', key: 'status_window' },
+    configSchema: {
+      style: f.enum('Window style', ['classic-rpg', 'minimal', 'ornate', 'sci-fi-hud'], 'classic-rpg'),
+      showHiddenStats: f.bool('Reveal hidden stats', false),
+      titleSystem: f.bool('Earnable titles', true),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+  {
+    id: 'skill-affinity-world',
+    category: CATEGORIES.CHARACTER,
+    displayName: 'World Skill Affinity',
+    description: 'Per-world potency multipliers — a power means different things in different worlds (magic 1.5x here, hacking 0.1x there).',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'rule_modulator', key: 'skill_affinity' },
+    configSchema: {
+      magic: f.number('Magic affinity (%)', 0, 300, 100),
+      technology: f.number('Technology affinity (%)', 0, 300, 100),
+      martial: f.number('Martial affinity (%)', 0, 300, 100),
+      psionics: f.number('Psionics affinity (%)', 0, 300, 100),
+      nature: f.number('Nature affinity (%)', 0, 300, 100),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+  {
+    id: 'skill-affinity-player',
+    category: CATEGORIES.CHARACTER,
+    displayName: 'Per-Player Skill Learning',
+    description: 'Skills a player uses heavily grow personal affinity that travels with them — distinct from the per-world multipliers.',
+    worldScope: 'player',
+    status: 'stub', // Phase 7
+    activation: { kind: 'always_on' },
+    configSchema: {
+      learnRate: f.number('Learn rate (%)', 25, 400, 100),
+      decayWhenUnused: f.bool('Affinity decays when unused', true),
+      crossWorldCarry: f.bool('Carries across worlds', true),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+  {
+    id: 'isekai-reincarnation',
+    category: CATEGORIES.CHARACTER,
+    displayName: 'Isekai Reincarnation',
+    description: 'On death, a character can reincarnate into the world — carrying a fraction of prior progress as an inherited boon.',
+    worldScope: 'world',
+    status: 'stub', // Phase 7
+    activation: { kind: 'rule_modulator', key: 'reincarnation' },
+    configSchema: {
+      enabled: f.bool('Reincarnation enabled', true),
+      inheritedFraction: f.number('Progress carried over (%)', 0, 75, 20),
+      rerollAppearance: f.bool('New appearance each life', true),
+      memoryFragments: f.bool('Fragmentary past-life memories', true),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+  {
+    id: 'persistent-inventory',
+    category: CATEGORIES.CHARACTER,
+    displayName: 'Cross-World Persistent Inventory',
+    description: 'Items follow the player per world (migration 101). With Concord Link enabled, inventory travels across worlds.',
+    worldScope: 'player',
+    status: 'available',
+    activation: { kind: 'always_on' },
+    configSchema: {
+      slotCap: f.number('Inventory slots', 10, 500, 80),
+      bindOnPickup: f.bool('Items bind on pickup', false),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+  {
+    id: 'appearance-customization',
+    category: CATEGORIES.CHARACTER,
+    displayName: 'Appearance & Customization',
+    description: 'Character creation + in-world re-customization, persisted as a RichAppearanceConfig.',
+    worldScope: 'player',
+    status: 'available',
+    activation: { kind: 'always_on' },
+    configSchema: {
+      depth: f.enum('Customization depth', ['preset', 'standard', 'deep'], 'standard'),
+      lockAfterCreation: f.bool('Lock appearance after creation', false),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+
+  // ===== COMBAT & ACTION =======================================================
+  {
+    id: 'combat-motor',
+    category: CATEGORIES.COMBAT,
+    displayName: 'Combat Motor Driver',
+    description: 'Sekiro-precision + Spider-Man-fluidity combat motor — server-validated reach/damage, env-coupled potency, DBZ-style stagger.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'rule_modulator', key: 'combat' },
+    configSchema: {
+      combatAllowed: f.bool('Combat allowed in this world', true),
+      lethality: f.enum('Lethality', ['training', 'standard', 'hardcore'], 'standard'),
+      friendlyFire: f.bool('Friendly fire', false),
+      envCoupling: f.bool('Environmental potency coupling', true),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+  {
+    id: 'armor-weapon-reflex',
+    category: CATEGORIES.COMBAT,
+    displayName: 'Armor / Weapon / Reflex',
+    description: 'Equipment slots with armor meshes, weapon archetypes, and a reflex layer (block/parry/dodge over the base animation).',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'rule_modulator', key: 'equipment' },
+    configSchema: {
+      armorSlots: f.number('Armor slots', 0, 8, 5),
+      reflexActions: f.bool('Block / parry / dodge', true),
+      durability: f.bool('Equipment durability', true),
+    },
+    dependsOn: ['combat-motor'],
+    conflictsWith: [],
+  },
+  {
+    id: 'elemental-status-effects',
+    category: CATEGORIES.COMBAT,
+    displayName: 'Elemental & Status Effects',
+    description: 'Fire/frost/lightning/bio/poison elements with environment coupling, plus status effects (burn, freeze, poison, stun).',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'rule_modulator', key: 'elements' },
+    configSchema: {
+      enabledElements: f.enum('Element set', ['classical-four', 'extended-six', 'all', 'none'], 'extended-six'),
+      statusStacking: f.bool('Status effects stack', true),
+    },
+    dependsOn: ['combat-motor'],
+    conflictsWith: [],
+  },
+  {
+    id: 'boss-phases',
+    category: CATEGORIES.COMBAT,
+    displayName: 'Boss Phase Scripting',
+    description: 'Multi-phase boss encounters — HP-threshold phase transitions wired into the combat/attack path.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'content_seed', key: 'boss_phases' },
+    configSchema: {
+      maxPhases: f.number('Max phases per boss', 1, 6, 3),
+      cinematicTransitions: f.bool('Cinematic phase transitions', true),
+    },
+    dependsOn: ['combat-motor'],
+    conflictsWith: [],
+  },
+  {
+    id: 'aerial-mount-combat',
+    category: CATEGORIES.COMBAT,
+    displayName: 'Aerial & Mount Combat',
+    description: 'Flight-physics combat and mounted combat — strikes, gait-aware attacks, rider-IK during engagements.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'rule_modulator', key: 'aerial_combat' },
+    configSchema: {
+      aerialCombat: f.bool('Aerial combat', true),
+      mountedCombat: f.bool('Mounted combat', true),
+    },
+    dependsOn: ['combat-motor'],
+    conflictsWith: [],
+  },
+  {
+    id: 'size-scaled-combat',
+    category: CATEGORIES.COMBAT,
+    displayName: 'Size-Scaled Combat',
+    description: 'Combat mechanics that change with player scale — small = precision/evasion, large = AoE/knockback.',
+    worldScope: 'world',
+    status: 'stub', // Phase 7 — rides on size-scaling
+    activation: { kind: 'rule_modulator', key: 'size_combat' },
+    configSchema: {
+      smallDamageModel: f.enum('Small-scale damage', ['precision', 'evasion', 'swarm'], 'precision'),
+      largeDamageModel: f.enum('Large-scale damage', ['aoe', 'knockback', 'crush'], 'aoe'),
+    },
+    dependsOn: ['combat-motor', 'size-scaling'],
+    conflictsWith: [],
+  },
+
+  // ===== NPC & AI INTELLIGENCE =================================================
+  {
+    id: 'llm-npcs',
+    category: CATEGORIES.NPC,
+    displayName: 'Living LLM NPCs',
+    description: 'NPCs with memory, grudges, dreams, schemes, and ambition — driven by the oracle-brain + asymmetry substrate.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'content_seed', key: 'npcs' },
+    configSchema: {
+      npcCount: f.number('Seeded NPC count', 0, 200, 24),
+      memoryDepth: f.enum('Memory depth', ['shallow', 'standard', 'deep'], 'standard'),
+      grudgesEnabled: f.bool('Grudges & preoccupations', true),
+      dreamsEnabled: f.bool('NPC dreams', true),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+  {
+    id: 'npc-schedules',
+    category: CATEGORIES.NPC,
+    displayName: 'NPC Schedules & Daily Routines',
+    description: 'Deterministic per-NPC daily schedules — work, patrol, trade, socialize — advanced by the npc-routine-cycle heartbeat.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'heartbeat_optin', key: 'npc_routines' },
+    configSchema: {
+      scheduleGranularity: f.enum('Schedule granularity', ['coarse', 'standard', 'fine'], 'standard'),
+      activityTags: f.bool('Floating activity tags', true),
+    },
+    dependsOn: ['llm-npcs'],
+    conflictsWith: [],
+  },
+  {
+    id: 'npc-voice-idiolect',
+    category: CATEGORIES.NPC,
+    displayName: 'NPC Voice & Idiolect',
+    description: 'Each NPC develops a distinct speaking style over time via the persona idiolect substrate.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'rule_modulator', key: 'npc_voice' },
+    configSchema: {
+      voiceVariety: f.enum('Voice variety', ['uniform', 'regional', 'per-npc'], 'per-npc'),
+      spokenAudio: f.bool('TTS spoken dialogue', false),
+    },
+    dependsOn: ['llm-npcs'],
+    conflictsWith: [],
+  },
+  {
+    id: 'emergent-events',
+    category: CATEGORIES.NPC,
+    displayName: 'Emergent Events',
+    description: 'NPCs and factions start wars, form alliances, stage coups — the faction-strategy + ambition cycles, surfaced as world events.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'heartbeat_optin', key: 'emergent_events' },
+    configSchema: {
+      intensity: f.enum('Emergent intensity', ['calm', 'lively', 'turbulent'], 'lively'),
+      warsEnabled: f.bool('Faction wars', true),
+      coupsEnabled: f.bool('Coups & rebellions', true),
+    },
+    dependsOn: ['llm-npcs'],
+    conflictsWith: [],
+  },
+  {
+    id: 'npc-sponsorship-staking',
+    category: CATEGORIES.NPC,
+    displayName: 'NPC Sponsorship & Staking',
+    description: 'Players can sponsor or stake on NPCs — backing their ambitions for a share of the outcome.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'rule_modulator', key: 'npc_sponsorship' },
+    configSchema: {
+      sponsorshipEnabled: f.bool('Sponsorship enabled', true),
+      stakingEnabled: f.bool('Staking on NPC outcomes', true),
+    },
+    dependsOn: ['llm-npcs'],
+    conflictsWith: [],
+  },
+
+  // ===== ECONOMY & CREATION ====================================================
+  {
+    id: 'royalty-cascade',
+    category: CATEGORIES.ECONOMY,
+    displayName: 'Multi-Generational Royalty Cascade',
+    description: 'Every cited asset pays its lineage up to 50 generations deep. Lattice-global — applies the same everywhere.',
+    worldScope: 'global',
+    status: 'available',
+    activation: { kind: 'always_on' },
+    configSchema: {
+      // global system — config here is advisory; the cascade math is constitutional
+      acknowledged: f.bool('Royalty cascade applies (lattice-global)', true),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+  {
+    id: 'recipe-authoring',
+    category: CATEGORIES.ECONOMY,
+    displayName: 'Recipe Authoring',
+    description: 'Players author skills, spells, buildings, and items as recipe DTUs. Effectiveness is modulated by world skill-affinity.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'rule_modulator', key: 'recipe_authoring' },
+    configSchema: {
+      allowedKinds: f.enum('Authorable kinds', ['items-only', 'items-and-skills', 'all'], 'all'),
+      personalScopeDefault: f.bool('New recipes default to personal scope', true),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+  {
+    id: 'player-orgs',
+    category: CATEGORIES.ECONOMY,
+    displayName: 'Companies, Guilds & Kingdoms',
+    description: 'Player-run organizations with governance voting, treasuries, and per-world presence.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'rule_modulator', key: 'orgs' },
+    configSchema: {
+      orgTypes: f.enum('Org types', ['guilds-only', 'companies-and-guilds', 'all'], 'all'),
+      kingdomsEnabled: f.bool('Kingdoms & realms', true),
+      governanceVoting: f.bool('Governance voting', true),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+  {
+    id: 'insurance-construction',
+    category: CATEGORIES.ECONOMY,
+    displayName: 'Insurance & Construction Economies',
+    description: 'Construction projects (blueprint -> world spawn) plus an insurance layer against loss.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'rule_modulator', key: 'construction' },
+    configSchema: {
+      constructionEnabled: f.bool('Player construction', true),
+      insuranceEnabled: f.bool('Insurance market', true),
+      buildOverlapCheck: f.bool('Enforce build bounding-box checks', true),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+  {
+    id: 'marketplace-spectator-betting',
+    category: CATEGORIES.ECONOMY,
+    displayName: 'Marketplace & Spectator Betting',
+    description: 'The creative marketplace plus spectator betting on events, matches, and NPC outcomes.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'rule_modulator', key: 'marketplace' },
+    configSchema: {
+      marketplaceEnabled: f.bool('In-world marketplace', true),
+      spectatorBetting: f.bool('Spectator betting', false),
+      bettingCurrency: f.enum('Betting currency', ['cc', 'sparks', 'disabled'], 'sparks'),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+
+  // ===== SOCIAL & MULTIPLAYER ==================================================
+  {
+    id: 'realtime-coop-pvp',
+    category: CATEGORIES.SOCIAL,
+    displayName: 'Real-Time Co-op & PvP',
+    description: 'Real-time shared presence with spatial chunking + anti-cheat. Co-op and/or PvP per the world ruleset.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'rule_modulator', key: 'multiplayer' },
+    configSchema: {
+      mode: f.enum('Multiplayer mode', ['solo', 'coop', 'pvp', 'coop-and-pvp'], 'coop'),
+      maxConcurrent: f.number('Max concurrent players', 1, 200, 50),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+  {
+    id: 'factions-politics',
+    category: CATEGORIES.SOCIAL,
+    displayName: 'Factions & Persistent Politics',
+    description: 'Authored + emergent factions with relations, territory, decrees, and persistent political state.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'content_seed', key: 'factions' },
+    configSchema: {
+      factionCount: f.number('Seeded factions', 0, 20, 4),
+      territoryControl: f.bool('Territorial control', true),
+      decreeSystem: f.bool('Realm decrees', true),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+  {
+    id: 'live-spectator',
+    category: CATEGORIES.SOCIAL,
+    displayName: 'Live Spectator Mode',
+    description: 'Non-participants can watch the world live — events, matches, and emergent drama as a broadcast surface.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'rule_modulator', key: 'spectator' },
+    configSchema: {
+      spectatorEnabled: f.bool('Spectator mode', true),
+      observerReports: f.bool('Auto-composed observer reports', true),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+  {
+    id: 'voice-chat-proximity',
+    category: CATEGORIES.SOCIAL,
+    displayName: 'Voice Chat & Proximity Voice',
+    description: 'WebRTC mesh voice with proximity falloff — hear who is near you in-world.',
+    worldScope: 'world',
+    status: 'available',
+    activation: { kind: 'rule_modulator', key: 'voice' },
+    configSchema: {
+      voiceMode: f.enum('Voice mode', ['off', 'global', 'proximity', 'proximity-and-channels'], 'proximity'),
+      proximityRange: f.number('Proximity range (m)', 5, 100, 25),
+    },
+    dependsOn: [],
+    conflictsWith: [],
+  },
+]);
+
+// ── Indexes ─────────────────────────────────────────────────────────────────
+const _byId = new Map(SYSTEM_REGISTRY.map((s) => [s.id, s]));
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/** All system ids. */
+export function allSystemIds() {
+  return SYSTEM_REGISTRY.map((s) => s.id);
+}
+
+/** Look up one system by id. Returns null if unknown. */
+export function getSystem(id) {
+  return _byId.get(id) || null;
+}
+
+/** List systems, optionally filtered by category. */
+export function listSystems({ category } = {}) {
+  if (!category) return SYSTEM_REGISTRY.slice();
+  return SYSTEM_REGISTRY.filter((s) => s.category === category);
+}
+
+/** Systems grouped by category, in CATEGORY_LABELS order. */
+export function systemsByCategory() {
+  const out = {};
+  for (const key of Object.values(CATEGORIES)) {
+    out[key] = { label: CATEGORY_LABELS[key], systems: listSystems({ category: key }) };
+  }
+  return out;
+}
+
+/** The config schema for one system (the shape the ConfigPanel renders). */
+export function getConfigSchema(id) {
+  const sys = getSystem(id);
+  return sys ? sys.configSchema : null;
+}
+
+/**
+ * Coerce + validate a config object against a system's schema. Unknown
+ * keys are dropped; missing keys fall back to the schema default; values
+ * out of range are clamped (numbers) or rejected (enums/bools).
+ * Returns { ok, config, errors }.
+ */
+export function coerceConfig(id, rawConfig = {}) {
+  const schema = getConfigSchema(id);
+  if (!schema) return { ok: false, config: {}, errors: [`unknown system: ${id}`] };
+  const config = {};
+  const errors = [];
+  for (const [field, desc] of Object.entries(schema)) {
+    const raw = rawConfig[field];
+    if (raw === undefined || raw === null) {
+      config[field] = desc.default;
+      continue;
+    }
+    switch (desc.type) {
+      case 'number': {
+        const n = Number(raw);
+        if (!Number.isFinite(n)) { errors.push(`${id}.${field}: not a number`); config[field] = desc.default; }
+        else config[field] = Math.min(desc.max, Math.max(desc.min, n));
+        break;
+      }
+      case 'bool':
+        config[field] = Boolean(raw);
+        break;
+      case 'enum':
+        if (desc.options.includes(raw)) config[field] = raw;
+        else { errors.push(`${id}.${field}: '${raw}' not in [${desc.options.join(', ')}]`); config[field] = desc.default; }
+        break;
+      case 'text': {
+        const s = String(raw);
+        config[field] = desc.maxLength ? s.slice(0, desc.maxLength) : s;
+        break;
+      }
+      case 'range': {
+        if (Array.isArray(raw) && raw.length === 2) {
+          const lo = Math.min(desc.max, Math.max(desc.min, Number(raw[0])));
+          const hi = Math.min(desc.max, Math.max(desc.min, Number(raw[1])));
+          config[field] = [Math.min(lo, hi), Math.max(lo, hi)];
+        } else { errors.push(`${id}.${field}: expected [lo, hi]`); config[field] = desc.default; }
+        break;
+      }
+      default:
+        config[field] = raw;
+    }
+  }
+  return { ok: errors.length === 0, config, errors };
+}
+
+/**
+ * Validate a worldspec's system selection — the dependency + conflict
+ * graph plus per-system config coercion. This is the gate Phase 2's
+ * foundry.validate and Phase 3's publish pipeline both call.
+ *
+ * @param {Array<{id: string, config?: object}>} systems
+ * @returns {{ ok, errors, warnings, resolved }}
+ *   resolved — the systems list with coerced configs, ready to persist.
+ */
+export function validateSystemSelection(systems = []) {
+  const errors = [];
+  const warnings = [];
+  const resolved = [];
+  if (!Array.isArray(systems)) {
+    return { ok: false, errors: ['systems must be an array'], warnings, resolved };
+  }
+
+  const selectedIds = new Set();
+  for (const entry of systems) {
+    const id = entry && entry.id;
+    if (!id || !_byId.has(id)) { errors.push(`unknown system: ${id}`); continue; }
+    if (selectedIds.has(id)) { warnings.push(`duplicate system dropped: ${id}`); continue; }
+    selectedIds.add(id);
+  }
+
+  for (const id of selectedIds) {
+    const sys = _byId.get(id);
+
+    // dependency check
+    for (const dep of sys.dependsOn) {
+      if (!selectedIds.has(dep)) {
+        errors.push(`'${id}' depends on '${dep}' — add it or remove '${id}'`);
+      }
+    }
+    // conflict check
+    for (const conflict of sys.conflictsWith) {
+      if (selectedIds.has(conflict)) {
+        errors.push(`'${id}' conflicts with '${conflict}' — pick one`);
+      }
+    }
+    // stub advisory — not an error; it just won't activate until Phase 7 lands
+    if (sys.status === 'stub') {
+      warnings.push(`'${id}' is not built yet (status: stub) — selectable, activates once Phase 7 ships`);
+    }
+
+    const raw = (systems.find((s) => s.id === id) || {}).config || {};
+    const coerced = coerceConfig(id, raw);
+    if (!coerced.ok) errors.push(...coerced.errors);
+    resolved.push({ id, config: coerced.config });
+  }
+
+  return { ok: errors.length === 0, errors, warnings, resolved };
+}
+
+export const REGISTRY_INTERNALS = Object.freeze({ _byId, f });

--- a/server/lib/foundry/templates.js
+++ b/server/lib/foundry/templates.js
@@ -1,0 +1,86 @@
+// server/lib/foundry/templates.js
+//
+// Foundry — game templates (Phase 6).
+//
+// A template is a pre-filled worldspec: a coherent starting set of
+// systems with sensible configs, so a builder isn't staring at a blank
+// canvas. They live as JSON in content/foundry-templates/ — same
+// authored-content pattern as content/world/ and content/quests/ —
+// so new templates are a file drop, no code change.
+//
+// foundry.create accepts a templateId and starts the new draft from
+// the template's worldspec (still validated + normalized like any
+// other spec, so a stale template can't corrupt anything).
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// server/lib/foundry/ -> repo root -> content/foundry-templates
+const TEMPLATES_DIR = path.resolve(__dirname, "../../../content/foundry-templates");
+
+/** Parse one template file into the canonical { id, name, description, worldspec } shape. */
+function parseTemplateFile(filePath) {
+  let raw;
+  try {
+    raw = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null; // malformed template — skip, never crash the lens
+  }
+  const id = typeof raw.id === "string" ? raw.id : path.basename(filePath, ".json");
+  if (!id || typeof raw.name !== "string") return null;
+  return {
+    id,
+    name: raw.name,
+    description: typeof raw.description === "string" ? raw.description : "",
+    worldspec: {
+      version: 1,
+      template: id,
+      theme: {
+        universeType: typeof raw.universeType === "string" ? raw.universeType : "fantasy",
+        displayName: raw.name,
+        palette: null,
+      },
+      systems: Array.isArray(raw.systems) ? raw.systems : [],
+      rules: Array.isArray(raw.rules) ? raw.rules : [],
+    },
+  };
+}
+
+/** Read every template from the content dir. Best-effort — a missing
+ *  dir or a malformed file yields a shorter list, never an error. */
+export function loadAllTemplates() {
+  let files;
+  try {
+    files = fs.readdirSync(TEMPLATES_DIR).filter((f) => f.endsWith(".json"));
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const f of files) {
+    const tpl = parseTemplateFile(path.join(TEMPLATES_DIR, f));
+    if (tpl) out.push(tpl);
+  }
+  out.sort((a, b) => a.name.localeCompare(b.name));
+  return out;
+}
+
+/** Summary list for the template picker — no full worldspec. */
+export function listTemplates() {
+  return loadAllTemplates().map((t) => ({
+    id: t.id,
+    name: t.name,
+    description: t.description,
+    universeType: t.worldspec.theme.universeType,
+    systemCount: t.worldspec.systems.length,
+  }));
+}
+
+/** One full template (with its worldspec) by id, or null. */
+export function getTemplate(id) {
+  if (!id) return null;
+  return loadAllTemplates().find((t) => t.id === String(id)) || null;
+}
+
+export const TEMPLATES_INTERNALS = Object.freeze({ TEMPLATES_DIR, parseTemplateFile });

--- a/server/lib/foundry/worldspec.js
+++ b/server/lib/foundry/worldspec.js
@@ -1,0 +1,123 @@
+// server/lib/foundry/worldspec.js
+//
+// Foundry — the Worldspec format (Phase 2).
+//
+// A worldspec is the persistable description of a game/world built in
+// Foundry: which systems are selected, how each is configured, the
+// theme, and (Phase 6) the authored rules. It's stored as JSON in
+// foundry_worlds.worldspec_json and compiled by the publish pipeline
+// (Phase 3) into a real `worlds` row's rule_modulators /
+// physics_modulators / seed content.
+//
+// Shape:
+//   {
+//     version: 1,
+//     template: string | null,        // template id this was based on
+//     theme: { universeType, displayName?, palette? },
+//     systems: [ { id, config } ],     // selected systems + their config
+//     rules:   [ ... ],                // Phase 6 — NL-authored rules
+//   }
+
+import { validateSystemSelection } from "./system-registry.js";
+
+export const WORLDSPEC_VERSION = 1;
+
+const VALID_UNIVERSE_TYPES = [
+  "fantasy", "scifi", "noir", "cyber", "post-apocalyptic",
+  "historical", "surreal", "slice-of-life", "horror", "mythic",
+];
+
+/** A fresh, empty worldspec — what foundry.create starts from. */
+export function emptyWorldspec() {
+  return {
+    version: WORLDSPEC_VERSION,
+    template: null,
+    theme: { universeType: "fantasy", displayName: "", palette: null },
+    systems: [],
+    rules: [],
+  };
+}
+
+/**
+ * Normalize a (possibly partial / user-supplied) worldspec into the
+ * canonical shape. Unknown top-level keys are dropped; missing keys
+ * fall back to emptyWorldspec() defaults. System configs are NOT
+ * coerced here — that happens in validateWorldspec via the registry,
+ * which also surfaces the per-field errors.
+ */
+export function normalizeWorldspec(raw = {}) {
+  const base = emptyWorldspec();
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return base;
+
+  const theme = raw.theme && typeof raw.theme === "object" ? raw.theme : {};
+  const universeType = VALID_UNIVERSE_TYPES.includes(theme.universeType)
+    ? theme.universeType
+    : base.theme.universeType;
+
+  return {
+    version: WORLDSPEC_VERSION,
+    template: typeof raw.template === "string" ? raw.template : null,
+    theme: {
+      universeType,
+      displayName: typeof theme.displayName === "string" ? theme.displayName.slice(0, 200) : "",
+      palette: theme.palette && typeof theme.palette === "object" ? theme.palette : null,
+    },
+    systems: Array.isArray(raw.systems)
+      ? raw.systems
+          .filter((s) => s && typeof s === "object" && typeof s.id === "string")
+          .map((s) => ({ id: s.id, config: s.config && typeof s.config === "object" ? s.config : {} }))
+      : [],
+    rules: Array.isArray(raw.rules) ? raw.rules.slice(0, 200) : [],
+  };
+}
+
+/**
+ * Full worldspec validation: envelope shape + the system selection
+ * (dependency / conflict / config graph via the registry). This is the
+ * gate foundry.validate (Phase 2) and foundry.publish (Phase 3) call.
+ *
+ * @returns {{ ok, errors, warnings, normalized }}
+ *   normalized — the worldspec with systems' configs coerced, ready to
+ *                persist / compile.
+ */
+export function validateWorldspec(raw = {}) {
+  const errors = [];
+  const warnings = [];
+
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return { ok: false, errors: ["worldspec must be an object"], warnings, normalized: emptyWorldspec() };
+  }
+
+  const spec = normalizeWorldspec(raw);
+
+  if (raw.version !== undefined && Number(raw.version) !== WORLDSPEC_VERSION) {
+    warnings.push(`worldspec version ${raw.version} normalized to ${WORLDSPEC_VERSION}`);
+  }
+  if (!VALID_UNIVERSE_TYPES.includes(spec.theme.universeType)) {
+    errors.push(`theme.universeType '${spec.theme.universeType}' is not valid`);
+  }
+  if (raw.theme && raw.theme.universeType && !VALID_UNIVERSE_TYPES.includes(raw.theme.universeType)) {
+    warnings.push(`theme.universeType '${raw.theme.universeType}' unknown — using '${spec.theme.universeType}'`);
+  }
+
+  // System selection — dependency / conflict / config graph.
+  const sel = validateSystemSelection(spec.systems);
+  errors.push(...sel.errors);
+  warnings.push(...sel.warnings);
+  spec.systems = sel.resolved; // coerced configs
+
+  // A worldspec with zero systems is allowed as a draft, but the
+  // publish pipeline (Phase 3) will reject it — flag it here as a hint.
+  if (spec.systems.length === 0) {
+    warnings.push("worldspec has no systems selected — drafts are fine, but publishing needs at least one");
+  }
+
+  return { ok: errors.length === 0, errors, warnings, normalized: spec };
+}
+
+/** Convenience: the set of system ids in a (normalized) worldspec. */
+export function worldspecSystemIds(spec) {
+  return Array.isArray(spec?.systems) ? spec.systems.map((s) => s.id) : [];
+}
+
+export const WORLDSPEC_INTERNALS = Object.freeze({ VALID_UNIVERSE_TYPES });

--- a/server/lib/lens-features.js
+++ b/server/lib/lens-features.js
@@ -1503,6 +1503,24 @@ const _FEATURES = {
     botAccess: false,
     usbIntegration: false,
   },
+
+  foundry: {
+    lensId: "foundry",
+    lensNumber: 66,
+    category: "AI_EXT",
+    features: [
+      f("system_registry", "Composable System Registry", "Browse and select from ~34 Concord systems as game-building blocks", "creation", ["foundry"]),
+      f("worldspec_builder", "Worldspec Builder", "Compose, configure, and persist a game/world as a worldspec", "creation", ["foundry"]),
+      f("publish_pipeline", "Publish to the Lattice", "Compile a worldspec into a real, travelable world node", "creation", ["foundry", "concord_link"]),
+      f("live_preview", "Live 3D Preview", "Preview the world being built in the 3D renderer in real time", "creation", ["foundry", "world_lens"]),
+      f("game_templates", "Game Templates & NL Rules", "Start from a template and author rules in natural language", "creation", ["foundry"]),
+    ],
+    featureCount: 5,
+    economicIntegrations: ["royalty_cascade"],
+    emergentAccess: false,
+    botAccess: false,
+    usbIntegration: false,
+  },
 };
 
 export const LENS_FEATURES = Object.freeze({ ..._FEATURES, ...EXTENDED_FEATURES });

--- a/server/lib/lens-features.js
+++ b/server/lib/lens-features.js
@@ -1506,7 +1506,7 @@ const _FEATURES = {
 
   foundry: {
     lensId: "foundry",
-    lensNumber: 66,
+    lensNumber: 125,
     category: "AI_EXT",
     features: [
       f("system_registry", "Composable System Registry", "Browse and select from ~34 Concord systems as game-building blocks", "creation", ["foundry"]),

--- a/server/migrations/191_foundry_worlds.js
+++ b/server/migrations/191_foundry_worlds.js
@@ -1,0 +1,39 @@
+// server/migrations/191_foundry_worlds.js
+//
+// Foundry (lens #66) — Phase 2. The worldspec persistence table.
+//
+// A foundry_worlds row is a game/world a user is building in the
+// Foundry lens. worldspec_json holds the full composable-systems spec
+// (see server/lib/foundry/worldspec.js). The publish pipeline (Phase 3)
+// compiles a worldspec into a real `worlds` row and stores its id on
+// published_world_id; the live-preview flow (Phase 5) uses a throwaway
+// `worlds` row tracked on preview_world_id.
+//
+// Hybrid publish model: `promoted` 0 = config overlay (a worlds row
+// driven by rule_modulators/physics_modulators, no authored content
+// dir); 1 = promoted to a full first-class world node with persisted
+// seed content. Phase 3 ships the overlay path; promotion lands later.
+
+export function up(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS foundry_worlds (
+      id                 TEXT PRIMARY KEY,
+      creator_id         TEXT NOT NULL,
+      name               TEXT NOT NULL,
+      description        TEXT,
+      worldspec_json     TEXT NOT NULL,
+      status             TEXT NOT NULL DEFAULT 'draft'
+                           CHECK (status IN ('draft', 'published')),
+      published_world_id TEXT,
+      preview_world_id   TEXT,
+      promoted           INTEGER NOT NULL DEFAULT 0,
+      created_at         INTEGER NOT NULL,
+      updated_at         INTEGER NOT NULL
+    )
+  `);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_foundry_worlds_creator ON foundry_worlds(creator_id, updated_at DESC)`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_foundry_worlds_status ON foundry_worlds(status)`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_foundry_worlds_published ON foundry_worlds(published_world_id)`);
+}
+
+export function down(_db) { /* forward-only */ }

--- a/server/migrations/192_foundry_phase7.js
+++ b/server/migrations/192_foundry_phase7.js
@@ -1,0 +1,67 @@
+// server/migrations/192_foundry_phase7.js
+//
+// Foundry — Phase 7. The four systems the design spec listed that did
+// NOT exist in the codebase (the substrate audit flagged them), now
+// built as real substrate so the registry stubs can flip to
+// 'available':
+//
+//   player_size           — Size Scaling (Ant-Man / Giant): per-player,
+//                            per-world current scale
+//   player_titles         — Status Window: earnable, world-scoped titles
+//   player_skill_affinity  — per-player skill learning, distinct from
+//                            the per-world skill_affinity modulator
+//   reincarnations        — Isekai Reincarnation: a per-world ledger of
+//                            a player's lives + the inherited boon
+//
+// All four are world-aware (a Foundry world enables them via its
+// worldspec; the rule_modulators carry the per-world config).
+
+export function up(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS player_size (
+      user_id     TEXT NOT NULL,
+      world_id    TEXT NOT NULL,
+      scale       REAL NOT NULL DEFAULT 1.0,
+      changed_at  INTEGER NOT NULL,
+      PRIMARY KEY (user_id, world_id)
+    )
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS player_titles (
+      id         TEXT PRIMARY KEY,
+      user_id    TEXT NOT NULL,
+      world_id   TEXT NOT NULL,
+      title      TEXT NOT NULL,
+      earned_at  INTEGER NOT NULL
+    )
+  `);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_player_titles_user_world ON player_titles(user_id, world_id)`);
+  db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_player_titles_unique ON player_titles(user_id, world_id, title)`);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS player_skill_affinity (
+      user_id       TEXT NOT NULL,
+      skill_id      TEXT NOT NULL,
+      affinity      REAL NOT NULL DEFAULT 1.0,
+      uses          INTEGER NOT NULL DEFAULT 0,
+      last_used_at  INTEGER NOT NULL,
+      PRIMARY KEY (user_id, skill_id)
+    )
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS reincarnations (
+      id               TEXT PRIMARY KEY,
+      user_id          TEXT NOT NULL,
+      world_id         TEXT NOT NULL,
+      life_number      INTEGER NOT NULL,
+      prior_avatar_id  TEXT,
+      inherited_json   TEXT NOT NULL DEFAULT '{}',
+      reincarnated_at  INTEGER NOT NULL
+    )
+  `);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_reincarnations_user_world ON reincarnations(user_id, world_id, life_number)`);
+}
+
+export function down(_db) { /* forward-only */ }

--- a/server/server.js
+++ b/server/server.js
@@ -23023,10 +23023,14 @@ registerKnowledgeTradeMacros(register);
 // inserts beats; these macros let the player surface and resolve them.
 import registerBeatsMacros from "./domains/beats.js";
 registerBeatsMacros(register);
-// Foundry (lens #66) — no-code game-builder. Phase 1: System Registry
-// read surface (foundry.systems / system_schema / validate_systems).
+// Foundry (lens #66) — no-code game-builder. Builder surface
+// (registry / worldspec / publish / preview / templates / rules).
 import registerFoundryMacros from "./domains/foundry.js";
 registerFoundryMacros(register);
+// Foundry Phase 7 — the four net-new gameplay systems' macro surface
+// (size.* / skill_affinity.* / status.* / reincarnation.*).
+import registerFoundrySystemsMacros from "./domains/foundry-systems.js";
+registerFoundrySystemsMacros(register);
 import registerSecretsMacros from "./domains/secrets.js";
 registerSecretsMacros(register);
 import registerSchemesMacros from "./domains/schemes.js";

--- a/server/server.js
+++ b/server/server.js
@@ -23227,6 +23227,9 @@ registerHeartbeat("aging-cycle", { frequency: 480, handler: runAgingCycle });
 registerHeartbeat("ration-floor-cycle", { frequency: 1440, handler: runRationFloorCycle });
 registerHeartbeat("council-session-cycle", { frequency: 480, handler: runCouncilSessionCycle });
 registerHeartbeat("underwater-threat-cycle", { frequency: 6, handler: runUnderwaterThreatCycle });
+// Foundry (lens #66) — sweep stale live-preview worlds (Phase 5).
+import { runFoundryPreviewCleanup } from "./emergent/foundry-preview-cleanup.js";
+registerHeartbeat("foundry-preview-cleanup", { frequency: 240, handler: runFoundryPreviewCleanup });
 
 // Theme deferred (game-feel pass): hidden quest triggers — substrate
 // for unmarked, environment-gated quest activation. Pure runMacro

--- a/server/server.js
+++ b/server/server.js
@@ -23023,6 +23023,10 @@ registerKnowledgeTradeMacros(register);
 // inserts beats; these macros let the player surface and resolve them.
 import registerBeatsMacros from "./domains/beats.js";
 registerBeatsMacros(register);
+// Foundry (lens #66) — no-code game-builder. Phase 1: System Registry
+// read surface (foundry.systems / system_schema / validate_systems).
+import registerFoundryMacros from "./domains/foundry.js";
+registerFoundryMacros(register);
 import registerSecretsMacros from "./domains/secrets.js";
 registerSecretsMacros(register);
 import registerSchemesMacros from "./domains/schemes.js";

--- a/server/tests/foundry-phase7-systems.test.js
+++ b/server/tests/foundry-phase7-systems.test.js
@@ -1,0 +1,264 @@
+/**
+ * Tier-2 contract tests for Foundry Phase 7 — the four net-new systems.
+ *
+ * The substrate audit flagged Size Scaling, Status Window, per-player
+ * Skill Affinity, and Isekai Reincarnation as listed-in-spec but
+ * absent from the codebase. Phase 7 builds them as real substrate;
+ * this pins:
+ *   - size-scaling: clamp, effect bands, scaled combat profile, state
+ *     round-trip
+ *   - skill-affinity: per-use growth, idle decay, effective combine
+ *   - status-window: idempotent titles, world-adaptive composition
+ *   - reincarnation: inheritance math, life ledger
+ *   - the size.* / skill_affinity.* / status.* / reincarnation.*
+ *     macros against an in-memory DB (migration 192 + a worlds row
+ *     carrying the per-world config)
+ *   - the registry: every stub flipped to 'available'
+ *
+ * Run: node --test server/tests/foundry-phase7-systems.test.js
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+
+import {
+  clampScale, scaleEffects, scaledCombatProfile, setPlayerScale, getPlayerScale,
+} from "../lib/foundry/size-scaling.js";
+import {
+  recordSkillUse, getPlayerAffinity, effectiveAffinity, SKILL_AFFINITY_INTERNALS,
+} from "../lib/foundry/skill-affinity.js";
+import {
+  awardTitle, listTitles, composeStatusWindow,
+} from "../lib/foundry/status-window.js";
+import {
+  computeInheritance, reincarnate, getLives,
+} from "../lib/foundry/reincarnation.js";
+import { SYSTEM_REGISTRY } from "../lib/foundry/system-registry.js";
+import { up as migrate192 } from "../migrations/192_foundry_phase7.js";
+import registerFoundrySystemsMacros from "../domains/foundry-systems.js";
+
+// ── size-scaling.js ─────────────────────────────────────────────────────────
+
+describe("size-scaling", () => {
+  it("clamps a requested scale into the world's bounds", () => {
+    assert.equal(clampScale(9999, { minScale: 15, maxScale: 800 }), 800);
+    assert.equal(clampScale(1, { minScale: 15, maxScale: 800 }), 15);
+    assert.equal(clampScale(100, {}), 100);
+  });
+
+  it("derives small / normal / large effect bands", () => {
+    const small = scaleEffects(20, { smallGrantsFlight: true });
+    assert.equal(small.band, "small");
+    assert.equal(small.canFly, true);
+    assert.ok(small.stealthBonus > 0);
+
+    const large = scaleEffects(400, { largeGrantsDestruction: true });
+    assert.equal(large.band, "large");
+    assert.equal(large.canDestroy, true);
+    assert.ok(large.reachBonus > 0);
+
+    assert.equal(scaleEffects(100, {}).band, "normal");
+  });
+
+  it("scaledCombatProfile: small = precision, large = aoe", () => {
+    assert.equal(scaledCombatProfile(20, {}).model, "precision");
+    assert.equal(scaledCombatProfile(400, {}).model, "aoe");
+    assert.ok(scaledCombatProfile(400, {}).damageMult > 1);
+    assert.equal(scaledCombatProfile(100, {}).model, "balanced");
+  });
+
+  it("setPlayerScale / getPlayerScale round-trip + clamp on write", () => {
+    const db = new Database(":memory:");
+    migrate192(db);
+    const r = setPlayerScale(db, "u1", "w1", 9999, { maxScale: 800 });
+    assert.equal(r.ok, true);
+    assert.equal(r.scale, 800);
+    assert.equal(getPlayerScale(db, "u1", "w1"), 800);
+    assert.equal(getPlayerScale(db, "u1", "never-set"), 100); // default
+  });
+});
+
+// ── skill-affinity.js ───────────────────────────────────────────────────────
+
+describe("skill-affinity", () => {
+  it("recordSkillUse grows personal affinity per use", () => {
+    const db = new Database(":memory:");
+    migrate192(db);
+    const a1 = recordSkillUse(db, "u1", "frost-bolt", {});
+    const a2 = recordSkillUse(db, "u1", "frost-bolt", {});
+    assert.ok(a2.affinity > a1.affinity, "affinity should grow");
+    assert.equal(a2.uses, 2);
+  });
+
+  it("getPlayerAffinity returns 1.0 for an unused skill, applies idle decay", () => {
+    const db = new Database(":memory:");
+    migrate192(db);
+    assert.equal(getPlayerAffinity(db, "u1", "never-used", {}), 1.0);
+    recordSkillUse(db, "u1", "fireball", {});
+    const fresh = getPlayerAffinity(db, "u1", "fireball", {});
+    // 30 days later, with decayWhenUnused on, it should be lower.
+    const later = getPlayerAffinity(db, "u1", "fireball", { decayWhenUnused: true }, Date.now() + 30 * 24 * 3600 * 1000);
+    assert.ok(later < fresh, "idle decay should reduce affinity");
+    assert.ok(later >= SKILL_AFFINITY_INTERNALS.MIN_AFFINITY, "decay floors at MIN_AFFINITY");
+  });
+
+  it("effectiveAffinity is player x world", () => {
+    assert.equal(effectiveAffinity(1.5, 150), 2.25);
+    assert.equal(effectiveAffinity(1.0, 100), 1.0);
+    assert.equal(effectiveAffinity(2.0, 50), 1.0);
+  });
+});
+
+// ── status-window.js ────────────────────────────────────────────────────────
+
+describe("status-window", () => {
+  it("awardTitle is idempotent; listTitles reads them back", () => {
+    const db = new Database(":memory:");
+    migrate192(db);
+    const first = awardTitle(db, "u1", "w1", "Dragonslayer");
+    assert.equal(first.awarded, true);
+    const again = awardTitle(db, "u1", "w1", "Dragonslayer");
+    assert.equal(again.awarded, false); // already had it
+    awardTitle(db, "u1", "w1", "Realm Founder");
+    assert.equal(listTitles(db, "u1", "w1").length, 2);
+  });
+
+  it("composeStatusWindow assembles a world-adaptive panel", () => {
+    const db = new Database(":memory:");
+    migrate192(db);
+    awardTitle(db, "u1", "w1", "Champion");
+    const r = composeStatusWindow(db, "u1", "w1", { style: "sci-fi-hud", showHiddenStats: true }, {
+      stats: { hp: 100 }, skills: [{ id: "x", level: 3 }], hiddenStats: { luck: 7 },
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.window.style, "sci-fi-hud");
+    assert.equal(r.window.activeTitle, "Champion");
+    assert.equal(r.window.stats.hp, 100);
+    assert.equal(r.window.hiddenStats.luck, 7); // surfaced because showHiddenStats
+  });
+
+  it("composeStatusWindow hides hidden stats by default + coerces a bad style", () => {
+    const db = new Database(":memory:");
+    migrate192(db);
+    const r = composeStatusWindow(db, "u1", "w1", { style: "banana" }, { hiddenStats: { luck: 7 } });
+    assert.equal(r.window.style, "classic-rpg"); // coerced
+    assert.ok(!("hiddenStats" in r.window));
+  });
+});
+
+// ── reincarnation.js ────────────────────────────────────────────────────────
+
+describe("reincarnation", () => {
+  it("computeInheritance carries a fraction of numeric progress", () => {
+    const inh = computeInheritance({ xp: 1000, level: 10, currency: 500 }, { inheritedFraction: 20 });
+    assert.equal(inh.fraction, 0.2);
+    assert.equal(inh.inherited.xp, 200);
+    assert.equal(inh.inherited.level, 2); // floored
+    assert.equal(inh.inherited.currency, 100);
+  });
+
+  it("reincarnate writes a life ledger; getLives reads it newest-first", () => {
+    const db = new Database(":memory:");
+    migrate192(db);
+    const r1 = reincarnate(db, "u1", "w1", { xp: 1000, level: 8 }, { inheritedFraction: 25 });
+    assert.equal(r1.ok, true);
+    assert.equal(r1.lifeNumber, 2); // life 1 was the original
+    const r2 = reincarnate(db, "u1", "w1", { xp: 400 }, { inheritedFraction: 25 });
+    assert.equal(r2.lifeNumber, 3);
+    const lives = getLives(db, "u1", "w1");
+    assert.equal(lives.length, 2);
+    assert.equal(lives[0].lifeNumber, 3); // newest first
+  });
+
+  it("reincarnate respects the disabled flag", () => {
+    const db = new Database(":memory:");
+    migrate192(db);
+    const r = reincarnate(db, "u1", "w1", {}, { enabled: false });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "reincarnation_disabled");
+  });
+});
+
+// ── macros ──────────────────────────────────────────────────────────────────
+
+function makeHarness() {
+  const db = new Database(":memory:");
+  migrate192(db);
+  db.exec(`CREATE TABLE worlds (id TEXT PRIMARY KEY, rule_modulators TEXT DEFAULT '{}')`);
+  // A world that enables size-scaling + reincarnation with config.
+  db.prepare(`INSERT INTO worlds (id, rule_modulators) VALUES (?, ?)`).run(
+    "w-foundry",
+    JSON.stringify({
+      size_scaling: { minScale: 10, maxScale: 500, smallGrantsFlight: true },
+      reincarnation: { inheritedFraction: 30, enabled: true },
+      status_window: { style: "ornate", titleSystem: true },
+    }),
+  );
+  const macros = new Map();
+  registerFoundrySystemsMacros((domain, name, handler) => macros.set(`${domain}.${name}`, handler));
+  const call = (name, input, actor = { userId: "user-1" }) =>
+    macros.get(name)({ db, actor }, input || {});
+  return { db, call };
+}
+
+describe("foundry-systems macros", () => {
+  let h;
+  beforeEach(() => { h = makeHarness(); });
+
+  it("size.set / size.get use the world's config", () => {
+    const set = h.call("size.set", { worldId: "w-foundry", scale: 9999 });
+    assert.equal(set.ok, true);
+    assert.equal(set.scale, 500); // clamped to the world's maxScale
+    const get = h.call("size.get", { worldId: "w-foundry" });
+    assert.equal(get.scale, 500);
+    assert.equal(get.effects.band, "large");
+  });
+
+  it("size.combat_profile reflects the player's current scale", () => {
+    h.call("size.set", { worldId: "w-foundry", scale: 15 });
+    const cp = h.call("size.combat_profile", { worldId: "w-foundry" });
+    assert.equal(cp.ok, true);
+    assert.equal(cp.profile.band, "small");
+  });
+
+  it("skill_affinity.record + get", () => {
+    h.call("skill_affinity.record", { skillId: "ice-shard" });
+    h.call("skill_affinity.record", { skillId: "ice-shard" });
+    const g = h.call("skill_affinity.get", { skillId: "ice-shard", worldAffinityPct: 150 });
+    assert.equal(g.ok, true);
+    assert.ok(g.playerAffinity > 1.0);
+    assert.ok(g.effective > g.playerAffinity); // world 150% amplifies
+  });
+
+  it("status.award_title / status.titles / status.window", () => {
+    h.call("status.award_title", { worldId: "w-foundry", title: "Worldsmith" });
+    assert.equal(h.call("status.titles", { worldId: "w-foundry" }).titles.length, 1);
+    const w = h.call("status.window", { worldId: "w-foundry" });
+    assert.equal(w.ok, true);
+    assert.equal(w.window.style, "ornate");
+    assert.equal(w.window.activeTitle, "Worldsmith");
+  });
+
+  it("reincarnation.reincarnate / lives use the world's config", () => {
+    const r = h.call("reincarnation.reincarnate", { worldId: "w-foundry", priorState: { xp: 1000, level: 10 } });
+    assert.equal(r.ok, true);
+    assert.equal(r.lifeNumber, 2);
+    assert.equal(r.inherited.xp, 300); // 30% per the world config
+    assert.equal(h.call("reincarnation.lives", { worldId: "w-foundry" }).lives.length, 1);
+  });
+
+  it("macros require an actor + a world id", () => {
+    assert.equal(h.call("size.get", { worldId: "w-foundry" }, {}).reason, "no_actor");
+    assert.equal(h.call("size.get", {}).reason, "missing_world_id");
+  });
+});
+
+// ── registry: no stubs remain ───────────────────────────────────────────────
+
+describe("registry after Phase 7", () => {
+  it("every system is now 'available' — no stubs", () => {
+    const stubs = SYSTEM_REGISTRY.filter((s) => s.status === "stub").map((s) => s.id);
+    assert.deepEqual(stubs, [], `still stubbed: ${stubs.join(", ")}`);
+  });
+});

--- a/server/tests/foundry-preview.test.js
+++ b/server/tests/foundry-preview.test.js
@@ -1,0 +1,162 @@
+/**
+ * Tier-2 contract tests for Foundry Phase 5 — live 3D preview.
+ *
+ * Pins:
+ *   - foundry.preview: compiles the draft into a status='preview'
+ *     worlds row, reuses an attached preview row instead of
+ *     accumulating, blocks an empty worldspec, creator-scoped
+ *   - foundry.preview_end: deletes the preview world, clears
+ *     preview_world_id, idempotent, creator-scoped
+ *   - runFoundryPreviewCleanup: sweeps stale preview rows past the TTL,
+ *     leaves fresh ones, clears dangling preview_world_id pointers,
+ *     never throws (heartbeat-safe)
+ *
+ * Run: node --test server/tests/foundry-preview.test.js
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+
+import { up as migrate191 } from "../migrations/191_foundry_worlds.js";
+import registerFoundryMacros from "../domains/foundry.js";
+import {
+  runFoundryPreviewCleanup,
+  FOUNDRY_PREVIEW_CLEANUP_INTERNALS,
+} from "../emergent/foundry-preview-cleanup.js";
+
+function makeHarness() {
+  const db = new Database(":memory:");
+  migrate191(db);
+  db.exec(`
+    CREATE TABLE worlds (
+      id TEXT PRIMARY KEY, name TEXT NOT NULL, universe_type TEXT NOT NULL,
+      description TEXT, physics_modulators TEXT DEFAULT '{}', rule_modulators TEXT DEFAULT '{}',
+      created_by TEXT, status TEXT NOT NULL DEFAULT 'active', total_visits INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch())
+    )
+  `);
+  const macros = new Map();
+  registerFoundryMacros((domain, name, handler) => macros.set(`${domain}.${name}`, handler));
+  const call = (name, input, actor = { userId: "user-1" }) =>
+    macros.get(name)({ db, actor }, input || {});
+  return { db, call };
+}
+
+describe("foundry.preview", () => {
+  let h;
+  beforeEach(() => { h = makeHarness(); });
+
+  function draftWith(systems) {
+    return h.call("foundry.create", { name: "Previewable", worldspec: { systems } }).world.id;
+  }
+
+  it("compiles the draft into a status='preview' worlds row", () => {
+    const id = draftWith([{ id: "physics-modifiers", config: { gravity: 40 } }, { id: "combat-motor" }]);
+    const pv = h.call("foundry.preview", { id });
+    assert.equal(pv.ok, true);
+    assert.ok(pv.previewWorldId.startsWith("preview-"));
+    const w = h.db.prepare(`SELECT * FROM worlds WHERE id = ?`).get(pv.previewWorldId);
+    assert.ok(w);
+    assert.equal(w.status, "preview");
+    assert.equal(JSON.parse(w.physics_modulators).movement.gravity, 40);
+    // foundry_worlds row now points at it
+    const fw = h.db.prepare(`SELECT preview_world_id FROM foundry_worlds WHERE id = ?`).get(id);
+    assert.equal(fw.preview_world_id, pv.previewWorldId);
+  });
+
+  it("reuses an attached preview row instead of accumulating", () => {
+    const id = draftWith([{ id: "combat-motor" }]);
+    const first = h.call("foundry.preview", { id });
+    const second = h.call("foundry.preview", { id });
+    assert.equal(first.previewWorldId, second.previewWorldId);
+    const count = h.db.prepare(`SELECT COUNT(*) c FROM worlds WHERE status = 'preview'`).get().c;
+    assert.equal(count, 1);
+  });
+
+  it("blocks previewing an empty worldspec", () => {
+    const id = h.call("foundry.create", { name: "Empty" }).world.id;
+    const pv = h.call("foundry.preview", { id });
+    assert.equal(pv.ok, false);
+    assert.equal(pv.reason, "no_systems");
+  });
+
+  it("is creator-scoped", () => {
+    const id = draftWith([{ id: "combat-motor" }]);
+    assert.equal(h.call("foundry.preview", { id }, { userId: "intruder" }).reason, "not_owner");
+  });
+
+  it("activates Phase 7 systems in the preview (no stubs skipped)", () => {
+    const id = draftWith([{ id: "combat-motor" }, { id: "status-window" }]);
+    const pv = h.call("foundry.preview", { id });
+    assert.equal(pv.ok, true);
+    assert.deepEqual(pv.skippedStubs, []);
+    assert.ok(pv.activatedSystems.includes("status-window"));
+  });
+});
+
+describe("foundry.preview_end", () => {
+  let h;
+  beforeEach(() => { h = makeHarness(); });
+
+  it("deletes the preview world and clears the pointer", () => {
+    const id = h.call("foundry.create", { name: "X", worldspec: { systems: [{ id: "combat-motor" }] } }).world.id;
+    const pv = h.call("foundry.preview", { id });
+    const end = h.call("foundry.preview_end", { id });
+    assert.equal(end.ok, true);
+    assert.equal(h.db.prepare(`SELECT * FROM worlds WHERE id = ?`).get(pv.previewWorldId), undefined);
+    assert.equal(h.db.prepare(`SELECT preview_world_id FROM foundry_worlds WHERE id = ?`).get(id).preview_world_id, null);
+  });
+
+  it("is idempotent when there is no preview", () => {
+    const id = h.call("foundry.create", { name: "X" }).world.id;
+    const end = h.call("foundry.preview_end", { id });
+    assert.equal(end.ok, true);
+    assert.equal(end.alreadyClear, true);
+  });
+
+  it("is creator-scoped", () => {
+    const id = h.call("foundry.create", { name: "X", worldspec: { systems: [{ id: "combat-motor" }] } }).world.id;
+    h.call("foundry.preview", { id });
+    assert.equal(h.call("foundry.preview_end", { id }, { userId: "intruder" }).reason, "not_owner");
+  });
+});
+
+describe("runFoundryPreviewCleanup", () => {
+  let h;
+  beforeEach(() => { h = makeHarness(); });
+
+  it("sweeps preview worlds past the TTL, leaves fresh ones", () => {
+    const ttl = FOUNDRY_PREVIEW_CLEANUP_INTERNALS.PREVIEW_TTL_SECONDS;
+    const nowSec = Math.floor(Date.now() / 1000);
+    h.db.prepare(`INSERT INTO worlds (id, name, universe_type, status, created_at) VALUES (?, ?, ?, 'preview', ?)`)
+      .run("preview-stale", "stale", "fantasy", nowSec - ttl - 100);
+    h.db.prepare(`INSERT INTO worlds (id, name, universe_type, status, created_at) VALUES (?, ?, ?, 'preview', ?)`)
+      .run("preview-fresh", "fresh", "fantasy", nowSec - 60);
+    h.db.prepare(`INSERT INTO worlds (id, name, universe_type, status, created_at) VALUES (?, ?, ?, 'active', ?)`)
+      .run("world-real", "real", "fantasy", nowSec - ttl - 999); // active — must NOT be swept
+
+    const r = runFoundryPreviewCleanup({ db: h.db });
+    assert.equal(r.ok, true);
+    assert.equal(r.swept, 1);
+    assert.equal(h.db.prepare(`SELECT * FROM worlds WHERE id = 'preview-stale'`).get(), undefined);
+    assert.ok(h.db.prepare(`SELECT * FROM worlds WHERE id = 'preview-fresh'`).get());
+    assert.ok(h.db.prepare(`SELECT * FROM worlds WHERE id = 'world-real'`).get());
+  });
+
+  it("clears dangling preview_world_id pointers", () => {
+    const id = h.call("foundry.create", { name: "X", worldspec: { systems: [{ id: "combat-motor" }] } }).world.id;
+    const pv = h.call("foundry.preview", { id });
+    // Simulate the preview world vanishing out from under the pointer.
+    h.db.prepare(`DELETE FROM worlds WHERE id = ?`).run(pv.previewWorldId);
+    const r = runFoundryPreviewCleanup({ db: h.db });
+    assert.equal(r.ok, true);
+    assert.equal(r.danglingCleared, 1);
+    assert.equal(h.db.prepare(`SELECT preview_world_id FROM foundry_worlds WHERE id = ?`).get(id).preview_world_id, null);
+  });
+
+  it("never throws — returns ok even with no db", () => {
+    assert.equal(runFoundryPreviewCleanup({}).ok, true);
+    assert.equal(runFoundryPreviewCleanup().ok, true);
+  });
+});

--- a/server/tests/foundry-publish.test.js
+++ b/server/tests/foundry-publish.test.js
@@ -53,15 +53,19 @@ describe("worldspec compiler", () => {
     assert.ok(!("royalty-cascade" in c.rule_modulators));
   });
 
-  it("skips stub systems but records them in provenance", () => {
+  it("activates the Phase 7 systems (no longer stubs)", () => {
+    // size-scaling + status-window were built in Phase 7 — the compiler
+    // now activates them instead of skipping. (The stub-skip code path
+    // still exists for any future status:'stub' system.)
     const spec = normalizeWorldspec({
-      systems: [{ id: "combat-motor" }, { id: "size-scaling" }, { id: "status-window" }],
+      systems: [{ id: "combat-motor" }, { id: "physics-modifiers" }, { id: "size-scaling" }, { id: "status-window" }],
     });
     const c = compileWorldspec(spec);
-    assert.deepEqual(c.skippedStubs.sort(), ["size-scaling", "status-window"]);
-    assert.deepEqual(c.activatedSystems, ["combat-motor"]);
-    assert.deepEqual(c.rule_modulators.foundry.stubs.sort(), ["size-scaling", "status-window"]);
-    assert.deepEqual(c.rule_modulators.foundry.systems, ["combat-motor"]);
+    assert.deepEqual(c.skippedStubs, []);
+    assert.deepEqual(c.activatedSystems.sort(), ["combat-motor", "physics-modifiers", "size-scaling", "status-window"]);
+    assert.equal(typeof c.rule_modulators.size_scaling, "object"); // size-scaling activated
+    assert.equal(typeof c.rule_modulators.status_window, "object"); // status-window activated
+    assert.deepEqual(c.rule_modulators.foundry.stubs, []);
   });
 
   it("writes a provenance marker", () => {
@@ -168,16 +172,15 @@ describe("foundry.publish", () => {
     assert.equal(pub.reason, "not_owner");
   });
 
-  it("a published worldspec with a stub system publishes, stub skipped", () => {
-    // status-window is a stub with no dependencies — selectable + persists
-    // in the spec, but the compiler skips it until Phase 7 flips its status.
+  it("publishes a worldspec including a Phase 7 system — it activates", () => {
+    // status-window was built in Phase 7; publishing now activates it.
     const id = h.call("foundry.create", {
       name: "Future", worldspec: { systems: [{ id: "combat-motor" }, { id: "status-window" }] },
     }).world.id;
     const pub = h.call("foundry.publish", { id });
     assert.equal(pub.ok, true);
-    assert.deepEqual(pub.skippedStubs, ["status-window"]);
-    assert.deepEqual(pub.activatedSystems, ["combat-motor"]);
+    assert.deepEqual(pub.skippedStubs, []);
+    assert.deepEqual(pub.activatedSystems.sort(), ["combat-motor", "status-window"]);
   });
 });
 

--- a/server/tests/foundry-publish.test.js
+++ b/server/tests/foundry-publish.test.js
@@ -1,0 +1,231 @@
+/**
+ * Tier-2 contract tests for Foundry Phase 3 — compiler + publish pipeline.
+ *
+ * Pins:
+ *   - compiler.js: activation routing (physics_modulator /
+ *     rule_modulator / heartbeat_optin / content_seed / always_on),
+ *     stub-skip, provenance marker, concordLinkAnchor extraction,
+ *     buildConcordLinkAnchor shape
+ *   - foundry.publish: validation hard-gate (invalid spec / no systems
+ *     blocked), creates a real `worlds` row with compiled modulators,
+ *     flips foundry_worlds to published, blocks re-publish,
+ *     creator-scoped
+ *   - foundry.unpublish: deletes an unvisited overlay world, archives a
+ *     visited one, resets the foundry_worlds row to draft, blocks
+ *     not-published, creator-scoped
+ *
+ * Run: node --test server/tests/foundry-publish.test.js
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+
+import { compileWorldspec, buildConcordLinkAnchor } from "../lib/foundry/compiler.js";
+import { normalizeWorldspec } from "../lib/foundry/worldspec.js";
+import { up as migrate191 } from "../migrations/191_foundry_worlds.js";
+import registerFoundryMacros from "../domains/foundry.js";
+
+// ── compiler.js ─────────────────────────────────────────────────────────────
+
+describe("worldspec compiler", () => {
+  it("routes each activation kind to the right artifact", () => {
+    const spec = normalizeWorldspec({
+      systems: [
+        { id: "physics-modifiers", config: { gravity: 50 } },   // physics_modulator
+        { id: "combat-motor", config: { lethality: "hardcore" } }, // rule_modulator
+        { id: "fauna-flocks", config: { density: "abundant" } }, // heartbeat_optin
+        { id: "concord-link", config: { travelMode: "open" } },  // content_seed
+        { id: "llm-npcs", config: { npcCount: 12 } },            // content_seed
+        { id: "royalty-cascade" },                                // always_on
+      ],
+    });
+    const c = compileWorldspec(spec);
+    assert.deepEqual(Object.keys(c.physics_modulators), ["movement"]);
+    assert.equal(c.physics_modulators.movement.gravity, 50);
+    assert.equal(c.rule_modulators.combat.lethality, "hardcore");
+    assert.equal(c.rule_modulators.fauna.density, "abundant");
+    assert.equal(c.rule_modulators.foundry_heartbeats.fauna, true);
+    assert.equal(c.contentSeeds.length, 2); // concord-link + llm-npcs
+    assert.ok(c.concordLinkAnchor);
+    assert.equal(c.concordLinkAnchor.travelMode, "open");
+    // royalty-cascade is always_on — writes no per-world modulator
+    assert.ok(!("royalty-cascade" in c.rule_modulators));
+  });
+
+  it("skips stub systems but records them in provenance", () => {
+    const spec = normalizeWorldspec({
+      systems: [{ id: "combat-motor" }, { id: "size-scaling" }, { id: "status-window" }],
+    });
+    const c = compileWorldspec(spec);
+    assert.deepEqual(c.skippedStubs.sort(), ["size-scaling", "status-window"]);
+    assert.deepEqual(c.activatedSystems, ["combat-motor"]);
+    assert.deepEqual(c.rule_modulators.foundry.stubs.sort(), ["size-scaling", "status-window"]);
+    assert.deepEqual(c.rule_modulators.foundry.systems, ["combat-motor"]);
+  });
+
+  it("writes a provenance marker", () => {
+    const c = compileWorldspec(normalizeWorldspec({ template: "starter", systems: [{ id: "combat-motor" }] }));
+    assert.equal(c.rule_modulators.foundry.template, "starter");
+    assert.equal(c.rule_modulators.foundry.worldspecVersion, 1);
+  });
+
+  it("buildConcordLinkAnchor produces the anchor row shape", () => {
+    const a = buildConcordLinkAnchor("world-xyz", "Test Realm", { travelMode: "walker-escort" });
+    assert.equal(a.id, "anchor-world-xyz");
+    assert.equal(a.world_id, "world-xyz");
+    assert.equal(a.access_method, "walker-escort");
+    assert.equal(a.stability, 1.0);
+  });
+
+  it("buildConcordLinkAnchor returns null when concord-link wasn't selected", () => {
+    assert.equal(buildConcordLinkAnchor("w", "n", null), null);
+  });
+});
+
+// ── publish / unpublish macros ──────────────────────────────────────────────
+
+function makeHarness() {
+  const db = new Database(":memory:");
+  migrate191(db);
+  // Minimal `worlds` table — just the columns the publish path touches.
+  db.exec(`
+    CREATE TABLE worlds (
+      id TEXT PRIMARY KEY, name TEXT NOT NULL, universe_type TEXT NOT NULL,
+      description TEXT, physics_modulators TEXT DEFAULT '{}', rule_modulators TEXT DEFAULT '{}',
+      created_by TEXT, status TEXT NOT NULL DEFAULT 'active', total_visits INTEGER NOT NULL DEFAULT 0
+    )
+  `);
+  const macros = new Map();
+  registerFoundryMacros((domain, name, handler) => macros.set(`${domain}.${name}`, handler));
+  const call = (name, input, actor = { userId: "user-1" }) =>
+    macros.get(name)({ db, actor }, input || {});
+  return { db, call };
+}
+
+describe("foundry.publish", () => {
+  let h;
+  beforeEach(() => { h = makeHarness(); });
+
+  it("publishes a valid worldspec into a real worlds row", () => {
+    const id = h.call("foundry.create", {
+      name: "Skyforge",
+      worldspec: {
+        theme: { universeType: "scifi" },
+        systems: [
+          { id: "physics-modifiers", config: { gravity: 60 } },
+          { id: "combat-motor" },
+          { id: "concord-link" },
+        ],
+      },
+    }).world.id;
+
+    const pub = h.call("foundry.publish", { id });
+    assert.equal(pub.ok, true);
+    assert.ok(pub.publishedWorldId.startsWith("world-"));
+    assert.equal(pub.world.status, "published");
+    assert.equal(pub.world.publishedWorldId, pub.publishedWorldId);
+
+    const w = h.db.prepare(`SELECT * FROM worlds WHERE id = ?`).get(pub.publishedWorldId);
+    assert.ok(w, "worlds row created");
+    assert.equal(w.universe_type, "scifi");
+    assert.equal(w.created_by, "user-1");
+    const phys = JSON.parse(w.physics_modulators);
+    const rules = JSON.parse(w.rule_modulators);
+    assert.equal(phys.movement.gravity, 60);
+    assert.ok(rules.combat);
+    assert.deepEqual(rules.foundry.systems.sort(), ["combat-motor", "concord-link", "physics-modifiers"]);
+  });
+
+  it("blocks publishing a worldspec with an unsatisfied dependency", () => {
+    const id = h.call("foundry.create", {
+      name: "Broken", worldspec: { systems: [{ id: "boss-phases" }] }, // needs combat-motor
+    }).world.id;
+    const pub = h.call("foundry.publish", { id });
+    assert.equal(pub.ok, false);
+    assert.equal(pub.reason, "worldspec_invalid");
+    assert.ok(pub.errors.some((e) => e.includes("combat-motor")));
+  });
+
+  it("blocks publishing an empty worldspec", () => {
+    const id = h.call("foundry.create", { name: "Empty" }).world.id;
+    const pub = h.call("foundry.publish", { id });
+    assert.equal(pub.ok, false);
+    assert.equal(pub.reason, "no_systems");
+  });
+
+  it("blocks re-publishing an already-published world", () => {
+    const id = h.call("foundry.create", { name: "Once", worldspec: { systems: [{ id: "combat-motor" }] } }).world.id;
+    assert.equal(h.call("foundry.publish", { id }).ok, true);
+    const again = h.call("foundry.publish", { id });
+    assert.equal(again.ok, false);
+    assert.equal(again.reason, "already_published");
+  });
+
+  it("is creator-scoped", () => {
+    const id = h.call("foundry.create", { name: "Mine", worldspec: { systems: [{ id: "combat-motor" }] } }).world.id;
+    const pub = h.call("foundry.publish", { id }, { userId: "intruder" });
+    assert.equal(pub.reason, "not_owner");
+  });
+
+  it("a published worldspec with a stub system publishes, stub skipped", () => {
+    // status-window is a stub with no dependencies — selectable + persists
+    // in the spec, but the compiler skips it until Phase 7 flips its status.
+    const id = h.call("foundry.create", {
+      name: "Future", worldspec: { systems: [{ id: "combat-motor" }, { id: "status-window" }] },
+    }).world.id;
+    const pub = h.call("foundry.publish", { id });
+    assert.equal(pub.ok, true);
+    assert.deepEqual(pub.skippedStubs, ["status-window"]);
+    assert.deepEqual(pub.activatedSystems, ["combat-motor"]);
+  });
+});
+
+describe("foundry.unpublish", () => {
+  let h;
+  beforeEach(() => { h = makeHarness(); });
+
+  function publishOne(name = "W") {
+    const id = h.call("foundry.create", { name, worldspec: { systems: [{ id: "combat-motor" }] } }).world.id;
+    const pub = h.call("foundry.publish", { id });
+    return { id, worldId: pub.publishedWorldId };
+  }
+
+  it("deletes the overlay world when nobody has visited it", () => {
+    const { id, worldId } = publishOne();
+    const un = h.call("foundry.unpublish", { id });
+    assert.equal(un.ok, true);
+    assert.equal(un.disposition, "deleted");
+    assert.equal(h.db.prepare(`SELECT * FROM worlds WHERE id = ?`).get(worldId), undefined);
+    assert.equal(h.call("foundry.get", { id }).world.status, "draft");
+    assert.equal(h.call("foundry.get", { id }).world.publishedWorldId, null);
+  });
+
+  it("archives the overlay world when it has visits", () => {
+    const { id, worldId } = publishOne();
+    h.db.prepare(`UPDATE worlds SET total_visits = 5 WHERE id = ?`).run(worldId);
+    const un = h.call("foundry.unpublish", { id });
+    assert.equal(un.ok, true);
+    assert.equal(un.disposition, "archived");
+    assert.equal(h.db.prepare(`SELECT status FROM worlds WHERE id = ?`).get(worldId).status, "archived");
+  });
+
+  it("blocks unpublishing a draft", () => {
+    const id = h.call("foundry.create", { name: "Draft" }).world.id;
+    const un = h.call("foundry.unpublish", { id });
+    assert.equal(un.ok, false);
+    assert.equal(un.reason, "not_published");
+  });
+
+  it("is creator-scoped", () => {
+    const { id } = publishOne();
+    assert.equal(h.call("foundry.unpublish", { id }, { userId: "intruder" }).reason, "not_owner");
+  });
+
+  it("unpublish then delete works (the delete-guard lifts)", () => {
+    const { id } = publishOne();
+    assert.equal(h.call("foundry.delete", { id }).reason, "world_published");
+    assert.equal(h.call("foundry.unpublish", { id }).ok, true);
+    assert.equal(h.call("foundry.delete", { id }).ok, true);
+  });
+});

--- a/server/tests/foundry-system-registry.test.js
+++ b/server/tests/foundry-system-registry.test.js
@@ -85,12 +85,19 @@ describe("catalog integrity", () => {
     }
   });
 
-  it("the 4 spec-missing systems are present and flagged stub", () => {
+  it("the 4 formerly-missing systems are present and built (Phase 7)", () => {
+    // The substrate audit flagged these as listed-in-spec but absent.
+    // Phase 7 built them; they're now status:'available'.
     for (const id of ["size-scaling", "status-window", "skill-affinity-player", "isekai-reincarnation"]) {
       const s = getSystem(id);
       assert.ok(s, `${id} missing from catalog`);
-      assert.equal(s.status, "stub", `${id} should be status:'stub' until Phase 7`);
+      assert.equal(s.status, "available", `${id} should be 'available' after Phase 7`);
     }
+  });
+
+  it("no systems remain stubbed", () => {
+    const stubs = SYSTEM_REGISTRY.filter((s) => s.status === "stub").map((s) => s.id);
+    assert.deepEqual(stubs, [], `still stubbed: ${stubs.join(", ")}`);
   });
 
   it("config schema fields all declare a valid type + default", () => {
@@ -176,10 +183,12 @@ describe("validateSystemSelection", () => {
     assert.ok(r.warnings.some((w) => w.includes("duplicate")));
   });
 
-  it("stub systems warn but do not error", () => {
-    const r = validateSystemSelection([{ id: "status-window" }]);
+  it("available systems produce no stub warning", () => {
+    // Post-Phase-7 every system is built, so a clean selection of
+    // available systems carries no "not built yet" advisory.
+    const r = validateSystemSelection([{ id: "status-window" }, { id: "combat-motor" }]);
     assert.equal(r.ok, true);
-    assert.ok(r.warnings.some((w) => w.includes("not built yet")));
+    assert.ok(!r.warnings.some((w) => w.includes("not built yet")));
   });
 
   it("size-scaled-combat needs both combat-motor and size-scaling", () => {

--- a/server/tests/foundry-system-registry.test.js
+++ b/server/tests/foundry-system-registry.test.js
@@ -1,0 +1,218 @@
+/**
+ * Tier-2 contract tests for the Foundry System Registry (Phase 1).
+ *
+ * Pins:
+ *   - catalog integrity: every entry has the required fields, valid
+ *     category, valid worldScope/status/activation.kind
+ *   - dependency graph is closed (no entry depends on / conflicts with
+ *     an unknown id) and acyclic-enough (no self-dep)
+ *   - the 4 spec-missing systems are present and flagged status:'stub'
+ *   - coerceConfig: clamps numbers, drops unknown keys, rejects bad
+ *     enums to default, fills missing from default
+ *   - validateSystemSelection: dependency + conflict + unknown-id +
+ *     duplicate handling, and stub -> warning (not error)
+ *
+ * Run: node --test server/tests/foundry-system-registry.test.js
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  SYSTEM_REGISTRY,
+  CATEGORIES,
+  CATEGORY_LABELS,
+  allSystemIds,
+  getSystem,
+  listSystems,
+  systemsByCategory,
+  getConfigSchema,
+  coerceConfig,
+  validateSystemSelection,
+} from "../lib/foundry/system-registry.js";
+
+const VALID_CATEGORIES = new Set(Object.values(CATEGORIES));
+const VALID_SCOPES = new Set(["world", "global", "player"]);
+const VALID_STATUS = new Set(["available", "stub"]);
+const VALID_ACTIVATION = new Set([
+  "rule_modulator", "physics_modulator", "content_seed", "heartbeat_optin", "always_on",
+]);
+
+describe("catalog integrity", () => {
+  it("has a substantial catalog", () => {
+    assert.ok(SYSTEM_REGISTRY.length >= 30, `expected >=30 systems, got ${SYSTEM_REGISTRY.length}`);
+  });
+
+  it("every entry has the required shape", () => {
+    for (const s of SYSTEM_REGISTRY) {
+      assert.equal(typeof s.id, "string", `id missing on ${JSON.stringify(s).slice(0, 80)}`);
+      assert.ok(VALID_CATEGORIES.has(s.category), `${s.id}: bad category ${s.category}`);
+      assert.equal(typeof s.displayName, "string", `${s.id}: displayName`);
+      assert.equal(typeof s.description, "string", `${s.id}: description`);
+      assert.ok(VALID_SCOPES.has(s.worldScope), `${s.id}: bad worldScope ${s.worldScope}`);
+      assert.ok(VALID_STATUS.has(s.status), `${s.id}: bad status ${s.status}`);
+      assert.ok(s.activation && VALID_ACTIVATION.has(s.activation.kind), `${s.id}: bad activation.kind`);
+      assert.ok(Array.isArray(s.dependsOn), `${s.id}: dependsOn not array`);
+      assert.ok(Array.isArray(s.conflictsWith), `${s.id}: conflictsWith not array`);
+      assert.equal(typeof s.configSchema, "object", `${s.id}: configSchema`);
+    }
+  });
+
+  it("ids are unique", () => {
+    const ids = allSystemIds();
+    assert.equal(ids.length, new Set(ids).size, "duplicate system id");
+  });
+
+  it("dependency + conflict graph references only known ids, no self-reference", () => {
+    const known = new Set(allSystemIds());
+    for (const s of SYSTEM_REGISTRY) {
+      for (const dep of s.dependsOn) {
+        assert.ok(known.has(dep), `${s.id}: depends on unknown '${dep}'`);
+        assert.notEqual(dep, s.id, `${s.id}: depends on itself`);
+      }
+      for (const c of s.conflictsWith) {
+        assert.ok(known.has(c), `${s.id}: conflicts with unknown '${c}'`);
+        assert.notEqual(c, s.id, `${s.id}: conflicts with itself`);
+      }
+    }
+  });
+
+  it("every category has a label and at least one system", () => {
+    const grouped = systemsByCategory();
+    for (const key of Object.values(CATEGORIES)) {
+      assert.ok(CATEGORY_LABELS[key], `no label for ${key}`);
+      assert.ok(grouped[key].systems.length >= 1, `category ${key} is empty`);
+    }
+  });
+
+  it("the 4 spec-missing systems are present and flagged stub", () => {
+    for (const id of ["size-scaling", "status-window", "skill-affinity-player", "isekai-reincarnation"]) {
+      const s = getSystem(id);
+      assert.ok(s, `${id} missing from catalog`);
+      assert.equal(s.status, "stub", `${id} should be status:'stub' until Phase 7`);
+    }
+  });
+
+  it("config schema fields all declare a valid type + default", () => {
+    const VALID_FIELD_TYPES = new Set(["enum", "number", "bool", "text", "range"]);
+    for (const s of SYSTEM_REGISTRY) {
+      for (const [field, desc] of Object.entries(s.configSchema)) {
+        assert.ok(VALID_FIELD_TYPES.has(desc.type), `${s.id}.${field}: bad type ${desc.type}`);
+        assert.ok("default" in desc, `${s.id}.${field}: no default`);
+        if (desc.type === "enum") {
+          assert.ok(Array.isArray(desc.options) && desc.options.length >= 2, `${s.id}.${field}: enum needs >=2 options`);
+          assert.ok(desc.options.includes(desc.default), `${s.id}.${field}: default not in options`);
+        }
+        if (desc.type === "number") {
+          assert.ok(desc.min <= desc.default && desc.default <= desc.max, `${s.id}.${field}: default out of [min,max]`);
+        }
+      }
+    }
+  });
+});
+
+describe("coerceConfig", () => {
+  it("clamps numbers into [min, max]", () => {
+    const r = coerceConfig("physics-modifiers", { gravity: 99999 });
+    assert.equal(r.config.gravity, 300);
+    const r2 = coerceConfig("physics-modifiers", { gravity: -5 });
+    assert.equal(r2.config.gravity, 10);
+  });
+
+  it("drops unknown keys", () => {
+    const r = coerceConfig("physics-modifiers", { gravity: 100, totallyBogus: 42 });
+    assert.ok(!("totallyBogus" in r.config));
+  });
+
+  it("fills missing fields from default", () => {
+    const r = coerceConfig("physics-modifiers", {});
+    assert.equal(r.config.gravity, 100);
+    assert.equal(r.config.glideEnabled, true);
+  });
+
+  it("rejects bad enum values to default + reports error", () => {
+    const r = coerceConfig("terrain-biomes", { biomeSet: "not-a-biome" });
+    assert.equal(r.config.biomeSet, "mixed");
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some((e) => e.includes("biomeSet")));
+  });
+
+  it("coerces bool-ish values", () => {
+    const r = coerceConfig("physics-modifiers", { glideEnabled: "" , swimEnabled: 1 });
+    assert.equal(r.config.glideEnabled, false);
+    assert.equal(r.config.swimEnabled, true);
+  });
+
+  it("unknown system id fails cleanly", () => {
+    const r = coerceConfig("does-not-exist", {});
+    assert.equal(r.ok, false);
+    assert.ok(r.errors[0].includes("unknown system"));
+  });
+});
+
+describe("validateSystemSelection", () => {
+  it("passes a selection with satisfied dependencies", () => {
+    const r = validateSystemSelection([{ id: "combat-motor" }, { id: "boss-phases" }]);
+    assert.equal(r.ok, true);
+    assert.equal(r.errors.length, 0);
+    assert.equal(r.resolved.length, 2);
+  });
+
+  it("fails when a dependency is missing", () => {
+    const r = validateSystemSelection([{ id: "boss-phases" }]);
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some((e) => e.includes("combat-motor")));
+  });
+
+  it("fails on unknown system id", () => {
+    const r = validateSystemSelection([{ id: "ghost-system" }]);
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some((e) => e.includes("ghost-system")));
+  });
+
+  it("drops duplicates with a warning", () => {
+    const r = validateSystemSelection([{ id: "concord-link" }, { id: "concord-link" }]);
+    assert.equal(r.resolved.length, 1);
+    assert.ok(r.warnings.some((w) => w.includes("duplicate")));
+  });
+
+  it("stub systems warn but do not error", () => {
+    const r = validateSystemSelection([{ id: "status-window" }]);
+    assert.equal(r.ok, true);
+    assert.ok(r.warnings.some((w) => w.includes("not built yet")));
+  });
+
+  it("size-scaled-combat needs both combat-motor and size-scaling", () => {
+    const partial = validateSystemSelection([{ id: "combat-motor" }, { id: "size-scaled-combat" }]);
+    assert.equal(partial.ok, false);
+    assert.ok(partial.errors.some((e) => e.includes("size-scaling")));
+    const full = validateSystemSelection([
+      { id: "combat-motor" }, { id: "size-scaling" }, { id: "physics-modifiers" }, { id: "size-scaled-combat" },
+    ]);
+    assert.equal(full.ok, true);
+  });
+
+  it("resolved configs are coerced", () => {
+    const r = validateSystemSelection([{ id: "physics-modifiers", config: { gravity: 5000 } }]);
+    assert.equal(r.ok, true);
+    assert.equal(r.resolved[0].config.gravity, 300);
+  });
+
+  it("rejects a non-array input cleanly", () => {
+    const r = validateSystemSelection("nope");
+    assert.equal(r.ok, false);
+  });
+});
+
+describe("read helpers", () => {
+  it("listSystems filters by category", () => {
+    const combat = listSystems({ category: CATEGORIES.COMBAT });
+    assert.ok(combat.length >= 1);
+    assert.ok(combat.every((s) => s.category === "combat"));
+  });
+
+  it("getConfigSchema returns the schema or null", () => {
+    assert.ok(getConfigSchema("terrain-biomes"));
+    assert.equal(getConfigSchema("nope"), null);
+  });
+});

--- a/server/tests/foundry-templates-rules.test.js
+++ b/server/tests/foundry-templates-rules.test.js
@@ -1,0 +1,203 @@
+/**
+ * Tier-2 contract tests for Foundry Phase 6 — templates + NL rules.
+ *
+ * Pins:
+ *   - templates.js: all authored templates load + each produces a
+ *     VALID worldspec (dependency graph satisfied)
+ *   - rules.js: deterministic NL->rule classification + target
+ *     extraction, validateRule coercion, parseRuleFromLLM
+ *   - foundry.templates macro; foundry.create with a templateId;
+ *     foundry.compose_rule (deterministic fallback when no LLM in
+ *     ctx — the macro must still return a usable rule), persist-to-
+ *     world path, creator-scoping
+ *   - compiler folds worldspec.rules into rule_modulators.foundry.rules
+ *
+ * Run: node --test server/tests/foundry-templates-rules.test.js
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+
+import { listTemplates, getTemplate } from "../lib/foundry/templates.js";
+import {
+  composeRuleDeterministic, validateRule, parseRuleFromLLM, buildRulePrompt,
+  RULE_TRIGGERS, RULE_EFFECTS,
+} from "../lib/foundry/rules.js";
+import { validateWorldspec, normalizeWorldspec } from "../lib/foundry/worldspec.js";
+import { compileWorldspec } from "../lib/foundry/compiler.js";
+import { up as migrate191 } from "../migrations/191_foundry_worlds.js";
+import registerFoundryMacros from "../domains/foundry.js";
+
+// ── templates.js ────────────────────────────────────────────────────────────
+
+describe("foundry templates", () => {
+  it("loads the authored template catalog", () => {
+    const t = listTemplates();
+    assert.ok(t.length >= 3, `expected >=3 templates, got ${t.length}`);
+    for (const tpl of t) {
+      assert.equal(typeof tpl.id, "string");
+      assert.equal(typeof tpl.name, "string");
+      assert.ok(tpl.systemCount > 0, `${tpl.id} has no systems`);
+    }
+  });
+
+  it("every template produces a VALID worldspec (deps satisfied)", () => {
+    for (const summary of listTemplates()) {
+      const full = getTemplate(summary.id);
+      assert.ok(full, `getTemplate(${summary.id}) returned null`);
+      const v = validateWorldspec(full.worldspec);
+      assert.equal(v.ok, true, `template ${summary.id} is invalid: ${v.errors.join("; ")}`);
+    }
+  });
+
+  it("getTemplate returns null for an unknown id", () => {
+    assert.equal(getTemplate("does-not-exist"), null);
+    assert.equal(getTemplate(""), null);
+  });
+});
+
+// ── rules.js ────────────────────────────────────────────────────────────────
+
+describe("rule composition", () => {
+  it("classifies a clear NL rule deterministically", () => {
+    const r = composeRuleDeterministic("when a player enters the boss arena, lock the doors");
+    assert.equal(r.trigger.kind, "player_enters");
+    assert.equal(r.effect.kind, "lock");
+    assert.equal(r.trigger.target, "boss arena");
+    assert.equal(r.composedBy, "deterministic");
+    assert.ok(r.confidence > 0 && r.confidence <= 1);
+  });
+
+  it("classifies time/spawn, death/announce, gather/unlock", () => {
+    assert.equal(composeRuleDeterministic("every 5 minutes spawn a merchant").trigger.kind, "on_time");
+    assert.equal(composeRuleDeterministic("every 5 minutes spawn a merchant").effect.kind, "spawn");
+    assert.equal(composeRuleDeterministic("when the dragon dies, announce victory").trigger.kind, "on_death");
+    assert.equal(composeRuleDeterministic("when the dragon dies, announce victory").effect.kind, "announce");
+    assert.equal(composeRuleDeterministic("unlock the vault when a player gathers the key").effect.kind, "unlock");
+  });
+
+  it("unclassifiable input still yields a stored rule with low confidence", () => {
+    const r = composeRuleDeterministic("the weather feels nice today");
+    assert.equal(r.trigger.kind, "unknown");
+    assert.equal(r.effect.kind, "unknown");
+    assert.ok(r.confidence < 0.4);
+    assert.ok(r.source.length > 0);
+  });
+
+  it("validateRule coerces unknown kinds to 'unknown' rather than rejecting", () => {
+    const v = validateRule({ source: "x", trigger: { kind: "banana" }, effect: { kind: "wat" } });
+    assert.equal(v.ok, true);
+    assert.equal(v.rule.trigger.kind, "unknown");
+    assert.equal(v.rule.effect.kind, "unknown");
+    assert.ok(v.warnings.length >= 2);
+  });
+
+  it("validateRule rejects a rule with no source text", () => {
+    assert.equal(validateRule({ trigger: {}, effect: {} }).ok, false);
+    assert.equal(validateRule(null).ok, false);
+  });
+
+  it("parseRuleFromLLM parses well-formed JSON, returns null on garbage", () => {
+    const good = parseRuleFromLLM("x", '{"trigger":{"kind":"on_death","target":"the king"},"effect":{"kind":"announce","target":null,"value":"dead"}}');
+    assert.ok(good);
+    assert.equal(good.trigger.kind, "on_death");
+    assert.equal(good.composedBy, "llm");
+    assert.equal(parseRuleFromLLM("x", "I think the rule should..."), null);
+    assert.equal(parseRuleFromLLM("x", ""), null);
+  });
+
+  it("buildRulePrompt names every trigger + effect kind", () => {
+    const p = buildRulePrompt("test");
+    for (const t of RULE_TRIGGERS) assert.ok(p.includes(t), `prompt missing trigger ${t}`);
+    for (const e of RULE_EFFECTS) assert.ok(p.includes(e), `prompt missing effect ${e}`);
+  });
+});
+
+// ── compiler folds rules ────────────────────────────────────────────────────
+
+describe("compiler — rules", () => {
+  it("folds worldspec.rules into rule_modulators.foundry.rules", () => {
+    const spec = normalizeWorldspec({
+      systems: [{ id: "combat-motor" }],
+      rules: [composeRuleDeterministic("when the boss dies, unlock the gate")],
+    });
+    const c = compileWorldspec(spec);
+    assert.equal(c.rule_modulators.foundry.rules.length, 1);
+    assert.equal(c.rule_modulators.foundry.rules[0].effect.kind, "unlock");
+  });
+});
+
+// ── macros ──────────────────────────────────────────────────────────────────
+
+function makeHarness() {
+  const db = new Database(":memory:");
+  migrate191(db);
+  const macros = new Map();
+  registerFoundryMacros((domain, name, handler) => macros.set(`${domain}.${name}`, handler));
+  // ctx has no `llm` — compose_rule must fall back to deterministic.
+  const call = (name, input, actor = { userId: "user-1" }) =>
+    macros.get(name)({ db, actor }, input || {});
+  return { db, call };
+}
+
+describe("foundry.templates + create-from-template + compose_rule", () => {
+  let h;
+  beforeEach(() => { h = makeHarness(); });
+
+  it("foundry.templates lists the catalog", () => {
+    const r = h.call("foundry.templates", {});
+    assert.equal(r.ok, true);
+    assert.ok(r.count >= 3);
+  });
+
+  it("foundry.create starts from a templateId", () => {
+    const tplId = listTemplates()[0].id;
+    const r = h.call("foundry.create", { name: "From Template", templateId: tplId });
+    assert.equal(r.ok, true);
+    assert.equal(r.world.worldspec.template, tplId);
+    assert.ok(r.world.worldspec.systems.length > 0);
+  });
+
+  it("foundry.create rejects an unknown templateId", () => {
+    const r = h.call("foundry.create", { name: "X", templateId: "no-such-template" });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "unknown_template");
+  });
+
+  it("compose_rule returns a usable rule with no LLM in ctx (deterministic fallback)", async () => {
+    const r = await h.call("foundry.compose_rule", {
+      naturalLanguage: "when a player enters the throne room, lock the exits",
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.composedBy, "deterministic");
+    assert.equal(r.rule.trigger.kind, "player_enters");
+    assert.equal(r.rule.effect.kind, "lock");
+    assert.equal(r.saved, false); // no id given
+  });
+
+  it("compose_rule persists the rule onto a foundry world when id is given", async () => {
+    const id = h.call("foundry.create", { name: "Ruled", worldspec: { systems: [{ id: "combat-motor" }] } }).world.id;
+    const r = await h.call("foundry.compose_rule", {
+      id, naturalLanguage: "when the boss dies, announce the victory",
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.saved, true);
+    const stored = h.call("foundry.get", { id }).world;
+    assert.equal(stored.worldspec.rules.length, 1);
+    assert.equal(stored.worldspec.rules[0].trigger.kind, "on_death");
+  });
+
+  it("compose_rule is creator-scoped when persisting", async () => {
+    const id = h.call("foundry.create", { name: "Mine", worldspec: { systems: [{ id: "combat-motor" }] } }).world.id;
+    const r = await h.call("foundry.compose_rule",
+      { id, naturalLanguage: "spawn a boss every hour" }, { userId: "intruder" });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "not_owner");
+  });
+
+  it("compose_rule rejects empty / over-long input", async () => {
+    assert.equal((await h.call("foundry.compose_rule", { naturalLanguage: "" })).reason, "missing_natural_language");
+    assert.equal((await h.call("foundry.compose_rule", { naturalLanguage: "x".repeat(501) })).reason, "rule_too_long");
+  });
+});

--- a/server/tests/foundry-worldspec.test.js
+++ b/server/tests/foundry-worldspec.test.js
@@ -1,0 +1,210 @@
+/**
+ * Tier-2 contract tests for Foundry Phase 2 — Worldspec + persistence.
+ *
+ * Pins:
+ *   - worldspec.js: emptyWorldspec shape, normalizeWorldspec (drops
+ *     junk, fills defaults, coerces universe type), validateWorldspec
+ *     (envelope + system graph; normalize-and-warn for fixables,
+ *     hard-error for unfixables)
+ *   - the foundry.{create,update,get,list,delete,validate} macros
+ *     against an in-memory DB with migration 191 applied:
+ *     creator-scoping, draft lifecycle, published-world delete guard,
+ *     not-found / not-owner / no-actor handling
+ *
+ * Run: node --test server/tests/foundry-worldspec.test.js
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+
+import {
+  emptyWorldspec,
+  normalizeWorldspec,
+  validateWorldspec,
+  worldspecSystemIds,
+} from "../lib/foundry/worldspec.js";
+import { up as migrate191 } from "../migrations/191_foundry_worlds.js";
+import registerFoundryMacros from "../domains/foundry.js";
+
+// ── worldspec.js ────────────────────────────────────────────────────────────
+
+describe("worldspec format", () => {
+  it("emptyWorldspec has the canonical shape", () => {
+    const e = emptyWorldspec();
+    assert.equal(e.version, 1);
+    assert.equal(e.template, null);
+    assert.equal(e.theme.universeType, "fantasy");
+    assert.deepEqual(e.systems, []);
+    assert.deepEqual(e.rules, []);
+  });
+
+  it("normalizeWorldspec drops junk keys + non-system entries", () => {
+    const n = normalizeWorldspec({
+      junkKey: 1,
+      template: "starter-rpg",
+      systems: [{ id: "combat-motor", config: { lethality: "hardcore" } }, "junk", { noId: 1 }],
+    });
+    assert.ok(!("junkKey" in n));
+    assert.equal(n.template, "starter-rpg");
+    assert.equal(n.systems.length, 1);
+    assert.equal(n.systems[0].id, "combat-motor");
+  });
+
+  it("normalizeWorldspec coerces an unknown universe type to the default", () => {
+    const n = normalizeWorldspec({ theme: { universeType: "banana" } });
+    assert.equal(n.theme.universeType, "fantasy");
+  });
+
+  it("normalizeWorldspec keeps a valid universe type", () => {
+    const n = normalizeWorldspec({ theme: { universeType: "cyber" } });
+    assert.equal(n.theme.universeType, "cyber");
+  });
+
+  it("validateWorldspec hard-errors on an unsatisfied dependency", () => {
+    const r = validateWorldspec({ systems: [{ id: "boss-phases" }] });
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some((e) => e.includes("combat-motor")));
+  });
+
+  it("validateWorldspec passes a well-formed spec + coerces configs", () => {
+    const r = validateWorldspec({
+      theme: { universeType: "scifi" },
+      systems: [{ id: "physics-modifiers", config: { gravity: 99999 } }],
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.normalized.systems[0].config.gravity, 300); // clamped
+  });
+
+  it("validateWorldspec warns (not errors) on a fixable bad universe type", () => {
+    const r = validateWorldspec({ theme: { universeType: "banana" }, systems: [] });
+    assert.equal(r.ok, true);
+    assert.ok(r.warnings.some((w) => w.toLowerCase().includes("universetype")));
+  });
+
+  it("validateWorldspec warns on an empty system selection", () => {
+    const r = validateWorldspec({ systems: [] });
+    assert.equal(r.ok, true);
+    assert.ok(r.warnings.some((w) => w.includes("no systems")));
+  });
+
+  it("validateWorldspec rejects a non-object", () => {
+    assert.equal(validateWorldspec("nope").ok, false);
+    assert.equal(validateWorldspec(null).ok, false);
+  });
+
+  it("worldspecSystemIds extracts the id list", () => {
+    const spec = normalizeWorldspec({ systems: [{ id: "concord-link" }, { id: "mount-system" }] });
+    assert.deepEqual(worldspecSystemIds(spec), ["concord-link", "mount-system"]);
+  });
+});
+
+// ── CRUD macros against an in-memory DB ─────────────────────────────────────
+
+function makeHarness() {
+  const db = new Database(":memory:");
+  migrate191(db);
+  const macros = new Map();
+  registerFoundryMacros((domain, name, handler) => macros.set(`${domain}.${name}`, handler));
+  const call = (name, input, actor = { userId: "user-1" }) =>
+    macros.get(name)({ db, actor }, input || {});
+  return { db, call };
+}
+
+describe("foundry CRUD macros", () => {
+  let h;
+  beforeEach(() => { h = makeHarness(); });
+
+  it("create requires an actor and a name", () => {
+    assert.equal(h.call("foundry.create", { name: "X" }, {}).reason, "no_actor");
+    assert.equal(h.call("foundry.create", {}).reason, "missing_name");
+  });
+
+  it("create -> get round-trips", () => {
+    const created = h.call("foundry.create", { name: "My Game", description: "a test" });
+    assert.equal(created.ok, true);
+    assert.ok(created.world.id.startsWith("fw_"));
+    assert.equal(created.world.status, "draft");
+    const got = h.call("foundry.get", { id: created.world.id });
+    assert.equal(got.ok, true);
+    assert.equal(got.world.name, "My Game");
+    assert.equal(got.world.description, "a test");
+  });
+
+  it("create normalizes a supplied worldspec", () => {
+    const created = h.call("foundry.create", {
+      name: "Spec Game",
+      worldspec: { theme: { universeType: "noir" }, systems: [{ id: "concord-link" }], junk: 1 },
+    });
+    assert.equal(created.ok, true);
+    assert.equal(created.world.worldspec.theme.universeType, "noir");
+    assert.equal(created.world.worldspec.systems.length, 1);
+    assert.ok(!("junk" in created.world.worldspec));
+  });
+
+  it("get/update/delete are creator-scoped", () => {
+    const created = h.call("foundry.create", { name: "Mine" });
+    const id = created.world.id;
+    assert.equal(h.call("foundry.get", { id }, { userId: "user-2" }).reason, "not_owner");
+    assert.equal(h.call("foundry.update", { id, name: "Hijack" }, { userId: "user-2" }).reason, "not_owner");
+    assert.equal(h.call("foundry.delete", { id }, { userId: "user-2" }).reason, "not_owner");
+  });
+
+  it("update patches name/description/worldspec", () => {
+    const id = h.call("foundry.create", { name: "Before" }).world.id;
+    const upd = h.call("foundry.update", {
+      id, name: "After", worldspec: { systems: [{ id: "combat-motor" }] },
+    });
+    assert.equal(upd.ok, true);
+    assert.equal(upd.world.name, "After");
+    assert.equal(upd.world.worldspec.systems[0].id, "combat-motor");
+  });
+
+  it("update with no fields is a no-op error", () => {
+    const id = h.call("foundry.create", { name: "X" }).world.id;
+    assert.equal(h.call("foundry.update", { id }).reason, "nothing_to_update");
+  });
+
+  it("list returns the caller's worlds newest-first", () => {
+    h.call("foundry.create", { name: "A" });
+    h.call("foundry.create", { name: "B" });
+    h.call("foundry.create", { name: "C" }, { userId: "other" });
+    const listed = h.call("foundry.list", {});
+    assert.equal(listed.ok, true);
+    assert.equal(listed.count, 2); // only user-1's
+  });
+
+  it("delete removes a draft", () => {
+    const id = h.call("foundry.create", { name: "Trash" }).world.id;
+    assert.equal(h.call("foundry.delete", { id }).ok, true);
+    assert.equal(h.call("foundry.get", { id }).reason, "not_found");
+  });
+
+  it("delete is blocked on a published world", () => {
+    const id = h.call("foundry.create", { name: "Live" }).world.id;
+    // Simulate publish (Phase 3 will do this for real).
+    h.db.prepare(`UPDATE foundry_worlds SET status='published', published_world_id='world-x' WHERE id=?`).run(id);
+    const del = h.call("foundry.delete", { id });
+    assert.equal(del.ok, false);
+    assert.equal(del.reason, "world_published");
+  });
+
+  it("validate works on a stored id and on a bare worldspec", () => {
+    const id = h.call("foundry.create", {
+      name: "ValidateMe",
+      worldspec: { systems: [{ id: "boss-phases" }] }, // missing dep
+    }).world.id;
+    const byId = h.call("foundry.validate", { id });
+    assert.equal(byId.ok, false);
+    assert.ok(byId.errors.some((e) => e.includes("combat-motor")));
+
+    const bySpec = h.call("foundry.validate", {
+      worldspec: { systems: [{ id: "combat-motor" }, { id: "boss-phases" }] },
+    });
+    assert.equal(bySpec.ok, true);
+  });
+
+  it("validate needs either an id or a worldspec", () => {
+    assert.equal(h.call("foundry.validate", {}).reason, "missing_worldspec_or_id");
+  });
+});


### PR DESCRIPTION
Foundry (lens #66) is a no-code game-builder: users compose
games/worlds by selecting + configuring Concord's existing systems as
building blocks. Phase 1 is the foundation — the declarative catalog
that turns ~40 already-built systems into composable units.

server/lib/foundry/system-registry.js — 34 systems across 6
categories (World / Character / Combat / NPC / Economy / Social).
Each entry declares:
  - configSchema     — typed config fields (enum/number/bool/text/
                       range); the Foundry canvas renders config
                       panels straight off this
  - worldScope       — world | global | player, from the substrate
                       audit (most are already per-world configurable)
  - activation       — how the publish pipeline applies it:
                       rule_modulator / physics_modulator /
                       content_seed / heartbeat_optin / always_on
  - dependsOn / conflictsWith — the composition graph
  - status           — available | stub. The 4 spec systems that
                       don't exist yet (size-scaling, status-window,
                       skill-affinity-player, isekai-reincarnation,
                       + size-scaled-combat) are registered as 'stub'
                       so the catalog is the single source of truth
                       and Phase 7 just flips the flag.

Helpers: getSystem, listSystems, systemsByCategory, coerceConfig
(clamps numbers, drops unknown keys, bad enums -> default), and
validateSystemSelection (dependency + conflict + duplicate + config
check — the gate Phase 2's foundry.validate and Phase 3's publish
pipeline both call).

server/domains/foundry.js — Phase 1 macro surface:
  - foundry.systems         — the catalog (flat + grouped)
  - foundry.system_schema   — one system's config schema + metadata
  - foundry.validate_systems — live dependency/conflict/config check
Registered in server.js next to the beats domain.

Tests: server/tests/foundry-system-registry.test.js, 23/23 — catalog
integrity, closed dependency graph, the 4 stubs flagged, config
coercion (clamp/drop/default/reject), and selection validation
(deps/conflicts/unknown/duplicate/stub-warns-not-errors).

No collision with the existing /lenses/forge (polyglot app generator)
— different domain namespace, different product.