### PR TITLE
fix(ci): exempt health probes from bot guard + use /health in playthrough wait loop

### DIFF
--- a/.github/workflows/playthrough.yml
+++ b/.github/workflows/playthrough.yml
@@ -74,8 +74,10 @@ jobs:
 
       - name: Wait for server
         run: |
+          # /health (not /api/health) so the loop polls the unauthenticated
+          # health probe — matches ci.yml's Integration Test wait pattern.
           for i in $(seq 1 60); do
-            if curl -fsS http://localhost:5050/api/health > /dev/null 2>&1; then
+            if curl -fsS http://localhost:5050/health > /dev/null 2>&1; then
               echo "Server ready after ${i} attempt(s)"
               exit 0
             fi

--- a/server/server.js
+++ b/server/server.js
@@ -6628,10 +6628,13 @@ if (rateLimit) {
 // ---- Bot / Scraper Detection --------------------------------------------------
 // Known automated UA patterns are blocked on /api/ paths when not authenticated.
 // Authenticated bots (API keys, Bearer tokens) are exempt — they accepted ToS.
+// Health probes are always exempt — orchestrators (k8s, load balancers,
+// monitoring) and CI wait-loops legitimately hit them with curl/wget UAs.
 const _BOT_UA_RE = /\b(bot|crawler|spider|scraper|python-requests|aiohttp|httpx|go-http-client|java\/|libwww|wget|curl\/)\b/i;
 function botGuardMiddleware(req, res, next) {
   if (req.user?.id) return next(); // authenticated — pass
   if (!req.path.startsWith("/api/")) return next(); // non-API — pass
+  if (_HEALTH_PROBE_RE.test(req.path)) return next(); // health probes — pass
   const ua = req.headers["user-agent"] || "";
   if (!ua || _BOT_UA_RE.test(ua)) {
     return res.status(403).json({


### PR DESCRIPTION
## Why

#368's `CONCORD_FORCE_LISTEN` fix made playthrough's backend actually bind `:5050` — which exposed the next layer. The wait-loop curled `http://localhost:5050/api/health` for 120s and got nothing but **`403 bot_access_denied`**: the bot-guard middleware was returning 403 to every `curl`-UA request on `/api/` paths, including health probes. Server logs confirm the server was alive (~1ms response time) — it was just refusing curl on policy.

## The fix (two levels)

- **`botGuardMiddleware` exempts `_HEALTH_PROBE_RE`** (same regex the rate limiter already uses). Health/readiness probes must always respond — orchestrators (k8s, load balancers, monitoring, CI wait loops) legitimately hit them with `curl`/`wget` UAs, and "automated access requires authentication" doesn't apply to liveness checks.
- **`playthrough.yml` wait loop polls `/health`** (not `/api/health`) — matches `ci.yml`'s Integration Test pattern. `/health` is outside the `/api/` prefix so bot guard never inspects it. Defence in depth against this whole class of issue.

## Verified

Live server with the fix:
- `curl /health` → **200** ✓
- `curl /api/health` → **307** (redirect, still "alive") ✓
- `curl /api/dtus` → **403** ✓ (non-health `/api/` paths still correctly bot-guarded)

Syntax + YAML clean.

## Test plan

- [ ] playthrough's "Wait for server" no longer times out
- [ ] No regression in bot-guard behaviour for non-health `/api/` paths

https://claude.ai/code/session_01FGy6Zu9XB1Uk7Jr5SrLcKE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGy6Zu9XB1Uk7Jr5SrLcKE)_