### PR TITLE
eco lens: Joro/Klima/Windy/iNaturalist parity — 6 components, 10 backend macros, weather + AQI + species ID + solar

### DIFF
--- a/concord-frontend/app/lenses/eco/page.tsx
+++ b/concord-frontend/app/lenses/eco/page.tsx
@@ -2,6 +2,13 @@
 
 import { useState, useMemo, useCallback, useRef} from 'react';
 import { LensShell } from '@/components/lens/LensShell';
+import { WeatherRadar } from '@/components/eco/WeatherRadar';
+import { AQIPanel } from '@/components/eco/AQIPanel';
+import { ClimateActions } from '@/components/eco/ClimateActions';
+import { SpeciesIdentifier } from '@/components/eco/SpeciesIdentifier';
+import { EnergyEstimator } from '@/components/eco/EnergyEstimator';
+import { BiodiversityLog } from '@/components/eco/BiodiversityLog';
+import { api } from '@/lib/api/client';
 import { ManifestActionBar } from '@/components/lens/ManifestActionBar';
 import { useLensNav } from '@/hooks/useLensNav';
 import { useLensCommand } from '@/hooks/useLensCommand';
@@ -26,7 +33,7 @@ import WeatherHero, { type WeatherPayload } from '@/components/lens/WeatherHero'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-type EcoTab = 'overview' | 'populations' | 'climate' | 'biodiversity' | 'impact';
+type EcoTab = 'overview' | 'populations' | 'climate' | 'biodiversity' | 'impact' | 'weather' | 'air' | 'actions' | 'species' | 'energy' | 'lifelist';
 
 interface PopulationEntry {
   species: string;
@@ -256,9 +263,15 @@ export default function EcoLensPage() {
 
   const tabs: { id: EcoTab; label: string; icon: React.ComponentType<{ className?: string }> }[] = [
     { id: 'overview', label: 'Overview', icon: Globe },
+    { id: 'weather', label: 'Weather', icon: Cloud },
+    { id: 'air', label: 'Air quality', icon: Wind },
+    { id: 'actions', label: 'Climate actions', icon: Leaf },
+    { id: 'species', label: 'Species ID', icon: Bug },
+    { id: 'lifelist', label: 'Life list', icon: TreeDeciduous },
+    { id: 'energy', label: 'Solar estimator', icon: Sun },
     { id: 'populations', label: 'Populations', icon: Fish },
-    { id: 'climate', label: 'Climate', icon: Thermometer },
-    { id: 'biodiversity', label: 'Biodiversity', icon: Leaf },
+    { id: 'climate', label: 'Climate sim', icon: Thermometer },
+    { id: 'biodiversity', label: 'Biodiversity sim', icon: Sprout },
     { id: 'impact', label: 'Impact', icon: AlertTriangle },
   ];
 
@@ -1221,6 +1234,39 @@ export default function EcoLensPage() {
       {activeTab === 'climate' && renderClimate()}
       {activeTab === 'biodiversity' && renderBiodiversity()}
       {activeTab === 'impact' && renderImpact()}
+      {activeTab === 'weather' && <WeatherRadar />}
+      {activeTab === 'air' && <AQIPanel />}
+      {activeTab === 'actions' && (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          <div className="lg:col-span-2">
+            <ClimateActions />
+          </div>
+          <div className="lens-card text-xs text-gray-400 space-y-2">
+            <h3 className="text-sm font-bold text-white">Why this matters</h3>
+            <p>Each action below cites real lifecycle research. The kgCO₂e saved is a per-instance estimate; the more you log, the more accurate your annual delta.</p>
+            <p>Pair with the offsets marketplace (coming) to neutralise the residual emissions you can&apos;t cut.</p>
+          </div>
+        </div>
+      )}
+      {activeTab === 'species' && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <SpeciesIdentifier
+            onAccept={async (s, imageDataUrl) => {
+              try {
+                await api.post('/api/lens/run', {
+                  domain: 'eco', action: 'biodiversity-log',
+                  input: { commonName: s.commonName, scientificName: s.scientificName, imageDataUrl, observedAt: new Date().toISOString() },
+                });
+              } catch (e) {
+                console.error('[Eco] log species failed', e);
+              }
+            }}
+          />
+          <BiodiversityLog />
+        </div>
+      )}
+      {activeTab === 'lifelist' && <BiodiversityLog />}
+      {activeTab === 'energy' && <EnergyEstimator />}
     </div>
     </LensShell>
   );

--- a/concord-frontend/components/eco/AQIPanel.tsx
+++ b/concord-frontend/components/eco/AQIPanel.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Wind, AlertCircle, Loader2, MapPin } from 'lucide-react';
+import { api } from '@/lib/api/client';
+import { cn } from '@/lib/utils';
+
+interface AQIData {
+  aqi: number;
+  pm25: number;
+  pm10: number;
+  o3: number;
+  no2: number;
+  co: number;
+  so2: number;
+  category: 'good' | 'moderate' | 'sensitive' | 'unhealthy' | 'very-unhealthy' | 'hazardous';
+  recommendation: string;
+  source: string;
+  lat: number;
+  lng: number;
+}
+
+const CATEGORY_COLORS: Record<AQIData['category'], { bg: string; text: string; label: string }> = {
+  good: { bg: 'bg-green-500/20', text: 'text-green-300', label: 'Good (0-50)' },
+  moderate: { bg: 'bg-yellow-500/20', text: 'text-yellow-300', label: 'Moderate (51-100)' },
+  sensitive: { bg: 'bg-orange-500/20', text: 'text-orange-300', label: 'Unhealthy for Sensitive (101-150)' },
+  unhealthy: { bg: 'bg-red-500/20', text: 'text-red-300', label: 'Unhealthy (151-200)' },
+  'very-unhealthy': { bg: 'bg-purple-500/20', text: 'text-purple-300', label: 'Very Unhealthy (201-300)' },
+  hazardous: { bg: 'bg-rose-500/30', text: 'text-rose-200', label: 'Hazardous (301+)' },
+};
+
+interface AQIPanelProps {
+  lat?: number;
+  lng?: number;
+}
+
+export function AQIPanel({ lat, lng }: AQIPanelProps) {
+  const [coords, setCoords] = useState<{ lat: number; lng: number } | null>(
+    lat != null && lng != null ? { lat, lng } : null
+  );
+  const [data, setData] = useState<AQIData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!coords && typeof navigator !== 'undefined' && navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        pos => setCoords({ lat: pos.coords.latitude, lng: pos.coords.longitude }),
+        () => setCoords({ lat: 37.7749, lng: -122.4194 }),
+        { maximumAge: 5 * 60 * 1000, timeout: 5000 }
+      );
+    }
+  }, [coords]);
+
+  useEffect(() => {
+    if (!coords) return;
+    setLoading(true); setError(null);
+    (async () => {
+      try {
+        const res = await api.post('/api/lens/run', {
+          domain: 'eco', action: 'aqi-current',
+          input: { lat: coords.lat, lng: coords.lng },
+        });
+        setData(res.data?.result as AQIData || null);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'fetch failed');
+      } finally { setLoading(false); }
+    })();
+  }, [coords]);
+
+  if (loading || !coords) {
+    return (
+      <div className="bg-[#0d1117] border border-lattice-border rounded-lg p-6 flex items-center justify-center text-gray-500">
+        <Loader2 className="w-5 h-5 animate-spin mr-2" /> {coords ? 'Loading air quality…' : 'Locating…'}
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="bg-[#0d1117] border border-red-500/30 rounded-lg p-4 text-red-400 text-sm">
+        AQI failed: {error || 'no data'}
+      </div>
+    );
+  }
+
+  const cat = CATEGORY_COLORS[data.category];
+
+  return (
+    <div className="bg-[#0d1117] border border-cyan-500/20 rounded-lg overflow-hidden">
+      <header className="px-4 py-2 border-b border-white/10 flex items-center gap-2">
+        <Wind className="w-4 h-4 text-cyan-400" />
+        <span className="text-xs uppercase font-semibold text-gray-300 tracking-wider">Air quality</span>
+        <span className="ml-auto text-[10px] text-gray-500 inline-flex items-center gap-1">
+          <MapPin className="w-3 h-3" /> {data.lat.toFixed(2)}, {data.lng.toFixed(2)}
+        </span>
+      </header>
+      <div className={cn('px-4 py-4 flex items-center gap-4', cat.bg)}>
+        <div>
+          <div className="text-5xl font-bold tabular-nums text-white">{Math.round(data.aqi)}</div>
+          <div className={cn('text-xs font-bold', cat.text)}>{cat.label}</div>
+        </div>
+        <p className="text-xs text-gray-300 flex-1">{data.recommendation}</p>
+      </div>
+      <div className="grid grid-cols-3 gap-2 px-4 py-3 border-t border-white/5 text-xs">
+        <PolPill label="PM2.5" value={data.pm25} unit="µg/m³" />
+        <PolPill label="PM10" value={data.pm10} unit="µg/m³" />
+        <PolPill label="O₃" value={data.o3} unit="µg/m³" />
+        <PolPill label="NO₂" value={data.no2} unit="µg/m³" />
+        <PolPill label="SO₂" value={data.so2} unit="µg/m³" />
+        <PolPill label="CO" value={data.co} unit="mg/m³" />
+      </div>
+      <footer className="px-4 py-1.5 border-t border-white/10 text-[10px] text-gray-500 flex items-center gap-2">
+        <AlertCircle className="w-3 h-3" />
+        Source: {data.source} · refresh every 5 min
+      </footer>
+    </div>
+  );
+}
+
+function PolPill({ label, value, unit }: { label: string; value: number; unit: string }) {
+  return (
+    <div className="bg-white/[0.03] rounded px-2 py-1.5">
+      <div className="text-[10px] text-gray-500">{label}</div>
+      <div className="text-sm text-white font-mono tabular-nums">{value?.toFixed(1) ?? '—'} <span className="text-[9px] text-gray-500">{unit}</span></div>
+    </div>
+  );
+}
+
+export default AQIPanel;

--- a/concord-frontend/components/eco/BiodiversityLog.tsx
+++ b/concord-frontend/components/eco/BiodiversityLog.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { TreeDeciduous, Loader2, MapPin, Calendar, X } from 'lucide-react';
+import { api } from '@/lib/api/client';
+
+export interface BioObservation {
+  id: string;
+  commonName: string;
+  scientificName: string;
+  observedAt: string;
+  lat?: number;
+  lng?: number;
+  imageDataUrl?: string;
+  notes?: string;
+}
+
+export function BiodiversityLog() {
+  const [observations, setObservations] = useState<BioObservation[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => { refresh(); }, []);
+
+  async function refresh() {
+    setLoading(true);
+    try {
+      const res = await api.post('/api/lens/run', {
+        domain: 'eco', action: 'biodiversity-list', input: { limit: 50 },
+      });
+      setObservations((res.data?.result?.observations || []) as BioObservation[]);
+    } catch (e) {
+      console.error('[BioLog] list failed', e);
+    } finally { setLoading(false); }
+  }
+
+  async function remove(id: string) {
+    try {
+      await api.post('/api/lens/run', {
+        domain: 'eco', action: 'biodiversity-delete', input: { id },
+      });
+      setObservations(prev => prev.filter(o => o.id !== id));
+    } catch (e) {
+      console.error('[BioLog] delete failed', e);
+    }
+  }
+
+  return (
+    <div className="bg-[#0d1117] border border-cyan-500/20 rounded-lg overflow-hidden">
+      <header className="px-4 py-2 border-b border-white/10 flex items-center gap-2">
+        <TreeDeciduous className="w-4 h-4 text-green-400" />
+        <span className="text-xs uppercase font-semibold text-gray-300 tracking-wider">Life list</span>
+        <span className="ml-auto text-[10px] text-gray-500">{observations.length} observation{observations.length === 1 ? '' : 's'}</span>
+      </header>
+      <div className="max-h-96 overflow-y-auto">
+        {loading ? (
+          <div className="flex items-center justify-center py-8 text-xs text-gray-500">
+            <Loader2 className="w-4 h-4 animate-spin mr-2" /> Loading…
+          </div>
+        ) : observations.length === 0 ? (
+          <div className="px-3 py-10 text-center text-xs text-gray-500">
+            <TreeDeciduous className="w-8 h-8 mx-auto mb-2 opacity-30" />
+            No species observed yet. Use the Species ID panel to identify and log.
+          </div>
+        ) : (
+          <ul className="divide-y divide-white/5">
+            {observations.map(o => (
+              <li key={o.id} className="px-3 py-2 hover:bg-white/[0.03] group">
+                <div className="flex items-start gap-3">
+                  {o.imageDataUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={o.imageDataUrl} alt={o.commonName} className="w-12 h-12 rounded object-cover border border-white/10 shrink-0" />
+                  ) : (
+                    <div className="w-12 h-12 rounded bg-green-500/10 border border-green-500/30 flex items-center justify-center shrink-0">
+                      <TreeDeciduous className="w-5 h-5 text-green-400" />
+                    </div>
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm text-white">{o.commonName}</div>
+                    <div className="text-xs italic text-gray-400">{o.scientificName}</div>
+                    <div className="flex items-center gap-3 text-[10px] text-gray-500 mt-0.5">
+                      <span className="inline-flex items-center gap-0.5">
+                        <Calendar className="w-3 h-3" /> {new Date(o.observedAt).toLocaleDateString()}
+                      </span>
+                      {o.lat != null && o.lng != null && (
+                        <span className="inline-flex items-center gap-0.5">
+                          <MapPin className="w-3 h-3" /> {o.lat.toFixed(2)}, {o.lng.toFixed(2)}
+                        </span>
+                      )}
+                    </div>
+                    {o.notes && <p className="text-[11px] text-gray-300 mt-1">{o.notes}</p>}
+                  </div>
+                  <button
+                    onClick={() => remove(o.id)}
+                    title="Remove"
+                    className="opacity-0 group-hover:opacity-100 p-1 text-gray-500 hover:text-red-400"
+                  >
+                    <X className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default BiodiversityLog;

--- a/concord-frontend/components/eco/ClimateActions.tsx
+++ b/concord-frontend/components/eco/ClimateActions.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Leaf, Plus, Check, Filter, Loader2, TrendingDown } from 'lucide-react';
+import { api } from '@/lib/api/client';
+import { cn } from '@/lib/utils';
+
+export interface ClimateAction {
+  slug: string;
+  title: string;
+  category: 'transport' | 'food' | 'home' | 'shopping' | 'advocacy' | 'energy';
+  effort: 1 | 2 | 3 | 4 | 5;
+  kgCo2eSavedPerYear: number;
+  description: string;
+  citation: string;
+}
+
+interface ClimateActionsProps {
+  onLogged?: (slug: string, kgSaved: number) => void;
+}
+
+const CATEGORIES: Array<ClimateAction['category']> = ['transport', 'food', 'home', 'shopping', 'advocacy', 'energy'];
+
+export function ClimateActions({ onLogged }: ClimateActionsProps) {
+  const [actions, setActions] = useState<ClimateAction[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [logged, setLogged] = useState<Record<string, number>>({});
+  const [filter, setFilter] = useState<ClimateAction['category'] | 'all'>('all');
+  const [effortMax, setEffortMax] = useState<number>(5);
+
+  useEffect(() => { refresh(); }, []);
+  useEffect(() => { refreshLogged(); }, []);
+
+  async function refresh() {
+    setLoading(true);
+    try {
+      const res = await api.post('/api/lens/run', {
+        domain: 'eco', action: 'climate-actions-list', input: {},
+      });
+      setActions((res.data?.result?.actions || []) as ClimateAction[]);
+    } catch (e) {
+      console.error('[Actions] list failed', e);
+    } finally { setLoading(false); }
+  }
+
+  async function refreshLogged() {
+    try {
+      const res = await api.post('/api/lens/run', {
+        domain: 'eco', action: 'climate-actions-logged', input: { sinceDays: 30 },
+      });
+      const counts: Record<string, number> = {};
+      for (const e of (res.data?.result?.entries || [])) {
+        counts[e.slug] = (counts[e.slug] || 0) + 1;
+      }
+      setLogged(counts);
+    } catch { /* best effort */ }
+  }
+
+  async function logAction(action: ClimateAction) {
+    setLogged(prev => ({ ...prev, [action.slug]: (prev[action.slug] || 0) + 1 }));
+    try {
+      await api.post('/api/lens/run', {
+        domain: 'eco', action: 'climate-actions-log',
+        input: { slug: action.slug, kgCo2eSavedThisInstance: action.kgCo2eSavedPerYear / 52 },
+      });
+      onLogged?.(action.slug, action.kgCo2eSavedPerYear / 52);
+    } catch (e) {
+      console.error('[Actions] log failed', e);
+    }
+  }
+
+  const visible = useMemo(() => {
+    return actions.filter(a => (filter === 'all' || a.category === filter) && a.effort <= effortMax);
+  }, [actions, filter, effortMax]);
+
+  const totalThisMonth = useMemo(() => {
+    let total = 0;
+    for (const a of actions) {
+      const count = logged[a.slug] || 0;
+      total += count * (a.kgCo2eSavedPerYear / 52);
+    }
+    return total;
+  }, [actions, logged]);
+
+  return (
+    <div className="bg-[#0d1117] border border-cyan-500/20 rounded-lg overflow-hidden">
+      <header className="px-4 py-2 border-b border-white/10 flex items-center gap-2">
+        <Leaf className="w-4 h-4 text-green-400" />
+        <span className="text-xs uppercase font-semibold text-gray-300 tracking-wider">Climate actions</span>
+        <span className="ml-auto text-xs text-green-300 inline-flex items-center gap-1">
+          <TrendingDown className="w-3 h-3" /> {totalThisMonth.toFixed(1)} kgCO₂e saved this month
+        </span>
+      </header>
+      <div className="px-3 py-2 border-b border-white/5 flex items-center gap-2 text-xs flex-wrap">
+        <Filter className="w-3.5 h-3.5 text-gray-500" />
+        <select
+          value={filter}
+          onChange={e => setFilter(e.target.value as ClimateAction['category'] | 'all')}
+          className="px-2 py-1 text-xs bg-lattice-deep border border-lattice-border rounded text-white"
+        >
+          <option value="all">All categories</option>
+          {CATEGORIES.map(c => <option key={c} value={c}>{c}</option>)}
+        </select>
+        <label className="ml-2 text-gray-400">Max effort:</label>
+        <input
+          type="range" min={1} max={5} value={effortMax}
+          onChange={e => setEffortMax(Number(e.target.value))}
+          className="accent-green-400 w-24"
+        />
+        <span className="text-green-300 font-mono">{effortMax}/5</span>
+      </div>
+      <div className="max-h-96 overflow-y-auto">
+        {loading ? (
+          <div className="flex items-center justify-center py-6 text-xs text-gray-500">
+            <Loader2 className="w-4 h-4 animate-spin mr-2" /> Loading…
+          </div>
+        ) : visible.length === 0 ? (
+          <div className="px-3 py-8 text-xs text-gray-500 text-center">No actions match.</div>
+        ) : (
+          <ul className="divide-y divide-white/5">
+            {visible.map(a => {
+              const count = logged[a.slug] || 0;
+              return (
+                <li key={a.slug} className="px-3 py-2 hover:bg-white/[0.03]">
+                  <div className="flex items-start gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-0.5">
+                        <span className="text-sm text-white font-medium">{a.title}</span>
+                        <span className="text-[9px] text-gray-500 uppercase">{a.category}</span>
+                        <span className="text-[9px] text-yellow-400">{'★'.repeat(a.effort)}{'☆'.repeat(5 - a.effort)}</span>
+                      </div>
+                      <p className="text-[11px] text-gray-400 mb-1">{a.description}</p>
+                      <div className="flex items-center gap-3 text-[10px]">
+                        <span className="text-green-400">~{a.kgCo2eSavedPerYear.toFixed(0)} kgCO₂e/yr saved</span>
+                        <span className="text-gray-500">· {a.citation}</span>
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => logAction(a)}
+                      className={cn(
+                        'shrink-0 inline-flex items-center gap-1 px-2.5 py-1 text-[11px] rounded',
+                        count > 0
+                          ? 'bg-green-500/20 text-green-300 border border-green-500/40'
+                          : 'bg-cyan-500 text-black font-bold hover:bg-cyan-400'
+                      )}
+                      title={count > 0 ? `Logged ${count} time${count === 1 ? '' : 's'}` : 'Log it'}
+                    >
+                      {count > 0 ? <Check className="w-3 h-3" /> : <Plus className="w-3 h-3" />}
+                      {count > 0 ? `Logged ${count}x` : 'Log it'}
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default ClimateActions;

--- a/concord-frontend/components/eco/EnergyEstimator.tsx
+++ b/concord-frontend/components/eco/EnergyEstimator.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Sun, Zap, Loader2 } from 'lucide-react';
+import { api } from '@/lib/api/client';
+
+interface EstimateResult {
+  systemKwp: number;
+  annualKwh: number;
+  monthlyKwh: number[];
+  co2AvoidedKgPerYear: number;
+  capacityFactor: number;
+  source: string;
+}
+
+export function EnergyEstimator() {
+  const [lat, setLat] = useState<number>(37.77);
+  const [lng, setLng] = useState<number>(-122.42);
+  const [systemKw, setSystemKw] = useState<number>(8);
+  const [tilt, setTilt] = useState<number>(30);
+  const [azimuth, setAzimuth] = useState<number>(180);
+  const [result, setResult] = useState<EstimateResult | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (typeof navigator !== 'undefined' && navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        pos => { setLat(pos.coords.latitude); setLng(pos.coords.longitude); },
+        () => { /* keep default */ },
+        { maximumAge: 5 * 60 * 1000, timeout: 5000 }
+      );
+    }
+  }, []);
+
+  async function estimate() {
+    setLoading(true);
+    try {
+      const res = await api.post('/api/lens/run', {
+        domain: 'eco', action: 'energy-estimate',
+        input: { lat, lng, systemKw, tilt, azimuth },
+      });
+      setResult(res.data?.result as EstimateResult || null);
+    } catch (e) {
+      console.error('[Energy] estimate failed', e);
+    } finally { setLoading(false); }
+  }
+
+  const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  const maxMonthly = result ? Math.max(...result.monthlyKwh) : 1;
+
+  return (
+    <div className="bg-[#0d1117] border border-cyan-500/20 rounded-lg overflow-hidden">
+      <header className="px-4 py-2 border-b border-white/10 flex items-center gap-2">
+        <Sun className="w-4 h-4 text-yellow-400" />
+        <span className="text-xs uppercase font-semibold text-gray-300 tracking-wider">Renewable estimator</span>
+      </header>
+      <div className="p-4 space-y-3">
+        <div className="grid grid-cols-2 gap-3 text-xs">
+          <Field label="Latitude">
+            <input type="number" step={0.01} value={lat} onChange={e => setLat(Number(e.target.value))} className="w-full px-2 py-1 bg-lattice-deep border border-lattice-border rounded text-white" />
+          </Field>
+          <Field label="Longitude">
+            <input type="number" step={0.01} value={lng} onChange={e => setLng(Number(e.target.value))} className="w-full px-2 py-1 bg-lattice-deep border border-lattice-border rounded text-white" />
+          </Field>
+          <Field label="System size (kW)">
+            <input type="number" step={0.5} value={systemKw} onChange={e => setSystemKw(Number(e.target.value))} className="w-full px-2 py-1 bg-lattice-deep border border-lattice-border rounded text-white" />
+          </Field>
+          <Field label="Tilt (°)">
+            <input type="number" step={1} value={tilt} onChange={e => setTilt(Number(e.target.value))} className="w-full px-2 py-1 bg-lattice-deep border border-lattice-border rounded text-white" />
+          </Field>
+          <Field label="Azimuth (° from N)">
+            <input type="number" step={1} value={azimuth} onChange={e => setAzimuth(Number(e.target.value))} className="w-full px-2 py-1 bg-lattice-deep border border-lattice-border rounded text-white" />
+          </Field>
+        </div>
+        <button
+          onClick={estimate}
+          disabled={loading}
+          className="w-full inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-yellow-500 text-black font-bold hover:bg-yellow-400 disabled:opacity-50"
+        >
+          {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Zap className="w-4 h-4" />}
+          Estimate production
+        </button>
+        {result && (
+          <div className="space-y-2 pt-2 border-t border-white/10">
+            <div className="grid grid-cols-3 gap-2 text-center">
+              <Stat label="Annual" value={`${result.annualKwh.toLocaleString(undefined, { maximumFractionDigits: 0 })} kWh`} accent="text-yellow-300" />
+              <Stat label="CO₂ avoided/yr" value={`${result.co2AvoidedKgPerYear.toLocaleString(undefined, { maximumFractionDigits: 0 })} kg`} accent="text-green-300" />
+              <Stat label="Capacity factor" value={`${(result.capacityFactor * 100).toFixed(0)}%`} accent="text-cyan-300" />
+            </div>
+            <div>
+              <p className="text-[10px] uppercase text-gray-500 tracking-wider mb-1">Monthly production (kWh)</p>
+              <div className="flex items-end gap-1 h-20">
+                {result.monthlyKwh.map((v, i) => (
+                  <div key={i} className="flex-1 flex flex-col items-center">
+                    <div className="bg-gradient-to-t from-yellow-500/60 to-yellow-300/40 w-full rounded-t" style={{ height: `${Math.max(4, (v / maxMonthly) * 100)}%` }} />
+                    <span className="text-[9px] text-gray-500 mt-0.5">{months[i]}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <p className="text-[10px] text-gray-500">Source: {result.source} · grid emission factor 0.4 kgCO₂/kWh (US avg).</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span className="text-[10px] uppercase tracking-wider text-gray-500 block mb-0.5">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function Stat({ label, value, accent }: { label: string; value: string; accent: string }) {
+  return (
+    <div className="bg-white/[0.03] rounded px-2 py-2">
+      <div className="text-[10px] text-gray-500">{label}</div>
+      <div className={`text-sm font-bold tabular-nums ${accent}`}>{value}</div>
+    </div>
+  );
+}
+
+export default EnergyEstimator;

--- a/concord-frontend/components/eco/SpeciesIdentifier.tsx
+++ b/concord-frontend/components/eco/SpeciesIdentifier.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { Camera, Upload, Loader2, Check, X, Star } from 'lucide-react';
+import { api } from '@/lib/api/client';
+import { cn } from '@/lib/utils';
+
+export interface SpeciesSuggestion {
+  commonName: string;
+  scientificName: string;
+  confidence: number;
+  taxonomicRank: string;
+  kingdom?: string;
+}
+
+interface SpeciesIdentifierProps {
+  onAccept?: (s: SpeciesSuggestion, imageDataUrl: string) => void;
+}
+
+export function SpeciesIdentifier({ onAccept }: SpeciesIdentifierProps) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [imageDataUrl, setImageDataUrl] = useState<string | null>(null);
+  const [suggestions, setSuggestions] = useState<SpeciesSuggestion[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [accepted, setAccepted] = useState<SpeciesSuggestion | null>(null);
+
+  function onFile(file: File) {
+    if (!file.type.startsWith('image/')) {
+      setError('Pick an image file.');
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      const url = reader.result as string;
+      setImageDataUrl(url);
+      setSuggestions([]);
+      setAccepted(null);
+      identify(url);
+    };
+    reader.readAsDataURL(file);
+  }
+
+  async function identify(dataUrl: string) {
+    setLoading(true); setError(null);
+    try {
+      const res = await api.post('/api/lens/run', {
+        domain: 'eco', action: 'species-identify',
+        input: { imageDataUrl: dataUrl },
+      });
+      const items = (res.data?.result?.suggestions || []) as SpeciesSuggestion[];
+      setSuggestions(items);
+      if (items.length === 0) setError('No species identified. Try a clearer or closer shot.');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'identify failed');
+    } finally { setLoading(false); }
+  }
+
+  function accept(s: SpeciesSuggestion) {
+    setAccepted(s);
+    if (imageDataUrl) onAccept?.(s, imageDataUrl);
+  }
+
+  function reset() {
+    setImageDataUrl(null);
+    setSuggestions([]);
+    setAccepted(null);
+    setError(null);
+  }
+
+  return (
+    <div className="bg-[#0d1117] border border-cyan-500/20 rounded-lg overflow-hidden">
+      <header className="px-4 py-2 border-b border-white/10 flex items-center gap-2">
+        <Camera className="w-4 h-4 text-green-400" />
+        <span className="text-xs uppercase font-semibold text-gray-300 tracking-wider">Species ID</span>
+        {imageDataUrl && (
+          <button
+            onClick={reset}
+            className="ml-auto p-1 text-gray-400 hover:text-white"
+            title="Reset"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        )}
+      </header>
+
+      <div className="p-4">
+        {!imageDataUrl ? (
+          <div className="flex flex-col items-center gap-3 py-8">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              capture="environment"
+              className="hidden"
+              onChange={(e) => { const f = e.target.files?.[0]; if (f) onFile(f); }}
+            />
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-green-500 text-black font-bold hover:bg-green-400"
+            >
+              <Upload className="w-4 h-4" /> Pick or capture photo
+            </button>
+            <p className="text-xs text-gray-500">
+              Powered by LLaVA vision (5th Concord brain). Snap any plant, animal, fungus, or insect.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={imageDataUrl} alt="Species candidate" className="w-full max-h-80 object-contain rounded border border-white/10" />
+            {loading && (
+              <div className="flex items-center gap-2 text-xs text-cyan-300">
+                <Loader2 className="w-4 h-4 animate-spin" /> Vision brain analysing…
+              </div>
+            )}
+            {error && <div className="text-xs text-red-400">{error}</div>}
+            {suggestions.length > 0 && (
+              <ul className="space-y-2">
+                {suggestions.slice(0, 5).map((s, i) => {
+                  const isAccepted = accepted?.scientificName === s.scientificName;
+                  return (
+                    <li key={i} className={cn(
+                      'p-3 rounded border flex items-start gap-3',
+                      isAccepted ? 'bg-green-500/10 border-green-500/40' : 'bg-white/[0.02] border-white/10'
+                    )}>
+                      <div className="flex items-center justify-center w-8 h-8 rounded-full bg-cyan-500/20 text-cyan-300 text-sm font-bold">
+                        {i + 1}
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm text-white">{s.commonName}</div>
+                        <div className="text-xs text-gray-400 italic">{s.scientificName}</div>
+                        <div className="text-[10px] text-gray-500 mt-0.5">
+                          {s.taxonomicRank}{s.kingdom ? ` · ${s.kingdom}` : ''} · {Math.round(s.confidence * 100)}% confidence
+                        </div>
+                      </div>
+                      <button
+                        onClick={() => accept(s)}
+                        disabled={isAccepted}
+                        className={cn(
+                          'shrink-0 inline-flex items-center gap-1 px-2 py-1 text-xs rounded',
+                          isAccepted
+                            ? 'bg-green-500/20 text-green-300 border border-green-500/40'
+                            : 'bg-cyan-500 text-black font-bold hover:bg-cyan-400'
+                        )}
+                      >
+                        {isAccepted ? <Check className="w-3 h-3" /> : <Star className="w-3 h-3" />}
+                        {isAccepted ? 'Logged' : 'Accept'}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default SpeciesIdentifier;

--- a/concord-frontend/components/eco/WeatherRadar.tsx
+++ b/concord-frontend/components/eco/WeatherRadar.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Cloud, CloudRain, Sun, Snowflake, Wind, Droplets, Thermometer, AlertTriangle, Loader2, MapPin } from 'lucide-react';
+import { api } from '@/lib/api/client';
+
+interface ForecastDay {
+  date: string;
+  high: number;
+  low: number;
+  precipitationMm: number;
+  precipitationProbability: number;
+  windSpeedMax: number;
+  weatherCode: number;
+  uvIndex: number;
+}
+
+interface CurrentWeather {
+  temperature: number;
+  feelsLike: number;
+  humidity: number;
+  windSpeed: number;
+  windDirection: number;
+  precipitationMm: number;
+  weatherCode: number;
+  isDay: boolean;
+}
+
+interface ForecastData {
+  current: CurrentWeather;
+  daily: ForecastDay[];
+  hourly: Array<{ time: string; temperature: number; precipitationMm: number; humidity: number }>;
+  location: { lat: number; lng: number; label?: string };
+  alerts?: Array<{ event: string; severity: string; description: string }>;
+}
+
+interface WeatherRadarProps {
+  lat?: number;
+  lng?: number;
+  locationLabel?: string;
+}
+
+const WEATHER_CODES: Record<number, { label: string; icon: typeof Sun }> = {
+  0: { label: 'Clear', icon: Sun },
+  1: { label: 'Mostly clear', icon: Sun },
+  2: { label: 'Partly cloudy', icon: Cloud },
+  3: { label: 'Overcast', icon: Cloud },
+  45: { label: 'Fog', icon: Cloud },
+  48: { label: 'Rime fog', icon: Cloud },
+  51: { label: 'Light drizzle', icon: CloudRain },
+  53: { label: 'Drizzle', icon: CloudRain },
+  55: { label: 'Heavy drizzle', icon: CloudRain },
+  61: { label: 'Light rain', icon: CloudRain },
+  63: { label: 'Rain', icon: CloudRain },
+  65: { label: 'Heavy rain', icon: CloudRain },
+  71: { label: 'Light snow', icon: Snowflake },
+  73: { label: 'Snow', icon: Snowflake },
+  75: { label: 'Heavy snow', icon: Snowflake },
+  80: { label: 'Showers', icon: CloudRain },
+  81: { label: 'Heavy showers', icon: CloudRain },
+  82: { label: 'Violent showers', icon: CloudRain },
+  95: { label: 'Thunderstorm', icon: CloudRain },
+  96: { label: 'Storm w/ hail', icon: CloudRain },
+};
+
+export function WeatherRadar({ lat, lng, locationLabel }: WeatherRadarProps) {
+  const [coords, setCoords] = useState<{ lat: number; lng: number; label?: string } | null>(
+    lat != null && lng != null ? { lat, lng, label: locationLabel } : null
+  );
+  const [data, setData] = useState<ForecastData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!coords && typeof navigator !== 'undefined' && navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        pos => setCoords({ lat: pos.coords.latitude, lng: pos.coords.longitude }),
+        () => setCoords({ lat: 37.7749, lng: -122.4194, label: 'San Francisco (default)' }),
+        { maximumAge: 5 * 60 * 1000, timeout: 5000 }
+      );
+    }
+  }, [coords]);
+
+  useEffect(() => {
+    if (!coords) return;
+    setLoading(true); setError(null);
+    (async () => {
+      try {
+        const res = await api.post('/api/lens/run', {
+          domain: 'eco', action: 'weather-forecast',
+          input: { lat: coords.lat, lng: coords.lng },
+        });
+        setData(res.data?.result as ForecastData || null);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'fetch failed');
+      } finally { setLoading(false); }
+    })();
+  }, [coords]);
+
+  if (!coords) {
+    return (
+      <div className="bg-[#0d1117] border border-lattice-border rounded-lg p-6 flex items-center justify-center text-gray-500">
+        <Loader2 className="w-5 h-5 animate-spin mr-2" /> Locating you…
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="bg-[#0d1117] border border-lattice-border rounded-lg p-6 flex items-center justify-center text-gray-500">
+        <Loader2 className="w-5 h-5 animate-spin mr-2" /> Loading forecast…
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="bg-[#0d1117] border border-red-500/30 rounded-lg p-4 text-red-400 text-sm">
+        Failed to load weather: {error || 'no data'}
+      </div>
+    );
+  }
+
+  const code = WEATHER_CODES[data.current.weatherCode] || { label: 'Unknown', icon: Cloud };
+  const CodeIcon = code.icon;
+
+  return (
+    <div className="bg-[#0d1117] border border-cyan-500/20 rounded-lg overflow-hidden">
+      <header className="px-4 py-2 border-b border-white/10 flex items-center gap-2">
+        <CloudRain className="w-4 h-4 text-cyan-400" />
+        <span className="text-xs uppercase font-semibold text-gray-300 tracking-wider">Weather forecast</span>
+        <span className="ml-auto text-[10px] text-gray-500 inline-flex items-center gap-1">
+          <MapPin className="w-3 h-3" /> {data.location.label || `${data.location.lat.toFixed(3)}, ${data.location.lng.toFixed(3)}`}
+        </span>
+      </header>
+
+      {data.alerts && data.alerts.length > 0 && (
+        <div className="px-4 py-2 bg-yellow-500/10 border-b border-yellow-500/30 space-y-1">
+          {data.alerts.slice(0, 3).map((a, i) => (
+            <div key={i} className="text-xs text-yellow-300 flex items-start gap-2">
+              <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+              <div>
+                <span className="font-bold">{a.event}</span> — {a.description}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="px-4 py-4 flex items-start gap-4 border-b border-white/5">
+        <div className="flex-1 flex items-center gap-3">
+          <CodeIcon className="w-14 h-14 text-cyan-300" />
+          <div>
+            <div className="text-4xl font-bold text-white tabular-nums">{Math.round(data.current.temperature)}°C</div>
+            <div className="text-sm text-gray-400">{code.label}</div>
+            <div className="text-xs text-gray-500">Feels like {Math.round(data.current.feelsLike)}°C</div>
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3 text-xs text-gray-300">
+          <Pill icon={Droplets} label="Humidity" value={`${data.current.humidity}%`} />
+          <Pill icon={Wind} label="Wind" value={`${Math.round(data.current.windSpeed)} km/h`} />
+          <Pill icon={CloudRain} label="Rain" value={`${data.current.precipitationMm.toFixed(1)} mm`} />
+          <Pill icon={Thermometer} label="UV today" value={`${Math.round(data.daily[0]?.uvIndex || 0)}`} />
+        </div>
+      </div>
+
+      <div className="px-4 py-3">
+        <h3 className="text-[10px] uppercase tracking-wider text-gray-500 mb-2">7-day forecast</h3>
+        <div className="grid grid-cols-7 gap-1">
+          {data.daily.slice(0, 7).map(d => {
+            const dc = WEATHER_CODES[d.weatherCode] || { label: '', icon: Cloud };
+            const DIcon = dc.icon;
+            return (
+              <div key={d.date} className="flex flex-col items-center gap-1 py-1.5 rounded hover:bg-white/[0.04]">
+                <span className="text-[10px] text-gray-500">{new Date(d.date).toLocaleDateString(undefined, { weekday: 'short' })}</span>
+                <DIcon className="w-5 h-5 text-cyan-300" />
+                <span className="text-[10px] text-gray-300 tabular-nums">{Math.round(d.high)}°</span>
+                <span className="text-[10px] text-gray-500 tabular-nums">{Math.round(d.low)}°</span>
+                {d.precipitationProbability > 30 && (
+                  <span className="text-[9px] text-blue-300">{d.precipitationProbability}%</span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <footer className="px-4 py-1.5 border-t border-white/10 text-[10px] text-gray-500">
+        Source: Open-Meteo · refreshed at {new Date().toLocaleTimeString()}
+      </footer>
+    </div>
+  );
+}
+
+function Pill({ icon: Icon, label, value }: { icon: typeof Sun; label: string; value: string }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <Icon className="w-3.5 h-3.5 text-cyan-400" />
+      <span className="text-gray-500">{label}:</span>
+      <span className="text-white tabular-nums">{value}</span>
+    </div>
+  );
+}
+
+export default WeatherRadar;

--- a/server/domains/eco.js
+++ b/server/domains/eco.js
@@ -482,4 +482,413 @@ export default function registerEcoActions(registerLensAction) {
       },
     };
   });
+
+  // ─── Parity-sprint macros: Joro / Klima / Windy / iNaturalist / NREL ───
+
+  function getEcoState() {
+    const STATE = globalThis._concordSTATE;
+    if (!STATE) return null;
+    if (!STATE.ecoLens) {
+      STATE.ecoLens = {
+        biodiversity: new Map(),  // userId → observation[]
+        actionLog: new Map(),     // userId → entry[]
+      };
+    }
+    return STATE.ecoLens;
+  }
+
+  /**
+   * weather-forecast — Open-Meteo (no API key) current + daily + hourly + alerts.
+   * params: { lat, lng }
+   */
+  registerLensAction("eco", "weather-forecast", async (_ctx, _artifact, params = {}) => {
+    const lat = Number(params.lat);
+    const lng = Number(params.lng);
+    if (!isFinite(lat) || !isFinite(lng)) return { ok: false, error: "lat, lng required" };
+    try {
+      const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lng}&current=temperature_2m,relative_humidity_2m,apparent_temperature,is_day,precipitation,weather_code,wind_speed_10m,wind_direction_10m&hourly=temperature_2m,precipitation,relative_humidity_2m&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_sum,precipitation_probability_max,wind_speed_10m_max,uv_index_max&forecast_days=7&timezone=auto`;
+      const r = await safeFetchJson(url);
+      const daily = (r.daily?.time || []).map((d, i) => ({
+        date: d,
+        high: r.daily.temperature_2m_max[i],
+        low: r.daily.temperature_2m_min[i],
+        precipitationMm: r.daily.precipitation_sum[i] || 0,
+        precipitationProbability: r.daily.precipitation_probability_max?.[i] || 0,
+        windSpeedMax: r.daily.wind_speed_10m_max[i],
+        weatherCode: r.daily.weather_code[i],
+        uvIndex: r.daily.uv_index_max?.[i] || 0,
+      }));
+      const hourly = (r.hourly?.time || []).slice(0, 24).map((t, i) => ({
+        time: t,
+        temperature: r.hourly.temperature_2m[i],
+        precipitationMm: r.hourly.precipitation[i] || 0,
+        humidity: r.hourly.relative_humidity_2m[i] || 0,
+      }));
+      return {
+        ok: true,
+        result: {
+          current: {
+            temperature: r.current.temperature_2m,
+            feelsLike: r.current.apparent_temperature,
+            humidity: r.current.relative_humidity_2m,
+            windSpeed: r.current.wind_speed_10m,
+            windDirection: r.current.wind_direction_10m,
+            precipitationMm: r.current.precipitation || 0,
+            weatherCode: r.current.weather_code,
+            isDay: r.current.is_day === 1,
+          },
+          daily, hourly,
+          location: { lat, lng },
+          alerts: [],
+        },
+      };
+    } catch (e) {
+      return {
+        ok: true,
+        result: synthesizeWeatherFallback(lat, lng, e),
+      };
+    }
+  });
+
+  /**
+   * aqi-current — Open-Meteo Air Quality (no API key) — PM2.5/PM10/O3/NO2/CO/SO2 + US AQI.
+   */
+  registerLensAction("eco", "aqi-current", async (_ctx, _artifact, params = {}) => {
+    const lat = Number(params.lat);
+    const lng = Number(params.lng);
+    if (!isFinite(lat) || !isFinite(lng)) return { ok: false, error: "lat, lng required" };
+    try {
+      const url = `https://air-quality-api.open-meteo.com/v1/air-quality?latitude=${lat}&longitude=${lng}&current=us_aqi,pm10,pm2_5,carbon_monoxide,nitrogen_dioxide,sulphur_dioxide,ozone`;
+      const r = await safeFetchJson(url);
+      const cur = r.current || {};
+      const aqi = Number(cur.us_aqi) || 0;
+      const cat = categoriseAqi(aqi);
+      return {
+        ok: true,
+        result: {
+          aqi,
+          pm25: Number(cur.pm2_5) || 0,
+          pm10: Number(cur.pm10) || 0,
+          o3: Number(cur.ozone) || 0,
+          no2: Number(cur.nitrogen_dioxide) || 0,
+          co: (Number(cur.carbon_monoxide) || 0) / 1000,
+          so2: Number(cur.sulphur_dioxide) || 0,
+          category: cat.key,
+          recommendation: cat.recommendation,
+          source: "Open-Meteo Air Quality",
+          lat, lng,
+        },
+      };
+    } catch (e) {
+      const fallback = 42;
+      return {
+        ok: true,
+        result: {
+          aqi: fallback, pm25: 8, pm10: 14, o3: 60, no2: 12, co: 0.4, so2: 2,
+          category: 'good', recommendation: "Air quality good (fallback estimate).",
+          source: `fallback (${e?.message || 'network unavailable'})`,
+          lat, lng,
+        },
+      };
+    }
+  });
+
+  /**
+   * climate-actions-list — curated library of high-impact climate actions
+   * (per Project Drawdown + IPCC AR6 mitigation), each as a slug with
+   * effort 1-5 + kgCO2e saved per year + citation.
+   */
+  registerLensAction("eco", "climate-actions-list", (_ctx, _artifact, _params = {}) => {
+    return { ok: true, result: { actions: CLIMATE_ACTIONS_LIBRARY, count: CLIMATE_ACTIONS_LIBRARY.length } };
+  });
+
+  /**
+   * climate-actions-log — record one instance of an action.
+   * params: { slug, kgCo2eSavedThisInstance? }
+   */
+  registerLensAction("eco", "climate-actions-log", (ctx, _artifact, params = {}) => {
+    const state = getEcoState();
+    if (!state) return { ok: false, error: "STATE unavailable" };
+    const slug = String(params.slug || "");
+    if (!slug) return { ok: false, error: "slug required" };
+    const userId = ctx?.actor?.userId || ctx?.userId || "anon";
+    const action = CLIMATE_ACTIONS_LIBRARY.find(a => a.slug === slug);
+    if (!action) return { ok: false, error: "unknown action slug" };
+    const kgSaved = Number(params.kgCo2eSavedThisInstance) || (action.kgCo2eSavedPerYear / 52);
+    if (!state.actionLog.has(userId)) state.actionLog.set(userId, []);
+    const entry = {
+      id: `act_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+      slug, kgSaved, at: new Date().toISOString(),
+    };
+    state.actionLog.get(userId).push(entry);
+    if (typeof globalThis._concordSaveStateDebounced === "function") {
+      try { globalThis._concordSaveStateDebounced(); } catch (_e) { /* best effort */ }
+    }
+    return { ok: true, result: { entry } };
+  });
+
+  /**
+   * climate-actions-logged — list recent action log entries for the user.
+   */
+  registerLensAction("eco", "climate-actions-logged", (ctx, _artifact, params = {}) => {
+    const state = getEcoState();
+    if (!state) return { ok: false, error: "STATE unavailable" };
+    const userId = ctx?.actor?.userId || ctx?.userId || "anon";
+    const sinceDays = Math.max(1, Math.min(365, Number(params.sinceDays) || 30));
+    const cutoff = Date.now() - sinceDays * 86400000;
+    const entries = (state.actionLog.get(userId) || []).filter(e => new Date(e.at).getTime() >= cutoff);
+    const totalKgSaved = entries.reduce((s, e) => s + (e.kgSaved || 0), 0);
+    return { ok: true, result: { entries, totalKgSaved, sinceDays } };
+  });
+
+  /**
+   * species-identify — LLaVA vision identification of an organism photo.
+   * params: { imageDataUrl } — accepts data URL or raw base64
+   * Returns: { suggestions: [{ commonName, scientificName, confidence, taxonomicRank, kingdom }] }
+   */
+  registerLensAction("eco", "species-identify", async (_ctx, _artifact, params = {}) => {
+    const dataUrl = String(params.imageDataUrl || "");
+    if (!dataUrl) return { ok: false, error: "imageDataUrl required" };
+    const imageB64 = dataUrl.startsWith("data:") ? dataUrl.split(",")[1] : dataUrl;
+    if (!imageB64) return { ok: false, error: "could not decode image" };
+    try {
+      const { callVision } = await import("../lib/vision-inference.js");
+      const prompt = `You are a biologist identifying organisms from photos. Look at this image and return JSON only — no prose, no markdown:
+{"suggestions":[
+  {"commonName":"...", "scientificName":"...", "confidence":0.85, "taxonomicRank":"species|genus|family|order|class|phylum|kingdom", "kingdom":"Plantae|Animalia|Fungi|Bacteria|Archaea|Protista"},
+  ... up to 5 candidates ordered by confidence
+]}
+If unsure, fall back to coarser ranks. Always include at least one suggestion even if low confidence.`;
+      const out = await callVision(imageB64, prompt, { temperature: 0.1, max_tokens: 512 });
+      const text = String(out?.text || out?.content || out?.response || "").trim();
+      const parsed = extractJson(text);
+      const suggestions = Array.isArray(parsed?.suggestions) ? parsed.suggestions.slice(0, 5).map(s => ({
+        commonName: String(s.commonName || s.common_name || "Unknown"),
+        scientificName: String(s.scientificName || s.scientific_name || ""),
+        confidence: clamp01(Number(s.confidence) || 0.5),
+        taxonomicRank: String(s.taxonomicRank || s.taxonomic_rank || "species"),
+        kingdom: s.kingdom ? String(s.kingdom) : undefined,
+      })) : [];
+      return { ok: true, result: { suggestions, source: "llava-vision", raw: text.slice(0, 200) } };
+    } catch (e) {
+      return {
+        ok: true,
+        result: {
+          suggestions: [
+            { commonName: "Vision brain unavailable", scientificName: "—", confidence: 0, taxonomicRank: "kingdom" },
+          ],
+          source: "fallback",
+          error: e instanceof Error ? e.message : "vision call failed",
+        },
+      };
+    }
+  });
+
+  /**
+   * energy-estimate — Deterministic solar PV production estimate.
+   * Uses a simplified PVWatts-like model: irradiance × system size × derate.
+   * Defaults to a global solar resource of ~4.5 kWh/m²/day, modulated by
+   * latitude (cosine of |lat-23.5|°), tilt match, and azimuth deviation.
+   * params: { lat, lng, systemKw, tilt?, azimuth? }
+   */
+  registerLensAction("eco", "energy-estimate", (_ctx, _artifact, params = {}) => {
+    const lat = Number(params.lat) || 0;
+    const lng = Number(params.lng) || 0;
+    const systemKw = Math.max(0.1, Number(params.systemKw) || 5);
+    const tilt = Math.min(89, Math.max(0, Number(params.tilt) || 30));
+    const azimuth = params.azimuth != null ? Number(params.azimuth) : 180;
+
+    // Baseline daily insolation (kWh/m²/day) — NREL average for the US is
+    // ~4.5; we modulate by absolute latitude (higher = lower) and seasonal
+    // monthly factor.
+    const baseGHI = 4.5;
+    const absLat = Math.abs(lat);
+    const latFactor = Math.cos((Math.PI / 180) * Math.max(0, absLat - 23.5)) * 0.5 + 0.6; // 0.6–1.1 range
+    const optimalTilt = absLat;
+    const tiltDeltaPenalty = 1 - 0.005 * Math.abs(tilt - optimalTilt);
+    const azDeviation = Math.min(180, Math.abs(((lat >= 0 ? 180 : 0) - azimuth) % 360));
+    const azPenalty = 1 - Math.min(0.4, (azDeviation / 180) * 0.5);
+    const derate = 0.85; // system losses
+
+    // Monthly distribution: simple sinusoidal seasonality keyed by hemisphere
+    const monthlyKwh = [];
+    for (let m = 0; m < 12; m++) {
+      const seasonal = lat >= 0
+        ? 0.85 + 0.35 * Math.cos((m - 6) * Math.PI / 6) // peak summer (Jun = m=5)
+        : 0.85 + 0.35 * Math.cos((m - 0) * Math.PI / 6); // S-hemisphere offset
+      const daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][m];
+      const kwh = baseGHI * latFactor * tiltDeltaPenalty * azPenalty * derate * seasonal * systemKw * daysInMonth;
+      monthlyKwh.push(Math.max(0, kwh));
+    }
+    const annualKwh = monthlyKwh.reduce((s, k) => s + k, 0);
+    const capacityFactor = annualKwh / (systemKw * 8760);
+    const co2AvoidedKgPerYear = annualKwh * 0.4; // US avg grid 0.4 kgCO2/kWh
+
+    return {
+      ok: true,
+      result: {
+        systemKwp: systemKw,
+        annualKwh: Math.round(annualKwh),
+        monthlyKwh: monthlyKwh.map(v => Math.round(v)),
+        co2AvoidedKgPerYear: Math.round(co2AvoidedKgPerYear),
+        capacityFactor,
+        source: "concord-pvmodel (NREL-derived constants, deterministic)",
+        location: { lat, lng },
+      },
+    };
+  });
+
+  /**
+   * biodiversity-log / list / delete — Personal life list of species observations.
+   */
+  registerLensAction("eco", "biodiversity-log", (ctx, _artifact, params = {}) => {
+    const state = getEcoState();
+    if (!state) return { ok: false, error: "STATE unavailable" };
+    const userId = ctx?.actor?.userId || ctx?.userId || "anon";
+    const commonName = String(params.commonName || "").trim();
+    const scientificName = String(params.scientificName || "").trim();
+    if (!commonName) return { ok: false, error: "commonName required" };
+    if (!state.biodiversity.has(userId)) state.biodiversity.set(userId, []);
+    const entry = {
+      id: `obs_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+      commonName, scientificName,
+      observedAt: params.observedAt || new Date().toISOString(),
+      lat: params.lat != null ? Number(params.lat) : undefined,
+      lng: params.lng != null ? Number(params.lng) : undefined,
+      imageDataUrl: params.imageDataUrl ? String(params.imageDataUrl).slice(0, 500_000) : undefined,
+      notes: params.notes ? String(params.notes).slice(0, 1000) : undefined,
+    };
+    state.biodiversity.get(userId).push(entry);
+    if (typeof globalThis._concordSaveStateDebounced === "function") {
+      try { globalThis._concordSaveStateDebounced(); } catch (_e) { /* best effort */ }
+    }
+    return { ok: true, result: { entry } };
+  });
+
+  registerLensAction("eco", "biodiversity-list", (ctx, _artifact, params = {}) => {
+    const state = getEcoState();
+    if (!state) return { ok: false, error: "STATE unavailable" };
+    const userId = ctx?.actor?.userId || ctx?.userId || "anon";
+    const limit = Math.min(200, Math.max(1, Number(params.limit) || 50));
+    const all = state.biodiversity.get(userId) || [];
+    const observations = [...all].reverse().slice(0, limit);
+    return { ok: true, result: { observations, total: all.length } };
+  });
+
+  registerLensAction("eco", "biodiversity-delete", (ctx, _artifact, params = {}) => {
+    const state = getEcoState();
+    if (!state) return { ok: false, error: "STATE unavailable" };
+    const userId = ctx?.actor?.userId || ctx?.userId || "anon";
+    const id = String(params.id || "");
+    const list = state.biodiversity.get(userId) || [];
+    const idx = list.findIndex(o => o.id === id);
+    if (idx < 0) return { ok: false, error: "observation not found" };
+    list.splice(idx, 1);
+    if (typeof globalThis._concordSaveStateDebounced === "function") {
+      try { globalThis._concordSaveStateDebounced(); } catch (_e) { /* best effort */ }
+    }
+    return { ok: true, result: { id, deleted: true } };
+  });
 }
+
+// ─── helpers ─────────────────────────────────────────────────────────────
+
+async function safeFetchJson(url) {
+  if (typeof fetch !== "function") throw new Error("fetch unavailable");
+  const ac = new AbortController();
+  const t = setTimeout(() => ac.abort(), 6000);
+  try {
+    const r = await fetch(url, { signal: ac.signal, headers: { "user-agent": "ConcordEcoLens/1.0" } });
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    return await r.json();
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function categoriseAqi(aqi) {
+  if (aqi <= 50) return { key: "good", recommendation: "Air quality is good. Outdoor activities encouraged." };
+  if (aqi <= 100) return { key: "moderate", recommendation: "Acceptable. Unusually sensitive people should consider reducing prolonged outdoor exertion." };
+  if (aqi <= 150) return { key: "sensitive", recommendation: "People with lung/heart conditions, older adults, and children should reduce prolonged outdoor exertion." };
+  if (aqi <= 200) return { key: "unhealthy", recommendation: "Everyone may begin to experience health effects; sensitive groups more serious." };
+  if (aqi <= 300) return { key: "very-unhealthy", recommendation: "Health alert: everyone may experience more serious health effects. Limit outdoor activity." };
+  return { key: "hazardous", recommendation: "Health warning of emergency conditions: the entire population is more likely to be affected. Stay indoors." };
+}
+
+function clamp01(n) { return Math.max(0, Math.min(1, n)); }
+
+function extractJson(text) {
+  if (!text) return null;
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+  const body = fence ? fence[1] : text;
+  const first = body.indexOf("{");
+  const last = body.lastIndexOf("}");
+  if (first < 0 || last <= first) return null;
+  try { return JSON.parse(body.slice(first, last + 1)); } catch { return null; }
+}
+
+function synthesizeWeatherFallback(lat, lng, err) {
+  // Deterministic-ish synthetic week so the UI stays useful when Open-Meteo unreachable
+  const seasonAmp = 10;
+  const base = 18 - Math.abs(lat) * 0.3;
+  const daily = Array.from({ length: 7 }, (_, i) => ({
+    date: new Date(Date.now() + i * 86400000).toISOString().slice(0, 10),
+    high: base + 8 + Math.sin(i / 2) * seasonAmp / 2,
+    low: base - 2 + Math.sin(i / 2) * seasonAmp / 2,
+    precipitationMm: i % 3 === 0 ? 2.5 : 0,
+    precipitationProbability: i % 3 === 0 ? 60 : 10,
+    windSpeedMax: 18 + i,
+    weatherCode: i % 3 === 0 ? 61 : i % 2 === 0 ? 2 : 0,
+    uvIndex: 5,
+  }));
+  return {
+    current: {
+      temperature: base + 5, feelsLike: base + 4, humidity: 60,
+      windSpeed: 12, windDirection: 270, precipitationMm: 0,
+      weatherCode: 1, isDay: true,
+    },
+    daily,
+    hourly: Array.from({ length: 24 }, (_, i) => ({
+      time: new Date(Date.now() + i * 3600000).toISOString(),
+      temperature: base + 3 + Math.sin(i / 4) * 3,
+      precipitationMm: 0,
+      humidity: 60,
+    })),
+    location: { lat, lng, label: "fallback" },
+    alerts: [],
+    error: err instanceof Error ? err.message : String(err),
+  };
+}
+
+const CLIMATE_ACTIONS_LIBRARY = [
+  // Transport
+  { slug: "bike-commute-week", title: "Bike to work for a week (vs car)", category: "transport", effort: 3, kgCo2eSavedPerYear: 380, description: "Replacing a 10 km daily round-trip car commute with a bike for a year saves ~380 kgCO₂e.", citation: "EPA emission factor (passenger car 171 gCO₂e/km)" },
+  { slug: "skip-flight-domestic", title: "Skip one domestic flight (replace w/ train)", category: "transport", effort: 4, kgCo2eSavedPerYear: 250, description: "A typical 1000-km domestic flight emits ~250 kgCO₂e per passenger. Train averages ~40 kg.", citation: "DEFRA 2024 transport conversion factors" },
+  { slug: "public-transit-month", title: "Use public transit for a month", category: "transport", effort: 2, kgCo2eSavedPerYear: 200, description: "Replacing car commute with bus/train for a month saves ~200 kg over a year if continued.", citation: "EPA fast-facts" },
+  { slug: "ev-switch", title: "Switch primary car to EV", category: "transport", effort: 5, kgCo2eSavedPerYear: 2700, description: "Average ICE → EV switch saves ~2.7 tCO₂e/year on a US grid mix.", citation: "Carbon Brief 2024 EV lifecycle study" },
+
+  // Food
+  { slug: "veggie-day", title: "One veggie day per week", category: "food", effort: 2, kgCo2eSavedPerYear: 120, description: "Swapping one beef-based meal for plant-based weekly saves ~120 kgCO₂e/year.", citation: "Poore & Nemecek (Science 2018)" },
+  { slug: "no-beef-month", title: "Cut beef for a month", category: "food", effort: 4, kgCo2eSavedPerYear: 540, description: "Beef is 27 kgCO₂e/kg; cutting it for 30 days saves ~540 kg if you'd normally eat 2 kg/week.", citation: "Poore & Nemecek (2018)" },
+  { slug: "compost-organics", title: "Compost food waste", category: "food", effort: 2, kgCo2eSavedPerYear: 220, description: "Diverting ~150 kg/yr of food waste from landfill prevents ~220 kgCO₂e of methane.", citation: "EPA WARM model" },
+  { slug: "buy-local-seasonal", title: "Shop seasonal & local produce", category: "food", effort: 1, kgCo2eSavedPerYear: 90, description: "Reduces shipping + cold-storage emissions by ~90 kg/year for a household of 2.", citation: "Drawdown #3" },
+
+  // Home / energy
+  { slug: "led-retrofit", title: "Retrofit all home lights to LED", category: "home", effort: 2, kgCo2eSavedPerYear: 300, description: "LEDs use 75% less energy; an average household saves ~300 kg CO₂e/year.", citation: "DOE Energy Saver" },
+  { slug: "smart-thermostat", title: "Install a smart thermostat", category: "home", effort: 2, kgCo2eSavedPerYear: 470, description: "Programmable + smart thermostats cut HVAC use ~10–15% (~470 kgCO₂e/year US avg).", citation: "Nest energy savings study" },
+  { slug: "lower-thermostat-2c", title: "Lower thermostat 2°C in winter", category: "home", effort: 1, kgCo2eSavedPerYear: 350, description: "Each 1°C reduction trims ~7% off heating use; 2°C ≈ ~350 kgCO₂e in a typical home.", citation: "Carbon Trust" },
+  { slug: "cold-wash-laundry", title: "Wash laundry in cold water", category: "home", effort: 1, kgCo2eSavedPerYear: 100, description: "Hot water heating dominates a wash cycle. ~100 kgCO₂e saved per household/year.", citation: "Cold Water Saves" },
+  { slug: "rooftop-solar", title: "Install rooftop solar", category: "energy", effort: 5, kgCo2eSavedPerYear: 3200, description: "Average 8 kW residential system offsets ~3.2 tCO₂e/year against the US grid mix.", citation: "NREL PVWatts" },
+  { slug: "switch-renewable-electricity", title: "Switch to renewable electricity plan", category: "energy", effort: 1, kgCo2eSavedPerYear: 1500, description: "Average US household uses ~10,500 kWh/yr; switching to 100% renewable saves ~1.5 tCO₂e.", citation: "EPA Green Power Partnership" },
+
+  // Shopping / consumer
+  { slug: "buy-secondhand", title: "Buy secondhand vs new", category: "shopping", effort: 2, kgCo2eSavedPerYear: 180, description: "Cutting 4 new clothing items/month for secondhand saves ~180 kg embodied emissions.", citation: "thredUP Resale Report 2024" },
+  { slug: "repair-vs-replace", title: "Repair appliances vs replace", category: "shopping", effort: 3, kgCo2eSavedPerYear: 240, description: "Repairing a fridge instead of replacing avoids ~240 kg manufacturing emissions.", citation: "Right to Repair coalition" },
+  { slug: "no-fast-fashion", title: "Cut fast fashion purchases", category: "shopping", effort: 2, kgCo2eSavedPerYear: 200, description: "Average wardrobe replacement is ~30 items/year × 5-10 kgCO₂e per garment.", citation: "Quantis fashion LCA" },
+
+  // Advocacy
+  { slug: "contact-representative", title: "Contact representative on climate bill", category: "advocacy", effort: 1, kgCo2eSavedPerYear: 0, description: "Symbolic per-action carbon impact ~0; structural impact much larger via policy.", citation: "Citizens' Climate Lobby" },
+  { slug: "switch-bank-fossil", title: "Move bank to a fossil-free option", category: "advocacy", effort: 3, kgCo2eSavedPerYear: 2000, description: "Average US bank account funds ~2 tCO₂e of fossil lending per $1k held; switching diverts that.", citation: "Bank.Green / Rainforest Action Network" },
+  { slug: "join-clean-energy-coop", title: "Join a community solar co-op", category: "advocacy", effort: 3, kgCo2eSavedPerYear: 1200, description: "Community solar shares offset grid electricity at scale; ~1.2 tCO₂e/share/year.", citation: "DOE Community Solar program" },
+];
+

--- a/server/tests/eco-domain-parity.test.js
+++ b/server/tests/eco-domain-parity.test.js
@@ -1,0 +1,205 @@
+// Contract tests for the eco-lens parity macros added in server/domains/eco.js.
+// Existing analytical macros (carbonFootprint, biodiversity*, sustainability*)
+// continue to work; new IDE-grade macros (weather-forecast, aqi-current,
+// climate-actions-list/log/logged, species-identify, energy-estimate,
+// biodiversity-log/list/delete) are exercised via fallback paths so the
+// suite is hermetic — no network calls reach the wire.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import registerEcoActions from "../domains/eco.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, params = {}) {
+  const fn = ACTIONS.get(`eco.${name}`);
+  assert.ok(fn, `eco.${name} not registered`);
+  return fn(ctx, { id: null, data: {}, meta: {} }, params);
+}
+
+before(() => { registerEcoActions(register); });
+
+beforeEach(() => {
+  globalThis._concordSTATE = { dtus: new Map(), ecoLens: { biodiversity: new Map(), actionLog: new Map() } };
+  globalThis._concordSaveStateDebounced = () => {};
+  globalThis.fetch = async () => { throw new Error("network disabled in tests"); };
+});
+
+const userA = "user_a";
+const userB = "user_b";
+const ctxA = { actor: { userId: userA }, userId: userA };
+const ctxB = { actor: { userId: userB }, userId: userB };
+
+describe("eco.weather-forecast", () => {
+  it("returns the deterministic fallback forecast when Open-Meteo unreachable", async () => {
+    const r = await call("weather-forecast", ctxA, { lat: 37.7, lng: -122.4 });
+    assert.equal(r.ok, true);
+    assert.ok(r.result.daily.length === 7);
+    for (const d of r.result.daily) {
+      assert.ok(typeof d.high === "number");
+      assert.ok(typeof d.low === "number");
+      assert.ok(d.high >= d.low);
+    }
+    assert.equal(r.result.location.lat, 37.7);
+  });
+
+  it("rejects missing lat/lng", async () => {
+    assert.equal((await call("weather-forecast", ctxA, {})).ok, false);
+  });
+});
+
+describe("eco.aqi-current", () => {
+  it("returns fallback AQI when network unreachable", async () => {
+    const r = await call("aqi-current", ctxA, { lat: 37.7, lng: -122.4 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.category, "good");
+    assert.ok(typeof r.result.aqi === "number");
+    assert.match(r.result.source, /fallback/);
+  });
+
+  it("rejects missing coords", async () => {
+    assert.equal((await call("aqi-current", ctxA, {})).ok, false);
+  });
+});
+
+describe("eco.climate-actions-* (list / log / logged)", () => {
+  it("list returns a curated library spanning all 6 categories", () => {
+    const r = call("climate-actions-list", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.ok(r.result.actions.length >= 15);
+    const cats = new Set(r.result.actions.map(a => a.category));
+    for (const c of ["transport", "food", "home", "shopping", "advocacy", "energy"]) {
+      assert.ok(cats.has(c), `category ${c} missing`);
+    }
+    for (const a of r.result.actions) {
+      assert.ok(a.slug && typeof a.slug === "string");
+      assert.ok(a.effort >= 1 && a.effort <= 5);
+      assert.ok(typeof a.kgCo2eSavedPerYear === "number");
+      assert.ok(a.citation);
+    }
+  });
+
+  it("log + logged round-trip scoped per user", () => {
+    const r1 = call("climate-actions-log", ctxA, { slug: "led-retrofit" });
+    assert.equal(r1.ok, true);
+    const r2 = call("climate-actions-log", ctxA, { slug: "led-retrofit" });
+    assert.equal(r2.ok, true);
+    const logged = call("climate-actions-logged", ctxA, { sinceDays: 30 });
+    assert.equal(logged.result.entries.length, 2);
+    assert.ok(logged.result.totalKgSaved > 0);
+
+    // Other user: empty
+    const otherLogged = call("climate-actions-logged", ctxB, { sinceDays: 30 });
+    assert.equal(otherLogged.result.entries.length, 0);
+  });
+
+  it("log rejects unknown slug + missing slug", () => {
+    assert.equal(call("climate-actions-log", ctxA, { slug: "" }).ok, false);
+    assert.equal(call("climate-actions-log", ctxA, { slug: "made-up-slug" }).ok, false);
+  });
+
+  it("logged sinceDays filter excludes old entries", () => {
+    const state = globalThis._concordSTATE.ecoLens;
+    state.actionLog.set(userA, [
+      { id: "old", slug: "led-retrofit", kgSaved: 1, at: new Date(Date.now() - 60 * 86400000).toISOString() },
+      { id: "new", slug: "led-retrofit", kgSaved: 2, at: new Date().toISOString() },
+    ]);
+    const r = call("climate-actions-logged", ctxA, { sinceDays: 7 });
+    assert.equal(r.result.entries.length, 1);
+    assert.equal(r.result.entries[0].id, "new");
+  });
+});
+
+describe("eco.species-identify", () => {
+  it("rejects missing imageDataUrl", async () => {
+    const r = await call("species-identify", ctxA, {});
+    assert.equal(r.ok, false);
+  });
+
+  it("returns a graceful fallback when vision call fails", async () => {
+    const r = await call("species-identify", ctxA, { imageDataUrl: "data:image/png;base64,iVBOR" });
+    assert.equal(r.ok, true);
+    // callVision may either throw (→ source=fallback) or return empty
+    // content (→ source=llava-vision, suggestions=[]). Both are valid
+    // graceful-degradation outcomes; the contract is just that ok:true.
+    assert.ok(["fallback", "llava-vision"].includes(r.result.source));
+    assert.ok(Array.isArray(r.result.suggestions));
+  });
+});
+
+describe("eco.energy-estimate", () => {
+  it("returns 12 months of production data + annual + capacity factor", () => {
+    const r = call("energy-estimate", ctxA, { lat: 37.7, lng: -122.4, systemKw: 8, tilt: 30, azimuth: 180 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.monthlyKwh.length, 12);
+    assert.ok(r.result.annualKwh > 0);
+    assert.ok(r.result.capacityFactor > 0 && r.result.capacityFactor < 1);
+    assert.ok(r.result.co2AvoidedKgPerYear > 0);
+    assert.ok(r.result.systemKwp === 8);
+  });
+
+  it("scales output with system size", () => {
+    const r4 = call("energy-estimate", ctxA, { lat: 37, lng: -122, systemKw: 4 });
+    const r8 = call("energy-estimate", ctxA, { lat: 37, lng: -122, systemKw: 8 });
+    assert.ok(r8.result.annualKwh > r4.result.annualKwh * 1.5);
+  });
+
+  it("higher absolute latitude → lower capacity factor (more or less)", () => {
+    const equator = call("energy-estimate", ctxA, { lat: 0, lng: 0, systemKw: 5 });
+    const arctic = call("energy-estimate", ctxA, { lat: 70, lng: 0, systemKw: 5 });
+    assert.ok(equator.result.annualKwh > arctic.result.annualKwh);
+  });
+
+  it("clamps system size to positive", () => {
+    const r = call("energy-estimate", ctxA, { lat: 30, lng: 0, systemKw: -5 });
+    assert.ok(r.result.systemKwp > 0);
+  });
+});
+
+describe("eco.biodiversity-log / list / delete", () => {
+  it("log creates an observation; list returns user-scoped reverse-chrono", () => {
+    const r1 = call("biodiversity-log", ctxA, { commonName: "Red-tailed Hawk", scientificName: "Buteo jamaicensis", lat: 37.7, lng: -122.4 });
+    assert.equal(r1.ok, true);
+    const r2 = call("biodiversity-log", ctxA, { commonName: "Western Scrub Jay", scientificName: "Aphelocoma californica" });
+    assert.equal(r2.ok, true);
+
+    const list = call("biodiversity-list", ctxA, { limit: 50 });
+    assert.equal(list.result.observations.length, 2);
+    // Newest first
+    assert.equal(list.result.observations[0].commonName, "Western Scrub Jay");
+
+    // Other user empty
+    const otherList = call("biodiversity-list", ctxB, {});
+    assert.equal(otherList.result.observations.length, 0);
+  });
+
+  it("delete removes an observation", () => {
+    const r = call("biodiversity-log", ctxA, { commonName: "Coyote", scientificName: "Canis latrans" });
+    const id = r.result.entry.id;
+    const del = call("biodiversity-delete", ctxA, { id });
+    assert.equal(del.ok, true);
+    assert.equal(call("biodiversity-list", ctxA, {}).result.observations.length, 0);
+  });
+
+  it("log rejects missing commonName", () => {
+    assert.equal(call("biodiversity-log", ctxA, { scientificName: "x" }).ok, false);
+  });
+
+  it("delete rejects unknown id", () => {
+    assert.equal(call("biodiversity-delete", ctxA, { id: "no-such" }).ok, false);
+  });
+});
+
+describe("regression: pre-existing analytical macros still work", () => {
+  it("carbonFootprint returns CO2 total + scope breakdown", () => {
+    const r = ACTIONS.get("eco.carbonFootprint")(ctxA, {
+      data: { activities: [
+        { category: "electricity", type: "electricity_kwh", quantity: 1000, unit: "kwh", scope: 2 },
+        { category: "transport", type: "car_km", quantity: 5000, unit: "km", scope: 1 },
+      ] },
+    }, {});
+    assert.equal(r.ok, true);
+    assert.ok(typeof r.result === "object");
+  });
+});


### PR DESCRIPTION
## Summary

Brings the eco lens to genuine 2026 parity with the top sustainability / climate apps. 6 new frontend components, 10 new backend macros, 19 contract tests, 100% hermetic (no network in tests).

## What's new

### Frontend — 6 components (~1.4k LOC)
- **WeatherRadar** — Open-Meteo current + 7-day forecast + UV index + alerts (no API key)
- **AQIPanel** — Open-Meteo Air Quality with US AQI categorisation + 6 pollutants
- **ClimateActions** — Earth Hero-style curated library w/ effort × impact pills + per-action log
- **SpeciesIdentifier** — iNaturalist-style: photo → LLaVA → 5 candidates → accept to life list
- **EnergyEstimator** — NREL PVWatts-style solar production estimator
- **BiodiversityLog** — life list grid w/ thumbnail, date, location

### Page integration (page.tsx +60 LOC)
- 6 new tabs added (total 11)
- All existing 5 sim tabs preserved

### Backend (`server/domains/eco.js` +335 LOC, 10 macros)
- `weather-forecast` — Open-Meteo `/v1/forecast` w/ synthetic fallback
- `aqi-current` — Open-Meteo Air Quality w/ US AQI categorisation
- `climate-actions-list` — 20-entry curated library spanning 6 categories
- `climate-actions-log` / `logged` — per-user log w/ sinceDays filter
- `species-identify` — LLaVA vision via `vision-inference.js`
- `energy-estimate` — deterministic PV math
- `biodiversity-log` / `list` / `delete` — per-user life list CRUD

## Tests
**19 contract tests passing**, hermetic (fetch mocked to throw):
- weather + AQI fallback paths
- climate actions: library spans 6 categories, log scoped per user, sinceDays filter, reject unknowns
- species ID: rejects missing image, graceful fallback
- energy estimate: 12 months, scales w/ system size, lat → capacity factor inverse
- biodiversity log: round-trip scoped per user, reverse-chrono, delete
- regression: carbonFootprint still green

Type-check clean. Lint clean.

## Test plan
- [ ] Open `/lenses/eco`, see 11 tabs
- [ ] Weather tab shows live current conditions + 7-day forecast
- [ ] Air quality tab shows AQI + pollutant breakdown
- [ ] Climate actions: log an action → monthly tally updates
- [ ] Species ID: pick photo → LLaVA returns candidates → accept → appears in Life list
- [ ] Solar estimator: change system size → annual kWh + monthly bars update

https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp)_