### PR TITLE
world lens: Roblox / UEFN polish — faction overlay, quest log, marketplace, share-spot

### DIFF
--- a/concord-frontend/app/lenses/world/page.tsx
+++ b/concord-frontend/app/lenses/world/page.tsx
@@ -31,6 +31,10 @@ import { DEMO_DISTRICT } from '@/lib/world-lens/district-seed';
 import { themeForWorldId, CONCORDIA_THEMES } from '@/lib/world-lens/concordia-theme';
 import { BARE_HANDS as controlSchemeForLegend } from '@/lib/concordia/combat/control-schemes';
 import { useHUDContext } from '@/components/world/concordia-hud/HUDContextProvider';
+import FactionOverlay from '@/components/world/FactionOverlay';
+import WorldShareButton from '@/components/world/WorldShareButton';
+import WorldQuestLogPanel from '@/components/world/WorldQuestLogPanel';
+import WorldMarketplacePanel from '@/components/world/WorldMarketplacePanel';
 import {
   DeformationStore,
   replayDeformations,
@@ -799,8 +803,11 @@ import {
   Gamepad2,
   Trophy,
   Briefcase,
+  Store,
+  ScrollText,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { cn } from '@/lib/utils';
 import { api } from '@/lib/api/client';
 import { useRunArtifact } from '@/lib/hooks/use-lens-artifacts';
 // Wave 1 deferral 5: reads the player's stored quality preset (set via /lenses/settings)
@@ -1526,6 +1533,13 @@ export default function WorldLensPage() {
   const [creationMode, setCreationMode] = useState<CreationMode | null>(null);
   const [zoom, setZoom] = useState(1);
   const [rotation, setRotation] = useState<0 | 1 | 2 | 3>(0);
+
+  // 2026 parity polish — slide-overs surfacing existing simulation.
+  // Mirrors the systemsPanel pattern from the chat lens.
+  const [factionOverlayOpen, setFactionOverlayOpen] = useState(false);
+  const [questLogOpen, setQuestLogOpen] = useState(false);
+  const [marketplacePanelOpen, setMarketplacePanelOpen] = useState(false);
+  const [currentWorldId] = useState<string>('concordia-hub');
 
   // District tools state
   const [activeTool, setActiveTool] = useState<DistrictTool>(null);
@@ -5605,8 +5619,64 @@ export default function WorldLensPage() {
         </div>
       )}
 
+      {/* 2026 parity polish — affordance bar surfacing existing simulation:
+          faction overlay (state machine), quest log (with pin-to-HUD),
+          marketplace (in-world commerce), share-this-spot (UEFN-style link). */}
+      <div className="px-3 py-1.5 border-t border-white/10 flex items-center gap-2 flex-wrap bg-black/30">
+        <button
+          type="button"
+          onClick={() => setFactionOverlayOpen((v) => !v)}
+          className={cn(
+            'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs transition-colors',
+            factionOverlayOpen
+              ? 'border-violet-500/50 bg-violet-500/10 text-violet-200'
+              : 'border-white/10 text-gray-400 hover:border-violet-500/30 hover:text-violet-300',
+          )}
+          title="Faction overlay — stance, momentum, relations"
+        >
+          <MapIcon className="w-3 h-3" />
+          Factions
+        </button>
+        <button
+          type="button"
+          onClick={() => setQuestLogOpen(true)}
+          className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-white/10 text-xs text-gray-400 hover:border-amber-500/30 hover:text-amber-300 transition-colors"
+          title="Quest log — collapsible chains + pin to HUD"
+        >
+          <ScrollText className="w-3 h-3" />
+          Quests
+        </button>
+        <button
+          type="button"
+          onClick={() => setMarketplacePanelOpen(true)}
+          className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-white/10 text-xs text-gray-400 hover:border-cyan-500/30 hover:text-cyan-300 transition-colors"
+          title="Marketplace — spells, blueprints, recipes, DTUs"
+        >
+          <Store className="w-3 h-3" />
+          Marketplace
+        </button>
+        <WorldShareButton worldId={currentWorldId} />
+      </div>
+
       {/* Bottom Status Bar */}
       <StatusBar district={viewMode === 'district' ? activeDistrict : null} />
+
+      {/* 2026 parity slide-overs — mounted at the lens shell root */}
+      <FactionOverlay
+        worldId={currentWorldId}
+        open={factionOverlayOpen}
+        onClose={() => setFactionOverlayOpen(false)}
+      />
+      <WorldQuestLogPanel
+        worldId={currentWorldId}
+        open={questLogOpen}
+        onClose={() => setQuestLogOpen(false)}
+      />
+      <WorldMarketplacePanel
+        worldId={currentWorldId}
+        open={marketplacePanelOpen}
+        onClose={() => setMarketplacePanelOpen(false)}
+      />
 
       {/* World Actions Panel */}
       <div className="px-4 py-3 border-t border-white/10">

--- a/concord-frontend/components/world/FactionOverlay.tsx
+++ b/concord-frontend/components/world/FactionOverlay.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { Map, X, Loader2, Swords } from 'lucide-react';
+import { api } from '@/lib/api/client';
+import { cn } from '@/lib/utils';
+
+export interface FactionNode {
+  id: string;
+  name: string;
+  stance: string;
+  momentum: number;
+  color: string;
+  cx: number;
+  cy: number;
+  radius: number;
+}
+
+export interface FactionRelation {
+  a: string;
+  b: string;
+  kind: 'neutral' | 'tension' | 'truce' | 'war' | 'alliance' | 'tribute';
+  score: number;
+}
+
+interface Props {
+  worldId: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+const RELATION_STYLE: Record<FactionRelation['kind'], { color: string; dash?: string; label: string }> = {
+  neutral:  { color: '#6b7280', dash: '4,4', label: 'neutral' },
+  tension:  { color: '#fb923c', dash: '6,3', label: 'tension' },
+  truce:    { color: '#a3e635',               label: 'truce' },
+  war:      { color: '#ef4444',               label: 'war' },
+  alliance: { color: '#67e8f9',               label: 'alliance' },
+  tribute:  { color: '#fcd34d', dash: '8,2', label: 'tribute' },
+};
+
+const STANCE_LABEL: Record<string, string> = {
+  consolidate: 'Consolidating',
+  expand:      'Expanding',
+  war:         'At war',
+  alliance:    'In alliance',
+  rebuild:     'Rebuilding',
+  isolation:   'Isolated',
+};
+
+export function FactionOverlay({ worldId, open, onClose }: Props) {
+  const [factions, setFactions] = useState<FactionNode[]>([]);
+  const [relations, setRelations] = useState<FactionRelation[]>([]);
+  const [source, setSource] = useState<'live' | 'sample'>('sample');
+  const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await api.post('/api/lens/run', {
+        domain: 'world',
+        action: 'faction-overlay-data',
+        input: { worldId },
+      });
+      const result = (res.data as {
+        result?: { factions?: FactionNode[]; relations?: FactionRelation[]; source?: 'live' | 'sample' };
+      })?.result;
+      setFactions(result?.factions || []);
+      setRelations(result?.relations || []);
+      setSource(result?.source || 'sample');
+    } catch (e) {
+      console.error('[FactionOverlay] fetch failed', e);
+    } finally {
+      setLoading(false);
+    }
+  }, [worldId]);
+
+  useEffect(() => {
+    if (open) refresh();
+  }, [open, refresh]);
+
+  if (!open) return null;
+
+  const selectedNode = selected ? factions.find((f) => f.id === selected) : null;
+  const selectedRelations = selectedNode
+    ? relations.filter((r) => r.a === selected || r.b === selected)
+    : [];
+
+  return (
+    <div className="fixed top-20 right-4 w-[420px] max-w-[100vw] z-40 bg-[#0d1117]/95 backdrop-blur border border-cyan-500/30 rounded-lg shadow-2xl overflow-hidden flex flex-col">
+      <header className="px-4 py-2 border-b border-white/10 flex items-center justify-between bg-gradient-to-r from-violet-950/40 to-transparent">
+        <div className="flex items-center gap-2">
+          <Map className="w-4 h-4 text-violet-400" />
+          <span className="text-xs uppercase font-semibold text-gray-200 tracking-wider">
+            Faction overlay
+          </span>
+          <span
+            className={cn(
+              'text-[10px] px-1.5 py-0.5 rounded',
+              source === 'live'
+                ? 'bg-emerald-500/15 text-emerald-300'
+                : 'bg-amber-500/15 text-amber-300',
+            )}
+          >
+            {source}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="p-1 rounded-md hover:bg-white/5 text-gray-400"
+          aria-label="Close faction overlay"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </header>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-8 text-xs text-gray-500">
+          <Loader2 className="w-4 h-4 animate-spin mr-2" /> Loading…
+        </div>
+      ) : (
+        <div className="flex flex-col">
+          <svg viewBox="0 0 800 600" className="w-full bg-black/30">
+            {/* Relations as lines under nodes */}
+            {relations.map((r) => {
+              const a = factions.find((f) => f.id === r.a);
+              const b = factions.find((f) => f.id === r.b);
+              if (!a || !b) return null;
+              const style = RELATION_STYLE[r.kind];
+              return (
+                <line
+                  key={`${r.a}-${r.b}`}
+                  x1={a.cx}
+                  y1={a.cy}
+                  x2={b.cx}
+                  y2={b.cy}
+                  stroke={style.color}
+                  strokeWidth={1 + Math.abs(r.score) * 3}
+                  strokeDasharray={style.dash}
+                  opacity={0.6}
+                />
+              );
+            })}
+            {/* Faction territory circles */}
+            {factions.map((f) => (
+              <g key={f.id} className="cursor-pointer" onClick={() => setSelected(f.id === selected ? null : f.id)}>
+                <circle
+                  cx={f.cx}
+                  cy={f.cy}
+                  r={f.radius}
+                  fill={f.color}
+                  fillOpacity={selected === f.id ? 0.35 : 0.18}
+                  stroke={f.color}
+                  strokeWidth={selected === f.id ? 3 : 1.5}
+                />
+                <text
+                  x={f.cx}
+                  y={f.cy}
+                  fill="#f3f4f6"
+                  fontSize="12"
+                  fontWeight="600"
+                  textAnchor="middle"
+                  className="pointer-events-none select-none"
+                >
+                  {f.name}
+                </text>
+                <text
+                  x={f.cx}
+                  y={f.cy + 16}
+                  fill="#9ca3af"
+                  fontSize="10"
+                  textAnchor="middle"
+                  className="pointer-events-none select-none"
+                >
+                  {STANCE_LABEL[f.stance] || f.stance}
+                </text>
+              </g>
+            ))}
+          </svg>
+
+          {selectedNode ? (
+            <div className="px-4 py-3 border-t border-white/10 bg-black/40">
+              <div className="flex items-center gap-2 mb-2">
+                <span
+                  className="w-3 h-3 rounded-full"
+                  style={{ backgroundColor: selectedNode.color }}
+                />
+                <span className="text-sm font-semibold text-gray-100">{selectedNode.name}</span>
+                <span className="text-[10px] text-gray-500 ml-auto">
+                  momentum {selectedNode.momentum >= 0 ? '+' : ''}
+                  {selectedNode.momentum.toFixed(2)}
+                </span>
+              </div>
+              <p className="text-xs text-gray-400 mb-2">
+                Stance: <span className="text-gray-200">{STANCE_LABEL[selectedNode.stance] || selectedNode.stance}</span>
+              </p>
+              {selectedRelations.length > 0 && (
+                <div>
+                  <p className="text-[10px] uppercase tracking-wider text-gray-500 mb-1">Relations</p>
+                  <ul className="space-y-1">
+                    {selectedRelations.map((r) => {
+                      const otherId = r.a === selectedNode.id ? r.b : r.a;
+                      const other = factions.find((f) => f.id === otherId);
+                      if (!other) return null;
+                      const style = RELATION_STYLE[r.kind];
+                      return (
+                        <li
+                          key={`${r.a}-${r.b}`}
+                          className="flex items-center justify-between text-xs"
+                        >
+                          <span className="text-gray-300">{other.name}</span>
+                          <span style={{ color: style.color }}>{style.label}</span>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="px-4 py-3 border-t border-white/10 bg-black/40 text-[11px] text-gray-500 inline-flex items-center gap-2">
+              <Swords className="w-3 h-3" />
+              Click a faction to view its stance, momentum, and relations.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default FactionOverlay;

--- a/concord-frontend/components/world/WorldMarketplacePanel.tsx
+++ b/concord-frontend/components/world/WorldMarketplacePanel.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { Store, X, Loader2, Sparkles, Hammer, ScrollText, Flame } from 'lucide-react';
+import { api } from '@/lib/api/client';
+import { cn } from '@/lib/utils';
+
+export interface MarketplaceListing {
+  id: string;
+  kind: string;
+  title: string;
+  price: number;
+  currency: string;
+  sellerName: string;
+  rarity: 'common' | 'uncommon' | 'rare' | 'legendary' | string;
+}
+
+interface Props {
+  worldId: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+const KIND_TABS = [
+  { id: 'all',                     label: 'All',         icon: Store },
+  { id: 'spell_recipe',            label: 'Spells',      icon: Sparkles },
+  { id: 'blueprint',               label: 'Blueprints',  icon: Hammer },
+  { id: 'fighting_style_recipe',   label: 'Recipes',     icon: Flame },
+  { id: 'dtu',                     label: 'DTUs',        icon: ScrollText },
+] as const;
+
+const RARITY_COLOR: Record<string, string> = {
+  common:    'text-gray-300',
+  uncommon:  'text-emerald-300',
+  rare:      'text-cyan-300',
+  legendary: 'text-amber-300',
+};
+
+export function WorldMarketplacePanel({ worldId, open, onClose }: Props) {
+  const [listings, setListings] = useState<MarketplaceListing[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [activeKind, setActiveKind] = useState<string>('all');
+  const [source, setSource] = useState<'live' | 'sample'>('sample');
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await api.post('/api/lens/run', {
+        domain: 'world',
+        action: 'marketplace-summary',
+        input: { worldId, kind: activeKind },
+      });
+      const result = (res.data as {
+        result?: { listings?: MarketplaceListing[]; source?: 'live' | 'sample' };
+      })?.result;
+      setListings(result?.listings || []);
+      setSource(result?.source || 'sample');
+    } catch (e) {
+      console.error('[WorldMarketplacePanel] fetch failed', e);
+    } finally {
+      setLoading(false);
+    }
+  }, [worldId, activeKind]);
+
+  useEffect(() => {
+    if (open) refresh();
+  }, [open, refresh]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-y-0 right-0 w-[460px] max-w-[100vw] z-40 bg-[#0d1117] border-l border-cyan-500/20 shadow-2xl overflow-hidden flex flex-col">
+      <header className="px-4 py-3 border-b border-white/10 flex items-center justify-between bg-gradient-to-r from-cyan-950/40 to-transparent">
+        <div className="flex items-center gap-2">
+          <Store className="w-4 h-4 text-cyan-400" />
+          <span className="text-sm font-semibold text-gray-200">Marketplace</span>
+          <span
+            className={cn(
+              'text-[10px] px-1.5 py-0.5 rounded',
+              source === 'live'
+                ? 'bg-emerald-500/15 text-emerald-300'
+                : 'bg-amber-500/15 text-amber-300',
+            )}
+          >
+            {source}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="p-1 rounded-md hover:bg-white/5 text-gray-400"
+          aria-label="Close marketplace"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </header>
+
+      <div className="px-3 py-2 border-b border-white/10 flex items-center gap-1 overflow-x-auto">
+        {KIND_TABS.map((tab) => {
+          const Icon = tab.icon;
+          const active = activeKind === tab.id;
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setActiveKind(tab.id)}
+              className={cn(
+                'inline-flex items-center gap-1 px-2 py-1 text-[11px] rounded uppercase tracking-wider transition flex-shrink-0',
+                active
+                  ? 'bg-cyan-500/15 text-cyan-200 border border-cyan-500/40'
+                  : 'text-gray-500 hover:text-gray-300 border border-transparent',
+              )}
+            >
+              <Icon className="w-3 h-3" />
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-3 space-y-2">
+        {loading ? (
+          <div className="flex items-center justify-center py-8 text-xs text-gray-500">
+            <Loader2 className="w-4 h-4 animate-spin mr-2" /> Loading…
+          </div>
+        ) : listings.length === 0 ? (
+          <div className="text-center py-8 px-4">
+            <Store className="w-8 h-8 mx-auto text-gray-600 mb-2" />
+            <p className="text-xs text-gray-500">No listings in this category</p>
+          </div>
+        ) : (
+          listings.map((l) => (
+            <div
+              key={l.id}
+              className="rounded-md border border-white/10 bg-black/20 p-3 hover:bg-white/5 transition"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex-1 min-w-0">
+                  <p className={cn('text-sm font-medium truncate', RARITY_COLOR[l.rarity] || 'text-gray-100')}>
+                    {l.title}
+                  </p>
+                  <p className="text-[10px] text-gray-500 mt-0.5">
+                    by {l.sellerName} · {l.kind}
+                  </p>
+                </div>
+                <div className="text-right flex-shrink-0">
+                  <p className="text-sm font-mono text-cyan-300">
+                    {l.price.toLocaleString()} <span className="text-[10px] text-gray-500 uppercase">{l.currency}</span>
+                  </p>
+                  <p className="text-[10px] text-gray-500 uppercase tracking-wider">{l.rarity}</p>
+                </div>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      <footer className="px-3 py-2 border-t border-white/10 text-[10px] text-gray-600 bg-black/40">
+        Listings are scoped to {worldId}. Prices in Concord Coin (CC).
+      </footer>
+    </div>
+  );
+}
+
+export default WorldMarketplacePanel;

--- a/concord-frontend/components/world/WorldQuestLogPanel.tsx
+++ b/concord-frontend/components/world/WorldQuestLogPanel.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import {
+  ScrollText, X, Loader2, Pin, PinOff, CheckCircle2, Circle, ChevronDown, ChevronRight,
+} from 'lucide-react';
+import { api } from '@/lib/api/client';
+import { cn } from '@/lib/utils';
+
+export interface QuestEntry {
+  id: string;
+  title: string;
+  chainId: string;
+  status: 'active' | 'completed' | 'failed';
+  step: number;
+  totalSteps: number;
+  breadcrumb?: string;
+  pinned: boolean;
+}
+
+export interface QuestChain {
+  chainId: string;
+  quests: QuestEntry[];
+  activeCount: number;
+  completedCount: number;
+}
+
+interface Props {
+  worldId: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+const CHAIN_LABEL: Record<string, string> = {
+  onboarding:         'Onboarding — First Cycle',
+  main_arc:           'Main arc — The Whisper from the Lattice',
+  faction_coalition:  'Faction — The Coalition',
+  faction_sovereign:  'Faction — The Sovereign',
+  faction_weavers:    'Faction — Weavers of Echoes',
+  faction_concord:    'Faction — Concord',
+  uncategorized:      'Other quests',
+};
+
+export function WorldQuestLogPanel({ worldId, open, onClose }: Props) {
+  const [chains, setChains] = useState<QuestChain[]>([]);
+  const [pinnedCount, setPinnedCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [filter, setFilter] = useState<'all' | 'active' | 'pinned'>('all');
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await api.post('/api/lens/run', {
+        domain: 'world',
+        action: 'quest-summary',
+        input: { worldId },
+      });
+      const result = (res.data as {
+        result?: { chains?: QuestChain[]; pinnedCount?: number };
+      })?.result;
+      setChains(result?.chains || []);
+      setPinnedCount(result?.pinnedCount || 0);
+      // Auto-expand chains with active quests on first load
+      const auto = new Set<string>();
+      for (const c of result?.chains || []) {
+        if (c.activeCount > 0) auto.add(c.chainId);
+      }
+      setExpanded(auto);
+    } catch (e) {
+      console.error('[WorldQuestLogPanel] fetch failed', e);
+    } finally {
+      setLoading(false);
+    }
+  }, [worldId]);
+
+  useEffect(() => {
+    if (open) refresh();
+  }, [open, refresh]);
+
+  const togglePin = async (questId: string) => {
+    try {
+      await api.post('/api/lens/run', {
+        domain: 'world',
+        action: 'quest-pin-toggle',
+        input: { questId },
+      });
+      await refresh();
+    } catch (e) {
+      console.error('[WorldQuestLogPanel] pin failed', e);
+    }
+  };
+
+  const toggleChain = (cid: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(cid)) next.delete(cid);
+      else next.add(cid);
+      return next;
+    });
+  };
+
+  if (!open) return null;
+
+  const filteredChains = chains
+    .map((c) => {
+      let quests = c.quests;
+      if (filter === 'active') quests = quests.filter((q) => q.status === 'active');
+      else if (filter === 'pinned') quests = quests.filter((q) => q.pinned);
+      return { ...c, quests };
+    })
+    .filter((c) => c.quests.length > 0);
+
+  return (
+    <div className="fixed inset-y-0 right-0 w-[440px] max-w-[100vw] z-40 bg-[#0d1117] border-l border-cyan-500/20 shadow-2xl overflow-hidden flex flex-col">
+      <header className="px-4 py-3 border-b border-white/10 flex items-center justify-between bg-gradient-to-r from-amber-950/40 to-transparent">
+        <div className="flex items-center gap-2">
+          <ScrollText className="w-4 h-4 text-amber-400" />
+          <span className="text-sm font-semibold text-gray-200">Quest log</span>
+          {pinnedCount > 0 && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-300">
+              {pinnedCount} pinned
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="p-1 rounded-md hover:bg-white/5 text-gray-400"
+          aria-label="Close quest log"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </header>
+
+      <div className="px-3 py-2 border-b border-white/10 flex items-center gap-2">
+        {(['all', 'active', 'pinned'] as const).map((f) => (
+          <button
+            key={f}
+            type="button"
+            onClick={() => setFilter(f)}
+            className={cn(
+              'px-2 py-1 text-[11px] rounded uppercase tracking-wider transition',
+              filter === f
+                ? 'bg-amber-500/15 text-amber-200 border border-amber-500/40'
+                : 'text-gray-500 hover:text-gray-300 border border-transparent',
+            )}
+          >
+            {f}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-3 space-y-2">
+        {loading ? (
+          <div className="flex items-center justify-center py-8 text-xs text-gray-500">
+            <Loader2 className="w-4 h-4 animate-spin mr-2" /> Loading…
+          </div>
+        ) : filteredChains.length === 0 ? (
+          <div className="text-center py-8 px-4">
+            <ScrollText className="w-8 h-8 mx-auto text-gray-600 mb-2" />
+            <p className="text-xs text-gray-500">
+              {filter === 'pinned' ? 'No pinned quests yet' : 'No quests'}
+            </p>
+          </div>
+        ) : (
+          filteredChains.map((c) => {
+            const isExpanded = expanded.has(c.chainId);
+            return (
+              <div
+                key={c.chainId}
+                className="rounded-md border border-white/10 bg-black/20 overflow-hidden"
+              >
+                <button
+                  type="button"
+                  onClick={() => toggleChain(c.chainId)}
+                  className="w-full px-3 py-2 flex items-center justify-between text-left hover:bg-white/5"
+                >
+                  <div className="flex items-center gap-2">
+                    {isExpanded ? (
+                      <ChevronDown className="w-3 h-3 text-gray-500" />
+                    ) : (
+                      <ChevronRight className="w-3 h-3 text-gray-500" />
+                    )}
+                    <span className="text-sm font-medium text-gray-200">
+                      {CHAIN_LABEL[c.chainId] || c.chainId}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2 text-[10px] text-gray-500">
+                    {c.activeCount > 0 && (
+                      <span className="text-amber-300">{c.activeCount} active</span>
+                    )}
+                    {c.completedCount > 0 && (
+                      <span className="text-emerald-400">{c.completedCount} done</span>
+                    )}
+                  </div>
+                </button>
+                {isExpanded && (
+                  <ul className="border-t border-white/5 divide-y divide-white/5">
+                    {c.quests.map((q) => (
+                      <li key={q.id} className="px-3 py-2 hover:bg-white/5 group">
+                        <div className="flex items-start gap-2">
+                          {q.status === 'completed' ? (
+                            <CheckCircle2 className="w-3.5 h-3.5 text-emerald-400 mt-0.5 flex-shrink-0" />
+                          ) : (
+                            <Circle className="w-3.5 h-3.5 text-amber-400 mt-0.5 flex-shrink-0" />
+                          )}
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center justify-between">
+                              <span
+                                className={cn(
+                                  'text-xs',
+                                  q.status === 'completed'
+                                    ? 'text-gray-500 line-through'
+                                    : 'text-gray-100 font-medium',
+                                )}
+                              >
+                                {q.title}
+                              </span>
+                              <span className="text-[10px] text-gray-600 ml-2 flex-shrink-0">
+                                {q.step}/{q.totalSteps}
+                              </span>
+                            </div>
+                            {q.breadcrumb && q.status === 'active' && (
+                              <p className="text-[11px] text-gray-500 mt-0.5 italic">
+                                → {q.breadcrumb}
+                              </p>
+                            )}
+                          </div>
+                          {q.status === 'active' && (
+                            <button
+                              type="button"
+                              onClick={() => togglePin(q.id)}
+                              className={cn(
+                                'p-1 rounded transition',
+                                q.pinned
+                                  ? 'text-amber-300'
+                                  : 'text-gray-600 opacity-0 group-hover:opacity-100 hover:text-amber-300',
+                              )}
+                              aria-label={q.pinned ? 'Unpin quest' : 'Pin quest'}
+                              title={q.pinned ? 'Unpin from HUD' : 'Pin to HUD'}
+                            >
+                              {q.pinned ? <PinOff className="w-3 h-3" /> : <Pin className="w-3 h-3" />}
+                            </button>
+                          )}
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default WorldQuestLogPanel;

--- a/concord-frontend/components/world/WorldShareButton.tsx
+++ b/concord-frontend/components/world/WorldShareButton.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState } from 'react';
+import { Share2, Check, Loader2, Link as LinkIcon } from 'lucide-react';
+import { api } from '@/lib/api/client';
+import { cn } from '@/lib/utils';
+
+interface Props {
+  worldId: string;
+  position?: { x: number; y: number; z: number } | null;
+  note?: string;
+  className?: string;
+}
+
+export function WorldShareButton({ worldId, position, note, className }: Props) {
+  const [state, setState] = useState<'idle' | 'pending' | 'copied' | 'error'>('idle');
+
+  const share = async () => {
+    if (state === 'pending') return;
+    setState('pending');
+    try {
+      const res = await api.post('/api/lens/run', {
+        domain: 'world',
+        action: 'share-link-create',
+        input: {
+          worldId,
+          x: position?.x,
+          y: position?.y,
+          z: position?.z,
+          note: note || '',
+        },
+      });
+      const link = (res.data as { result?: { link?: { url: string } } })?.result?.link;
+      if (!link?.url) throw new Error('no url returned');
+      const origin = typeof window !== 'undefined' ? window.location.origin : '';
+      const full = origin ? `${origin}${link.url}` : link.url;
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(full);
+      }
+      setState('copied');
+      setTimeout(() => setState('idle'), 2200);
+    } catch (e) {
+      console.error('[WorldShareButton] share failed', e);
+      setState('error');
+      setTimeout(() => setState('idle'), 1800);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={share}
+      disabled={state === 'pending'}
+      title={
+        state === 'copied'
+          ? 'Link copied to clipboard'
+          : state === 'error'
+          ? 'Share failed'
+          : 'Share this spot — copies a deep link to your clipboard'
+      }
+      className={cn(
+        'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs transition-colors',
+        state === 'copied'
+          ? 'border-emerald-500/50 bg-emerald-500/10 text-emerald-200'
+          : state === 'error'
+          ? 'border-rose-500/50 bg-rose-500/10 text-rose-200'
+          : 'border-cyan-500/30 bg-cyan-500/5 text-cyan-200 hover:brightness-110',
+        className,
+      )}
+    >
+      {state === 'pending' ? (
+        <Loader2 className="w-3 h-3 animate-spin" />
+      ) : state === 'copied' ? (
+        <Check className="w-3 h-3" />
+      ) : state === 'error' ? (
+        <LinkIcon className="w-3 h-3" />
+      ) : (
+        <Share2 className="w-3 h-3" />
+      )}
+      <span>
+        {state === 'copied' ? 'Copied!' : state === 'error' ? 'Failed' : 'Share spot'}
+      </span>
+    </button>
+  );
+}
+
+export default WorldShareButton;

--- a/server/domains/world.js
+++ b/server/domains/world.js
@@ -90,4 +90,211 @@ export default function registerWorldActions(registerLensAction) {
     const projectedPop10yr = Math.round(population * Math.pow(1 + growthRate / 100, 10));
     return { ok: true, result: { population, area: area > 0 ? `${area} km²` : null, density: density > 0 ? `${density}/km²` : null, urbanizationRate: urbanRate ? `${urbanRate}%` : null, growthRate: `${growthRate}%`, doublingTimeYears: doublingTime, medianAge, ageDistribution: Object.keys(ageDistribution).length > 0 ? ageDistribution : null, projections: { fiveYear: projectedPop5yr, tenYear: projectedPop10yr }, classification: density > 500 ? "densely populated" : density > 100 ? "moderately populated" : density > 25 ? "sparsely populated" : "very sparsely populated" } };
   });
+
+  // ─── 2026 parity polish macros — surfaces existing simulation in the lens ──
+  //
+  // Concord's world lens has a deep simulation substrate (faction strategy,
+  // glyph algebra, embodied signals, lattice-born quests, NPC asymmetry) that
+  // none of the competitors (Roblox/Minecraft/UEFN/Unreal/Unity/etc.) have.
+  // The polish gap is affordance, not capability — surface what already runs.
+  //
+  // These macros wrap per-world data (faction state, quests, marketplace
+  // listings, share links) into a lens-scoped read surface so the new UI
+  // components don't need to know about server.js routes.
+
+  function getWorldLensState() {
+    const STATE = globalThis._concordSTATE;
+    if (!STATE) return null;
+    if (!STATE.worldLens) {
+      STATE.worldLens = {
+        shareCache: new Map(),        // userId -> Map<linkId, link>
+        overlayPrefs: new Map(),      // userId -> { factionOverlay, hotbarMode, photoTemplate }
+        recentWorlds: new Map(),      // userId -> Array<{ worldId, lastVisitedAt }>
+        pinnedQuests: new Map(),      // userId -> Set<questId>
+      };
+    }
+    return STATE.worldLens;
+  }
+  function saveWorldLensState() {
+    if (typeof globalThis._concordSaveStateDebounced === "function") {
+      try { globalThis._concordSaveStateDebounced(); } catch (_e) { /* best effort */ }
+    }
+  }
+  function worldActorId(ctx) {
+    return ctx?.actor?.userId || ctx?.userId || "anon";
+  }
+  function nextWorldId(prefix) {
+    return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+  }
+  function nowIsoWorld() { return new Date().toISOString(); }
+
+  // ── Faction overlay data (mini-map painting + relations graph) ──
+
+  registerLensAction("world", "faction-overlay-data", (_ctx, _artifact, params = {}) => {
+    const worldId = String(params.worldId || "concordia-hub");
+    // Try real simulation state; fall back to a deterministic sample so the
+    // overlay can render even before factions are seeded.
+    const STATE = globalThis._concordSTATE;
+    const sim = STATE?.factionStrategy?.[worldId];
+    if (sim && Array.isArray(sim.factions) && sim.factions.length > 0) {
+      return { ok: true, result: { worldId, source: "live", factions: sim.factions, relations: sim.relations || [] } };
+    }
+    // Sample: 4 named factions with stance + relations
+    const factions = [
+      { id: "fac_sovereign", name: "The Sovereign", stance: "consolidate", momentum: 0.15, color: "#67e8f9", cx: 320, cy: 180, radius: 90 },
+      { id: "fac_coalition", name: "The Coalition", stance: "expand", momentum: 0.45, color: "#fcd34d", cx: 540, cy: 240, radius: 110 },
+      { id: "fac_weavers",   name: "Weavers of Echoes", stance: "alliance", momentum: 0.20, color: "#a78bfa", cx: 250, cy: 380, radius: 80 },
+      { id: "fac_concord",   name: "Concord", stance: "isolation", momentum: -0.05, color: "#34d399", cx: 480, cy: 420, radius: 95 },
+    ];
+    const relations = [
+      { a: "fac_sovereign", b: "fac_coalition", kind: "tension", score: -0.3 },
+      { a: "fac_coalition", b: "fac_weavers",   kind: "alliance", score: 0.55 },
+      { a: "fac_concord",   b: "fac_sovereign", kind: "truce",    score: 0.10 },
+    ];
+    return { ok: true, result: { worldId, source: "sample", factions, relations } };
+  });
+
+  // ── Share link primitive (copy-world-spot, UEFN-style island codes) ──
+
+  registerLensAction("world", "share-link-create", (ctx, _artifact, params = {}) => {
+    const s = getWorldLensState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = worldActorId(ctx);
+    const worldId = String(params.worldId || "").trim();
+    if (!worldId) return { ok: false, error: "worldId required" };
+    const x = Number.isFinite(Number(params.x)) ? Number(params.x) : null;
+    const y = Number.isFinite(Number(params.y)) ? Number(params.y) : null;
+    const z = Number.isFinite(Number(params.z)) ? Number(params.z) : null;
+    const note = String(params.note || "").slice(0, 200);
+    const link = {
+      id: nextWorldId("wlink"),
+      worldId, x, y, z, note,
+      createdBy: userId,
+      createdAt: nowIsoWorld(),
+    };
+    const qs = new URLSearchParams();
+    if (x !== null) qs.set("x", x.toFixed(1));
+    if (y !== null) qs.set("y", y.toFixed(1));
+    if (z !== null) qs.set("z", z.toFixed(1));
+    if (note) qs.set("n", note.slice(0, 80));
+    link.url = `/lenses/world?world=${encodeURIComponent(worldId)}${qs.toString() ? `&${qs.toString()}` : ""}`;
+    if (!s.shareCache.has(userId)) s.shareCache.set(userId, new Map());
+    s.shareCache.get(userId).set(link.id, link);
+    saveWorldLensState();
+    return { ok: true, result: { link } };
+  });
+
+  registerLensAction("world", "share-links-list", (ctx, _artifact, _params = {}) => {
+    const s = getWorldLensState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = worldActorId(ctx);
+    const map = s.shareCache.get(userId);
+    if (!map) return { ok: true, result: { links: [] } };
+    const links = Array.from(map.values())
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+      .slice(0, 30);
+    return { ok: true, result: { links } };
+  });
+
+  // ── Quest summary (grouped by chain + pin state) ──
+
+  registerLensAction("world", "quest-summary", (ctx, _artifact, params = {}) => {
+    const s = getWorldLensState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = worldActorId(ctx);
+    const worldId = String(params.worldId || "concordia-hub");
+    const STATE = globalThis._concordSTATE;
+    const live = STATE?.questEngine?.byUser?.[userId]?.[worldId];
+    const pinnedSet = s.pinnedQuests.get(userId) || new Set();
+    let quests = [];
+    if (live && Array.isArray(live.quests)) {
+      quests = live.quests;
+    } else {
+      quests = [
+        { id: "q_onb_1", title: "First fire", chainId: "onboarding", status: "completed", step: 1, totalSteps: 4 },
+        { id: "q_onb_2", title: "First meal",  chainId: "onboarding", status: "completed", step: 2, totalSteps: 4 },
+        { id: "q_onb_3", title: "First defence", chainId: "onboarding", status: "active",    step: 3, totalSteps: 4, breadcrumb: "Find the training dummy near the campfire" },
+        { id: "q_arc_1", title: "The Whisper from the Lattice", chainId: "main_arc",    status: "active", step: 1, totalSteps: 7, breadcrumb: "Speak to the Oracle in the central plaza" },
+        { id: "q_fac_1", title: "Coalition courier run", chainId: "faction_coalition", status: "active", step: 1, totalSteps: 3, breadcrumb: "Deliver the sealed scroll to The Sovereign" },
+      ];
+    }
+    const chains = {};
+    for (const q of quests) {
+      const cid = q.chainId || "uncategorized";
+      if (!chains[cid]) chains[cid] = { chainId: cid, quests: [], activeCount: 0, completedCount: 0 };
+      const enriched = { ...q, pinned: pinnedSet.has(q.id) };
+      chains[cid].quests.push(enriched);
+      if (q.status === "active") chains[cid].activeCount++;
+      if (q.status === "completed") chains[cid].completedCount++;
+    }
+    return { ok: true, result: { worldId, chains: Object.values(chains), pinnedCount: pinnedSet.size } };
+  });
+
+  registerLensAction("world", "quest-pin-toggle", (ctx, _artifact, params = {}) => {
+    const s = getWorldLensState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = worldActorId(ctx);
+    const questId = String(params.questId || "");
+    if (!questId) return { ok: false, error: "questId required" };
+    if (!s.pinnedQuests.has(userId)) s.pinnedQuests.set(userId, new Set());
+    const set = s.pinnedQuests.get(userId);
+    let pinned;
+    if (set.has(questId)) { set.delete(questId); pinned = false; }
+    else { set.add(questId); pinned = true; }
+    saveWorldLensState();
+    return { ok: true, result: { questId, pinned, totalPinned: set.size } };
+  });
+
+  // ── Marketplace summary (in-world commerce surface) ──
+
+  registerLensAction("world", "marketplace-summary", (_ctx, _artifact, params = {}) => {
+    const worldId = String(params.worldId || "concordia-hub");
+    const kind = String(params.kind || "all");
+    const STATE = globalThis._concordSTATE;
+    const live = STATE?.marketplace?.[worldId];
+    if (live && Array.isArray(live.listings)) {
+      const filtered = kind === "all" ? live.listings : live.listings.filter((l) => l.kind === kind);
+      return { ok: true, result: { worldId, source: "live", kind, listings: filtered.slice(0, 50) } };
+    }
+    const sample = [
+      { id: "lst_glyph_frost", kind: "spell_recipe", title: "Frost Lattice (level 2)", price: 120, currency: "cc", sellerName: "Elder Tinkerer", rarity: "uncommon" },
+      { id: "lst_blueprint_cabin", kind: "blueprint", title: "Stoneward Cabin (3×4)", price: 480, currency: "cc", sellerName: "Mason of the Vale", rarity: "common" },
+      { id: "lst_recipe_bread", kind: "fighting_style_recipe", title: "Hearth-grain Bread (cooked)", price: 12, currency: "cc", sellerName: "Mother Yarrow", rarity: "common" },
+      { id: "lst_dtu_oracle", kind: "dtu", title: "Oracle's Cipher (notebook page)", price: 240, currency: "cc", sellerName: "The Weaver", rarity: "rare" },
+      { id: "lst_glyph_storm", kind: "spell_recipe", title: "Stormcall (level 4)", price: 1100, currency: "cc", sellerName: "Sage Halloran", rarity: "rare" },
+    ];
+    const filtered = kind === "all" ? sample : sample.filter((l) => l.kind === kind);
+    return { ok: true, result: { worldId, source: "sample", kind, listings: filtered } };
+  });
+
+  // ── Overlay preferences (per-user) ──
+
+  registerLensAction("world", "overlay-prefs-get", (ctx, _artifact, _params = {}) => {
+    const s = getWorldLensState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = worldActorId(ctx);
+    const prefs = s.overlayPrefs.get(userId) || {
+      factionOverlay: false,
+      hotbarMode: "auto",
+      photoTemplate: "concord",
+    };
+    return { ok: true, result: { prefs } };
+  });
+
+  registerLensAction("world", "overlay-prefs-set", (ctx, _artifact, params = {}) => {
+    const s = getWorldLensState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = worldActorId(ctx);
+    const current = s.overlayPrefs.get(userId) || {
+      factionOverlay: false,
+      hotbarMode: "auto",
+      photoTemplate: "concord",
+    };
+    if (typeof params.factionOverlay === "boolean") current.factionOverlay = params.factionOverlay;
+    if (["auto", "combat", "build", "peace"].includes(params.hotbarMode)) current.hotbarMode = params.hotbarMode;
+    if (typeof params.photoTemplate === "string") current.photoTemplate = params.photoTemplate.slice(0, 24);
+    s.overlayPrefs.set(userId, current);
+    saveWorldLensState();
+    return { ok: true, result: { prefs: current } };
+  });
 }

--- a/server/tests/world-domain-parity.test.js
+++ b/server/tests/world-domain-parity.test.js
@@ -1,0 +1,213 @@
+// Tier-2 contract tests for world lens parity polish macros
+// (faction-overlay-data / share-link-create / quest-summary / marketplace-summary).
+// Pins per-user scoping + share link cache + quest pin toggle + overlay prefs.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerWorldActions from "../domains/world.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) {
+  ACTIONS.set(`${domain}.${name}`, fn);
+}
+function call(name, ctx, params = {}) {
+  const fn = ACTIONS.get(`world.${name}`);
+  if (!fn) throw new Error(`world.${name} not registered`);
+  return fn(ctx, { id: null, data: {}, meta: {} }, params);
+}
+
+before(() => {
+  registerWorldActions(register);
+});
+
+beforeEach(() => {
+  globalThis._concordSTATE = { dtus: new Map() };
+  globalThis._concordSaveStateDebounced = () => {};
+  globalThis.fetch = async () => {
+    throw new Error("network disabled");
+  };
+});
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+const ctxB = { actor: { userId: "user_b" }, userId: "user_b" };
+
+describe("world — faction overlay data", () => {
+  it("returns sample factions + relations when simulation absent", () => {
+    const r = call("faction-overlay-data", ctxA, { worldId: "concordia-hub" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.source, "sample");
+    assert.ok(r.result.factions.length >= 3);
+    assert.ok(Array.isArray(r.result.relations));
+    for (const f of r.result.factions) {
+      assert.ok(f.id, "faction id present");
+      assert.ok(f.name);
+      assert.ok(f.stance);
+      assert.ok(Number.isFinite(f.cx));
+      assert.ok(Number.isFinite(f.cy));
+      assert.ok(Number.isFinite(f.radius));
+    }
+  });
+
+  it("returns live data when simulation state seeded", () => {
+    globalThis._concordSTATE.factionStrategy = {
+      "world_test": {
+        factions: [{ id: "f1", name: "Live faction", stance: "war", momentum: 0.8, color: "#ff0000", cx: 100, cy: 100, radius: 50 }],
+        relations: [],
+      },
+    };
+    const r = call("faction-overlay-data", ctxA, { worldId: "world_test" });
+    assert.equal(r.result.source, "live");
+    assert.equal(r.result.factions[0].name, "Live faction");
+  });
+});
+
+describe("world — share link primitive", () => {
+  it("creates a link with position params encoded in URL", () => {
+    const r = call("share-link-create", ctxA, {
+      worldId: "concordia-hub",
+      x: 100.5,
+      y: 25.0,
+      z: -42.7,
+      note: "great view of the mountain",
+    });
+    assert.equal(r.ok, true);
+    assert.ok(r.result.link.url.includes("world=concordia-hub"));
+    assert.ok(r.result.link.url.includes("x=100.5"));
+    assert.ok(r.result.link.url.includes("y=25.0"));
+    assert.ok(r.result.link.url.includes("z=-42.7"));
+  });
+
+  it("rejects missing worldId", () => {
+    const r = call("share-link-create", ctxA, {});
+    assert.equal(r.ok, false);
+    assert.match(r.error, /worldId required/);
+  });
+
+  it("INVARIANT: share-links scoped per-user", () => {
+    call("share-link-create", ctxA, { worldId: "w_a" });
+    const listB = call("share-links-list", ctxB);
+    assert.equal(listB.result.links.length, 0);
+  });
+
+  it("share-links-list returns recent links sorted by createdAt desc", async () => {
+    call("share-link-create", ctxA, { worldId: "w1" });
+    await new Promise((r) => setTimeout(r, 2));
+    call("share-link-create", ctxA, { worldId: "w2" });
+    const list = call("share-links-list", ctxA);
+    assert.equal(list.result.links.length, 2);
+    assert.equal(list.result.links[0].worldId, "w2");
+  });
+});
+
+describe("world — quest summary", () => {
+  it("returns chains with active/completed counts", () => {
+    const r = call("quest-summary", ctxA, { worldId: "concordia-hub" });
+    assert.equal(r.ok, true);
+    assert.ok(r.result.chains.length > 0);
+    for (const chain of r.result.chains) {
+      assert.ok(chain.chainId);
+      assert.ok(Array.isArray(chain.quests));
+      assert.ok(Number.isInteger(chain.activeCount));
+      assert.ok(Number.isInteger(chain.completedCount));
+    }
+  });
+
+  it("quest-pin-toggle toggles pin state", () => {
+    const r1 = call("quest-pin-toggle", ctxA, { questId: "q_test_1" });
+    assert.equal(r1.result.pinned, true);
+    const r2 = call("quest-pin-toggle", ctxA, { questId: "q_test_1" });
+    assert.equal(r2.result.pinned, false);
+  });
+
+  it("rejects missing questId", () => {
+    const r = call("quest-pin-toggle", ctxA, {});
+    assert.equal(r.ok, false);
+    assert.match(r.error, /questId required/);
+  });
+
+  it("INVARIANT: pinned quests are scoped per-user", () => {
+    call("quest-pin-toggle", ctxA, { questId: "q_pinA" });
+    const summary = call("quest-summary", ctxB, { worldId: "concordia-hub" });
+    const allUserBQuests = summary.result.chains.flatMap((c) => c.quests);
+    const pinnedFromB = allUserBQuests.filter((q) => q.pinned);
+    assert.equal(pinnedFromB.length, 0);
+  });
+
+  it("pinned quests surface in quest-summary for the owning user", () => {
+    const sample = call("quest-summary", ctxA, { worldId: "concordia-hub" });
+    const someQuestId = sample.result.chains[0].quests[0].id;
+    call("quest-pin-toggle", ctxA, { questId: someQuestId });
+    const after = call("quest-summary", ctxA, { worldId: "concordia-hub" });
+    const allQuests = after.result.chains.flatMap((c) => c.quests);
+    const pinned = allQuests.find((q) => q.id === someQuestId);
+    assert.equal(pinned.pinned, true);
+  });
+});
+
+describe("world — marketplace summary", () => {
+  it("returns listings filtered by kind", () => {
+    const all = call("marketplace-summary", ctxA, { worldId: "concordia-hub", kind: "all" });
+    const spells = call("marketplace-summary", ctxA, { worldId: "concordia-hub", kind: "spell_recipe" });
+    assert.ok(all.result.listings.length > spells.result.listings.length);
+    for (const l of spells.result.listings) {
+      assert.equal(l.kind, "spell_recipe");
+    }
+  });
+
+  it("defaults to all when no kind provided", () => {
+    const r = call("marketplace-summary", ctxA, { worldId: "concordia-hub" });
+    assert.equal(r.result.kind, "all");
+  });
+
+  it("returns live data when STATE.marketplace seeded", () => {
+    globalThis._concordSTATE.marketplace = {
+      "world_test": {
+        listings: [{
+          id: "x", kind: "dtu", title: "Live", price: 100, currency: "cc",
+          sellerName: "Live seller", rarity: "rare",
+        }],
+      },
+    };
+    const r = call("marketplace-summary", ctxA, { worldId: "world_test" });
+    assert.equal(r.result.source, "live");
+    assert.equal(r.result.listings[0].title, "Live");
+  });
+});
+
+describe("world — overlay preferences", () => {
+  it("returns default prefs when unset", () => {
+    const r = call("overlay-prefs-get", ctxA);
+    assert.equal(r.result.prefs.factionOverlay, false);
+    assert.equal(r.result.prefs.hotbarMode, "auto");
+    assert.equal(r.result.prefs.photoTemplate, "concord");
+  });
+
+  it("persists prefs across calls", () => {
+    call("overlay-prefs-set", ctxA, { factionOverlay: true, hotbarMode: "combat" });
+    const r = call("overlay-prefs-get", ctxA);
+    assert.equal(r.result.prefs.factionOverlay, true);
+    assert.equal(r.result.prefs.hotbarMode, "combat");
+  });
+
+  it("INVARIANT: prefs are scoped per-user", () => {
+    call("overlay-prefs-set", ctxA, { factionOverlay: true });
+    const b = call("overlay-prefs-get", ctxB);
+    assert.equal(b.result.prefs.factionOverlay, false);
+  });
+
+  it("ignores invalid hotbarMode values", () => {
+    call("overlay-prefs-set", ctxA, { hotbarMode: "auto" });
+    call("overlay-prefs-set", ctxA, { hotbarMode: "invalid_mode" });
+    const r = call("overlay-prefs-get", ctxA);
+    assert.equal(r.result.prefs.hotbarMode, "auto");
+  });
+});
+
+describe("world — STATE unavailable path", () => {
+  it("returns error shape when STATE is missing for stateful macros", () => {
+    globalThis._concordSTATE = undefined;
+    const r = call("share-link-create", ctxA, { worldId: "x" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /STATE unavailable/);
+  });
+});


### PR DESCRIPTION
## Summary

Brings the world lens to 2026 parity vs the top UGC platforms (Roblox / Minecraft / UEFN / Unreal / Unity / Decentraland / VRChat / Manticore Core) along the four highest-ROI items from the polish list.

**Concord's structural edge** (faction strategy state machine, glyph algebra, embodied signals, lattice-born quests, NPC asymmetry, oracle dialogue, DTU royalties) is **already in the stack** — no competitor has any of these. The gap is **affordance, not capability**. This PR surfaces what already runs.

### Components added (4)
- **FactionOverlay** — toggleable SVG overlay with faction territory circles + relation lines (war/truce/alliance/tension/tribute) + click-to-inspect drawer. No competitor has this — Concord's faction strategy state machine has been silently running.
- **WorldShareButton** — UEFN island-code parity. One-button "share this spot" mints a deep link + copies to clipboard.
- **WorldQuestLogPanel** — collapsible chains, active/pinned/all filter, pin-to-HUD toggle. Surfaces existing quest engine + lattice-born quests with breadcrumb hints.
- **WorldMarketplacePanel** — tabbed surface (spells / blueprints / recipes / DTUs). Roblox UGC Limiteds + UEFN in-island transactions parity.

### Backend (8 macros in `server/domains/world.js`)
All state in-memory under `STATE.worldLens`, **per-user scoped** (CLAUDE.md migration-101 invariant). Macros gracefully fall back to deterministic sample data when simulation state isn't seeded — overlay renders even on cold boot.

| Group | Macros |
|---|---|
| Factions | `faction-overlay-data` |
| Sharing | `share-link-create`, `share-links-list` |
| Quests | `quest-summary`, `quest-pin-toggle` |
| Marketplace | `marketplace-summary` |
| Preferences | `overlay-prefs-get`, `overlay-prefs-set` |

### Wire-up
- 4 buttons in a new affordance bar just above the StatusBar
- Slide-over panels at `fixed inset-y-0 right-0`, z-40
- FactionOverlay is a non-modal floating panel at `top-20 right-4` so the world stays visible underneath

## Test plan
- [x] `node --test --test-force-exit --test-timeout=15000 server/tests/world-domain-parity.test.js` — **19/19 passing** (per-user scoping invariants, live-vs-sample fallback, pin-toggle, share-link cache, preference persistence, STATE-unavailable error path)
- [x] `npx tsc --noEmit` — zero errors (fixed shadowed `Map` global)
- [x] `npm run lint` — zero issues in world files
- [ ] Browser smoke test of the 4 panels — environment can't render UI; flagged per CLAUDE.md guidance

https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_