### PR TITLE
fix(physics): re-entrancy guard on Rapier3D world to stop wasm-bindgen panics

### DIFF
--- a/concord-frontend/lib/world-lens/physics-world.ts
+++ b/concord-frontend/lib/world-lens/physics-world.ts
@@ -89,6 +89,26 @@ class PhysicsWorld {
   private bodies:      Map<string, RigidBody>  = new Map();
   private colliders:   Map<string, Collider>   = new Map();
   private kinematic:   Map<string, KinematicState> = new Map();
+  // Re-entrancy guard. Rapier's WASM bindings panic ("recursive use of an
+  // object detected which would lead to unsafe aliasing in rust") if JS
+  // re-enters the world while another method is still executing on it —
+  // e.g. a synchronous event dispatched from inside step() that lands in
+  // an AvatarSystem3D handler calling knockbackKinematic. JS is single-
+  // threaded but Rapier's borrow check fires on logical recursion. Guard
+  // every world-touching method: if another op is in flight, skip safely
+  // and return a no-op fallback rather than crash the scene.
+  private _inOp: boolean = false;
+  private _guard<T>(label: string, fn: () => T, fallback: T): T {
+    if (this._inOp) {
+      if (typeof console !== 'undefined') {
+        console.warn(`[physicsWorld] reentrancy: ${label} skipped (another op in flight)`);
+      }
+      return fallback;
+    }
+    this._inOp = true;
+    try { return fn(); }
+    finally { this._inOp = false; }
+  }
 
   /** Load Rapier WASM and create the physics world. Call once at scene startup. */
   async init(): Promise<void> {
@@ -103,9 +123,11 @@ class PhysicsWorld {
 
   /** Advance physics simulation by dt seconds. Call every game-loop frame. */
   step(dt: number): void {
-    if (!this.world) return;
-    this.world.timestep = Math.min(dt, 0.05); // cap at 50ms
-    this.world.step();
+    this._guard('step', () => {
+      if (!this.world) return;
+      this.world.timestep = Math.min(dt, 0.05); // cap at 50ms
+      this.world.step();
+    }, undefined);
   }
 
   /**
@@ -420,10 +442,18 @@ class PhysicsWorld {
     desiredTranslation: { x: number; y: number; z: number },
     dt: number,
   ): CharacterMoveResult {
+    if (this._inOp) {
+      // Re-entrancy guard: Rapier WASM panics with "recursive use of an
+      // object" if JS calls into the world while another op is mid-flight.
+      // Skip this frame's move rather than crash. (Caused chromium/firefox
+      // playthrough failures on heavy 3D worlds — pre-#373.)
+      return desiredTranslation;
+    }
     if (!this.world) return desiredTranslation;
     const ctrl = this.controllers.get(id);
     const body = this.bodies.get(id);
     if (!ctrl || !body) return desiredTranslation;
+    this._inOp = true;
 
     const collider = this.world.getCollider(0); // character's own collider
     // Find the collider attached to this body
@@ -540,6 +570,7 @@ class PhysicsWorld {
       ks.isAirborne = true;
     }
 
+    this._inOp = false;
     return { x: corrected.x / dt, y: corrected.y / dt, z: corrected.z / dt };
   }
 


### PR DESCRIPTION
## Why

The chromium + firefox playthrough specs on main (`65e3fff1`) flood the console with hundreds of:

```
recursive use of an object detected which would lead to unsafe aliasing in rust
unreachable
```

then crash the scene. That's wasm-bindgen's borrow check firing when JS re-enters the Rapier3D world while another method is mid-execution on it — single-threaded JS but logically recursive.

**The interleaving:**
- `physicsWorld.step()` runs every game-loop frame from `ConcordiaScene`
- `physicsWorld.moveCharacter()` / event handlers fire from `AvatarSystem3D`
- A handler firing *synchronously* from inside Rapier's `step()` (collision event, character controller callback, or a CustomEvent dispatched from world logic) lands on `moveCharacter` while the world is still mid-borrow → panic.

mobile-chrome + webkit don't hit this on the same code — their slower RAF cadence happens to not interleave step + event dispatch as aggressively. Same code, different timing.

## The fix

Class-level `_inOp` re-entrancy flag on `PhysicsWorld`. Hot-path methods that actually touch `this.world.*`:

- **`step()`** — wrapped in `_guard('step', ...)` helper; set/clear flag in `try/finally`
- **`moveCharacter()`** — inline: early-return `desiredTranslation` if `_inOp` already set, set flag after early-returns, clear flag before the (single) final return

Skipped frames return a no-op fallback instead of crashing — character misses one frame's correction rather than the whole scene dying.

Other methods (`createCharacterController`, `knockbackKinematic`, `requestJump`, etc.) only mutate JS-side state (`controllers` / `kinematic` Maps) — they don't touch the WASM world, so no guard needed.

## Test plan

- [ ] chromium + firefox playthrough specs no longer panic on heavy worlds (concord-link-frontier, lattice-crucible, fantasy)
- [ ] No regression on mobile-chrome + webkit (already passing)
- [ ] One-frame physics correction misses are acceptable (would only happen under genuine re-entrancy)

https://claude.ai/code/session_01FGy6Zu9XB1Uk7Jr5SrLcKE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGy6Zu9XB1Uk7Jr5SrLcKE)_