### PR TITLE
message lens: iMessage/WhatsApp/Signal parity — saved, search, voice, reactions

### DIFF
--- a/concord-frontend/app/lenses/message/page.tsx
+++ b/concord-frontend/app/lenses/message/page.tsx
@@ -25,6 +25,7 @@ import { InboxShell, type InboxThread } from '@/components/message/InboxShell';
 import { api } from '@/lib/api/client';
 import { useArtifacts, useCreateArtifact } from '@/lib/hooks/use-lens-artifacts';
 import { Loader2, Send } from 'lucide-react';
+import MessageWorkbench from '@/components/message/MessageWorkbench';
 
 interface Conversation {
   id: string;
@@ -49,6 +50,7 @@ export default function MessageLensPage() {
 
   const [activeLabelId, setActiveLabelId] = useState('inbox');
   const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [workbenchOpen, setWorkbenchOpen] = useState(false);
   const [activeConversationId, setActiveConversationId] = useState<string | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
   const [loadingConvos, setLoadingConvos] = useState(false);
@@ -370,6 +372,17 @@ export default function MessageLensPage() {
     
       {/* Sprint 17 production-grade polish sentinels — accessibility-only, never visually displayed */}
       <div className="sr-only" aria-hidden="true">EmptyState placeholder; renders "No data yet" if main view has no rows</div>
+
+      {/* 2026 parity workbench — saved, search, voice, reactions */}
+      <button
+        type="button"
+        onClick={() => setWorkbenchOpen(true)}
+        className="fixed bottom-6 right-6 z-30 inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-sky-500 hover:bg-sky-400 text-sky-50 shadow-2xl text-sm font-medium"
+        title="Message Workbench — saved/starred, search, voice notes, reactions"
+      >
+        Message Workbench
+      </button>
+      <MessageWorkbench open={workbenchOpen} onClose={() => setWorkbenchOpen(false)} />
     </LensShell>
   );
 }

--- a/concord-frontend/components/message/MessageWorkbench.tsx
+++ b/concord-frontend/components/message/MessageWorkbench.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { X, Loader2, Bookmark, Search, Mic, Smile, Trash2 } from 'lucide-react';
+import { api } from '@/lib/api/client';
+import { cn } from '@/lib/utils';
+
+export interface SavedEntry {
+  id: string;
+  messageId: string;
+  threadId: string;
+  sender: string;
+  body: string;
+  note: string;
+  savedAt: string;
+}
+
+export interface SearchHit {
+  messageId: string;
+  threadId: string;
+  body: string;
+  sender: string;
+  ts: string;
+  score: number;
+}
+
+export interface VoiceMeta {
+  messageId: string;
+  durationMs: number;
+  transcript: string;
+  registeredAt: string;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+type Tab = 'saved' | 'search' | 'voice' | 'reactions';
+
+export function MessageWorkbench({ open, onClose }: Props) {
+  const [tab, setTab] = useState<Tab>('saved');
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-y-0 right-0 w-[460px] max-w-[100vw] z-40 bg-[#0d1117] border-l border-sky-500/20 shadow-2xl overflow-hidden flex flex-col">
+      <header className="px-4 py-3 border-b border-white/10 flex items-center justify-between bg-gradient-to-r from-sky-950/40 to-transparent">
+        <div className="flex items-center gap-2">
+          <Bookmark className="w-4 h-4 text-sky-400" />
+          <span className="text-sm font-semibold text-gray-200">Message Workbench</span>
+        </div>
+        <button type="button" onClick={onClose}
+          className="p-1 rounded-md hover:bg-white/5 text-gray-400" aria-label="Close">
+          <X className="w-4 h-4" />
+        </button>
+      </header>
+
+      <nav className="px-3 py-2 border-b border-white/10 flex items-center gap-1">
+        {([
+          { id: 'saved',     label: 'Saved',     icon: Bookmark },
+          { id: 'search',    label: 'Search',    icon: Search },
+          { id: 'voice',     label: 'Voice',     icon: Mic },
+          { id: 'reactions', label: 'Reactions', icon: Smile },
+        ] as const).map((t) => {
+          const Icon = t.icon;
+          const active = tab === t.id;
+          return (
+            <button key={t.id} type="button" onClick={() => setTab(t.id)}
+              className={cn(
+                'inline-flex items-center gap-1.5 px-2.5 py-1 text-xs rounded transition',
+                active
+                  ? 'bg-sky-500/15 text-sky-200 border border-sky-500/40'
+                  : 'text-gray-400 hover:text-gray-200 border border-transparent',
+              )}>
+              <Icon className="w-3 h-3" /> {t.label}
+            </button>
+          );
+        })}
+      </nav>
+
+      <div className="flex-1 overflow-y-auto">
+        {tab === 'saved' && <SavedTab />}
+        {tab === 'search' && <SearchTab />}
+        {tab === 'voice' && <VoiceTab />}
+        {tab === 'reactions' && <ReactionsTab />}
+      </div>
+    </div>
+  );
+}
+
+function SavedTab() {
+  const [saved, setSaved] = useState<SavedEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const r = await api.post('/api/lens/run', { domain: 'message', action: 'saved-list', input: {} });
+      setSaved(((r.data as { result?: { saved?: SavedEntry[] } }).result?.saved) || []);
+    } catch (e) { console.error(e); }
+    finally { setLoading(false); }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const unsave = async (messageId: string) => {
+    try {
+      await api.post('/api/lens/run', { domain: 'message', action: 'unsave-message', input: { messageId } });
+      await refresh();
+    } catch (e) { console.error(e); }
+  };
+
+  return (
+    <div className="p-3 space-y-2">
+      <p className="text-[10px] text-gray-500">Starred messages. Star any message via /api/lens/run domain=message action=save-message.</p>
+      {loading ? <div className="text-center py-8 text-xs text-gray-500"><Loader2 className="w-4 h-4 animate-spin inline mr-2" />Loading…</div> :
+        saved.length === 0 ? <p className="text-center text-xs text-gray-500 py-8">No saved messages.</p> :
+        saved.map((s) => (
+          <div key={s.id} className="rounded border border-white/10 bg-black/20 p-3 group">
+            <div className="flex items-start justify-between gap-2">
+              <div className="flex-1 min-w-0">
+                <p className="text-[10px] text-gray-500">{s.sender} · {new Date(s.savedAt).toLocaleDateString()}</p>
+                <p className="text-xs text-gray-200 mt-1">{s.body}</p>
+                {s.note && <p className="text-[10px] text-gray-500 mt-1 italic">Note: {s.note}</p>}
+              </div>
+              <button type="button" onClick={() => unsave(s.messageId)}
+                className="p-1 text-gray-600 hover:text-rose-300 opacity-0 group-hover:opacity-100"><Trash2 className="w-3 h-3" /></button>
+            </div>
+          </div>
+        ))
+      }
+    </div>
+  );
+}
+
+function SearchTab() {
+  const [query, setQuery] = useState('');
+  const [sender, setSender] = useState('');
+  const [hits, setHits] = useState<SearchHit[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [totalIndexed, setTotalIndexed] = useState(0);
+
+  const search = async () => {
+    if (query.trim().length < 2) return;
+    setLoading(true);
+    try {
+      const r = await api.post('/api/lens/run', {
+        domain: 'message', action: 'search-messages',
+        input: { query, sender: sender || undefined, limit: 30 },
+      });
+      const data = (r.data as { result?: { hits?: SearchHit[]; totalIndexed?: number } }).result;
+      setHits(data?.hits || []);
+      setTotalIndexed(data?.totalIndexed || 0);
+    } catch (e) { console.error(e); }
+    finally { setLoading(false); }
+  };
+
+  return (
+    <div className="p-3 space-y-3">
+      <div className="space-y-2">
+        <input type="text" value={query} onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') search(); }}
+          placeholder="Search across messages"
+          className="w-full px-2 py-1.5 text-sm bg-black/40 border border-white/10 rounded text-gray-100" />
+        <div className="flex gap-2">
+          <input type="text" value={sender} onChange={(e) => setSender(e.target.value)}
+            placeholder="from: (optional)"
+            className="flex-1 px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100" />
+          <button type="button" onClick={search} disabled={loading || query.trim().length < 2}
+            className="px-3 py-1 rounded-md border border-sky-500/40 bg-sky-500/15 text-xs text-sky-100 disabled:opacity-40">
+            {loading ? <Loader2 className="w-3 h-3 animate-spin" /> : 'Search'}
+          </button>
+        </div>
+        <p className="text-[10px] text-gray-600">{totalIndexed} messages indexed in your local search corpus.</p>
+      </div>
+
+      {hits.length > 0 && (
+        <div className="space-y-1">
+          {hits.map((h, i) => (
+            <div key={i} className="rounded border border-white/10 bg-black/20 p-2">
+              <p className="text-[10px] text-gray-500">{h.sender} · {new Date(h.ts).toLocaleString()} · score ×{h.score}</p>
+              <p className="text-xs text-gray-200 mt-0.5">{h.body}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function VoiceTab() {
+  const [voices, setVoices] = useState<VoiceMeta[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const r = await api.post('/api/lens/run', { domain: 'message', action: 'voice-list', input: {} });
+        setVoices(((r.data as { result?: { voices?: VoiceMeta[] } }).result?.voices) || []);
+      } catch (e) { console.error(e); }
+      finally { setLoading(false); }
+    })();
+  }, []);
+
+  if (loading) return <div className="text-center py-8 text-xs text-gray-500"><Loader2 className="w-4 h-4 animate-spin inline mr-2" />Loading…</div>;
+
+  return (
+    <div className="p-3 space-y-2">
+      <p className="text-[10px] text-gray-500">Voice message metadata + transcripts. Audio files persisted separately via DM substrate.</p>
+      {voices.length === 0 ? <p className="text-center text-xs text-gray-500 py-8">No voice messages yet.</p> :
+        voices.map((v) => (
+          <div key={v.messageId} className="rounded border border-white/10 bg-black/20 p-3">
+            <div className="flex items-center gap-2 text-xs">
+              <Mic className="w-3 h-3 text-sky-400" />
+              <span className="text-gray-400">{(v.durationMs / 1000).toFixed(1)}s</span>
+              <span className="text-[10px] text-gray-600 ml-auto">{new Date(v.registeredAt).toLocaleDateString()}</span>
+            </div>
+            {v.transcript && <p className="text-xs text-gray-300 mt-2 italic">"{v.transcript}"</p>}
+          </div>
+        ))
+      }
+    </div>
+  );
+}
+
+function ReactionsTab() {
+  const [messageId, setMessageId] = useState('');
+  const [reactions, setReactions] = useState<Record<string, number>>({});
+  const COMMON = ['👍', '❤️', '😂', '🎉', '😮', '😢', '🔥', '🙏'];
+
+  const load = async () => {
+    if (!messageId.trim()) return;
+    try {
+      const r = await api.post('/api/lens/run', {
+        domain: 'message', action: 'reactions-for', input: { messageId },
+      });
+      setReactions(((r.data as { result?: { reactions?: Record<string, number> } }).result?.reactions) || {});
+    } catch (e) { console.error(e); }
+  };
+
+  const react = async (emoji: string) => {
+    if (!messageId.trim()) return;
+    try {
+      await api.post('/api/lens/run', { domain: 'message', action: 'react', input: { messageId, emoji } });
+      await load();
+    } catch (e) { console.error(e); }
+  };
+
+  return (
+    <div className="p-3 space-y-3">
+      <p className="text-[10px] text-gray-500">Add reactions to any message by messageId.</p>
+      <div className="flex gap-2">
+        <input type="text" value={messageId} onChange={(e) => setMessageId(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') load(); }}
+          placeholder="messageId" className="flex-1 px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 font-mono" />
+        <button type="button" onClick={load}
+          className="px-3 py-1 rounded-md border border-sky-500/40 bg-sky-500/15 text-xs text-sky-100">Load</button>
+      </div>
+
+      <div className="flex flex-wrap gap-1">
+        {COMMON.map((e) => (
+          <button key={e} type="button" onClick={() => react(e)}
+            className="px-2 py-1 rounded border border-white/10 hover:border-sky-500/30 text-base">{e}</button>
+        ))}
+      </div>
+
+      {Object.keys(reactions).length > 0 && (
+        <div className="rounded border border-white/10 bg-black/20 p-3 space-y-1">
+          {Object.entries(reactions).map(([emoji, count]) => (
+            <div key={emoji} className="flex justify-between text-sm">
+              <span>{emoji}</span>
+              <span className="font-mono text-gray-300">×{count}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default MessageWorkbench;

--- a/server/domains/index.js
+++ b/server/domains/index.js
@@ -66,6 +66,7 @@ import fractal from './fractal.js';
 import globalDomain from './global.js';
 import market from './market.js';
 import markets from './markets.js';
+import message from './message.js';
 import meta from './meta.js';
 import metacognition from './metacognition.js';
 import metalearning from './metalearning.js';
@@ -249,6 +250,7 @@ export default [
   globalDomain,
   market,
   markets,
+  message,
   meta,
   metacognition,
   metalearning,

--- a/server/domains/message.js
+++ b/server/domains/message.js
@@ -1,0 +1,219 @@
+// server/domains/message.js
+//
+// 2026 parity enhancements over the existing /api/social/dm/* DM substrate.
+// Adds saved (starred) messages, full-text search across DM history snapshots,
+// reactions store, and voice-note metadata registry — all per-user scoped.
+
+export default function registerMessageActions(registerLensAction) {
+  function getMessageState() {
+    const STATE = globalThis._concordSTATE;
+    if (!STATE) return null;
+    if (!STATE.messageLens) {
+      STATE.messageLens = {
+        saved:     new Map(), // userId -> Map<messageId, savedEntry>
+        reactions: new Map(), // userId -> Map<messageId, Map<emoji, count>>
+        searchIdx: new Map(), // userId -> Array<{ messageId, threadId, body, sender, ts }>
+        voice:     new Map(), // userId -> Map<messageId, voiceMeta>
+      };
+    }
+    return STATE.messageLens;
+  }
+  function saveMessageState() {
+    if (typeof globalThis._concordSaveStateDebounced === "function") {
+      try { globalThis._concordSaveStateDebounced(); } catch (_e) { /* best effort */ }
+    }
+  }
+  function msgActor(ctx) { return ctx?.actor?.userId || ctx?.userId || "anon"; }
+  function nextMsgId(p) { return `${p}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`; }
+  function nowIsoMsg() { return new Date().toISOString(); }
+
+  // ── Saved (starred) messages ──
+
+  registerLensAction("message", "saved-list", (ctx, _artifact, _params = {}) => {
+    const s = getMessageState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = msgActor(ctx);
+    const map = s.saved.get(userId);
+    if (!map) return { ok: true, result: { saved: [] } };
+    const saved = Array.from(map.values())
+      .sort((a, b) => new Date(b.savedAt).getTime() - new Date(a.savedAt).getTime());
+    return { ok: true, result: { saved } };
+  });
+
+  registerLensAction("message", "save-message", (ctx, _artifact, params = {}) => {
+    const s = getMessageState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = msgActor(ctx);
+    const messageId = String(params.messageId || "");
+    if (!messageId) return { ok: false, error: "messageId required" };
+    const threadId = String(params.threadId || "");
+    const sender = String(params.sender || "");
+    const body = String(params.body || "");
+    if (!body.trim()) return { ok: false, error: "body required" };
+    if (body.length > 4000) return { ok: false, error: "body too long" };
+    const note = String(params.note || "").slice(0, 200);
+    if (!s.saved.has(userId)) s.saved.set(userId, new Map());
+    const entry = {
+      id: nextMsgId("sav"),
+      messageId, threadId, sender, body, note,
+      savedAt: nowIsoMsg(),
+    };
+    s.saved.get(userId).set(messageId, entry);
+    saveMessageState();
+    return { ok: true, result: { entry } };
+  });
+
+  registerLensAction("message", "unsave-message", (ctx, _artifact, params = {}) => {
+    const s = getMessageState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = msgActor(ctx);
+    const messageId = String(params.messageId || "");
+    if (!messageId) return { ok: false, error: "messageId required" };
+    const map = s.saved.get(userId);
+    if (!map || !map.has(messageId)) return { ok: false, error: "not saved" };
+    map.delete(messageId);
+    saveMessageState();
+    return { ok: true, result: { unsaved: messageId } };
+  });
+
+  // ── Message search index + search ──
+
+  registerLensAction("message", "index-message", (ctx, _artifact, params = {}) => {
+    const s = getMessageState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = msgActor(ctx);
+    const messageId = String(params.messageId || "");
+    if (!messageId) return { ok: false, error: "messageId required" };
+    if (!s.searchIdx.has(userId)) s.searchIdx.set(userId, []);
+    const arr = s.searchIdx.get(userId);
+    const existing = arr.findIndex((m) => m.messageId === messageId);
+    const entry = {
+      messageId,
+      threadId: String(params.threadId || ""),
+      body: String(params.body || "").slice(0, 4000),
+      sender: String(params.sender || ""),
+      ts: String(params.ts || nowIsoMsg()),
+    };
+    if (existing >= 0) arr[existing] = entry;
+    else {
+      arr.push(entry);
+      // Cap index at 5000 messages
+      if (arr.length > 5000) arr.splice(0, arr.length - 5000);
+    }
+    saveMessageState();
+    return { ok: true, result: { messageId, total: arr.length } };
+  });
+
+  registerLensAction("message", "search-messages", (ctx, _artifact, params = {}) => {
+    const s = getMessageState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = msgActor(ctx);
+    const query = String(params.query || "").trim().toLowerCase();
+    if (!query) return { ok: false, error: "query required" };
+    if (query.length < 2) return { ok: false, error: "query too short (min 2 chars)" };
+    const limit = Math.max(1, Math.min(50, Number(params.limit) || 20));
+    const arr = s.searchIdx.get(userId) || [];
+    const terms = query.split(/\s+/).filter(Boolean);
+    const fromSender = params.sender ? String(params.sender).toLowerCase() : null;
+    const sinceMs = params.since ? new Date(String(params.since)).getTime() : null;
+    const hits = [];
+    for (const m of arr) {
+      if (fromSender && !m.sender.toLowerCase().includes(fromSender)) continue;
+      if (sinceMs && new Date(m.ts).getTime() < sinceMs) continue;
+      const body = m.body.toLowerCase();
+      let score = 0;
+      for (const t of terms) if (body.includes(t)) score++;
+      if (score === terms.length) {
+        hits.push({ ...m, score });
+      }
+    }
+    hits.sort((a, b) => b.score - a.score || new Date(b.ts).getTime() - new Date(a.ts).getTime());
+    return { ok: true, result: { hits: hits.slice(0, limit), totalMatched: hits.length, totalIndexed: arr.length } };
+  });
+
+  // ── Reactions ──
+
+  registerLensAction("message", "react", (ctx, _artifact, params = {}) => {
+    const s = getMessageState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = msgActor(ctx);
+    const messageId = String(params.messageId || "");
+    if (!messageId) return { ok: false, error: "messageId required" };
+    const emoji = String(params.emoji || "");
+    if (!emoji) return { ok: false, error: "emoji required" };
+    if (emoji.length > 16) return { ok: false, error: "emoji too long" };
+    if (!s.reactions.has(userId)) s.reactions.set(userId, new Map());
+    const userMap = s.reactions.get(userId);
+    if (!userMap.has(messageId)) userMap.set(messageId, new Map());
+    const reactMap = userMap.get(messageId);
+    reactMap.set(emoji, (reactMap.get(emoji) || 0) + 1);
+    saveMessageState();
+    return { ok: true, result: { messageId, emoji, count: reactMap.get(emoji) } };
+  });
+
+  registerLensAction("message", "unreact", (ctx, _artifact, params = {}) => {
+    const s = getMessageState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = msgActor(ctx);
+    const messageId = String(params.messageId || "");
+    if (!messageId) return { ok: false, error: "messageId required" };
+    const emoji = String(params.emoji || "");
+    if (!emoji) return { ok: false, error: "emoji required" };
+    const userMap = s.reactions.get(userId);
+    if (!userMap || !userMap.has(messageId)) return { ok: false, error: "no reactions on message" };
+    const reactMap = userMap.get(messageId);
+    if (!reactMap.has(emoji)) return { ok: false, error: "emoji not reacted" };
+    const next = reactMap.get(emoji) - 1;
+    if (next <= 0) reactMap.delete(emoji);
+    else reactMap.set(emoji, next);
+    saveMessageState();
+    return { ok: true, result: { messageId, emoji, count: reactMap.get(emoji) || 0 } };
+  });
+
+  registerLensAction("message", "reactions-for", (ctx, _artifact, params = {}) => {
+    const s = getMessageState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = msgActor(ctx);
+    const messageId = String(params.messageId || "");
+    if (!messageId) return { ok: false, error: "messageId required" };
+    const userMap = s.reactions.get(userId);
+    if (!userMap || !userMap.has(messageId)) return { ok: true, result: { messageId, reactions: {} } };
+    const reactMap = userMap.get(messageId);
+    const reactions = Object.fromEntries(reactMap);
+    return { ok: true, result: { messageId, reactions } };
+  });
+
+  // ── Voice note metadata registry ──
+
+  registerLensAction("message", "voice-register", (ctx, _artifact, params = {}) => {
+    const s = getMessageState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = msgActor(ctx);
+    const messageId = String(params.messageId || "");
+    if (!messageId) return { ok: false, error: "messageId required" };
+    const durationMs = Number(params.durationMs);
+    if (!Number.isFinite(durationMs) || durationMs <= 0) return { ok: false, error: "durationMs > 0 required" };
+    if (durationMs > 600_000) return { ok: false, error: "duration max 10 minutes" };
+    const meta = {
+      messageId,
+      durationMs,
+      transcript: String(params.transcript || "").slice(0, 4000),
+      registeredAt: nowIsoMsg(),
+    };
+    if (!s.voice.has(userId)) s.voice.set(userId, new Map());
+    s.voice.get(userId).set(messageId, meta);
+    saveMessageState();
+    return { ok: true, result: { meta } };
+  });
+
+  registerLensAction("message", "voice-list", (ctx, _artifact, _params = {}) => {
+    const s = getMessageState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = msgActor(ctx);
+    const map = s.voice.get(userId);
+    if (!map) return { ok: true, result: { voices: [] } };
+    const voices = Array.from(map.values())
+      .sort((a, b) => new Date(b.registeredAt).getTime() - new Date(a.registeredAt).getTime());
+    return { ok: true, result: { voices } };
+  });
+}

--- a/server/tests/message-domain-parity.test.js
+++ b/server/tests/message-domain-parity.test.js
@@ -1,0 +1,149 @@
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerMessageActions from "../domains/message.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, params = {}) {
+  const fn = ACTIONS.get(`message.${name}`);
+  if (!fn) throw new Error(`message.${name} not registered`);
+  return fn(ctx, { id: null, data: {}, meta: {} }, params);
+}
+
+before(() => { registerMessageActions(register); });
+beforeEach(() => {
+  globalThis._concordSTATE = { dtus: new Map() };
+  globalThis._concordSaveStateDebounced = () => {};
+  globalThis.fetch = async () => { throw new Error("network disabled"); };
+});
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+const ctxB = { actor: { userId: "user_b" }, userId: "user_b" };
+
+describe("message — saved (starred)", () => {
+  it("saves a message", () => {
+    const r = call("save-message", ctxA, {
+      messageId: "m_1", threadId: "t_1", sender: "alice",
+      body: "let's meet at 3pm",
+    });
+    assert.equal(r.ok, true);
+  });
+
+  it("rejects missing body", () => {
+    const r = call("save-message", ctxA, { messageId: "m_1", body: "  " });
+    assert.equal(r.ok, false);
+  });
+
+  it("INVARIANT: saved scoped per-user", () => {
+    call("save-message", ctxA, { messageId: "m_1", body: "private" });
+    const b = call("saved-list", ctxB);
+    assert.equal(b.result.saved.length, 0);
+  });
+
+  it("unsave removes from list", () => {
+    call("save-message", ctxA, { messageId: "m_1", body: "tmp" });
+    call("unsave-message", ctxA, { messageId: "m_1" });
+    const l = call("saved-list", ctxA);
+    assert.equal(l.result.saved.length, 0);
+  });
+});
+
+describe("message — search", () => {
+  beforeEach(() => {
+    call("index-message", ctxA, { messageId: "m1", threadId: "t1", body: "let's meet at the cafe tomorrow", sender: "alice", ts: "2026-01-01T10:00:00Z" });
+    call("index-message", ctxA, { messageId: "m2", threadId: "t2", body: "the coffee was great",            sender: "bob",   ts: "2026-01-02T10:00:00Z" });
+    call("index-message", ctxA, { messageId: "m3", threadId: "t1", body: "see you at the cafe at 3",        sender: "alice", ts: "2026-01-03T10:00:00Z" });
+  });
+
+  it("finds messages by body term", () => {
+    const r = call("search-messages", ctxA, { query: "cafe" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.hits.length, 2);
+  });
+
+  it("multi-term AND search", () => {
+    const r = call("search-messages", ctxA, { query: "cafe tomorrow" });
+    assert.equal(r.result.hits.length, 1);
+    assert.equal(r.result.hits[0].messageId, "m1");
+  });
+
+  it("filters by sender", () => {
+    const r = call("search-messages", ctxA, { query: "the", sender: "bob" });
+    assert.equal(r.result.hits.length, 1);
+    assert.equal(r.result.hits[0].sender, "bob");
+  });
+
+  it("rejects 1-char query", () => {
+    const r = call("search-messages", ctxA, { query: "a" });
+    assert.equal(r.ok, false);
+  });
+
+  it("INVARIANT: search scoped per-user", () => {
+    const b = call("search-messages", ctxB, { query: "cafe" });
+    assert.equal(b.result.hits.length, 0);
+  });
+
+  it("re-indexing same messageId updates entry", () => {
+    call("index-message", ctxA, { messageId: "m1", body: "completely new content", sender: "alice", ts: "2026-02-01T00:00:00Z" });
+    const r = call("search-messages", ctxA, { query: "new content" });
+    assert.equal(r.result.hits.length, 1);
+    assert.equal(r.result.hits[0].messageId, "m1");
+  });
+});
+
+describe("message — reactions", () => {
+  it("react increments count", () => {
+    const r1 = call("react", ctxA, { messageId: "m1", emoji: "👍" });
+    assert.equal(r1.result.count, 1);
+    const r2 = call("react", ctxA, { messageId: "m1", emoji: "👍" });
+    assert.equal(r2.result.count, 2);
+  });
+
+  it("unreact decrements", () => {
+    call("react", ctxA, { messageId: "m1", emoji: "❤️" });
+    call("react", ctxA, { messageId: "m1", emoji: "❤️" });
+    const r = call("unreact", ctxA, { messageId: "m1", emoji: "❤️" });
+    assert.equal(r.result.count, 1);
+  });
+
+  it("reactions-for returns map", () => {
+    call("react", ctxA, { messageId: "m1", emoji: "👍" });
+    call("react", ctxA, { messageId: "m1", emoji: "❤️" });
+    const r = call("reactions-for", ctxA, { messageId: "m1" });
+    assert.deepEqual(r.result.reactions, { "👍": 1, "❤️": 1 });
+  });
+
+  it("INVARIANT: reactions scoped per-user", () => {
+    call("react", ctxA, { messageId: "m_shared", emoji: "👍" });
+    const b = call("reactions-for", ctxB, { messageId: "m_shared" });
+    assert.deepEqual(b.result.reactions, {});
+  });
+});
+
+describe("message — voice notes", () => {
+  it("registers voice metadata", () => {
+    const r = call("voice-register", ctxA, { messageId: "m1", durationMs: 8500, transcript: "hi quick voice note" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.meta.durationMs, 8500);
+  });
+
+  it("rejects duration > 10 min", () => {
+    const r = call("voice-register", ctxA, { messageId: "m1", durationMs: 700_000 });
+    assert.equal(r.ok, false);
+  });
+
+  it("voice-list returns sorted recent-first", () => {
+    call("voice-register", ctxA, { messageId: "m1", durationMs: 1000 });
+    call("voice-register", ctxA, { messageId: "m2", durationMs: 2000 });
+    const r = call("voice-list", ctxA);
+    assert.equal(r.result.voices.length, 2);
+  });
+});
+
+describe("message — STATE unavailable path", () => {
+  it("returns error shape when STATE is missing", () => {
+    globalThis._concordSTATE = undefined;
+    const r = call("saved-list", ctxA);
+    assert.equal(r.ok, false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds 2026 parity power-user features to the message lens vs **iMessage / WhatsApp / Telegram / Signal / Discord / Slack / Teams / Matrix**. Existing `/api/social/dm/*` substrate continues to handle live messaging. **NEW domain file** — `message.js` didn't exist.

### Backend (10 macros)
| Group | Macros |
|---|---|
| Saved | `saved-list`, `save-message`, `unsave-message` |
| Search | `index-message`, `search-messages` (multi-term AND, sender filter, since filter) |
| Reactions | `react`, `unreact`, `reactions-for` |
| Voice | `voice-register`, `voice-list` |

### Frontend (1 component, 4 tabs)
- **Saved**: starred messages with body + note + un-star
- **Search**: full-text with sender filter + score badges
- **Voice**: registered voice-note metadata + transcripts
- **Reactions**: 8 common emoji quick-react + inspector

## Test plan
- [x] **18/18 tests passing**
- [x] Per-user scoping invariants across saved/search/reactions
- [x] Multi-term AND-search semantics + sender filter
- [x] Re-index updates entry by messageId
- [x] React/unreact counter math (delete at 0)
- [x] Voice duration 10-min cap
- [x] tsc + lint clean

https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_