### PR TITLE
fix(ci): --ignore-scripts in SCA setup to dodge external-CDN flakes

### DIFF
--- a/.github/workflows/platinum-security.yml
+++ b/.github/workflows/platinum-security.yml
@@ -109,13 +109,18 @@ jobs:
             server/package-lock.json
             concord-frontend/package-lock.json
 
+      # --ignore-scripts: SCA scanners (npm audit, retire.js, license,
+      # SBOM) read package metadata — they don't need postinstall scripts
+      # to run. Skipping them avoids transient external-CDN failures
+      # (e.g. ffmpeg-static fetching a release asset from GitHub) that
+      # have no bearing on the security scan output.
       - name: Install server deps (primes cache)
         working-directory: ./server
-        run: npm ci --prefer-offline
+        run: npm ci --prefer-offline --ignore-scripts
 
       - name: Install frontend deps (primes cache)
         working-directory: ./concord-frontend
-        run: npm ci --prefer-offline
+        run: npm ci --prefer-offline --ignore-scripts
 
   # ════════════════════════════════════════════════════════════════════
   # Matrix-batched SCA + Supply Chain gates (Sprint 35 v2)
@@ -156,10 +161,13 @@ jobs:
       # primed setup-node's cache, so this is fast (~5-15s) instead of
       # the cold ~30-60s. Each matrix entry needs node_modules locally
       # because GitHub Actions doesn't share filesystems across jobs.
+      # --ignore-scripts for the same reason as npm-deps-setup above:
+      # SCA scanners read metadata, not built artifacts. Skipping
+      # postinstall avoids transient external-CDN failures.
       - name: Install deps (cache-hit fast path)
         run: |
-          cd server && npm ci --prefer-offline
-          cd ../concord-frontend && npm ci --prefer-offline
+          cd server && npm ci --prefer-offline --ignore-scripts
+          cd ../concord-frontend && npm ci --prefer-offline --ignore-scripts
 
       # ── Per-scan dispatcher ──────────────────────────────────────────
       - name: Run ${{ matrix.scan.id }}


### PR DESCRIPTION
## Why

SCA setup is failing back-to-back with the same external error: `ffmpeg-static`'s postinstall tries to download its linux-x64 binary from GitHub release assets and gets HTTP **504** from the CDN. Two consecutive runs hit it on different release-asset URLs (the `.gz` binary, then the `.LICENSE`) — not a transient flake, the CDN is in an ongoing degraded state for these paths.

## The fix

Add `--ignore-scripts` to the SCA `npm ci` calls.

The SCA scanners — npm audit, retire.js, license compliance, SBOM — all read **package metadata**. They don't need built binaries (ffmpeg or otherwise) to do their job. Skipping postinstall entirely sidesteps this whole class of external-CDN failures without weakening the security scan output.

Scoped to `platinum-security.yml` only: all four `npm ci` invocations across the `npm-deps-setup` primer and the per-matrix `sca-scan` install step. Other workflows (Lint & Test etc.) still run scripts so build/runtime artifacts are produced normally.

## Verified

- YAML parses; diff is +12/-4, scoped to one file
- `--ignore-scripts` is a documented npm flag; `node_modules/` is still fully populated — only postinstall hooks are skipped

## Test plan

- [ ] SCA setup no longer blocked by ffmpeg-static 504
- [ ] All five SCA matrix scans still produce results

https://claude.ai/code/session_01FGy6Zu9XB1Uk7Jr5SrLcKE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGy6Zu9XB1Uk7Jr5SrLcKE)_