### PR TITLE
fix(ci): playthrough scene timeouts + brain/health short-circuit + LLM-route budget

### DIFF
--- a/concord-frontend/playwright.config.ts
+++ b/concord-frontend/playwright.config.ts
@@ -59,9 +59,11 @@ export default defineConfig({
     actionTimeout: 60000,
   },
   // Per-test timeout — covers the whole spec body including setup
-  // and teardown. 90 s leaves a comfortable margin over a 60 s goto
-  // plus a 15 s assertion budget.
-  timeout: 90000,
+  // and teardown. 180 s lets cold-loading heavy Three.js worlds
+  // (concord-link-frontier etc.) finish on a slow CI runner; the
+  // happy-path browsers finish in 17–25 s, but a webkit/firefox cold
+  // boot of a heavy scene + screenshot can straddle the prior 90 s.
+  timeout: 180000,
 
   projects: [
     {

--- a/server/server.js
+++ b/server/server.js
@@ -6176,8 +6176,12 @@ function validate(schemaName, source = "body") {
 const DEFAULT_TIMEOUT_MS = parseInt(process.env.REQUEST_TIMEOUT_MS, 10) || 30000;
 const LLM_TIMEOUT_MS = parseInt(process.env.LLM_REQUEST_TIMEOUT_MS, 10) || 60000; // 60s is plenty on GPU
 
-// Routes that involve LLM calls get longer timeouts
-const _LLM_ROUTE_PREFIXES = ["/api/chat", "/api/forge", "/api/ask", "/api/swarm", "/api/sim", "/api/council/debate"];
+// Routes that involve LLM calls get longer timeouts. /api/lens/run and
+// /api/worlds/* dispatch to brain-backed macros (oracle dialogue, NPC
+// conversation, glyph composition) — without the longer budget, a slow
+// cold macro would 503 the request middleware here at 30 s while the
+// handler was still running, manifesting client-side as ECONNRESET.
+const _LLM_ROUTE_PREFIXES = ["/api/chat", "/api/forge", "/api/ask", "/api/swarm", "/api/sim", "/api/council/debate", "/api/lens/run", "/api/worlds/"];
 
 function requestTimeoutMiddleware(req, res, next) {
   // Skip for SSE/streaming (they manage their own lifecycle)
@@ -50321,6 +50325,18 @@ app.post("/api/brain/entity/explore", asyncHandler(async (req, res) => {
 const _brainHealthFailures = {};
 const BRAIN_HEALTH_FAILURE_THRESHOLD = 3; // Only mark offline after 3 consecutive failures
 app.get("/api/brain/health", asyncHandler(async (_req, res) => {
+  // CI / no-Ollama deployments set CONCORD_DISABLE_BRAINS=true. Skip the
+  // 5×8 s parallel Ollama probes that would otherwise return useless
+  // failure rows + leave the event loop holding 5 dead sockets during
+  // every poll — concurrent callers (frontend hero-mesh + scene boot)
+  // were filling the request-timeout window and triggering ECONNRESET.
+  if (String(process.env.CONCORD_DISABLE_BRAINS || "").toLowerCase() === "true") {
+    const health = {};
+    for (const [name, brain] of Object.entries(BRAIN)) {
+      health[name] = { online: false, healthy: false, model: brain.model, error: "brains_disabled" };
+    }
+    return res.json({ ok: true, allHealthy: false, brains_disabled: true, ...health, brains: health });
+  }
   const health = {};
   const probes = Object.entries(BRAIN).map(async ([name, brain]) => {
     try {


### PR DESCRIPTION
## Why

#369's `CONCORD_FORCE_LISTEN` fix made playthrough's backend actually bind, which exposed three pre-existing issues now visible on main:

- Some browsers (`chromium`/`firefox` on `concordia-hub`, all on `concord-link-frontier`) cold-load + screenshot heavy Three.js worlds in *just over* the 90 s test budget. `mobile-chrome` + `webkit` hit it in **17–25 s**; the failing browsers were straddling the cliff.
- `/api/brain/health` did **5×8 s parallel Ollama probes even with `CONCORD_DISABLE_BRAINS=true`** set, blocking the event loop for ~8 s per call and inflaming the concurrent-request window.
- `/api/lens/run` and `/api/worlds/*` dispatch to brain-backed macros (oracle dialogue, NPC conversation, glyph composition) but weren't in `_LLM_ROUTE_PREFIXES`, so `requestTimeoutMiddleware` 503'd them at 30 s while the handler was still running — manifesting client-side as `ECONNRESET` (`[WebServer] Failed to proxy … socket hang up`).

## The fix (three scoped changes)

- **`playwright.config.ts`**: per-test timeout `90 s → 180 s`
- **`server.js` `/api/brain/health`**: short-circuit when `CONCORD_DISABLE_BRAINS=true`, returning honest `brains_disabled` rows instantly instead of waiting on 5 dead probes
- **`server.js` `_LLM_ROUTE_PREFIXES`**: add `/api/lens/run` and `/api/worlds/` so brain-routed paths get the 60 s LLM budget, not the 30 s default

## Verified

Lint + syntax clean. The three fixes are independent and each addresses one of the three failure modes in the playthrough log.

## Test plan

- [ ] playthrough's heavy worlds no longer time out
- [ ] No `[WebServer] socket hang up` on `/api/lens/run` or `/api/worlds/*`
- [ ] No regression in `/api/brain/health` for non-CI deployments (the short-circuit is env-gated)

https://claude.ai/code/session_01FGy6Zu9XB1Uk7Jr5SrLcKE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGy6Zu9XB1Uk7Jr5SrLcKE)_