### PR TITLE
fix(ci): repair 3 pre-existing CI gate failures (Integration Test, E2E Core, playthrough)

### DIFF
--- a/.github/workflows/playthrough.yml
+++ b/.github/workflows/playthrough.yml
@@ -58,6 +58,15 @@ jobs:
           DB_PATH: ./data/concord.test.db
           PORT: 5050
           JWT_SECRET: test_secret_for_e2e_playthrough_phase_z
+          # NODE_ENV=test suppresses port binding (server.js:56647) —
+          # CONCORD_FORCE_LISTEN is the escape hatch for out-of-process
+          # integration boots. Without it nothing listens on :5050 and
+          # every spec hits ECONNREFUSED (the wait loop below never
+          # noticed because it didn't fail on timeout).
+          CONCORD_FORCE_LISTEN: 'true'
+          # No Ollama in CI — skip the 5 cold brain probes (~75-150s) so
+          # the server reaches listen quickly. Same flag ci.yml sets.
+          CONCORD_DISABLE_BRAINS: 'true'
           # The spec's beforeAll registers a fresh test user every run;
           # the per-IP daily registration cap (3/day) would 429 it after
           # a few CI runs. Same flag ci.yml sets to relax rate limits.
@@ -65,10 +74,16 @@ jobs:
 
       - name: Wait for server
         run: |
-          for i in {1..30}; do
-            curl -fsS http://localhost:5050/api/health && break
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:5050/api/health > /dev/null 2>&1; then
+              echo "Server ready after ${i} attempt(s)"
+              exit 0
+            fi
             sleep 2
           done
+          echo "Server failed to start within 120s. Logs:"
+          cat server/server.log || true
+          exit 1
 
       # Build the prod artifact only — do NOT start the frontend here.
       # playwright.config.ts owns the webServer (`npm run start:ci` on

--- a/concord-frontend/tests/e2e/all-lenses-walk.spec.ts
+++ b/concord-frontend/tests/e2e/all-lenses-walk.spec.ts
@@ -44,13 +44,25 @@ const IGNORABLE = [
   /Connection lost/i,
 ];
 
-// LENS_LIST env var lets a partial re-run target only specific lenses.
-// Defaults to the full enumeration at /tmp/lens-routes.txt.
-const LENS_LIST_PATH = process.env.LENS_LIST || '/tmp/lens-routes.txt';
-const LENSES = fs.readFileSync(LENS_LIST_PATH, 'utf8')
-  .split('\n')
-  .map((l) => l.trim())
-  .filter(Boolean);
+// LENS_LIST env var (or /tmp/lens-routes.txt) lets a partial re-run
+// target only specific lenses. When neither exists — the default in CI,
+// where nothing generates the /tmp file — enumerate every
+// app/lenses/<name>/page.tsx directly so the spec is self-sufficient.
+function loadLensList(): string[] {
+  const explicit = process.env.LENS_LIST || '/tmp/lens-routes.txt';
+  if (fs.existsSync(explicit)) {
+    return fs.readFileSync(explicit, 'utf8')
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
+  }
+  const lensesDir = path.resolve(__dirname, '../../app/lenses');
+  return fs.readdirSync(lensesDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && fs.existsSync(path.join(lensesDir, d.name, 'page.tsx')))
+    .map((d) => d.name)
+    .sort();
+}
+const LENSES = loadLensList();
 
 interface LensResult {
   lens: string;

--- a/server/tests/adversarial-critical-endpoints.test.js
+++ b/server/tests/adversarial-critical-endpoints.test.js
@@ -21,7 +21,11 @@ let serverProcess = null;
 before(async () => {
   if (process.env.API_BASE) {
     API_BASE = process.env.API_BASE;
-    const deadline = Date.now() + 30_000;
+    // 180s budget — matches the CI workflow's own "Wait for server"
+    // patience. A heavy server on a slow runner can have its event loop
+    // starved by early-life simulation churn well past 30s; the test
+    // should wait it out rather than assert a tight readiness SLA.
+    const deadline = Date.now() + 180_000;
     while (Date.now() < deadline) {
       try {
         const res = await fetch(`${API_BASE}/health`, { signal: AbortSignal.timeout(5_000) });
@@ -29,7 +33,7 @@ before(async () => {
       } catch { /* not ready */ }
       await new Promise(r => { setTimeout(r, 500); });
     }
-    throw new Error("External server not reachable within 30 seconds");
+    throw new Error("External server not reachable within 180 seconds");
   }
 
   const serverDir = join(__dirname, "..");
@@ -62,11 +66,24 @@ after(() => {
 async function api(method, path, body = null, { token, noAuth } = {}) {
   const headers = { "Content-Type": "application/json" };
   if (token && !noAuth) headers["Authorization"] = `Bearer ${token}`;
-  const opts = { method, headers, signal: AbortSignal.timeout(10_000) };
+  const opts = { method, headers };
   if (body) opts.body = JSON.stringify(body);
-  const res = await fetch(`${API_BASE}${path}`, opts);
-  const json = await res.json().catch(() => ({}));
-  return { ...json, _status: res.status };
+  // Cold CI servers can take well over 10s on early requests while
+  // startup simulation churns through a fresh seed corpus; retry
+  // transient timeouts/network errors so the suite asserts behaviour,
+  // not a tight latency SLA.
+  let lastErr;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await fetch(`${API_BASE}${path}`, { ...opts, signal: AbortSignal.timeout(30_000) });
+      const json = await res.json().catch(() => ({}));
+      return { ...json, _status: res.status };
+    } catch (err) {
+      lastErr = err;
+      await new Promise((r) => { setTimeout(r, 500 * (attempt + 1)); });
+    }
+  }
+  throw lastErr;
 }
 
 let _userSeq = Date.now();

--- a/server/tests/auth-security.test.js
+++ b/server/tests/auth-security.test.js
@@ -29,8 +29,12 @@ before(async () => {
   // If API_BASE is provided externally (e.g. integration-test CI), use it directly
   if (process.env.API_BASE) {
     API_BASE = process.env.API_BASE;
-    // Wait for the external server to be ready
-    const deadline = Date.now() + 30_000;
+    // Wait for the external server to be ready. 180s budget — matches
+    // the CI workflow's own "Wait for server" patience. A heavy server
+    // on a slow runner can have its event loop starved by early-life
+    // simulation churn well past 30s; wait it out rather than assert a
+    // tight readiness SLA.
+    const deadline = Date.now() + 180_000;
     while (Date.now() < deadline) {
       try {
         const res = await fetch(`${API_BASE}/health`, { signal: AbortSignal.timeout(5_000) });
@@ -40,7 +44,7 @@ before(async () => {
       }
       await new Promise(r => { setTimeout(r, 500); });
     }
-    throw new Error('External server not reachable within 30 seconds');
+    throw new Error('External server not reachable within 180 seconds');
   }
 
   // No external server — spawn our own on a random port
@@ -100,21 +104,31 @@ async function api(method, path, body = null, options = {}) {
   const fetchOptions = {
     method,
     headers,
-    credentials: 'include',
-    signal: AbortSignal.timeout(10_000)
+    credentials: 'include'
   };
   if (body) fetchOptions.body = JSON.stringify(body);
 
-  const res = await fetch(`${API_BASE}${path}`, fetchOptions);
-
-  // Capture cookies from response
-  const setCookie = res.headers.get('set-cookie');
-  if (setCookie) {
-    cookies = setCookie.split(',').map(c => c.split(';')[0]).join('; ');
+  // Cold CI servers can take well over 10s on early requests while
+  // startup simulation churns through a fresh seed corpus; retry
+  // transient timeouts/network errors so the suite asserts behaviour,
+  // not a tight latency SLA.
+  let lastErr;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await fetch(`${API_BASE}${path}`, { ...fetchOptions, signal: AbortSignal.timeout(30_000) });
+      // Capture cookies from response
+      const setCookie = res.headers.get('set-cookie');
+      if (setCookie) {
+        cookies = setCookie.split(',').map(c => c.split(';')[0]).join('; ');
+      }
+      const json = await res.json().catch(() => ({}));
+      return { ...json, status: res.status, headers: res.headers };
+    } catch (err) {
+      lastErr = err;
+      await new Promise((r) => { setTimeout(r, 500 * (attempt + 1)); });
+    }
   }
-
-  const json = await res.json().catch(() => ({}));
-  return { ...json, status: res.status, headers: res.headers };
+  throw lastErr;
 }
 
 // ============= Health Check Tests =============

--- a/server/tests/edge-cases-critical-paths.test.js
+++ b/server/tests/edge-cases-critical-paths.test.js
@@ -20,7 +20,11 @@ let serverProcess = null;
 before(async () => {
   if (process.env.API_BASE) {
     API_BASE = process.env.API_BASE;
-    const deadline = Date.now() + 30_000;
+    // 180s budget — matches the CI workflow's own "Wait for server"
+    // patience. A heavy server on a slow runner can have its event loop
+    // starved by early-life simulation churn well past 30s; the test
+    // should wait it out rather than assert a tight readiness SLA.
+    const deadline = Date.now() + 180_000;
     while (Date.now() < deadline) {
       try {
         const res = await fetch(`${API_BASE}/health`, { signal: AbortSignal.timeout(5_000) });
@@ -28,7 +32,7 @@ before(async () => {
       } catch { /* not ready */ }
       await new Promise(r => { setTimeout(r, 500); });
     }
-    throw new Error("External server not reachable within 30 seconds");
+    throw new Error("External server not reachable within 180 seconds");
   }
 
   const serverDir = join(__dirname, "..");
@@ -62,11 +66,24 @@ async function api(method, path, body = null, { token, rawAuth } = {}) {
   const headers = { "Content-Type": "application/json" };
   if (token) headers["Authorization"] = `Bearer ${token}`;
   if (rawAuth) headers["Authorization"] = rawAuth;
-  const opts = { method, headers, signal: AbortSignal.timeout(10_000) };
+  const opts = { method, headers };
   if (body) opts.body = JSON.stringify(body);
-  const res = await fetch(`${API_BASE}${path}`, opts);
-  const json = await res.json().catch(() => ({}));
-  return { ...json, _status: res.status };
+  // Cold CI servers can take well over 10s on early requests while
+  // startup simulation churns through a fresh seed corpus; retry
+  // transient timeouts/network errors so the suite asserts behaviour,
+  // not a tight latency SLA.
+  let lastErr;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await fetch(`${API_BASE}${path}`, { ...opts, signal: AbortSignal.timeout(30_000) });
+      const json = await res.json().catch(() => ({}));
+      return { ...json, _status: res.status };
+    } catch (err) {
+      lastErr = err;
+      await new Promise((r) => { setTimeout(r, 500 * (attempt + 1)); });
+    }
+  }
+  throw lastErr;
 }
 
 let _seq = Date.now();

--- a/server/tests/error-paths.test.js
+++ b/server/tests/error-paths.test.js
@@ -24,7 +24,11 @@ let serverProcess = null;
 before(async () => {
   if (process.env.API_BASE) {
     API_BASE = process.env.API_BASE;
-    const deadline = Date.now() + 30_000;
+    // 180s budget — matches the CI workflow's own "Wait for server"
+    // patience. A heavy server on a slow runner can have its event loop
+    // starved by early-life simulation churn well past 30s; the test
+    // should wait it out rather than assert a tight readiness SLA.
+    const deadline = Date.now() + 180_000;
     while (Date.now() < deadline) {
       try {
         const res = await fetch(`${API_BASE}/health`, { signal: AbortSignal.timeout(5_000) });
@@ -32,7 +36,7 @@ before(async () => {
       } catch { /* not ready */ }
       await new Promise(r => { setTimeout(r, 500); });
     }
-    throw new Error("External server not reachable within 30 seconds");
+    throw new Error("External server not reachable within 180 seconds");
   }
 
   const serverDir = join(__dirname, "..");
@@ -79,11 +83,26 @@ after(() => {
 async function api(method, path, body = null, { token } = {}) {
   const headers = { "Content-Type": "application/json" };
   if (token) headers["Authorization"] = `Bearer ${token}`;
-  const opts = { method, headers, signal: AbortSignal.timeout(15_000) };
+  const opts = { method, headers };
   if (body) opts.body = JSON.stringify(body);
-  const res = await fetch(`${API_BASE}${path}`, opts);
-  const json = await res.json().catch(() => ({}));
-  return { ...json, _status: res.status };
+  // Cold CI servers can take well over 10s on early requests while
+  // startup simulation churns through a fresh seed corpus; retry
+  // transient timeouts/network errors so the suite asserts behaviour,
+  // not a tight latency SLA. (Per-test degraded-mode timeout probes
+  // below use their own inline AbortSignal — this helper is the
+  // happy-path request path.)
+  let lastErr;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await fetch(`${API_BASE}${path}`, { ...opts, signal: AbortSignal.timeout(30_000) });
+      const json = await res.json().catch(() => ({}));
+      return { ...json, _status: res.status };
+    } catch (err) {
+      lastErr = err;
+      await new Promise((r) => { setTimeout(r, 500 * (attempt + 1)); });
+    }
+  }
+  throw lastErr;
 }
 
 let _seq = Date.now();


### PR DESCRIPTION
## Why

Three CI gates were red on `main` — all **pre-existing**, unmasked when #365 turned the Lint & Test gate green (Integration Test `needs` it; the others had been masked too). None were caused by #367's commits.

## The three root causes

### 1. Integration Test — server event-loop starvation in early life
The CI log shows ~6 requests timing out at *exactly* 10000ms (the `api()` helper's `AbortSignal`) in a ~70s window, then everything recovering to ~370ms. The server's event loop is starved by early-life emergent-simulation churn over a fresh seed corpus — on a slow CI runner even `/health` can't answer within 5s for tens of seconds. (The original #367 "stored-XSS" diagnosis was wrong — the CI log shows the XSS test *passing*.)

Two test-harness assumptions were too tight — both assert *latency*, not *behaviour*:
- `before()` readiness poll: **30s → 180s** (matches the CI workflow's own "Wait for server" budget)
- `api()` helper: **10s no-retry → 30s + retry transient timeouts 3×**

### 2. E2E Core — `ENOENT: /tmp/lens-routes.txt`
`all-lenses-walk.spec.ts` read that file at module load; nothing in CI generates it → exit 1 before any test ran. Now falls back to enumerating `app/lenses/*/page.tsx` directly — self-sufficient.

### 3. playthrough — `ECONNREFUSED 127.0.0.1:5050`
The backend booted with `NODE_ENV=test`, which suppresses port binding — nothing ever listened on :5050. The "Wait for server" loop had no `exit 1` on timeout, so it silently handed the specs a dead port. Added `CONCORD_FORCE_LISTEN=true` (+ `CONCORD_DISABLE_BRAINS`), and made the wait loop fail loud.

## Verification

- Integration suites: full CI-order sweep green against a fresh server — auth-security 24 / adversarial 35 / edge-cases 31 / error-paths 17, **0 fail 0 cancelled**
- lens enumeration yields 231 lenses; `playthrough.yml` parses; the `NODE_ENV=test + CONCORD_FORCE_LISTEN` combo is already proven by the edge-cases suite's own server spawn
- syntax + lint clean on all changed files

## Test plan

- [ ] CI: Integration Test gate goes green
- [ ] CI: E2E Core gets past module load
- [ ] CI: playthrough backend binds :5050

https://claude.ai/code/session_01FGy6Zu9XB1Uk7Jr5SrLcKE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGy6Zu9XB1Uk7Jr5SrLcKE)_