### PR TITLE
fix(deploy): align ecosystem.config.cjs to Blackwell target

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -22,8 +22,8 @@ module.exports = {
       instances: 1,
       exec_mode: 'fork',
       watch: false,
-      max_memory_restart: '8G',                                   // 62GB RAM — generous headroom
-      node_args: '--max-old-space-size=6144 --expose-gc',         // 6GB heap limit
+      max_memory_restart: '34G',                                  // matches 32G heap + ~2G headroom
+      node_args: '--max-old-space-size=32768 --expose-gc',         // 32GB heap — matches CLAUDE.md Blackwell default (server/package.json start script + docker-compose use the same)
       env: {
         // Default (Docker / docker-compose)
         NODE_ENV: 'production',
@@ -39,28 +39,34 @@ module.exports = {
         OLLAMA_HOST: 'http://ollama:11434',
       },
       env_runpod: {
-        // RunPod RTX Pro 4500 — 32GB VRAM, 62GB RAM, 28 vCPU
+        // RunPod RTX PRO 4500 Blackwell — 32GB GDDR7, 62GB RAM, 28 vCPU.
+        // Single Ollama instance hosts all 5 brain slots (vs the docker-compose
+        // split which puts each brain on its own container at 11434-11438).
         NODE_ENV: 'production',
         PORT: 5050,
         TRUST_PROXY: '1',
-        // All brains hit localhost Ollama — one instance, multiple model roles
+        // All five brain slots point at one on-pod Ollama; the model per slot
+        // is what differentiates them. (env_runpod overrides PM2's `env`
+        // block which has the docker-compose hostnames.)
         BRAIN_CONSCIOUS_URL: 'http://localhost:11434',
         BRAIN_SUBCONSCIOUS_URL: 'http://localhost:11434',
         BRAIN_UTILITY_URL: 'http://localhost:11434',
         BRAIN_REPAIR_URL: 'http://localhost:11434',
-        BRAIN_MULTIMODAL_URL: 'http://localhost:11434',
+        BRAIN_VISION_URL: 'http://localhost:11434',
         OLLAMA_HOST: 'http://localhost:11434',
-        // RTX Pro 4500 model selection (32GB VRAM):
-        //   qwen2.5:32b-instruct-q4_K_M  ≈ 20GB — best reasoning for chat
-        //   qwen2.5:14b-instruct-q4_K_M  ≈  8GB — background synthesis
-        //   qwen2.5:7b-instruct-q4_K_M   ≈  4GB — fast repair/utility
-        //   nomic-embed-text              ≈ 0.3GB — semantic cache
-        //   Total loaded (conscious+sub): ≈ 28GB — fits with 4GB headroom
-        BRAIN_CONSCIOUS_MODEL: 'qwen2.5:32b-instruct-q4_K_M',
-        BRAIN_SUBCONSCIOUS_MODEL: 'qwen2.5:14b-instruct-q4_K_M',
-        BRAIN_UTILITY_MODEL: 'qwen2.5:7b-instruct-q4_K_M',
-        BRAIN_REPAIR_MODEL: 'qwen2.5:7b-instruct-q4_K_M',
-        OLLAMA_VISION_MODEL: 'llava:13b',
+        // 5-brain model defaults — match server/lib/brain-config.js and
+        // .env.runpod. Previously this file held a legacy single-Ollama
+        // big-model config (qwen2.5:32b + 14b + 7b + 7b) that was 28GB
+        // loaded on a 32GB VRAM card with NO headroom for KV cache spikes
+        // under concurrent inference. The 5-brain set is concord-conscious
+        // (custom on qwen2.5 base) + qwen2.5:7b + qwen2.5:3b + qwen2.5:0.5b
+        // + llava:13b-v1.6-vicuna-q4_K_M; total much lighter and lets
+        // OLLAMA_MAX_LOADED_MODELS=2 actually rotate without OOMing.
+        BRAIN_CONSCIOUS_MODEL: 'concord-conscious:latest',
+        BRAIN_SUBCONSCIOUS_MODEL: 'qwen2.5:7b-instruct-q4_K_M',
+        BRAIN_UTILITY_MODEL: 'qwen2.5:3b',
+        BRAIN_REPAIR_MODEL: 'qwen2.5:0.5b',
+        BRAIN_VISION_MODEL: 'llava:13b-v1.6-vicuna-q4_K_M',
         // ALLOWED_ORIGINS and COOKIE_DOMAIN loaded from .env file
       },
       env_development: {
@@ -118,11 +124,23 @@ module.exports = {
       autorestart: true,
       env: {
         OLLAMA_HOST: '0.0.0.0:11434',
-        // RTX Pro 4500 (32GB VRAM, 28 vCPU): high parallelism, keep 2 models hot
-        // conscious (32b, ~20GB) + subconscious (14b, ~8GB) = 28GB loaded simultaneously
+        // RTX PRO 4500 Blackwell (32GB GDDR7, 28 vCPU). The 5-brain model set
+        // (concord-conscious + qwen2.5:7b + qwen2.5:3b + qwen2.5:0.5b + llava:13b)
+        // is much lighter than the old 32b+14b setup — total loaded weight stays
+        // well under 32GB even with 2 models hot, so we keep MAX_LOADED_MODELS=2
+        // for low-latency rotation between conscious and subconscious.
         OLLAMA_NUM_PARALLEL: '8',        // 8 concurrent inference streams
         OLLAMA_MAX_LOADED_MODELS: '2',   // keep conscious+subconscious in VRAM
         OLLAMA_NUM_THREAD: '14',         // half of 28 vCPU for Ollama CPU work
+        // Blackwell tensor-core / VRAM optimizations — matches docker-compose.yml.
+        // Previously these were docker-only, so the PM2 path on a real RunPod
+        // pod was running Ollama without flash-attn or q8 KV cache. That meant:
+        //  - no 5th-gen tensor-core acceleration (slower inference)
+        //  - 2× VRAM usage for KV cache (evicted hot models faster than expected)
+        // Aligning with docker-compose closes the gap.
+        OLLAMA_FLASH_ATTENTION: '1',
+        OLLAMA_KV_CACHE_TYPE: 'q8_0',
+        OLLAMA_KEEP_ALIVE: '24h',
       },
       error_file: 'logs/ollama-error.log',
       out_file: 'logs/ollama-out.log',


### PR DESCRIPTION
## What

Aligns `ecosystem.config.cjs` (the PM2 production deployment config) with the **RTX PRO 4500 Blackwell** target documented in CLAUDE.md. Four mistunings closed.

## Why

Audited every Blackwell-relevant config in the repo. Most things already line up:

| File | Blackwell-aligned? |
|---|---|
| `server/package.json` start script | ✅ `--max-old-space-size=32768` |
| `server/lib/brain-config.js` | ✅ 5-brain models (concord-conscious + qwen2.5 trio + llava:13b-v1.6-vicuna-q4_K_M) |
| `docker-compose.yml` | ✅ 32GB heap + `OLLAMA_FLASH_ATTENTION=1` + `OLLAMA_KV_CACHE_TYPE=q8_0` × 5 brains |
| `.env.runpod` | ✅ 5-brain model names |
| `CONCORD_*` capacity caps in code | ✅ all default to Blackwell values |
| **`ecosystem.config.cjs`** | ❌ **was misaligned on four axes** |

## The four mistunings

### 1. `node_args: --max-old-space-size=6144` → `32768`
The 6GB heap cap was **5.3× below** the Blackwell default. The DTU substrate is sized for ~1.5M entries on a 32GB heap; at 6GB it OOMs well before production load. `max_memory_restart` bumped `8G → 34G` to track.

### 2. Ollama PM2 app missing Blackwell tensor-core flags
`docker-compose.yml` has `OLLAMA_FLASH_ATTENTION=1` + `OLLAMA_KV_CACHE_TYPE=q8_0` on all 5 brain containers. The PM2 path didn't. Effect on a real Blackwell pod:
- no 5th-gen tensor-core acceleration → slower inference
- 2× VRAM usage for KV cache → evicts hot models prematurely under concurrent load

Added both + `OLLAMA_KEEP_ALIVE=24h` to match docker-compose's keep-warm policy.

### 3. `env_runpod` ran the legacy big-model setup

Was loading `qwen2.5:32b-instruct-q4_K_M` (~20GB) + `qwen2.5:14b-instruct-q4_K_M` (~8GB) = **28GB on a 32GB card with only ~4GB headroom**. Under concurrent inference, KV cache spikes can exceed 4GB → forced hot-model eviction → 10s+ load latency hitches visible to users.

Aligned with the canonical 5-brain set from `server/lib/brain-config.js` + `.env.runpod`:
- `BRAIN_CONSCIOUS_MODEL=concord-conscious:latest`
- `BRAIN_SUBCONSCIOUS_MODEL=qwen2.5:7b-instruct-q4_K_M`
- `BRAIN_UTILITY_MODEL=qwen2.5:3b`
- `BRAIN_REPAIR_MODEL=qwen2.5:0.5b`
- `BRAIN_VISION_MODEL=llava:13b-v1.6-vicuna-q4_K_M`

Total loaded weight much lower; rotation between conscious and subconscious is comfortable instead of edge-of-OOM.

### 4. `env_runpod` used `BRAIN_MULTIMODAL_URL` (old alias) instead of `BRAIN_VISION_URL`
Renamed for consistency with `brain-config.js` and the rest of the codebase.

## Scope

- **Touches:** `ecosystem.config.cjs` only
- **Doesn't touch:** any code path, any CI gate, any other config file
- **Doesn't affect:** docker-compose or CI runner sizing (those are correct for their environments)

The four configs in the repo (server start script, brain-config.js, docker-compose.yml, .env.runpod) were already in lockstep on the Blackwell defaults; this PR brings ecosystem.config.cjs into the same lockstep.

https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp)_