### PR TITLE
fix(physics): _ready gate + try/finally moveCharacter + full destroy reset

### DIFF
--- a/concord-frontend/lib/world-lens/physics-world.ts
+++ b/concord-frontend/lib/world-lens/physics-world.ts
@@ -98,7 +98,15 @@ class PhysicsWorld {
   // every world-touching method: if another op is in flight, skip safely
   // and return a no-op fallback rather than crash the scene.
   private _inOp: boolean = false;
+  // _ready gates every WASM-touching method on a fully-initialised world.
+  // Set true at the end of init() (after every await resolves), set false
+  // at the start of destroy() and after any unrecoverable internal panic.
+  // Without this gate, RAF can call step() between the RAPIER.init() await
+  // and the THREE import — exercising a half-initialised world and
+  // tripping wasm-bindgen's borrow check repeatedly.
+  private _ready: boolean = false;
   private _guard<T>(label: string, fn: () => T, fallback: T): T {
+    if (!this._ready) return fallback;
     if (this._inOp) {
       if (typeof console !== 'undefined') {
         console.warn(`[physicsWorld] reentrancy: ${label} skipped (another op in flight)`);
@@ -112,13 +120,25 @@ class PhysicsWorld {
 
   /** Load Rapier WASM and create the physics world. Call once at scene startup. */
   async init(): Promise<void> {
-    if (this.world) return;
+    if (this.world && this._ready) return;
+    // Allow re-init after destroy(): React strict-mode / route changes can
+    // unmount → remount the world host; the singleton's _destroyed flag
+    // was permanently stuck true post-destroy(), which is fine for the
+    // destroy guard itself but blocks a clean re-init. Reset it here so a
+    // second mount gets a fresh, working world instead of a half-state.
+    this._destroyed = false;
+    this._inOp = false;
     const RAPIER = await import('@dimforge/rapier3d-compat');
     await RAPIER.init();
     this.RAPIER = RAPIER;
     this.world  = new RAPIER.World({ x: 0, y: -9.81, z: 0 });
     // Pre-load THREE so building registration can compute bounding boxes synchronously.
     this.THREE = await import('three');
+    // Mark ready ONLY after every await has resolved. step() and the rest
+    // gate on this — without it, RAF could fire step() between the
+    // RAPIER.init() await and THREE.import() await, exercising a
+    // half-initialised world and tripping wasm-bindgen's borrow check.
+    this._ready = true;
   }
 
   /** Advance physics simulation by dt seconds. Call every game-loop frame. */
@@ -455,6 +475,10 @@ class PhysicsWorld {
     desiredTranslation: { x: number; y: number; z: number },
     dt: number,
   ): CharacterMoveResult {
+    // Gate on full readiness — half-initialised worlds during the init()
+    // await chain are the most common source of "recursive use of an
+    // object" panics from this method.
+    if (!this._ready) return desiredTranslation;
     if (this._inOp) {
       // Re-entrancy guard: Rapier WASM panics with "recursive use of an
       // object" if JS calls into the world while another op is mid-flight.
@@ -467,6 +491,25 @@ class PhysicsWorld {
     const body = this.bodies.get(id);
     if (!ctrl || !body) return desiredTranslation;
     this._inOp = true;
+    try {
+      return this._moveCharacterInner(id, desiredTranslation, dt, ctrl, body);
+    } finally {
+      // try/finally — without it, a Rapier panic mid-method left _inOp
+      // permanently true, silently blocking every subsequent step() and
+      // creator method. That looked like "physics randomly stops working"
+      // and turned single panics into cascading failures across frames.
+      this._inOp = false;
+    }
+  }
+
+  private _moveCharacterInner(
+    id: string,
+    desiredTranslation: { x: number; y: number; z: number },
+    dt: number,
+    ctrl: CharCtrl,
+    body: RigidBody,
+  ): CharacterMoveResult {
+    if (!this.world) return desiredTranslation;
 
     const collider = this.world.getCollider(0); // character's own collider
     // Find the collider attached to this body
@@ -583,7 +626,7 @@ class PhysicsWorld {
       ks.isAirborne = true;
     }
 
-    this._inOp = false;
+    // _inOp is reset by the caller's try/finally; never touch it from here.
     return { x: corrected.x / dt, y: corrected.y / dt, z: corrected.z / dt };
   }
 
@@ -963,10 +1006,21 @@ class PhysicsWorld {
    *  PhysicsWorld is constructed between two destroy() calls some
    *  internal Rapier handles can end up null when free() walks them
    *  ("null pointer passed to rust"). try/catch keeps the page alive
-   *  through the harmless double-destroy. */
+   *  through the harmless double-destroy.
+   *
+   *  Since physicsWorld is a module-level singleton, EVERY transient
+   *  lifecycle field (_ready, _inOp, _destroyed) AND the per-entity maps
+   *  must be cleared here. init() then resets _destroyed=false and
+   *  builds a fresh world. Without this, a remount after destroy would
+   *  inherit a stuck _inOp from a Rapier panic mid-frame, silently
+   *  blocking every subsequent step()/creator call ("physics randomly
+   *  stops working" after a route change in dev).
+   */
   destroy(): void {
     if (this._destroyed) return;
     this._destroyed = true;
+    this._ready = false;
+    this._inOp = false;
     try { this.world?.free(); }
     catch (err) { /* harmless under strict-mode double-mount */ void err; }
     this.world  = null;
@@ -975,6 +1029,15 @@ class PhysicsWorld {
     this.controllers.clear();
     this.bodies.clear();
     this.colliders.clear();
+    // kinematic state was previously NOT cleared on destroy. A subsequent
+    // init() that created a controller under the same id (e.g. 'player')
+    // would inherit the OLD world's KinematicState — stale verticalVel,
+    // stale isAirborne, stale knockback timers. Causes "player can't jump
+    // after a route change" type bugs. Drop it.
+    this.kinematic.clear();
+    this.waterLevels.clear();
+    this.projectiles.clear();
+    this.ragdolls.clear();
   }
   private _destroyed = false;
 }


### PR DESCRIPTION
## What

Three layered fixes to the Rapier3D lifecycle in `physics-world.ts`. The Rapier panics in the playthrough are not from a single bug, they're from three independent issues compounding.

## Why — what the log actually showed

After PR #382 wrapped every scene-init entry in `_guard`, the latest playthrough still produced **15+ Rapier panics per crashed scene** (`concordia-hub`, `lattice-crucible`, `sovereign-ruins`, `fantasy`). If `_guard` were catching the actual re-entry, we'd see `[physicsWorld] reentrancy: X skipped` console warnings — not the 15-error floods of `recursive use of an object detected which would lead to unsafe aliasing in rust`.

That's the smoking gun for **a stale lock** + **a half-initialised world** + **a stale singleton**, not for an unguarded entry. Reading the file carefully exposed three independent bugs:

### Bug 1: `moveCharacter` had no `try/finally` around its inline `_inOp` lock

```ts
this._inOp = true;
// ...many lines of Rapier calls...
this._inOp = false;
```

When any of those calls panicked, the function threw and `_inOp = false` never ran. The lock stayed permanently true, every subsequent `step()` / creator method skipped silently, and one panic turned into 15 "operation attempted but the lock is stuck" cascades on subsequent frames. That's the floor pattern of the failing log.

### Bug 2: singleton `physicsWorld` survived `destroy()` with dirty state

- `_destroyed = true` was set permanently — init's `if (this.world) return` worked, but `_destroyed` was never reset, so the destroy-guard couldn't fire correctly on a second cycle.
- `_inOp` could be stuck `true` if Bug 1 fired before destroy.
- `kinematic` / `waterLevels` / `projectiles` / `ragdolls` maps were never cleared — a remount that created `player` got the OLD world's KinematicState (stale knockback timers, stale verticalVel, stale isAirborne).

### Bug 3: `init()` set `this.world` before the second `await` resolved

```ts
this.world = new RAPIER.World({...});       // ← set
this.THREE = await import('three');         // ← await happens AFTER world is set
```

If RAF fired between those, `step()` saw `world ≠ null` and ran against a half-initialised world. wasm-bindgen's borrow check would fire immediately, **exactly the panic class we're seeing**.

## Fix

1. **Add `_ready: boolean`.** Set true at the **end** of `init()` (after every await resolves). Set false at the start of `destroy()`. `_guard` checks `_ready` first — operations on an unready world return the safe fallback without touching Rapier.

2. **`try/finally` on `moveCharacter`.** Extracted the body to `_moveCharacterInner`; the outer method now does:
   ```ts
   this._inOp = true;
   try { return this._moveCharacterInner(...); }
   finally { this._inOp = false; }
   ```
   Lock always resets, panic or not.

3. **Full state reset in `destroy()`.** Clears `_ready`, `_inOp`, `_destroyed`, `kinematic`, `waterLevels`, `projectiles`, `ragdolls` — every transient field that was leaking across the init/destroy cycle.

4. **`init()` resets `_destroyed` + `_inOp` at the start.** A clean re-init after destroy now works. `_ready` is set only at the **end** of the await chain.

## Expected outcome on the next playthrough run

Either passes cleanly OR surfaces a *different, narrower* error that names the actual unguarded path. The 15-panic floods (one real panic + 15 stuck-lock cascades) should be gone regardless. The "scene loads on retry" pattern (3 of 5 failing scenes flake-pass on retry) is exactly what you'd expect from a stuck-lock — first run sets the lock, second run gets a fresh singleton state.

## Verification

- `npm run type-check` exits 0
- Behaviour-identical on the happy path; only panic and lifecycle paths change

https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp)_