### PR TITLE
fix(physics): extend Rapier re-entrancy guard to every scene-load entry point

### DIFF
--- a/concord-frontend/lib/world-lens/physics-world.ts
+++ b/concord-frontend/lib/world-lens/physics-world.ts
@@ -142,17 +142,18 @@ class PhysicsWorld {
     hmHeight: number,
     worldScale: { x: number; y: number; z: number },
   ): void {
-    if (!this.RAPIER || !this.world) return;
-
-    const RAPIER = this.RAPIER;
-    const desc = RAPIER.ColliderDesc.heightfield(
-      hmHeight - 1,
-      hmWidth  - 1,
-      hmData,
-      { x: worldScale.x, y: worldScale.y, z: worldScale.z },
-    );
-    desc.setTranslation(0, 0, 0);
-    this.world.createCollider(desc);
+    this._guard('createHeightfieldCollider', () => {
+      if (!this.RAPIER || !this.world) return;
+      const RAPIER = this.RAPIER;
+      const desc = RAPIER.ColliderDesc.heightfield(
+        hmHeight - 1,
+        hmWidth  - 1,
+        hmData,
+        { x: worldScale.x, y: worldScale.y, z: worldScale.z },
+      );
+      desc.setTranslation(0, 0, 0);
+      this.world.createCollider(desc);
+    }, undefined);
   }
 
   /**
@@ -164,18 +165,18 @@ class PhysicsWorld {
     halfExtents: { x: number; y: number; z: number },
     entityId?: string,
   ): string {
-    if (!this.RAPIER || !this.world) return '';
-
-    const RAPIER = this.RAPIER;
-    const bodyDesc = RAPIER.RigidBodyDesc.fixed().setTranslation(position.x, position.y, position.z);
-    const body     = this.world.createRigidBody(bodyDesc);
-    const collDesc = RAPIER.ColliderDesc.cuboid(halfExtents.x, halfExtents.y, halfExtents.z);
-    const coll     = this.world.createCollider(collDesc, body);
-
-    const key = entityId ? `building:${entityId}` : `building_${Date.now()}_${Math.random()}`;
-    this.bodies.set(key, body);
-    this.colliders.set(key, coll);
-    return key;
+    return this._guard('createBuildingCollider', () => {
+      if (!this.RAPIER || !this.world) return '';
+      const RAPIER = this.RAPIER;
+      const bodyDesc = RAPIER.RigidBodyDesc.fixed().setTranslation(position.x, position.y, position.z);
+      const body     = this.world.createRigidBody(bodyDesc);
+      const collDesc = RAPIER.ColliderDesc.cuboid(halfExtents.x, halfExtents.y, halfExtents.z);
+      const coll     = this.world.createCollider(collDesc, body);
+      const key = entityId ? `building:${entityId}` : `building_${Date.now()}_${Math.random()}`;
+      this.bodies.set(key, body);
+      this.colliders.set(key, coll);
+      return key;
+    }, '');
   }
 
   /**
@@ -217,11 +218,13 @@ class PhysicsWorld {
 
   /** Remove a previously-registered building collider by its key. */
   removeBuildingCollider(key: string): void {
-    if (!this.world || !key) return;
-    const body = this.bodies.get(key);
-    if (body) this.world.removeRigidBody(body);
-    this.bodies.delete(key);
-    this.colliders.delete(key);
+    this._guard('removeBuildingCollider', () => {
+      if (!this.world || !key) return;
+      const body = this.bodies.get(key);
+      if (body) this.world.removeRigidBody(body);
+      this.bodies.delete(key);
+      this.colliders.delete(key);
+    }, undefined);
   }
 
   /**
@@ -291,6 +294,10 @@ class PhysicsWorld {
    * Static-only — trimesh on a dynamic body is not supported by Rapier.
    */
   private _registerTrimeshFromObject(obj: Object3DLike, entityId: string): string | null {
+    return this._guard('_registerTrimeshFromObject', () => this._registerTrimeshFromObjectInner(obj, entityId), null);
+  }
+
+  private _registerTrimeshFromObjectInner(obj: Object3DLike, entityId: string): string | null {
     if (!this.RAPIER || !this.world || !this.THREE) return null;
     const ud = obj.userData ?? (obj as Record<string, unknown>);
     const existing = (ud as Record<string, unknown>).physicsKey as string | undefined;
@@ -377,6 +384,10 @@ class PhysicsWorld {
    * outside the kinematic-controller path.
    */
   private _registerCapsuleFromObject(obj: Object3DLike, entityId: string): string | null {
+    return this._guard('_registerCapsuleFromObject', () => this._registerCapsuleFromObjectInner(obj, entityId), null);
+  }
+
+  private _registerCapsuleFromObjectInner(obj: Object3DLike, entityId: string): string | null {
     if (!this.RAPIER || !this.world || !this.THREE) return null;
     const ud = obj.userData ?? (obj as Record<string, unknown>);
     const existing = (ud as Record<string, unknown>).physicsKey as string | undefined;
@@ -412,25 +423,27 @@ class PhysicsWorld {
    * Returns the controller; also stored internally under `id`.
    */
   createCharacterController(id: string): CharCtrl | null {
-    if (!this.RAPIER || !this.world) return null;
+    return this._guard('createCharacterController', () => {
+      if (!this.RAPIER || !this.world) return null;
 
-    const RAPIER   = this.RAPIER;
-    const offset   = 0.01;
-    const ctrl     = this.world.createCharacterController(offset);
-    ctrl.setMaxSlopeClimbAngle((45 * Math.PI) / 180);
-    ctrl.setMinSlopeSlideAngle((30 * Math.PI) / 180);
-    ctrl.enableSnapToGround(0.5);
-    ctrl.setApplyImpulsesToDynamicBodies(true);
+      const RAPIER   = this.RAPIER;
+      const offset   = 0.01;
+      const ctrl     = this.world.createCharacterController(offset);
+      ctrl.setMaxSlopeClimbAngle((45 * Math.PI) / 180);
+      ctrl.setMinSlopeSlideAngle((30 * Math.PI) / 180);
+      ctrl.enableSnapToGround(0.5);
+      ctrl.setApplyImpulsesToDynamicBodies(true);
 
-    // Each controller needs its own collider (capsule shape)
-    const bodyDesc = RAPIER.RigidBodyDesc.kinematicPositionBased()
-      .setTranslation(0, 5, 0);
-    const body = this.world.createRigidBody(bodyDesc);
-    const collDesc = RAPIER.ColliderDesc.capsule(0.7, 0.3); // half-height, radius
-    this.world.createCollider(collDesc, body);
-    this.bodies.set(id, body);
-    this.controllers.set(id, ctrl);
-    return ctrl;
+      // Each controller needs its own collider (capsule shape)
+      const bodyDesc = RAPIER.RigidBodyDesc.kinematicPositionBased()
+        .setTranslation(0, 5, 0);
+      const body = this.world.createRigidBody(bodyDesc);
+      const collDesc = RAPIER.ColliderDesc.capsule(0.7, 0.3); // half-height, radius
+      this.world.createCollider(collDesc, body);
+      this.bodies.set(id, body);
+      this.controllers.set(id, ctrl);
+      return ctrl;
+    }, null);
   }
 
   /**
@@ -732,14 +745,16 @@ class PhysicsWorld {
 
   /** Remove a character controller and its body. */
   removeCharacter(id: string): void {
-    if (!this.world) return;
-    const body = this.bodies.get(id);
-    if (body) this.world.removeRigidBody(body);
-    this.bodies.delete(id);
-    const ctrl = this.controllers.get(id);
-    if (ctrl) this.world.removeCharacterController(ctrl);
-    this.controllers.delete(id);
-    this.kinematic.delete(id);
+    this._guard('removeCharacter', () => {
+      if (!this.world) return;
+      const body = this.bodies.get(id);
+      if (body) this.world.removeRigidBody(body);
+      this.bodies.delete(id);
+      const ctrl = this.controllers.get(id);
+      if (ctrl) this.world.removeCharacterController(ctrl);
+      this.controllers.delete(id);
+      this.kinematic.delete(id);
+    }, undefined);
   }
 
   // ── Projectiles ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Extends the Rapier3D re-entrancy guard (`_inOp` / `_guard`) from PR #373 to **every WASM-touching method called during scene init**.

## Why

Playthrough log on `4193f31` (commit prior to this PR) shows the guard from #373 is incomplete:

```
Fatal errors (sovereign-ruins load): [18×]
  "recursive use of an object detected which would lead to unsafe
   aliasing in rust"
  "attempted to take ownership of Rust value while it was borrowed"
  "unreachable"
```

Scene init walks the Three.js subtree via `syncFromScene()` → calls `createBuildingCollider` / `_registerTrimeshFromObject` / `_registerCapsuleFromObject` per child. Each touches `world.createRigidBody` + `world.createCollider` directly, **with no guard**. When `step()` fires from RAF between asset-load microtasks, its `_inOp=true` window overlaps with a yet-to-be-guarded creator method → Rapier's borrow check panics → the lens crashes → `expect(fatal).toHaveLength(0)` trips.

## Methods wrapped

| Method | Why it matters |
|---|---|
| `createHeightfieldCollider` | terrain registration |
| `createBuildingCollider` | building registration — hottest path during syncFromScene |
| `removeBuildingCollider` | building despawn |
| `createCharacterController` | player + NPC spawn |
| `removeCharacter` | player + NPC despawn |
| `_registerTrimeshFromObject` | vegetation mesh colliders |
| `_registerCapsuleFromObject` | vegetation capsule colliders |

Each wrap returns a safe fallback (`''` / `null` / `undefined`) when re-entrancy is detected — same shape as the existing guards on `step()` and `moveCharacter()`.

`syncFromScene()` itself doesn't need its own guard because every method it calls now self-guards.

## Failure pattern this fixes (from the playthrough log)

15 specs, chromium-only, 16.7m total:
- 10 passed
- **2 hard failures**: `cyber`, `fantasy`
- **3 flaky** (passed on retry): `concordia-hub`, `lattice-crucible`, `sovereign-ruins`

The flaky ones are the smoking gun — same scene loads on retry, racy WASM re-entrancy, sometimes survives, sometimes doesn't. With the full guard surface, retries should be unnecessary.

## Verification

- `npm run type-check` → exit 0
- Behaviour change is isolated to the re-entrancy path; happy-path scene loads are unchanged

https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp)_