### PR TITLE
chat lens: Claude Projects / ChatGPT Projects-Tasks / Perplexity Spaces parity — projects, prompts, thread search, scheduled, branches

### DIFF
--- a/concord-frontend/app/lenses/chat/page.tsx
+++ b/concord-frontend/app/lenses/chat/page.tsx
@@ -59,6 +59,8 @@ import {
   PlayCircle,
   GitBranch,
   Key,
+  FolderOpen,
+  Clock,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { UniversalActions } from '@/components/lens/UniversalActions';
@@ -89,6 +91,10 @@ import { MessageContinuationMarker } from '@/components/chat/MessageContinuation
 import { useOracleSolve, type OracleResponseData } from '@/hooks/useOracleSolve';
 import AtlasOverlay from '@/components/chat/AtlasOverlay';
 import AtlasViewer from '@/components/chat/AtlasViewer';
+import ProjectsPanel, { type ChatProject } from '@/components/chat/ProjectsPanel';
+import PromptsLibrary from '@/components/chat/PromptsLibrary';
+import ThreadSearchOverlay from '@/components/chat/ThreadSearchOverlay';
+import ScheduledTasksPanel from '@/components/chat/ScheduledTasksPanel';
 import {
   WelcomePanel,
   ModeSelector,
@@ -576,6 +582,15 @@ export default function ChatLensPage() {
   const [toolPaletteOpen, setToolPaletteOpen] = useState(false);
   // Sprint 11 — Agent Mode panel (slide-over, isolated session).
   const [agentPanelOpen, setAgentPanelOpen] = useState(false);
+
+  // 2026 parity — Projects / Prompts / Search / Scheduled slide-overs.
+  // Parity vs Claude Projects + ChatGPT Projects + Perplexity Spaces +
+  // ChatGPT scheduled-tasks. State management mirrors systemsPanelOpen.
+  const [projectsPanelOpen, setProjectsPanelOpen] = useState(false);
+  const [promptsPanelOpen, setPromptsPanelOpen] = useState(false);
+  const [scheduledPanelOpen, setScheduledPanelOpen] = useState(false);
+  const [threadSearchOpen, setThreadSearchOpen] = useState(false);
+  const [activeProject, setActiveProject] = useState<ChatProject | null>(null);
 
   // Tool execution traces — when Concord (or the user via the palette)
   // runs a tool, the result appears inline in the thread as a trace
@@ -1629,6 +1644,8 @@ export default function ChatLensPage() {
       { id: 'tool-palette', keys: 'mod+.', description: 'Open tool palette', category: 'actions', action: () => setToolPaletteOpen(true), global: true },
       { id: 'toggle-pause', keys: 'mod+shift+p', description: 'Pause / resume Concord initiatives', category: 'actions', action: toggleInitiativesPaused, global: true },
       { id: 'global-search', keys: 'mod+shift+f', description: 'Search across all conversations', category: 'navigation', action: openGlobalSearch, global: true },
+      { id: 'thread-search', keys: 'mod+k', description: 'Open thread search overlay', category: 'navigation', action: () => setThreadSearchOpen(true), global: true },
+      { id: 'projects-panel', keys: 'mod+shift+o', description: 'Open Projects panel', category: 'navigation', action: () => setProjectsPanelOpen(true), global: true },
     ],
     { lensId: 'chat' }
   );
@@ -2870,6 +2887,50 @@ export default function ChatLensPage() {
                 <Activity className="w-3 h-3" />
                 <span>Systems</span>
               </button>
+              {/* 2026 parity — Projects, Prompts, Scheduled, Search.
+                  Parity with Claude Projects / ChatGPT Projects-Tasks /
+                  Perplexity Spaces. */}
+              <button
+                type="button"
+                onClick={() => setProjectsPanelOpen(true)}
+                className={cn(
+                  'hidden sm:inline-flex items-center gap-1.5 px-2.5 py-1 bg-lattice-bg border rounded-full text-xs transition-colors',
+                  activeProject
+                    ? 'border-cyan-500/50 text-cyan-300'
+                    : 'border-lattice-border text-gray-400 hover:text-cyan-300 hover:border-cyan-500/30',
+                )}
+                title="Projects (Claude / ChatGPT / Perplexity Spaces parity)"
+              >
+                <FolderOpen className="w-3 h-3" />
+                <span>{activeProject ? activeProject.name.slice(0, 14) : 'Projects'}</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setPromptsPanelOpen(true)}
+                className="hidden sm:inline-flex items-center gap-1.5 px-2.5 py-1 bg-lattice-bg border border-lattice-border rounded-full text-xs text-gray-400 hover:text-emerald-300 hover:border-emerald-500/30 transition-colors"
+                title="Saved prompt library"
+              >
+                <BookOpen className="w-3 h-3" />
+                <span>Prompts</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setScheduledPanelOpen(true)}
+                className="hidden sm:inline-flex items-center gap-1.5 px-2.5 py-1 bg-lattice-bg border border-lattice-border rounded-full text-xs text-gray-400 hover:text-amber-300 hover:border-amber-500/30 transition-colors"
+                title="Scheduled tasks (recurring prompts)"
+              >
+                <Clock className="w-3 h-3" />
+                <span>Schedule</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setThreadSearchOpen(true)}
+                className="hidden sm:inline-flex items-center gap-1.5 px-2.5 py-1 bg-lattice-bg border border-lattice-border rounded-full text-xs text-gray-400 hover:text-neon-cyan hover:border-neon-cyan/30 transition-colors"
+                title="Search across all conversations (⌘K)"
+              >
+                <Search className="w-3 h-3" />
+                <span>Search</span>
+              </button>
             </div>
 
             {/* Cognitive Status Bar */}
@@ -3912,6 +3973,34 @@ export default function ChatLensPage() {
         Agent Mode
       </button>
       <AgentModePanel open={agentPanelOpen} onClose={() => setAgentPanelOpen(false)} />
+      <ProjectsPanel
+        open={projectsPanelOpen}
+        onClose={() => setProjectsPanelOpen(false)}
+        onSelectProject={(p) => setActiveProject(p)}
+        activeProjectId={activeProject?.id || null}
+      />
+      <PromptsLibrary
+        open={promptsPanelOpen}
+        onClose={() => setPromptsPanelOpen(false)}
+        onInsert={(content) => {
+          setInput((prev) => (prev ? `${prev}\n\n${content}` : content));
+          inputRef.current?.focus();
+        }}
+      />
+      <ScheduledTasksPanel
+        open={scheduledPanelOpen}
+        onClose={() => setScheduledPanelOpen(false)}
+        activeProjectId={activeProject?.id || null}
+      />
+      <ThreadSearchOverlay
+        open={threadSearchOpen}
+        onClose={() => setThreadSearchOpen(false)}
+        onSelect={(threadId) => {
+          setSelectedConversation(threadId);
+          setThreadSearchOpen(false);
+        }}
+        projectId={activeProject?.id || null}
+      />
       <div className="fixed top-4 right-20 z-30">
         <InitiativeBell />
       </div>

--- a/concord-frontend/components/chat/BranchForkButton.tsx
+++ b/concord-frontend/components/chat/BranchForkButton.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState } from 'react';
+import { GitBranch, Check, Loader2 } from 'lucide-react';
+import { api } from '@/lib/api/client';
+import { cn } from '@/lib/utils';
+
+export interface BranchSeed {
+  role: string;
+  content: string;
+  ts?: string;
+}
+
+interface Props {
+  sourceThreadId: string;
+  atMessageIdx: number;
+  messages: BranchSeed[];
+  onForked?: (branchId: string) => void;
+  className?: string;
+}
+
+export function BranchForkButton({
+  sourceThreadId,
+  atMessageIdx,
+  messages,
+  onForked,
+  className,
+}: Props) {
+  const [state, setState] = useState<'idle' | 'pending' | 'done'>('idle');
+
+  const fork = async () => {
+    if (state !== 'idle') return;
+    setState('pending');
+    try {
+      const res = await api.post('/api/lens/run', {
+        domain: 'chat',
+        action: 'branch-fork',
+        input: {
+          sourceThreadId,
+          atMessageIdx,
+          messages,
+        },
+      });
+      const result = (res.data as { result?: { branch?: { id: string } } })?.result;
+      if (result?.branch?.id) {
+        setState('done');
+        onForked?.(result.branch.id);
+        setTimeout(() => setState('idle'), 1800);
+      } else {
+        setState('idle');
+      }
+    } catch (e) {
+      console.error('[BranchForkButton] fork failed', e);
+      setState('idle');
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={fork}
+      disabled={state === 'pending'}
+      title={state === 'done' ? 'Branched' : 'Branch in new chat'}
+      aria-label="Branch in new chat from this message"
+      className={cn(
+        'inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[10px] transition',
+        state === 'done'
+          ? 'border border-emerald-500/40 bg-emerald-500/10 text-emerald-200'
+          : 'border border-white/10 text-gray-500 hover:border-cyan-500/30 hover:text-cyan-300 hover:bg-cyan-500/5',
+        className,
+      )}
+    >
+      {state === 'pending' ? (
+        <Loader2 className="w-3 h-3 animate-spin" />
+      ) : state === 'done' ? (
+        <Check className="w-3 h-3" />
+      ) : (
+        <GitBranch className="w-3 h-3" />
+      )}
+      <span>{state === 'done' ? 'Branched' : 'Branch'}</span>
+    </button>
+  );
+}
+
+export default BranchForkButton;

--- a/concord-frontend/components/chat/ProjectsPanel.tsx
+++ b/concord-frontend/components/chat/ProjectsPanel.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { FolderOpen, Plus, X, Edit3, Trash2, Loader2, Folder, Save } from 'lucide-react';
+import { api } from '@/lib/api/client';
+import { cn } from '@/lib/utils';
+
+export interface ChatProject {
+  id: string;
+  name: string;
+  systemPrompt: string;
+  attachedDtuIds: string[];
+  color: string;
+  threadIds: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSelectProject?: (project: ChatProject) => void;
+  activeProjectId?: string | null;
+}
+
+const COLORS = ['cyan', 'emerald', 'amber', 'rose', 'violet', 'sky'];
+
+export function ProjectsPanel({ open, onClose, onSelectProject, activeProjectId }: Props) {
+  const [projects, setProjects] = useState<ChatProject[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [draft, setDraft] = useState({ name: '', systemPrompt: '', color: 'cyan' });
+  const [saving, setSaving] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await api.post('/api/lens/run', {
+        domain: 'chat',
+        action: 'projects-list',
+        input: {},
+      });
+      const result = (res.data as { result?: { projects?: ChatProject[] } })?.result;
+      setProjects(result?.projects || []);
+    } catch (e) {
+      console.error('[ProjectsPanel] list failed', e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) refresh();
+  }, [open, refresh]);
+
+  const startEdit = (p: ChatProject) => {
+    setEditingId(p.id);
+    setCreating(false);
+    setDraft({ name: p.name, systemPrompt: p.systemPrompt, color: p.color });
+  };
+
+  const startCreate = () => {
+    setCreating(true);
+    setEditingId(null);
+    setDraft({ name: '', systemPrompt: '', color: 'cyan' });
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setCreating(false);
+    setDraft({ name: '', systemPrompt: '', color: 'cyan' });
+  };
+
+  const save = async () => {
+    if (!draft.name.trim()) return;
+    setSaving(true);
+    try {
+      if (creating) {
+        await api.post('/api/lens/run', {
+          domain: 'chat',
+          action: 'project-create',
+          input: draft,
+        });
+      } else if (editingId) {
+        await api.post('/api/lens/run', {
+          domain: 'chat',
+          action: 'project-update',
+          input: { id: editingId, ...draft },
+        });
+      }
+      cancelEdit();
+      await refresh();
+    } catch (e) {
+      console.error('[ProjectsPanel] save failed', e);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async (id: string) => {
+    if (!window.confirm('Delete this project? Conversations will not be deleted.')) return;
+    try {
+      await api.post('/api/lens/run', {
+        domain: 'chat',
+        action: 'project-delete',
+        input: { id },
+      });
+      await refresh();
+    } catch (e) {
+      console.error('[ProjectsPanel] delete failed', e);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-y-0 right-0 w-[420px] max-w-[100vw] z-40 bg-[#0d1117] border-l border-cyan-500/20 shadow-2xl overflow-hidden flex flex-col">
+      <header className="px-4 py-3 border-b border-white/10 flex items-center justify-between bg-gradient-to-r from-cyan-950/40 to-transparent">
+        <div className="flex items-center gap-2">
+          <FolderOpen className="w-4 h-4 text-cyan-400" />
+          <span className="text-sm font-semibold text-gray-200">Projects</span>
+          <span className="text-[10px] text-gray-500 ml-1">{projects.length}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={startCreate}
+            className="inline-flex items-center gap-1 rounded-md border border-cyan-500/30 bg-cyan-500/10 px-2 py-1 text-xs text-cyan-200 hover:brightness-110"
+          >
+            <Plus className="w-3 h-3" /> New
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 rounded-md hover:bg-white/5 text-gray-400"
+            aria-label="Close projects panel"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      </header>
+
+      <div className="flex-1 overflow-y-auto p-3 space-y-2">
+        {(creating || editingId) && (
+          <div className="rounded-md border border-cyan-500/30 bg-cyan-500/5 p-3 space-y-2">
+            <input
+              type="text"
+              value={draft.name}
+              onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+              placeholder="Project name"
+              maxLength={80}
+              className="w-full px-2 py-1.5 text-sm bg-black/40 border border-white/10 rounded text-gray-100 placeholder-gray-500 focus:border-cyan-500/50 focus:outline-none"
+            />
+            <textarea
+              value={draft.systemPrompt}
+              onChange={(e) => setDraft({ ...draft, systemPrompt: e.target.value })}
+              placeholder="System prompt for this project (optional)"
+              maxLength={4000}
+              rows={4}
+              className="w-full px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 placeholder-gray-500 focus:border-cyan-500/50 focus:outline-none resize-none"
+            />
+            <div className="flex items-center gap-1.5">
+              {COLORS.map((c) => (
+                <button
+                  key={c}
+                  type="button"
+                  onClick={() => setDraft({ ...draft, color: c })}
+                  className={cn(
+                    'w-5 h-5 rounded-full border-2 transition',
+                    draft.color === c ? 'border-white scale-110' : 'border-transparent',
+                    c === 'cyan' && 'bg-cyan-500',
+                    c === 'emerald' && 'bg-emerald-500',
+                    c === 'amber' && 'bg-amber-500',
+                    c === 'rose' && 'bg-rose-500',
+                    c === 'violet' && 'bg-violet-500',
+                    c === 'sky' && 'bg-sky-500',
+                  )}
+                  aria-label={`Color ${c}`}
+                />
+              ))}
+            </div>
+            <div className="flex items-center gap-2 pt-1">
+              <button
+                type="button"
+                onClick={save}
+                disabled={saving || !draft.name.trim()}
+                className="inline-flex items-center gap-1 rounded-md border border-cyan-500/40 bg-cyan-500/15 px-3 py-1 text-xs text-cyan-100 hover:brightness-110 disabled:opacity-40"
+              >
+                {saving ? <Loader2 className="w-3 h-3 animate-spin" /> : <Save className="w-3 h-3" />}
+                {creating ? 'Create' : 'Save'}
+              </button>
+              <button
+                type="button"
+                onClick={cancelEdit}
+                className="px-3 py-1 text-xs text-gray-400 hover:text-gray-200"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {loading ? (
+          <div className="flex items-center justify-center py-8 text-xs text-gray-500">
+            <Loader2 className="w-4 h-4 animate-spin mr-2" /> Loading projects…
+          </div>
+        ) : projects.length === 0 && !creating ? (
+          <div className="text-center py-8 px-4">
+            <Folder className="w-8 h-8 mx-auto text-gray-600 mb-2" />
+            <p className="text-xs text-gray-500">No projects yet</p>
+            <p className="text-[10px] text-gray-600 mt-1">
+              Group related chats with a shared system prompt and attached DTUs.
+            </p>
+          </div>
+        ) : (
+          projects.map((p) => (
+            <div
+              key={p.id}
+              className={cn(
+                'rounded-md border p-3 transition hover:bg-white/5',
+                activeProjectId === p.id
+                  ? 'border-cyan-500/50 bg-cyan-500/10'
+                  : 'border-white/10 bg-black/20',
+              )}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <button
+                  type="button"
+                  onClick={() => onSelectProject?.(p)}
+                  className="flex-1 text-left"
+                >
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={cn(
+                        'w-2 h-2 rounded-full',
+                        p.color === 'cyan' && 'bg-cyan-400',
+                        p.color === 'emerald' && 'bg-emerald-400',
+                        p.color === 'amber' && 'bg-amber-400',
+                        p.color === 'rose' && 'bg-rose-400',
+                        p.color === 'violet' && 'bg-violet-400',
+                        p.color === 'sky' && 'bg-sky-400',
+                      )}
+                    />
+                    <span className="text-sm font-medium text-gray-100 truncate">{p.name}</span>
+                  </div>
+                  {p.systemPrompt && (
+                    <p className="text-[11px] text-gray-500 mt-1 line-clamp-2">{p.systemPrompt}</p>
+                  )}
+                  <div className="flex items-center gap-3 mt-1.5 text-[10px] text-gray-600">
+                    <span>{p.threadIds.length} chats</span>
+                    <span>{p.attachedDtuIds.length} DTUs</span>
+                  </div>
+                </button>
+                <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    onClick={() => startEdit(p)}
+                    className="p-1 text-gray-500 hover:text-cyan-300"
+                    aria-label="Edit project"
+                  >
+                    <Edit3 className="w-3 h-3" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => remove(p.id)}
+                    className="p-1 text-gray-500 hover:text-rose-300"
+                    aria-label="Delete project"
+                  >
+                    <Trash2 className="w-3 h-3" />
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default ProjectsPanel;

--- a/concord-frontend/components/chat/PromptsLibrary.tsx
+++ b/concord-frontend/components/chat/PromptsLibrary.tsx
@@ -1,0 +1,322 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { BookOpen, Plus, X, Edit3, Trash2, Loader2, Save, Copy, Search } from 'lucide-react';
+import { api } from '@/lib/api/client';
+
+export interface SavedPrompt {
+  id: string;
+  name: string;
+  content: string;
+  tags: string[];
+  shortcut: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onInsert?: (content: string) => void;
+}
+
+export function PromptsLibrary({ open, onClose, onInsert }: Props) {
+  const [prompts, setPrompts] = useState<SavedPrompt[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [draft, setDraft] = useState({ name: '', content: '', tags: '', shortcut: '' });
+  const [saving, setSaving] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await api.post('/api/lens/run', {
+        domain: 'chat',
+        action: 'prompts-list',
+        input: {},
+      });
+      const result = (res.data as { result?: { prompts?: SavedPrompt[] } })?.result;
+      setPrompts(result?.prompts || []);
+    } catch (e) {
+      console.error('[PromptsLibrary] list failed', e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) refresh();
+  }, [open, refresh]);
+
+  const startCreate = () => {
+    setCreating(true);
+    setEditingId(null);
+    setDraft({ name: '', content: '', tags: '', shortcut: '' });
+  };
+
+  const startEdit = (p: SavedPrompt) => {
+    setEditingId(p.id);
+    setCreating(false);
+    setDraft({
+      name: p.name,
+      content: p.content,
+      tags: p.tags.join(', '),
+      shortcut: p.shortcut || '',
+    });
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setCreating(false);
+    setDraft({ name: '', content: '', tags: '', shortcut: '' });
+  };
+
+  const save = async () => {
+    if (!draft.name.trim() || !draft.content.trim()) return;
+    setSaving(true);
+    try {
+      const input = {
+        name: draft.name,
+        content: draft.content,
+        tags: draft.tags.split(',').map((t) => t.trim()).filter(Boolean),
+        shortcut: draft.shortcut.trim() || undefined,
+      };
+      if (creating) {
+        await api.post('/api/lens/run', {
+          domain: 'chat',
+          action: 'prompt-create',
+          input,
+        });
+      } else if (editingId) {
+        await api.post('/api/lens/run', {
+          domain: 'chat',
+          action: 'prompt-update',
+          input: { id: editingId, ...input },
+        });
+      }
+      cancelEdit();
+      await refresh();
+    } catch (e) {
+      console.error('[PromptsLibrary] save failed', e);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async (id: string) => {
+    if (!window.confirm('Delete this saved prompt?')) return;
+    try {
+      await api.post('/api/lens/run', {
+        domain: 'chat',
+        action: 'prompt-delete',
+        input: { id },
+      });
+      await refresh();
+    } catch (e) {
+      console.error('[PromptsLibrary] delete failed', e);
+    }
+  };
+
+  const filtered = filter
+    ? prompts.filter((p) => {
+        const q = filter.toLowerCase();
+        return (
+          p.name.toLowerCase().includes(q) ||
+          p.content.toLowerCase().includes(q) ||
+          p.tags.some((t) => t.toLowerCase().includes(q)) ||
+          (p.shortcut || '').toLowerCase().includes(q)
+        );
+      })
+    : prompts;
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-y-0 right-0 w-[460px] max-w-[100vw] z-40 bg-[#0d1117] border-l border-cyan-500/20 shadow-2xl overflow-hidden flex flex-col">
+      <header className="px-4 py-3 border-b border-white/10 flex items-center justify-between bg-gradient-to-r from-emerald-950/40 to-transparent">
+        <div className="flex items-center gap-2">
+          <BookOpen className="w-4 h-4 text-emerald-400" />
+          <span className="text-sm font-semibold text-gray-200">Saved Prompts</span>
+          <span className="text-[10px] text-gray-500 ml-1">{prompts.length}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={startCreate}
+            className="inline-flex items-center gap-1 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-xs text-emerald-200 hover:brightness-110"
+          >
+            <Plus className="w-3 h-3" /> New
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 rounded-md hover:bg-white/5 text-gray-400"
+            aria-label="Close prompts library"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      </header>
+
+      <div className="px-3 py-2 border-b border-white/10">
+        <div className="relative">
+          <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-gray-500" />
+          <input
+            type="text"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Filter by name, content, tag, or shortcut"
+            className="w-full pl-7 pr-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 placeholder-gray-500 focus:border-emerald-500/50 focus:outline-none"
+          />
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-3 space-y-2">
+        {(creating || editingId) && (
+          <div className="rounded-md border border-emerald-500/30 bg-emerald-500/5 p-3 space-y-2">
+            <input
+              type="text"
+              value={draft.name}
+              onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+              placeholder="Prompt name (e.g. 'Code review checklist')"
+              maxLength={60}
+              className="w-full px-2 py-1.5 text-sm bg-black/40 border border-white/10 rounded text-gray-100 placeholder-gray-500 focus:border-emerald-500/50 focus:outline-none"
+            />
+            <textarea
+              value={draft.content}
+              onChange={(e) => setDraft({ ...draft, content: e.target.value })}
+              placeholder="Prompt content (variables like {topic} are passed through verbatim)"
+              maxLength={8000}
+              rows={6}
+              className="w-full px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 placeholder-gray-500 focus:border-emerald-500/50 focus:outline-none resize-none font-mono"
+            />
+            <div className="grid grid-cols-2 gap-2">
+              <input
+                type="text"
+                value={draft.tags}
+                onChange={(e) => setDraft({ ...draft, tags: e.target.value })}
+                placeholder="Tags (comma-separated)"
+                className="px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 placeholder-gray-500 focus:border-emerald-500/50 focus:outline-none"
+              />
+              <input
+                type="text"
+                value={draft.shortcut}
+                onChange={(e) => setDraft({ ...draft, shortcut: e.target.value })}
+                placeholder="Shortcut (e.g. 'review')"
+                maxLength={24}
+                className="px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 placeholder-gray-500 focus:border-emerald-500/50 focus:outline-none"
+              />
+            </div>
+            <div className="flex items-center gap-2 pt-1">
+              <button
+                type="button"
+                onClick={save}
+                disabled={saving || !draft.name.trim() || !draft.content.trim()}
+                className="inline-flex items-center gap-1 rounded-md border border-emerald-500/40 bg-emerald-500/15 px-3 py-1 text-xs text-emerald-100 hover:brightness-110 disabled:opacity-40"
+              >
+                {saving ? <Loader2 className="w-3 h-3 animate-spin" /> : <Save className="w-3 h-3" />}
+                {creating ? 'Save prompt' : 'Update'}
+              </button>
+              <button
+                type="button"
+                onClick={cancelEdit}
+                className="px-3 py-1 text-xs text-gray-400 hover:text-gray-200"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {loading ? (
+          <div className="flex items-center justify-center py-8 text-xs text-gray-500">
+            <Loader2 className="w-4 h-4 animate-spin mr-2" /> Loading prompts…
+          </div>
+        ) : filtered.length === 0 && !creating ? (
+          <div className="text-center py-8 px-4">
+            <BookOpen className="w-8 h-8 mx-auto text-gray-600 mb-2" />
+            <p className="text-xs text-gray-500">
+              {prompts.length === 0 ? 'No saved prompts' : 'No matches'}
+            </p>
+            {prompts.length === 0 && (
+              <p className="text-[10px] text-gray-600 mt-1">
+                Save reusable prompt templates. Insert with one click.
+              </p>
+            )}
+          </div>
+        ) : (
+          filtered.map((p) => (
+            <div
+              key={p.id}
+              className="rounded-md border border-white/10 bg-black/20 p-3 hover:bg-white/5 transition group"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-gray-100 truncate">{p.name}</span>
+                    {p.shortcut && (
+                      <code className="text-[10px] px-1.5 py-0.5 rounded bg-emerald-500/10 border border-emerald-500/20 text-emerald-300">
+                        /{p.shortcut}
+                      </code>
+                    )}
+                  </div>
+                  <p className="text-[11px] text-gray-500 mt-1 line-clamp-2 font-mono">
+                    {p.content}
+                  </p>
+                  {p.tags.length > 0 && (
+                    <div className="flex items-center gap-1 mt-1.5 flex-wrap">
+                      {p.tags.map((t) => (
+                        <span
+                          key={t}
+                          className="text-[10px] px-1.5 py-0.5 rounded bg-white/5 text-gray-400"
+                        >
+                          {t}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <div className="flex flex-col gap-1 opacity-0 group-hover:opacity-100 transition">
+                  {onInsert && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        onInsert(p.content);
+                        onClose();
+                      }}
+                      className="p-1 text-gray-500 hover:text-emerald-300"
+                      aria-label="Insert prompt into composer"
+                      title="Insert into composer"
+                    >
+                      <Copy className="w-3 h-3" />
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => startEdit(p)}
+                    className="p-1 text-gray-500 hover:text-cyan-300"
+                    aria-label="Edit prompt"
+                  >
+                    <Edit3 className="w-3 h-3" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => remove(p.id)}
+                    className="p-1 text-gray-500 hover:text-rose-300"
+                    aria-label="Delete prompt"
+                  >
+                    <Trash2 className="w-3 h-3" />
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default PromptsLibrary;

--- a/concord-frontend/components/chat/ScheduledTasksPanel.tsx
+++ b/concord-frontend/components/chat/ScheduledTasksPanel.tsx
@@ -1,0 +1,314 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { Clock, Plus, X, Trash2, Loader2, Calendar, Repeat, Save } from 'lucide-react';
+import { api } from '@/lib/api/client';
+import { cn } from '@/lib/utils';
+
+export interface ScheduledTask {
+  id: string;
+  prompt: string;
+  runAt: string;
+  projectId: string | null;
+  recurring: 'daily' | 'weekly' | 'monthly' | null;
+  status: 'pending' | 'completed' | 'cancelled';
+  createdAt: string;
+  cancelledAt?: string;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  activeProjectId?: string | null;
+}
+
+function formatRunAt(iso: string): string {
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    month: 'short', day: 'numeric',
+    hour: 'numeric', minute: '2-digit',
+  });
+}
+
+function timeUntil(iso: string): string {
+  const ms = new Date(iso).getTime() - Date.now();
+  if (!Number.isFinite(ms)) return '';
+  if (ms <= 0) return 'overdue';
+  const m = Math.floor(ms / 60_000);
+  if (m < 60) return `in ${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `in ${h}h`;
+  const d = Math.floor(h / 24);
+  return `in ${d}d`;
+}
+
+export function ScheduledTasksPanel({ open, onClose, activeProjectId }: Props) {
+  const [tasks, setTasks] = useState<ScheduledTask[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [draft, setDraft] = useState<{
+    prompt: string;
+    runAt: string;
+    recurring: '' | 'daily' | 'weekly' | 'monthly';
+  }>({ prompt: '', runAt: '', recurring: '' });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await api.post('/api/lens/run', {
+        domain: 'chat',
+        action: 'scheduled-list',
+        input: {},
+      });
+      const result = (res.data as { result?: { tasks?: ScheduledTask[] } })?.result;
+      setTasks(result?.tasks || []);
+    } catch (e) {
+      console.error('[ScheduledTasksPanel] list failed', e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) refresh();
+  }, [open, refresh]);
+
+  const startCreate = () => {
+    setCreating(true);
+    setError(null);
+    // Default to 1 hour from now, rounded to next 15-min
+    const now = new Date(Date.now() + 60 * 60 * 1000);
+    now.setMinutes(Math.ceil(now.getMinutes() / 15) * 15, 0, 0);
+    const local = new Date(now.getTime() - now.getTimezoneOffset() * 60_000)
+      .toISOString()
+      .slice(0, 16);
+    setDraft({ prompt: '', runAt: local, recurring: '' });
+  };
+
+  const cancelEdit = () => {
+    setCreating(false);
+    setDraft({ prompt: '', runAt: '', recurring: '' });
+    setError(null);
+  };
+
+  const save = async () => {
+    if (!draft.prompt.trim() || !draft.runAt) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const isoUtc = new Date(draft.runAt).toISOString();
+      const res = await api.post('/api/lens/run', {
+        domain: 'chat',
+        action: 'scheduled-create',
+        input: {
+          prompt: draft.prompt,
+          runAt: isoUtc,
+          recurring: draft.recurring || undefined,
+          projectId: activeProjectId || undefined,
+        },
+      });
+      const ok = (res.data as { ok?: boolean; error?: string })?.ok;
+      if (!ok) {
+        setError((res.data as { error?: string })?.error || 'Failed to schedule');
+        return;
+      }
+      cancelEdit();
+      await refresh();
+    } catch (e) {
+      console.error('[ScheduledTasksPanel] save failed', e);
+      setError('Failed to schedule');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const cancel = async (id: string) => {
+    if (!window.confirm('Cancel this scheduled task?')) return;
+    try {
+      await api.post('/api/lens/run', {
+        domain: 'chat',
+        action: 'scheduled-cancel',
+        input: { id },
+      });
+      await refresh();
+    } catch (e) {
+      console.error('[ScheduledTasksPanel] cancel failed', e);
+    }
+  };
+
+  if (!open) return null;
+
+  const pending = tasks.filter((t) => t.status === 'pending');
+  const cancelled = tasks.filter((t) => t.status !== 'pending');
+
+  return (
+    <div className="fixed inset-y-0 right-0 w-[440px] max-w-[100vw] z-40 bg-[#0d1117] border-l border-cyan-500/20 shadow-2xl overflow-hidden flex flex-col">
+      <header className="px-4 py-3 border-b border-white/10 flex items-center justify-between bg-gradient-to-r from-amber-950/40 to-transparent">
+        <div className="flex items-center gap-2">
+          <Clock className="w-4 h-4 text-amber-400" />
+          <span className="text-sm font-semibold text-gray-200">Scheduled</span>
+          <span className="text-[10px] text-gray-500 ml-1">{pending.length} pending</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={startCreate}
+            className="inline-flex items-center gap-1 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-xs text-amber-200 hover:brightness-110"
+          >
+            <Plus className="w-3 h-3" /> Schedule
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 rounded-md hover:bg-white/5 text-gray-400"
+            aria-label="Close scheduled tasks"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      </header>
+
+      <div className="flex-1 overflow-y-auto p-3 space-y-2">
+        {creating && (
+          <div className="rounded-md border border-amber-500/30 bg-amber-500/5 p-3 space-y-2">
+            <textarea
+              value={draft.prompt}
+              onChange={(e) => setDraft({ ...draft, prompt: e.target.value })}
+              placeholder="Prompt to run at the scheduled time"
+              maxLength={4000}
+              rows={4}
+              className="w-full px-2 py-1.5 text-sm bg-black/40 border border-white/10 rounded text-gray-100 placeholder-gray-500 focus:border-amber-500/50 focus:outline-none resize-none"
+            />
+            <div className="grid grid-cols-2 gap-2">
+              <label className="flex flex-col gap-1">
+                <span className="text-[10px] uppercase tracking-wider text-gray-500 inline-flex items-center gap-1">
+                  <Calendar className="w-3 h-3" /> Run at
+                </span>
+                <input
+                  type="datetime-local"
+                  value={draft.runAt}
+                  onChange={(e) => setDraft({ ...draft, runAt: e.target.value })}
+                  className="px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 focus:border-amber-500/50 focus:outline-none"
+                />
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="text-[10px] uppercase tracking-wider text-gray-500 inline-flex items-center gap-1">
+                  <Repeat className="w-3 h-3" /> Repeat
+                </span>
+                <select
+                  value={draft.recurring}
+                  onChange={(e) =>
+                    setDraft({ ...draft, recurring: e.target.value as typeof draft.recurring })
+                  }
+                  className="px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 focus:border-amber-500/50 focus:outline-none"
+                >
+                  <option value="">Once</option>
+                  <option value="daily">Daily</option>
+                  <option value="weekly">Weekly</option>
+                  <option value="monthly">Monthly</option>
+                </select>
+              </label>
+            </div>
+            {error && <p className="text-[11px] text-rose-300">{error}</p>}
+            <div className="flex items-center gap-2 pt-1">
+              <button
+                type="button"
+                onClick={save}
+                disabled={saving || !draft.prompt.trim() || !draft.runAt}
+                className="inline-flex items-center gap-1 rounded-md border border-amber-500/40 bg-amber-500/15 px-3 py-1 text-xs text-amber-100 hover:brightness-110 disabled:opacity-40"
+              >
+                {saving ? <Loader2 className="w-3 h-3 animate-spin" /> : <Save className="w-3 h-3" />}
+                Schedule
+              </button>
+              <button
+                type="button"
+                onClick={cancelEdit}
+                className="px-3 py-1 text-xs text-gray-400 hover:text-gray-200"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {loading ? (
+          <div className="flex items-center justify-center py-8 text-xs text-gray-500">
+            <Loader2 className="w-4 h-4 animate-spin mr-2" /> Loading…
+          </div>
+        ) : pending.length === 0 && !creating ? (
+          <div className="text-center py-8 px-4">
+            <Clock className="w-8 h-8 mx-auto text-gray-600 mb-2" />
+            <p className="text-xs text-gray-500">No scheduled tasks</p>
+            <p className="text-[10px] text-gray-600 mt-1">
+              Schedule a prompt to run at a future time. Recurring options: daily, weekly, monthly.
+            </p>
+          </div>
+        ) : (
+          <>
+            {pending.map((t) => (
+              <div
+                key={t.id}
+                className="rounded-md border border-amber-500/20 bg-black/20 p-3 hover:bg-white/5 transition group"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm text-gray-100 line-clamp-3">{t.prompt}</p>
+                    <div className="flex items-center gap-2 mt-2 text-[10px] text-gray-500 flex-wrap">
+                      <span className="inline-flex items-center gap-1">
+                        <Calendar className="w-2.5 h-2.5" />
+                        {formatRunAt(t.runAt)}
+                      </span>
+                      <span className={cn(
+                        'inline-flex items-center gap-1 px-1.5 py-0.5 rounded',
+                        timeUntil(t.runAt) === 'overdue'
+                          ? 'bg-rose-500/10 text-rose-300'
+                          : 'bg-amber-500/10 text-amber-300',
+                      )}>
+                        {timeUntil(t.runAt)}
+                      </span>
+                      {t.recurring && (
+                        <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-cyan-500/10 text-cyan-300">
+                          <Repeat className="w-2.5 h-2.5" /> {t.recurring}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => cancel(t.id)}
+                    className="p-1 text-gray-500 hover:text-rose-300 opacity-0 group-hover:opacity-100 transition"
+                    aria-label="Cancel scheduled task"
+                  >
+                    <Trash2 className="w-3 h-3" />
+                  </button>
+                </div>
+              </div>
+            ))}
+            {cancelled.length > 0 && (
+              <details className="mt-4">
+                <summary className="text-[10px] uppercase tracking-wider text-gray-600 cursor-pointer hover:text-gray-400">
+                  {cancelled.length} cancelled / completed
+                </summary>
+                <div className="mt-2 space-y-1.5">
+                  {cancelled.map((t) => (
+                    <div key={t.id} className="rounded-md border border-white/5 bg-black/10 p-2 opacity-60">
+                      <p className="text-[11px] text-gray-400 line-clamp-2">{t.prompt}</p>
+                      <span className="text-[9px] text-gray-600 mt-1 block">
+                        {t.status} · {formatRunAt(t.runAt)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </details>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default ScheduledTasksPanel;

--- a/concord-frontend/components/chat/ThreadSearchOverlay.tsx
+++ b/concord-frontend/components/chat/ThreadSearchOverlay.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { Search, X, Loader2, MessageSquare, Clock } from 'lucide-react';
+import { api } from '@/lib/api/client';
+import { cn } from '@/lib/utils';
+
+export interface ThreadHit {
+  threadId: string;
+  title: string;
+  snippet: string;
+  projectId: string | null;
+  lastMsgAt: string;
+  indexedAt: string;
+  score: number;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSelect: (threadId: string) => void;
+  projectId?: string | null;
+}
+
+function relativeTime(iso: string): string {
+  const now = Date.now();
+  const then = new Date(iso).getTime();
+  if (!Number.isFinite(then)) return '';
+  const diff = Math.max(0, now - then);
+  const m = Math.floor(diff / 60_000);
+  if (m < 1) return 'just now';
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 30) return `${d}d ago`;
+  const mo = Math.floor(d / 30);
+  return `${mo}mo ago`;
+}
+
+export function ThreadSearchOverlay({ open, onClose, onSelect, projectId }: Props) {
+  const [query, setQuery] = useState('');
+  const [hits, setHits] = useState<ThreadHit[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [totalIndexed, setTotalIndexed] = useState(0);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      setHits([]);
+      setActiveIdx(0);
+      setTimeout(() => inputRef.current?.focus(), 50);
+    }
+  }, [open]);
+
+  const search = useCallback(async (q: string) => {
+    const trimmed = q.trim();
+    if (trimmed.length < 2) {
+      setHits([]);
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await api.post('/api/lens/run', {
+        domain: 'chat',
+        action: 'threads-search',
+        input: { query: trimmed, projectId: projectId || undefined, limit: 30 },
+      });
+      const result = (res.data as {
+        result?: { hits?: ThreadHit[]; totalIndexed?: number };
+      })?.result;
+      setHits(result?.hits || []);
+      setTotalIndexed(result?.totalIndexed || 0);
+      setActiveIdx(0);
+    } catch (e) {
+      console.error('[ThreadSearchOverlay] search failed', e);
+      setHits([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => search(query), 200);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query, search]);
+
+  const onKey = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIdx((i) => Math.min(hits.length - 1, i + 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIdx((i) => Math.max(0, i - 1));
+    } else if (e.key === 'Enter' && hits[activeIdx]) {
+      e.preventDefault();
+      onSelect(hits[activeIdx].threadId);
+      onClose();
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[10vh] px-4 bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-[640px] bg-[#0d1117] border border-cyan-500/30 rounded-xl shadow-2xl overflow-hidden flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={onKey}
+      >
+        <div className="px-4 py-3 border-b border-white/10 flex items-center gap-2">
+          <Search className="w-4 h-4 text-cyan-400 flex-shrink-0" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={projectId ? 'Search this project…' : 'Search all conversations…'}
+            className="flex-1 bg-transparent text-sm text-gray-100 placeholder-gray-500 focus:outline-none"
+          />
+          {loading && <Loader2 className="w-3 h-3 animate-spin text-cyan-400" />}
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 rounded-md hover:bg-white/5 text-gray-400"
+            aria-label="Close search"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="max-h-[60vh] overflow-y-auto">
+          {query.trim().length < 2 ? (
+            <div className="px-4 py-12 text-center">
+              <Search className="w-8 h-8 mx-auto text-gray-700 mb-2" />
+              <p className="text-xs text-gray-500">Start typing to search</p>
+              <p className="text-[10px] text-gray-600 mt-1">
+                {totalIndexed} thread{totalIndexed === 1 ? '' : 's'} indexed
+              </p>
+            </div>
+          ) : hits.length === 0 && !loading ? (
+            <div className="px-4 py-12 text-center">
+              <MessageSquare className="w-8 h-8 mx-auto text-gray-700 mb-2" />
+              <p className="text-xs text-gray-500">No matches</p>
+              <p className="text-[10px] text-gray-600 mt-1">
+                Try different keywords. Searching across {totalIndexed} threads.
+              </p>
+            </div>
+          ) : (
+            <ul className="divide-y divide-white/5">
+              {hits.map((h, i) => (
+                <li key={h.threadId}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onSelect(h.threadId);
+                      onClose();
+                    }}
+                    onMouseEnter={() => setActiveIdx(i)}
+                    className={cn(
+                      'w-full text-left px-4 py-3 transition',
+                      i === activeIdx ? 'bg-cyan-500/10' : 'hover:bg-white/5',
+                    )}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <MessageSquare className="w-3 h-3 text-cyan-400 flex-shrink-0" />
+                          <span className="text-sm font-medium text-gray-100 truncate">
+                            {h.title || 'Untitled conversation'}
+                          </span>
+                        </div>
+                        <p className="text-[11px] text-gray-500 mt-1 line-clamp-2">{h.snippet}</p>
+                      </div>
+                      <div className="flex flex-col items-end gap-1 flex-shrink-0">
+                        <span className="text-[10px] text-cyan-400 font-mono">×{h.score}</span>
+                        <span className="text-[10px] text-gray-600 inline-flex items-center gap-1">
+                          <Clock className="w-2.5 h-2.5" />
+                          {relativeTime(h.lastMsgAt)}
+                        </span>
+                      </div>
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="px-4 py-2 border-t border-white/10 flex items-center justify-between text-[10px] text-gray-600 bg-black/40">
+          <div className="flex items-center gap-3">
+            <span><kbd className="px-1 py-0.5 rounded border border-white/10 bg-white/5">↑↓</kbd> navigate</span>
+            <span><kbd className="px-1 py-0.5 rounded border border-white/10 bg-white/5">↵</kbd> open</span>
+            <span><kbd className="px-1 py-0.5 rounded border border-white/10 bg-white/5">esc</kbd> close</span>
+          </div>
+          {hits.length > 0 && <span>{hits.length} result{hits.length === 1 ? '' : 's'}</span>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ThreadSearchOverlay;

--- a/server/domains/chat.js
+++ b/server/domains/chat.js
@@ -388,4 +388,373 @@ export default function registerChatActions(registerLensAction) {
       },
     };
   });
+
+  // ─── 2026 parity macros — Projects / Prompts / Search / Branches / Scheduled ──
+  //
+  // Parity targets: Claude Projects + ChatGPT Projects/Tasks + Perplexity Spaces.
+  // All state is in-memory, per-user (CLAUDE.md migration-101 invariant),
+  // and lives under STATE.chatLens.
+
+  function getChatState() {
+    const STATE = globalThis._concordSTATE;
+    if (!STATE) return null;
+    if (!STATE.chatLens) {
+      STATE.chatLens = {
+        projects: new Map(),
+        prompts: new Map(),
+        threadIndex: new Map(),
+        branches: new Map(),
+        scheduled: new Map(),
+      };
+    }
+    return STATE.chatLens;
+  }
+  function saveChatState() {
+    if (typeof globalThis._concordSaveStateDebounced === "function") {
+      try { globalThis._concordSaveStateDebounced(); } catch (_e) { /* best effort */ }
+    }
+  }
+  function actorIdFor(ctx) {
+    return ctx?.actor?.userId || ctx?.userId || "anon";
+  }
+  function nextChatId(prefix) {
+    return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+  }
+  function nowIsoChat() { return new Date().toISOString(); }
+  function asStringArr(v, max) {
+    if (!Array.isArray(v)) return [];
+    return v.slice(0, max).map((x) => String(x));
+  }
+
+  // ── Projects (Claude / ChatGPT Projects, Perplexity Spaces) ──
+
+  registerLensAction("chat", "projects-list", (ctx, _artifact, _params = {}) => {
+    const s = getChatState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = actorIdFor(ctx);
+    const map = s.projects.get(userId);
+    if (!map) return { ok: true, result: { projects: [] } };
+    const projects = Array.from(map.values())
+      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+    return { ok: true, result: { projects } };
+  });
+
+  registerLensAction("chat", "project-create", (ctx, _artifact, params = {}) => {
+    const s = getChatState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = actorIdFor(ctx);
+    const name = String(params.name || "").trim();
+    if (!name) return { ok: false, error: "name required" };
+    if (name.length > 80) return { ok: false, error: "name too long (max 80)" };
+    const systemPrompt = String(params.systemPrompt || "").slice(0, 4000);
+    const attachedDtuIds = asStringArr(params.attachedDtuIds, 50);
+    const color = String(params.color || "cyan").slice(0, 16);
+    const project = {
+      id: nextChatId("proj"),
+      name, systemPrompt, attachedDtuIds, color,
+      threadIds: [],
+      createdAt: nowIsoChat(),
+      updatedAt: nowIsoChat(),
+    };
+    if (!s.projects.has(userId)) s.projects.set(userId, new Map());
+    s.projects.get(userId).set(project.id, project);
+    saveChatState();
+    return { ok: true, result: { project } };
+  });
+
+  registerLensAction("chat", "project-update", (ctx, _artifact, params = {}) => {
+    const s = getChatState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = actorIdFor(ctx);
+    const id = String(params.id || "");
+    if (!id) return { ok: false, error: "id required" };
+    const map = s.projects.get(userId);
+    if (!map || !map.has(id)) return { ok: false, error: "not found" };
+    const p = map.get(id);
+    if (typeof params.name === "string") {
+      const n = params.name.trim();
+      if (!n) return { ok: false, error: "name cannot be empty" };
+      p.name = n.slice(0, 80);
+    }
+    if (typeof params.systemPrompt === "string") p.systemPrompt = params.systemPrompt.slice(0, 4000);
+    if (Array.isArray(params.attachedDtuIds)) p.attachedDtuIds = asStringArr(params.attachedDtuIds, 50);
+    if (typeof params.color === "string") p.color = params.color.slice(0, 16);
+    if (Array.isArray(params.threadIds)) p.threadIds = asStringArr(params.threadIds, 500);
+    p.updatedAt = nowIsoChat();
+    saveChatState();
+    return { ok: true, result: { project: p } };
+  });
+
+  registerLensAction("chat", "project-delete", (ctx, _artifact, params = {}) => {
+    const s = getChatState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = actorIdFor(ctx);
+    const id = String(params.id || "");
+    if (!id) return { ok: false, error: "id required" };
+    const map = s.projects.get(userId);
+    if (!map || !map.has(id)) return { ok: false, error: "not found" };
+    map.delete(id);
+    saveChatState();
+    return { ok: true, result: { deleted: id } };
+  });
+
+  registerLensAction("chat", "project-get", (ctx, _artifact, params = {}) => {
+    const s = getChatState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = actorIdFor(ctx);
+    const id = String(params.id || "");
+    if (!id) return { ok: false, error: "id required" };
+    const map = s.projects.get(userId);
+    if (!map || !map.has(id)) return { ok: false, error: "not found" };
+    return { ok: true, result: { project: map.get(id) } };
+  });
+
+  // ── Saved prompt library (slash-command extensible templates) ──
+
+  registerLensAction("chat", "prompts-list", (ctx, _artifact, _params = {}) => {
+    const s = getChatState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = actorIdFor(ctx);
+    const map = s.prompts.get(userId);
+    if (!map) return { ok: true, result: { prompts: [] } };
+    const prompts = Array.from(map.values())
+      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+    return { ok: true, result: { prompts } };
+  });
+
+  registerLensAction("chat", "prompt-create", (ctx, _artifact, params = {}) => {
+    const s = getChatState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = actorIdFor(ctx);
+    const name = String(params.name || "").trim();
+    if (!name) return { ok: false, error: "name required" };
+    if (name.length > 60) return { ok: false, error: "name too long (max 60)" };
+    const content = String(params.content || "");
+    if (!content.trim()) return { ok: false, error: "content required" };
+    if (content.length > 8000) return { ok: false, error: "content too long (max 8000)" };
+    const tags = asStringArr(params.tags, 10);
+    const shortcut = typeof params.shortcut === "string"
+      ? params.shortcut.toLowerCase().replace(/[^a-z0-9_-]/g, "").slice(0, 24)
+      : null;
+    const prompt = {
+      id: nextChatId("pmt"),
+      name, content, tags, shortcut,
+      createdAt: nowIsoChat(),
+      updatedAt: nowIsoChat(),
+    };
+    if (!s.prompts.has(userId)) s.prompts.set(userId, new Map());
+    s.prompts.get(userId).set(prompt.id, prompt);
+    saveChatState();
+    return { ok: true, result: { prompt } };
+  });
+
+  registerLensAction("chat", "prompt-update", (ctx, _artifact, params = {}) => {
+    const s = getChatState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = actorIdFor(ctx);
+    const id = String(params.id || "");
+    if (!id) return { ok: false, error: "id required" };
+    const map = s.prompts.get(userId);
+    if (!map || !map.has(id)) return { ok: false, error: "not found" };
+    const p = map.get(id);
+    if (typeof params.name === "string") {
+      const n = params.name.trim();
+      if (!n) return { ok: false, error: "name cannot be empty" };
+      p.name = n.slice(0, 60);
+    }
+    if (typeof params.content === "string") {
+      if (!params.content.trim()) return { ok: false, error: "content cannot be empty" };
+      p.content = params.content.slice(0, 8000);
+    }
+    if (Array.isArray(params.tags)) p.tags = asStringArr(params.tags, 10);
+    if (typeof params.shortcut === "string") {
+      p.shortcut = params.shortcut.toLowerCase().replace(/[^a-z0-9_-]/g, "").slice(0, 24);
+    }
+    p.updatedAt = nowIsoChat();
+    saveChatState();
+    return { ok: true, result: { prompt: p } };
+  });
+
+  registerLensAction("chat", "prompt-delete", (ctx, _artifact, params = {}) => {
+    const s = getChatState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = actorIdFor(ctx);
+    const id = String(params.id || "");
+    if (!id) return { ok: false, error: "id required" };
+    const map = s.prompts.get(userId);
+    if (!map || !map.has(id)) return { ok: false, error: "not found" };
+    map.delete(id);
+    saveChatState();
+    return { ok: true, result: { deleted: id } };
+  });
+
+  // ── Thread search across the user's indexed conversation snapshots ──
+
+  registerLensAction("chat", "thread-index", (ctx, _artifact, params = {}) => {
+    const s = getChatState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = actorIdFor(ctx);
+    const threadId = String(params.threadId || "");
+    if (!threadId) return { ok: false, error: "threadId required" };
+    const title = String(params.title || "").slice(0, 200);
+    const snippet = String(params.snippet || "").slice(0, 4000);
+    const lastMsgAt = String(params.lastMsgAt || nowIsoChat());
+    const projectId = params.projectId ? String(params.projectId) : null;
+    if (!s.threadIndex.has(userId)) s.threadIndex.set(userId, []);
+    const arr = s.threadIndex.get(userId);
+    const existingIdx = arr.findIndex((x) => x.threadId === threadId);
+    const entry = { threadId, title, snippet, projectId, lastMsgAt, indexedAt: nowIsoChat() };
+    if (existingIdx >= 0) arr[existingIdx] = entry;
+    else {
+      arr.push(entry);
+      if (arr.length > 1000) arr.splice(0, arr.length - 1000);
+    }
+    saveChatState();
+    return { ok: true, result: { threadId, total: arr.length } };
+  });
+
+  registerLensAction("chat", "threads-search", (ctx, _artifact, params = {}) => {
+    const s = getChatState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = actorIdFor(ctx);
+    const query = String(params.query || "").trim();
+    if (!query) return { ok: false, error: "query required" };
+    if (query.length < 2) return { ok: false, error: "query too short (min 2 chars)" };
+    if (query.length > 200) return { ok: false, error: "query too long (max 200)" };
+    const projectId = params.projectId ? String(params.projectId) : null;
+    const limit = Math.max(1, Math.min(50, Number(params.limit) || 20));
+    const arr = s.threadIndex.get(userId) || [];
+    const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+    const scored = [];
+    for (const entry of arr) {
+      if (projectId && entry.projectId !== projectId) continue;
+      const titleLower = (entry.title || "").toLowerCase();
+      const snippetLower = (entry.snippet || "").toLowerCase();
+      let score = 0;
+      for (const t of terms) {
+        if (titleLower.includes(t)) score += 5;
+        if (snippetLower.includes(t)) score += 1;
+      }
+      if (score > 0) scored.push({ ...entry, score });
+    }
+    scored.sort((a, b) =>
+      b.score - a.score ||
+      new Date(b.lastMsgAt).getTime() - new Date(a.lastMsgAt).getTime()
+    );
+    return {
+      ok: true,
+      result: {
+        hits: scored.slice(0, limit),
+        totalIndexed: arr.length,
+        totalMatched: scored.length,
+      },
+    };
+  });
+
+  // ── Conversation branches (fork from a message) ──
+
+  registerLensAction("chat", "branches-list", (ctx, _artifact, params = {}) => {
+    const s = getChatState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = actorIdFor(ctx);
+    const sourceThreadId = params.sourceThreadId ? String(params.sourceThreadId) : null;
+    const map = s.branches.get(userId);
+    if (!map) return { ok: true, result: { branches: [] } };
+    let branches = Array.from(map.values());
+    if (sourceThreadId) branches = branches.filter((b) => b.sourceThreadId === sourceThreadId);
+    branches.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    return { ok: true, result: { branches } };
+  });
+
+  registerLensAction("chat", "branch-fork", (ctx, _artifact, params = {}) => {
+    const s = getChatState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = actorIdFor(ctx);
+    const sourceThreadId = String(params.sourceThreadId || "");
+    if (!sourceThreadId) return { ok: false, error: "sourceThreadId required" };
+    const atMessageIdx = Number.isInteger(params.atMessageIdx) ? params.atMessageIdx : -1;
+    if (atMessageIdx < 0) return { ok: false, error: "atMessageIdx required (>= 0)" };
+    const seededMessages = Array.isArray(params.messages)
+      ? params.messages.slice(0, atMessageIdx + 1)
+      : [];
+    const note = String(params.note || "").slice(0, 200);
+    const branch = {
+      id: nextChatId("br"),
+      sourceThreadId, atMessageIdx, note,
+      seededMessages,
+      createdAt: nowIsoChat(),
+    };
+    if (!s.branches.has(userId)) s.branches.set(userId, new Map());
+    s.branches.get(userId).set(branch.id, branch);
+    saveChatState();
+    return { ok: true, result: { branch } };
+  });
+
+  registerLensAction("chat", "branch-delete", (ctx, _artifact, params = {}) => {
+    const s = getChatState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = actorIdFor(ctx);
+    const id = String(params.id || "");
+    if (!id) return { ok: false, error: "id required" };
+    const map = s.branches.get(userId);
+    if (!map || !map.has(id)) return { ok: false, error: "not found" };
+    map.delete(id);
+    saveChatState();
+    return { ok: true, result: { deleted: id } };
+  });
+
+  // ── Scheduled tasks (ChatGPT-style scheduled prompts) ──
+
+  registerLensAction("chat", "scheduled-list", (ctx, _artifact, _params = {}) => {
+    const s = getChatState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = actorIdFor(ctx);
+    const map = s.scheduled.get(userId);
+    if (!map) return { ok: true, result: { tasks: [] } };
+    const tasks = Array.from(map.values())
+      .sort((a, b) => new Date(a.runAt).getTime() - new Date(b.runAt).getTime());
+    return { ok: true, result: { tasks } };
+  });
+
+  registerLensAction("chat", "scheduled-create", (ctx, _artifact, params = {}) => {
+    const s = getChatState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = actorIdFor(ctx);
+    const promptText = String(params.prompt || "").trim();
+    if (!promptText) return { ok: false, error: "prompt required" };
+    if (promptText.length > 4000) return { ok: false, error: "prompt too long (max 4000)" };
+    const runAt = String(params.runAt || "");
+    if (!runAt) return { ok: false, error: "runAt required (ISO timestamp)" };
+    const runAtMs = new Date(runAt).getTime();
+    if (!Number.isFinite(runAtMs)) return { ok: false, error: "runAt invalid timestamp" };
+    if (runAtMs <= Date.now()) return { ok: false, error: "runAt must be in the future" };
+    const projectId = params.projectId ? String(params.projectId) : null;
+    const recurring = ["daily", "weekly", "monthly"].includes(params.recurring)
+      ? params.recurring : null;
+    const task = {
+      id: nextChatId("sch"),
+      prompt: promptText, runAt, projectId, recurring,
+      status: "pending",
+      createdAt: nowIsoChat(),
+    };
+    if (!s.scheduled.has(userId)) s.scheduled.set(userId, new Map());
+    s.scheduled.get(userId).set(task.id, task);
+    saveChatState();
+    return { ok: true, result: { task } };
+  });
+
+  registerLensAction("chat", "scheduled-cancel", (ctx, _artifact, params = {}) => {
+    const s = getChatState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = actorIdFor(ctx);
+    const id = String(params.id || "");
+    if (!id) return { ok: false, error: "id required" };
+    const map = s.scheduled.get(userId);
+    if (!map || !map.has(id)) return { ok: false, error: "not found" };
+    const t = map.get(id);
+    t.status = "cancelled";
+    t.cancelledAt = nowIsoChat();
+    saveChatState();
+    return { ok: true, result: { task: t } };
+  });
 }

--- a/server/tests/chat-domain-parity.test.js
+++ b/server/tests/chat-domain-parity.test.js
@@ -1,0 +1,322 @@
+// Tier-2 contract tests for chat lens parity macros
+// (projects / prompts / threads-search / branches / scheduled).
+// Pins per-user scoping + input validation + idempotency.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerChatActions from "../domains/chat.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) {
+  ACTIONS.set(`${domain}.${name}`, fn);
+}
+function call(name, ctx, params = {}) {
+  const fn = ACTIONS.get(`chat.${name}`);
+  if (!fn) throw new Error(`chat.${name} not registered`);
+  return fn(ctx, { id: null, data: {}, meta: {} }, params);
+}
+
+before(() => {
+  registerChatActions(register);
+});
+
+beforeEach(() => {
+  globalThis._concordSTATE = { dtus: new Map() };
+  globalThis._concordSaveStateDebounced = () => {};
+  globalThis.fetch = async () => {
+    throw new Error("network disabled");
+  };
+});
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+const ctxB = { actor: { userId: "user_b" }, userId: "user_b" };
+
+describe("chat — projects parity", () => {
+  it("creates a project and returns it on list", () => {
+    const created = call("project-create", ctxA, {
+      name: "Q1 planning",
+      systemPrompt: "You are a planning assistant.",
+      color: "emerald",
+    });
+    assert.equal(created.ok, true);
+    assert.ok(created.result.project.id);
+    assert.equal(created.result.project.name, "Q1 planning");
+    assert.equal(created.result.project.systemPrompt, "You are a planning assistant.");
+    assert.equal(created.result.project.color, "emerald");
+
+    const listed = call("projects-list", ctxA);
+    assert.equal(listed.ok, true);
+    assert.equal(listed.result.projects.length, 1);
+    assert.equal(listed.result.projects[0].id, created.result.project.id);
+  });
+
+  it("rejects empty name on create", () => {
+    const r = call("project-create", ctxA, { name: "   " });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /name required/);
+  });
+
+  it("rejects oversized name (>80 chars)", () => {
+    const r = call("project-create", ctxA, { name: "x".repeat(81) });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /name too long/);
+  });
+
+  it("INVARIANT: per-user scoping — user A's projects invisible to user B", () => {
+    call("project-create", ctxA, { name: "user-a-secret" });
+    const listB = call("projects-list", ctxB);
+    assert.equal(listB.ok, true);
+    assert.equal(listB.result.projects.length, 0);
+  });
+
+  it("update preserves id + updates updatedAt", async () => {
+    const c = call("project-create", ctxA, { name: "v1" });
+    const id = c.result.project.id;
+    const originalUpdated = c.result.project.updatedAt;
+    await new Promise((r) => setTimeout(r, 2));
+    const u = call("project-update", ctxA, { id, name: "v2", color: "rose" });
+    assert.equal(u.ok, true);
+    assert.equal(u.result.project.id, id);
+    assert.equal(u.result.project.name, "v2");
+    assert.equal(u.result.project.color, "rose");
+    assert.notEqual(u.result.project.updatedAt, originalUpdated);
+  });
+
+  it("update rejects clearing name to empty string", () => {
+    const c = call("project-create", ctxA, { name: "keep" });
+    const r = call("project-update", ctxA, { id: c.result.project.id, name: "   " });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /cannot be empty/);
+  });
+
+  it("delete removes from list", () => {
+    const c = call("project-create", ctxA, { name: "tmp" });
+    const d = call("project-delete", ctxA, { id: c.result.project.id });
+    assert.equal(d.ok, true);
+    const l = call("projects-list", ctxA);
+    assert.equal(l.result.projects.length, 0);
+  });
+
+  it("get returns 404-shape on unknown id", () => {
+    const r = call("project-get", ctxA, { id: "proj_nope" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /not found/);
+  });
+});
+
+describe("chat — saved prompts parity", () => {
+  it("creates a prompt with shortcut sanitized", () => {
+    const r = call("prompt-create", ctxA, {
+      name: "Review checklist",
+      content: "Walk through PR using these criteria: ...",
+      tags: ["dev", "review"],
+      shortcut: "Review!Now",
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.prompt.name, "Review checklist");
+    assert.equal(r.result.prompt.shortcut, "reviewnow");
+    assert.deepEqual(r.result.prompt.tags, ["dev", "review"]);
+  });
+
+  it("rejects empty content", () => {
+    const r = call("prompt-create", ctxA, { name: "x", content: "  " });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /content required/);
+  });
+
+  it("INVARIANT: per-user scoping — user A's prompts invisible to user B", () => {
+    call("prompt-create", ctxA, { name: "secret", content: "do not share" });
+    const list = call("prompts-list", ctxB);
+    assert.equal(list.result.prompts.length, 0);
+  });
+
+  it("update sanitizes shortcut on edit", () => {
+    const c = call("prompt-create", ctxA, { name: "n", content: "c" });
+    const u = call("prompt-update", ctxA, {
+      id: c.result.prompt.id,
+      shortcut: "WITH$$Special@#chars",
+    });
+    assert.equal(u.ok, true);
+    assert.equal(u.result.prompt.shortcut, "withspecialchars");
+  });
+
+  it("delete removes from list", () => {
+    const c = call("prompt-create", ctxA, { name: "tmp", content: "x" });
+    const d = call("prompt-delete", ctxA, { id: c.result.prompt.id });
+    assert.equal(d.ok, true);
+    assert.equal(call("prompts-list", ctxA).result.prompts.length, 0);
+  });
+});
+
+describe("chat — thread search parity", () => {
+  beforeEach(() => {
+    call("thread-index", ctxA, {
+      threadId: "t_alpha",
+      title: "Notes on the Concordia faction war",
+      snippet: "Discussion of strategy. The bear faction has declared war.",
+      lastMsgAt: new Date(Date.now() - 86400_000).toISOString(),
+    });
+    call("thread-index", ctxA, {
+      threadId: "t_beta",
+      title: "Recipe brainstorm",
+      snippet: "Trying to think through a new soup recipe.",
+      lastMsgAt: new Date(Date.now() - 3600_000).toISOString(),
+    });
+    call("thread-index", ctxA, {
+      threadId: "t_gamma",
+      title: "Bear migration patterns",
+      snippet: "Studying how black bears move through the boreal forest.",
+      lastMsgAt: new Date(Date.now() - 600_000).toISOString(),
+    });
+  });
+
+  it("finds threads matching a term in title or snippet", () => {
+    const r = call("threads-search", ctxA, { query: "bear" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.hits.length, 2);
+    const ids = r.result.hits.map((h) => h.threadId).sort();
+    assert.deepEqual(ids, ["t_alpha", "t_gamma"]);
+  });
+
+  it("title hits outrank snippet-only hits", () => {
+    const r = call("threads-search", ctxA, { query: "bear" });
+    assert.equal(r.result.hits[0].threadId, "t_gamma");
+  });
+
+  it("rejects 1-char query", () => {
+    const r = call("threads-search", ctxA, { query: "a" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /query too short/);
+  });
+
+  it("INVARIANT: search results scoped per-user", () => {
+    const r = call("threads-search", ctxB, { query: "bear" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.hits.length, 0);
+  });
+
+  it("re-indexing the same threadId replaces the entry", () => {
+    call("thread-index", ctxA, {
+      threadId: "t_alpha",
+      title: "Renamed: Faction war retrospective",
+      snippet: "We won.",
+      lastMsgAt: new Date().toISOString(),
+    });
+    const r = call("threads-search", ctxA, { query: "retrospective" });
+    assert.equal(r.result.hits.length, 1);
+    assert.equal(r.result.hits[0].threadId, "t_alpha");
+  });
+});
+
+describe("chat — branches parity", () => {
+  it("forks at message index with seeded messages", () => {
+    const r = call("branch-fork", ctxA, {
+      sourceThreadId: "thread_x",
+      atMessageIdx: 3,
+      messages: [
+        { role: "user", content: "one" },
+        { role: "assistant", content: "two" },
+        { role: "user", content: "three" },
+        { role: "assistant", content: "four" },
+        { role: "user", content: "five" },
+      ],
+      note: "explore alternate path",
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.branch.sourceThreadId, "thread_x");
+    assert.equal(r.result.branch.atMessageIdx, 3);
+    assert.equal(r.result.branch.seededMessages.length, 4);
+    assert.equal(r.result.branch.note, "explore alternate path");
+  });
+
+  it("rejects missing atMessageIdx", () => {
+    const r = call("branch-fork", ctxA, { sourceThreadId: "t" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /atMessageIdx required/);
+  });
+
+  it("INVARIANT: branches are scoped per-user", () => {
+    call("branch-fork", ctxA, {
+      sourceThreadId: "t",
+      atMessageIdx: 0,
+      messages: [{ role: "user", content: "x" }],
+    });
+    const list = call("branches-list", ctxB);
+    assert.equal(list.result.branches.length, 0);
+  });
+
+  it("list filters by sourceThreadId when provided", () => {
+    call("branch-fork", ctxA, { sourceThreadId: "thread_x", atMessageIdx: 0, messages: [] });
+    call("branch-fork", ctxA, { sourceThreadId: "thread_y", atMessageIdx: 0, messages: [] });
+    const r = call("branches-list", ctxA, { sourceThreadId: "thread_x" });
+    assert.equal(r.result.branches.length, 1);
+    assert.equal(r.result.branches[0].sourceThreadId, "thread_x");
+  });
+});
+
+describe("chat — scheduled tasks parity", () => {
+  it("schedules a future task", () => {
+    const r = call("scheduled-create", ctxA, {
+      prompt: "Run a weekly recap.",
+      runAt: new Date(Date.now() + 60_000).toISOString(),
+      recurring: "weekly",
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.task.status, "pending");
+    assert.equal(r.result.task.recurring, "weekly");
+  });
+
+  it("rejects runAt in the past", () => {
+    const r = call("scheduled-create", ctxA, {
+      prompt: "x",
+      runAt: new Date(Date.now() - 1000).toISOString(),
+    });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /must be in the future/);
+  });
+
+  it("rejects invalid timestamp", () => {
+    const r = call("scheduled-create", ctxA, { prompt: "x", runAt: "not-a-date" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /invalid timestamp/);
+  });
+
+  it("ignores invalid recurring values (treats as one-shot)", () => {
+    const r = call("scheduled-create", ctxA, {
+      prompt: "x",
+      runAt: new Date(Date.now() + 60_000).toISOString(),
+      recurring: "yearly",
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.task.recurring, null);
+  });
+
+  it("cancel marks status cancelled and stamps cancelledAt", () => {
+    const c = call("scheduled-create", ctxA, {
+      prompt: "x",
+      runAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    const r = call("scheduled-cancel", ctxA, { id: c.result.task.id });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.task.status, "cancelled");
+    assert.ok(r.result.task.cancelledAt);
+  });
+
+  it("INVARIANT: tasks are scoped per-user", () => {
+    call("scheduled-create", ctxA, {
+      prompt: "user-a only",
+      runAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    const list = call("scheduled-list", ctxB);
+    assert.equal(list.result.tasks.length, 0);
+  });
+});
+
+describe("chat — STATE unavailable path", () => {
+  it("returns error shape when STATE is missing", () => {
+    globalThis._concordSTATE = undefined;
+    const r = call("projects-list", ctxA);
+    assert.equal(r.ok, false);
+    assert.match(r.error, /STATE unavailable/);
+  });
+});


### PR DESCRIPTION
## Summary
Brings the chat lens to 2026 parity vs **Claude Projects + ChatGPT Projects/Tasks + Perplexity Spaces** along the four highest-impact axes from the parity matrix (research dispatched this session, 40+ real-URL sources).

### Components added (5)
- **ProjectsPanel** — persistent workspaces with system prompt + attached DTUs + color label
- **PromptsLibrary** — slash-extensible saved-prompt templates with tags + shortcut + one-click insert
- **ThreadSearchOverlay** — ⌘K full-text search across indexed thread snapshots; title hits outrank snippet hits
- **ScheduledTasksPanel** — future runs with daily/weekly/monthly recurrence (ChatGPT scheduled-tasks parity)
- **BranchForkButton** — per-message "branch in new chat" affordance (ChatGPT regressed this in May 2026)

### Backend (17 macros in `server/domains/chat.js`)
All state in-memory under `STATE.chatLens`, **per-user scoped** (CLAUDE.md migration-101 invariant). All writes call the debounced save in try/catch.

| Group | Macros |
|---|---|
| Projects | `projects-list`, `project-create`, `project-update`, `project-delete`, `project-get` |
| Prompts | `prompts-list`, `prompt-create`, `prompt-update`, `prompt-delete` |
| Threads | `thread-index`, `threads-search` |
| Branches | `branches-list`, `branch-fork`, `branch-delete` |
| Scheduled | `scheduled-list`, `scheduled-create`, `scheduled-cancel` |

### Wire-up
- 4 new buttons in the chat header toolbar (Projects, Prompts, Schedule, Search) following the existing systemsPanel pattern
- Slide-over panels at `fixed inset-y-0 right-0`, z-40
- Keyboard shortcuts: `⌘K` thread search, `⌘⇧O` Projects panel
- Active-project state propagates into both ScheduledTasksPanel + ThreadSearchOverlay for scoped behaviour

## Test plan
- [x] `node --test --test-force-exit --test-timeout=15000 server/tests/chat-domain-parity.test.js` — **29/29 passing** (CRUD, per-user scoping invariants, validation, sanitization, recurring fallback, STATE-unavailable error path)
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run lint` — zero issues in chat files (pre-existing warnings in other lenses unchanged)
- [ ] Browser smoke test of the new tabs — environment can't render UI; flagged per CLAUDE.md guidance

https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_