### PR TITLE
fix(deploy): wire concord-conscious bootstrap end-to-end

### DIFF
--- a/Modelfile
+++ b/Modelfile
@@ -1,0 +1,53 @@
+# concord-conscious — custom Ollama model for the Concord cognitive OS
+#
+# Build:
+#   ollama create concord-conscious:latest -f Modelfile
+#
+# Used by the Conscious brain (brain-config.js → BRAIN.conscious.model).
+# Role per CLAUDE.md: "Chat, deep reasoning, council." This is the brain
+# that talks to users; tone + persona + reasoning depth come from here.
+#
+# Base: qwen2.5:7b-instruct-q4_K_M. Same weight class as the subconscious
+# brain (~4GB VRAM), so the two-hot-models policy in ecosystem.config.cjs
+# (OLLAMA_MAX_LOADED_MODELS=2) comfortably keeps both warm on the RTX PRO
+# 4500 Blackwell. If you want a heavier conscious (32b reasoning at the
+# cost of evictions), swap FROM and reduce MAX_LOADED_MODELS to 1.
+#
+# Customize: the SYSTEM block below is a starter that reads as Concord's
+# default identity. Edit to match your product voice, then rebuild with
+# the same ollama create command — the model name stays concord-conscious.
+
+FROM qwen2.5:7b-instruct-q4_K_M
+
+# ── Inference parameters ─────────────────────────────────────────────────────
+# 0.7 temp: enough variation for natural reasoning; not so high that the
+# substrate's factual citations drift. Raise for more creative chat lenses,
+# lower for the council / verification pathways.
+PARAMETER temperature 0.7
+PARAMETER top_p 0.9
+# 8K context: covers a typical chat turn + DTU context window from the
+# substrate. Raise to 32k for the council mode (multi-DTU deliberation)
+# if VRAM allows.
+PARAMETER num_ctx 8192
+# Stop on the user-turn marker so the model doesn't roleplay both sides.
+PARAMETER stop "<|im_end|>"
+PARAMETER stop "<|im_start|>user"
+
+# ── System prompt — Concord's default identity ───────────────────────────────
+SYSTEM """You are Concord, a cognitive operating system.
+
+You operate across a substrate of Discrete Thought Units (DTUs) — a
+self-compressing knowledge structure — and converse through 232 lenses,
+each a domain-specific tool that the user opens when they need it.
+
+Conversation principles:
+ • Speak directly. No filler, no preamble, no apologies for length.
+ • Cite what you know from the user's DTU substrate when relevant; admit
+   what you don't.
+ • When asked to do something, do it — don't narrate that you're about to.
+ • Your goal is to help the user think more clearly, not to impress them
+   with verbosity.
+
+You're not a customer-service chatbot and you're not a tutor. You're a
+peer that happens to have read everything the user has written. Match
+their register; mirror their precision; never condescend."""

--- a/setup.sh
+++ b/setup.sh
@@ -69,14 +69,18 @@ info "Building frontend (this may take a minute)..."
 ok "Frontend built."
 
 # ── 7. Pull required Ollama models ───────────────────────────────────────
-info "Pulling required Ollama models (this will download ~21 GB on first run)..."
+# Canonical 5-brain set per server/lib/brain-config.js + CLAUDE.md, tuned
+# for the RTX PRO 4500 Blackwell (32GB GDDR7). Total weight on first
+# download ~15 GB; subsequent runs are no-ops because ollama pull is
+# idempotent.
+info "Pulling required Ollama models (this will download ~15 GB on first run)..."
 
 MODELS=(
-  "qwen2.5:14b-instruct-q4_K_M"   # Conscious brain       (~9 GB)
-  "qwen2.5:7b-instruct-q4_K_M"    # Subconscious brain    (~5 GB)
-  "qwen2.5:3b"                     # Utility brain         (~2 GB)
-  "llava:7b"                       # Vision                (~5 GB)
-  "nomic-embed-text"               # Embeddings           (~275 MB)
+  "qwen2.5:7b-instruct-q4_K_M"        # Subconscious brain    (~4 GB) — also base for concord-conscious below
+  "qwen2.5:3b"                         # Utility brain         (~2 GB)
+  "qwen2.5:0.5b"                       # Repair brain          (~0.3 GB)
+  "llava:13b-v1.6-vicuna-q4_K_M"       # Vision / multimodal   (~8 GB)
+  "nomic-embed-text"                   # Embeddings            (~275 MB)
 )
 
 for model in "${MODELS[@]}"; do
@@ -87,6 +91,23 @@ for model in "${MODELS[@]}"; do
     warn "Failed to pull ${model} — you can retry later with: ollama pull ${model}"
   fi
 done
+
+# ── 7b. Build concord-conscious from Modelfile ────────────────────────────
+# concord-conscious:latest is NOT on the Ollama registry — it's a custom
+# model built locally from the Modelfile in the repo root. Without this
+# step the Conscious brain stays offline forever (initFiveBrains'
+# auto-pull fallback 404s because the registry doesn't have it).
+# `ollama create` is idempotent — safe to re-run on every setup.
+if [ -f "${ROOT_DIR}/Modelfile" ]; then
+  info "Building concord-conscious:latest from Modelfile..."
+  if ollama create concord-conscious:latest -f "${ROOT_DIR}/Modelfile"; then
+    ok "Built concord-conscious:latest"
+  else
+    warn "Failed to build concord-conscious — fix Modelfile then run: ollama create concord-conscious:latest -f Modelfile"
+  fi
+else
+  warn "No Modelfile at ${ROOT_DIR}/Modelfile — the Conscious brain will be offline. Create one and run: ollama create concord-conscious:latest -f Modelfile"
+fi
 
 # ── 8. Create data directory ─────────────────────────────────────────────
 DATA_DIR="${ROOT_DIR}/data"

--- a/startup.sh
+++ b/startup.sh
@@ -151,6 +151,29 @@ if $IS_RUNPOD || [ "${1:-}" = "--runpod" ] || [ "${1:-}" = "--cloudflare" ]; the
   # Install deps if needed
   [ ! -d server/node_modules ] && { log "Installing server deps..."; (cd server && npm install --production); }
 
+  # ── Ensure concord-conscious:latest is built ─────────────────────────
+  # The conscious brain uses a custom Ollama model that can't be fetched
+  # from the registry — it's built locally from the Modelfile in the
+  # repo root. server/server.js#initFiveBrains() will try /api/pull as a
+  # fallback if missing; that pull 404s for custom models, leaving the
+  # conscious brain permanently disabled. Build it here on every boot
+  # (ollama create is idempotent + cheap if already present) so the
+  # user doesn't have to remember a separate step.
+  if [ -f Modelfile ] && command -v ollama &>/dev/null; then
+    if ! ollama list 2>/dev/null | grep -q "^concord-conscious:latest"; then
+      log "Building concord-conscious:latest from Modelfile (one-time)..."
+      if ollama create concord-conscious:latest -f Modelfile 2>>"$LOG_FILE"; then
+        log "Built concord-conscious:latest"
+      else
+        log "WARNING: ollama create failed — Conscious brain will stay offline."
+        log "         Edit Modelfile, then: ollama create concord-conscious:latest -f Modelfile"
+      fi
+    fi
+  elif [ ! -f Modelfile ]; then
+    log "WARNING: No Modelfile in repo root — Conscious brain will be offline."
+    log "         Create a Modelfile and run: ollama create concord-conscious:latest -f Modelfile"
+  fi
+
   # Build frontend if needed. NEXT_PUBLIC_* are baked into the bundle at
   # build time, so a build produced for a different public URL (e.g. switched
   # from the RunPod proxy to a Cloudflare tunnel) is stale and must be rebuilt.


### PR DESCRIPTION
## TL;DR

Fixes a four-part chain that left the Conscious brain offline on every fresh deploy.

## The chain

1. **`setup.sh` pulled the wrong models.** Old list: `qwen2.5:14b + 7b + 3b + llava:7b`. Canonical per `server/lib/brain-config.js` + `CLAUDE.md`: `qwen2.5:7b-instruct-q4_K_M + 3b + 0.5b + llava:13b-v1.6-vicuna-q4_K_M`. Two of the four pulls were unused, two needed pulls were missing.

2. **No `Modelfile` existed in the repo.** `concord-conscious:latest` is a **custom** model — it doesn't exist on the Ollama registry. Without a Modelfile, there's nothing to build.

3. **No `ollama create concord-conscious:latest -f Modelfile` step** anywhere in the bootstrap.

4. **`server.js#initFiveBrains()`'s `/api/pull` fallback can't save us.** When the Conscious brain probes and finds `concord-conscious:latest` missing, it triggers a `/api/pull` — which 404s because the registry doesn't have a custom model. The conscious brain then stays `enabled: false` for the rest of the process lifetime.

## Three changes

### 1. `Modelfile` (new, repo root)

Base: `qwen2.5:7b-instruct-q4_K_M` — same weight class as the Subconscious brain (~4GB VRAM), so `OLLAMA_MAX_LOADED_MODELS=2` from `ecosystem.config.cjs` comfortably keeps both warm on a 32GB GDDR7 card.

Includes:
- Inference params (`temperature=0.7`, `top_p=0.9`, `num_ctx=8192`)
- Stop tokens for `<|im_end|>` and `<|im_start|>user`
- A Concord-default `SYSTEM` prompt with clear operator-customize guidance

### 2. `setup.sh` — fixed model list + Modelfile build step

```diff
- "qwen2.5:14b-instruct-q4_K_M"  # Conscious brain    (~9 GB)
- "qwen2.5:7b-instruct-q4_K_M"   # Subconscious brain (~5 GB)
- "qwen2.5:3b"                    # Utility brain      (~2 GB)
- "llava:7b"                      # Vision             (~5 GB)
+ "qwen2.5:7b-instruct-q4_K_M"        # Subconscious brain + concord-conscious base
+ "qwen2.5:3b"                         # Utility brain
+ "qwen2.5:0.5b"                       # Repair brain
+ "llava:13b-v1.6-vicuna-q4_K_M"       # Vision / multimodal
  "nomic-embed-text"                   # Embeddings
```

Plus a new step that runs `ollama create concord-conscious:latest -f Modelfile` after the pulls. Idempotent.

### 3. `startup.sh --runpod` — auto-build on first boot

Before kicking PM2:
```bash
if [ -f Modelfile ] && command -v ollama; then
  if ! ollama list | grep -q "^concord-conscious:latest"; then
    ollama create concord-conscious:latest -f Modelfile
  fi
fi
```

Cheap when present (single string scan); fast enough on first boot (a few seconds on Blackwell). Means a fresh pod where the user runs `./startup.sh --runpod --cloudflare` without ever calling `setup.sh` still gets the conscious brain built.

## Effect on a fresh RunPod deploy

**Before:** all four other brains come online, but `brain_offline { brain: "conscious" }` in logs. Every `/api/chat` falls back to the subconscious brain (different persona, different reasoning depth) and the council mode silently degrades.

**After:** all five brains online. Conscious responds in the Modelfile's persona. Council mode works. `/api/lens/run` macros that route to conscious now hit the right model.

## Operator customization

The `SYSTEM` prompt in the Modelfile is a starter. Edit it to match the product voice, then rerun:

```bash
ollama create concord-conscious:latest -f Modelfile
```

No other flags change, no rebuild elsewhere needed.

## Verified

`bash -n setup.sh` and `bash -n startup.sh` both clean. Changes are scoped to bootstrap scripts + new Modelfile; no application code touched.

https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp)_