### PR TITLE
fix(http): close socket on 503-timeout + cap request lifetime at 75 s

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -6201,6 +6201,16 @@ function requestTimeoutMiddleware(req, res, next) {
 
   const timer = setTimeout(() => {
     if (!res.headersSent) {
+      // Connection: close tells the proxy (Next.js/undici/nginx) to
+      // drop this socket after reading the 503 — don't return it to
+      // the keep-alive pool. Without this, the proxy reuses the socket
+      // for the next request, but Node may have started cleaning up
+      // its end (the original handler is still running and may write
+      // late, tripping ERR_HTTP_HEADERS_SENT internally), and the
+      // proxy sees ECONNRESET / socket hang up on the next write.
+      // Observed under E2E Core load — auth.spec.ts page loads hit
+      // these resets ~90 s into the run.
+      res.setHeader("Connection", "close");
       res.status(503).json({
         ok: false,
         error: "Request timeout",
@@ -56697,6 +56707,16 @@ const server = SHOULD_LISTEN ? app.listen(PORT, () => {
 if (server) {
   server.keepAliveTimeout = 65_000;
   server.headersTimeout = 66_000;
+  // requestTimeout = 75 s caps the maximum lifetime of an in-flight
+  // request at the socket layer. Without this, a handler that hangs
+  // (heavy DB query, blocked event-loop tick) holds the socket open
+  // until Node's default 5-min ceiling — long enough for the proxy
+  // to give up and ECONNRESET-on-reuse the next time it picks that
+  // socket from its keep-alive pool. 75 s sits just above the 60 s
+  // requestTimeoutMiddleware budget so the express layer always wins
+  // the race and writes a 503; the socket-level cap is the backstop
+  // for genuinely stuck requests.
+  server.requestTimeout = 75_000;
 }
 
 // Optional: enable thin realtime mirror (WebSockets) for queues/jobs/panels.


### PR DESCRIPTION
## What

Two-line defensive fix on the backend's HTTP layer:

1. `res.setHeader("Connection", "close")` on the 503 that `requestTimeoutMiddleware` writes after 60 s.
2. `server.requestTimeout = 75_000` at the Node socket layer.

## Why

E2E Core has been failing on a backend connection storm. ~90 s into sustained test load the Next.js proxy starts hitting **"socket hang up" ECONNRESETs** on `/api/onboarding/wizard-status`, `/api/metrics/vitals`, `/api/sub-lens/tree`. Tests that depend on those endpoints then bake against the 2-min actionTimeout, hundreds of them stack, and the 25-min E2E Core job times out (last cancelled at **25m15s** on commit `5d72a39`).

**Sequence of the bug:**
1. The `requestTimeoutMiddleware` fires at 60 s, writes a 503.
2. But the original handler is still running underneath — we only short-circuit if `!res.headersSent`; the handler isn't awaited or aborted.
3. When that late handler finally tries to write its real response, it trips `ERR_HTTP_HEADERS_SENT` internally and the socket ends up half-open.
4. The proxy returns the socket to its keep-alive pool.
5. Next request picks it up → `ECONNRESET`.

**Why these two layers fix it:**
- `Connection: close` on the 503 tells the proxy to drop the socket instead of pooling it. Surgical — only the timeout path is affected; normal responses keep the keep-alive optimisation.
- `server.requestTimeout = 75_000` is Node's socket-layer cap. Without this, a hanging handler holds the socket open until Node's default 5-min ceiling — long enough for the proxy to give up. 75 s sits just above the 60 s middleware budget, so the express layer always wins the race; the socket cap is the backstop for genuinely stuck handlers.

## Together with prior fixes

- PR #374 — `keepAliveTimeout 5s → 65s` closed the short-keepalive race
- PR #377 — playthrough parallel + try/catch hardening
- **This PR** — the residual zombie-socket pooling

## Verification

Server boots cleanly with both settings on:
```
NODE_ENV=test PORT=5051 node server.js → /health = 200 in 12s
```

The E2E Core failure will only fully validate against the next main run after merge. If E2E Core comes back green, the chain is closed; if not, the next failure mode will surface a different root cause (almost certainly an individual flaky spec rather than infra).

https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp)_