### PR TITLE
fix(ci): drop missing-icon reference so vsce package succeeds

### DIFF
--- a/concord-vscode/package.json
+++ b/concord-vscode/package.json
@@ -16,7 +16,6 @@
     "billing",
     "cognitive-engine"
   ],
-  "icon": "icons/concord-dx.png",
   "galleryBanner": {
     "color": "#0c0c0c",
     "theme": "dark"


### PR DESCRIPTION
## What

Drop the `"icon": "icons/concord-dx.png"` field from `concord-vscode/package.json`.

## Why

`dx-extension` workflow has been failing on `npx vsce package` for every main run since the extension was scaffolded in `11072e2`. vsce requires the icon file to exist on disk, and `icons/concord-dx.png` was deferred to a follow-up commit that never landed. The original commit message acknowledged the placeholder but assumed *"CI doesn't fail on missing image"* — turns out vsce actually does.

This failure was masked behind the tsc rootDir error fixed in #377; that fix let the compile step pass for the first time, exposing this latent packaging failure (visible on `dx-extension` run [25917160456](https://github.com/ryttps94jq-gif/concord-cognitive-engine/actions/runs/25917160456), step #7 `Package .vsix`).

## Trade-off

Until a real marketplace icon is authored, the extension will show VS Code's default extension icon in the Marketplace listing — a cosmetic loss, not functional. When the .png is ready, restore the `"icon"` field in the same commit that adds the file.

## Verified locally

```
$ cd concord-vscode && npx vsce package --no-yarn
...
DONE  Packaged: concord-dx.vsix (14 files, 20.26 KB)
```

https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp)_