### PR TITLE
fix(http): bump keepAliveTimeout 5s→65s to eliminate proxy/socket-reuse ECONNRESETs

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -56684,6 +56684,21 @@ const server = SHOULD_LISTEN ? app.listen(PORT, () => {
   }
 }) : null;
 
+// HTTP keep-alive timeouts. Node defaults (keepAliveTimeout=5s,
+// headersTimeout=60s) are too short when sitting behind a connection-
+// pooling proxy (Next.js dev/start in CI, nginx in prod): the proxy
+// reuses a socket the server has already closed → client sees the
+// "socket hang up" ECONNRESET we were getting on /api/metrics/vitals,
+// /api/onboarding/wizard-status, /api/sub-lens/tree during e2e load.
+// 65s/66s mirrors the AWS ALB recommendation and stays under the 70s
+// upstream timeout most proxies default to. headersTimeout MUST be
+// strictly greater than keepAliveTimeout (Node enforces this) — keep
+// the +1s gap.
+if (server) {
+  server.keepAliveTimeout = 65_000;
+  server.headersTimeout = 66_000;
+}
+
 // Optional: enable thin realtime mirror (WebSockets) for queues/jobs/panels.
 try { await tryInitWebSockets(server); } catch (e) {
   structuredLog("error", "websocket_init_failed", { error: String(e?.message || e), stack: String(e?.stack || "").slice(0, 500) });


### PR DESCRIPTION
## Why

The e2e-core + integration suites on main showed clusters of:
```
[WebServer] Failed to proxy http://127.0.0.1:5050/api/metrics/vitals [Error: socket hang up] { code: 'ECONNRESET' }
```

…on light backend endpoints (`/api/metrics/vitals`, `/api/onboarding/wizard-status`, `/api/sub-lens/tree`) under sustained playwright load — endpoints that should be near-instant.

## Root cause

Node's default HTTP server `keepAliveTimeout` is **5s** — far too short when sitting behind a connection-pooling proxy (Next.js dev/start in CI; nginx in prod). The proxy reuses an idle socket the server has already silently closed → client sees `ECONNRESET` on the next request riding that dead socket. Classic mismatch documented in [Node's HTTP keep-alive nuances](https://adamcrowder.net/posts/node-express-api-and-aws-alb-502/).

## The fix

- `server.keepAliveTimeout = 65_000`
- `server.headersTimeout = 66_000` (Node requires `headersTimeout > keepAliveTimeout`)

65s mirrors the AWS ALB recommendation and stays under the ~70s default of most upstream proxies, so the backend is the *closer* of the two — proxies see clean FINs instead of trying to reuse dead sockets.

## Scope

This addresses the **proxy-socket-reuse class** of ECONNRESET. A separate class (event-loop starvation during heavy heartbeat / governor-tick work) remains — that's a deeper investigation requiring local repro of the backend load to instrument cleanly. Tracked as known follow-up.

## Test plan

- [ ] No more `socket hang up` on `/api/metrics/vitals` etc. under e2e load
- [ ] No regression in normal-load behavior

https://claude.ai/code/session_01FGy6Zu9XB1Uk7Jr5SrLcKE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGy6Zu9XB1Uk7Jr5SrLcKE)_