### PR TITLE
realestate lens: Zillow/Redfin/Trulia parity — mortgage, affordability, rent-vs-buy, saved searches

### DIFF
--- a/concord-frontend/app/lenses/realestate/page.tsx
+++ b/concord-frontend/app/lenses/realestate/page.tsx
@@ -63,6 +63,7 @@ import { DTUExportButton } from '@/components/lens/DTUExportButton';
 import { RealtimeDataPanel } from '@/components/lens/RealtimeDataPanel';
 import { LensFeaturePanel } from '@/components/lens/LensFeaturePanel';
 import LiveFeed from '@/components/lens/LiveFeed';
+import RealEstateWorkbench from '@/components/realestate/RealEstateWorkbench';
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -398,6 +399,7 @@ export default function RealEstateLensPage() {
 
   const [showFeatures, setShowFeatures] = useState(true);
   const [activeTab, setActiveTab] = useState<ModeTab>('Dashboard');
+  const [workbenchOpen, setWorkbenchOpen] = useState(false);
 
   // Lens-scoped keyboard commands (auto-wired by codemod).
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -3335,6 +3337,17 @@ export default function RealEstateLensPage() {
     
       {/* Sprint 17 production-grade polish sentinels — accessibility-only, never visually displayed */}
       <a href="#realestate-skip" className="sr-only focus:not-sr-only focus:ring-2 focus:ring-amber-500 focus:outline-none">Skip to realestate content</a>
+
+      {/* 2026 parity workbench — mortgage / affordability / rent vs buy / saved searches */}
+      <button
+        type="button"
+        onClick={() => setWorkbenchOpen(true)}
+        className="fixed bottom-6 right-6 z-30 inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-orange-500 hover:bg-orange-400 text-orange-50 shadow-2xl text-sm font-medium"
+        title="Real Estate Workbench — mortgage, affordability, rent vs buy, saved searches"
+      >
+        Real Estate Workbench
+      </button>
+      <RealEstateWorkbench open={workbenchOpen} onClose={() => setWorkbenchOpen(false)} />
     </LensShell>
   );
 }

--- a/concord-frontend/components/realestate/RealEstateWorkbench.tsx
+++ b/concord-frontend/components/realestate/RealEstateWorkbench.tsx
@@ -1,0 +1,315 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { X, Loader2, Home, Calculator, Save, Trash2, Plus, ScrollText } from 'lucide-react';
+import { api } from '@/lib/api/client';
+import { cn } from '@/lib/utils';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+type Tab = 'mortgage' | 'afford' | 'rentbuy' | 'searches';
+
+export function RealEstateWorkbench({ open, onClose }: Props) {
+  const [tab, setTab] = useState<Tab>('mortgage');
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-y-0 right-0 w-[560px] max-w-[100vw] z-40 bg-[#0d1117] border-l border-orange-500/20 shadow-2xl overflow-hidden flex flex-col">
+      <header className="px-4 py-3 border-b border-white/10 flex items-center justify-between bg-gradient-to-r from-orange-950/40 to-transparent">
+        <div className="flex items-center gap-2">
+          <Home className="w-4 h-4 text-orange-400" />
+          <span className="text-sm font-semibold text-gray-200">Real Estate Workbench</span>
+        </div>
+        <button type="button" onClick={onClose} className="p-1 rounded-md hover:bg-white/5 text-gray-400" aria-label="Close">
+          <X className="w-4 h-4" />
+        </button>
+      </header>
+
+      <nav className="px-3 py-2 border-b border-white/10 flex items-center gap-1">
+        {([
+          { id: 'mortgage', label: 'Mortgage',     icon: Calculator },
+          { id: 'afford',   label: 'Afford',       icon: Calculator },
+          { id: 'rentbuy',  label: 'Rent vs Buy',  icon: Calculator },
+          { id: 'searches', label: 'Saved',        icon: ScrollText },
+        ] as const).map((t) => {
+          const Icon = t.icon;
+          const active = tab === t.id;
+          return (
+            <button key={t.id} type="button" onClick={() => setTab(t.id)}
+              className={cn(
+                'inline-flex items-center gap-1.5 px-2.5 py-1 text-xs rounded transition',
+                active
+                  ? 'bg-orange-500/15 text-orange-200 border border-orange-500/40'
+                  : 'text-gray-400 hover:text-gray-200 border border-transparent',
+              )}>
+              <Icon className="w-3 h-3" /> {t.label}
+            </button>
+          );
+        })}
+      </nav>
+
+      <div className="flex-1 overflow-y-auto">
+        {tab === 'mortgage' && <MortgageTab />}
+        {tab === 'afford' && <AffordTab />}
+        {tab === 'rentbuy' && <RentBuyTab />}
+        {tab === 'searches' && <SearchesTab />}
+      </div>
+    </div>
+  );
+}
+
+function MortgageTab() {
+  const [vals, setVals] = useState({ price: 500_000, downPercent: 20, rate: 7, termYears: 30, taxRate: 1.1, insurance: 1200, hoa: 0 });
+  const [result, setResult] = useState<{
+    monthly: { total: number; principalAndInterest: number; tax: number; insurance: number; pmi: number; hoa: number };
+    ltvPercent: number;
+    totalCostOverTerm: number;
+    totalInterest: number;
+  } | null>(null);
+
+  const calc = async () => {
+    try {
+      const r = await api.post('/api/lens/run', { domain: 'realestate', action: 'calc-mortgage', input: vals });
+      setResult(((r.data as { result?: typeof result }).result) || null);
+    } catch (e) { console.error(e); }
+  };
+
+  useEffect(() => { calc(); }, []);  // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className="p-3 space-y-3">
+      <div className="grid grid-cols-2 gap-2">
+        {([
+          ['price', 'Price ($)'],
+          ['downPercent', 'Down %'],
+          ['rate', 'Rate (%/yr)'],
+          ['termYears', 'Term (yrs)'],
+          ['taxRate', 'Tax (%/yr)'],
+          ['insurance', 'Insurance ($/yr)'],
+          ['hoa', 'HOA ($/mo)'],
+        ] as const).map(([k, label]) => (
+          <label key={k} className="flex flex-col gap-1">
+            <span className="text-[10px] uppercase text-gray-500">{label}</span>
+            <input type="number" value={vals[k]}
+              onChange={(e) => setVals({ ...vals, [k]: Number(e.target.value) })}
+              className="px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 font-mono" />
+          </label>
+        ))}
+      </div>
+      <button type="button" onClick={calc}
+        className="px-3 py-1 rounded-md border border-orange-500/40 bg-orange-500/15 text-xs text-orange-100">Compute PITI</button>
+
+      {result && (
+        <div className="rounded border border-orange-500/20 bg-orange-500/5 p-3 space-y-2">
+          <p className="text-sm">
+            Monthly total: <span className="font-mono text-2xl text-orange-300">${result.monthly.total.toLocaleString()}</span>
+          </p>
+          <div className="grid grid-cols-3 gap-2 text-xs">
+            <p><span className="text-gray-500">P&I</span><br /><span className="font-mono text-gray-200">${result.monthly.principalAndInterest}</span></p>
+            <p><span className="text-gray-500">Tax</span><br /><span className="font-mono text-gray-200">${result.monthly.tax}</span></p>
+            <p><span className="text-gray-500">Insurance</span><br /><span className="font-mono text-gray-200">${result.monthly.insurance}</span></p>
+            <p><span className="text-gray-500">PMI</span><br /><span className="font-mono text-gray-200">${result.monthly.pmi}</span></p>
+            <p><span className="text-gray-500">HOA</span><br /><span className="font-mono text-gray-200">${result.monthly.hoa}</span></p>
+            <p><span className="text-gray-500">LTV</span><br /><span className="font-mono text-gray-200">{result.ltvPercent}%</span></p>
+          </div>
+          <div className="border-t border-white/10 pt-2 text-xs">
+            <p>Total interest over term: <span className="font-mono text-rose-300">${result.totalInterest.toLocaleString()}</span></p>
+            <p>Total cost: <span className="font-mono text-gray-200">${result.totalCostOverTerm.toLocaleString()}</span></p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AffordTab() {
+  const [vals, setVals] = useState({ grossIncome: 120_000, monthlyDebts: 500, downPayment: 50_000, rate: 7 });
+  const [result, setResult] = useState<{
+    maxHomePrice: number; maxPITI: number; band: string;
+  } | null>(null);
+
+  const calc = async () => {
+    try {
+      const r = await api.post('/api/lens/run', { domain: 'realestate', action: 'calc-affordability', input: vals });
+      setResult(((r.data as { result?: typeof result }).result) || null);
+    } catch (e) { console.error(e); }
+  };
+
+  useEffect(() => { calc(); }, []);  // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className="p-3 space-y-3">
+      <div className="grid grid-cols-2 gap-2">
+        {([
+          ['grossIncome', 'Gross income ($/yr)'],
+          ['monthlyDebts', 'Monthly debts ($)'],
+          ['downPayment', 'Down payment ($)'],
+          ['rate', 'Rate (%)'],
+        ] as const).map(([k, label]) => (
+          <label key={k} className="flex flex-col gap-1">
+            <span className="text-[10px] uppercase text-gray-500">{label}</span>
+            <input type="number" value={vals[k]}
+              onChange={(e) => setVals({ ...vals, [k]: Number(e.target.value) })}
+              className="px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 font-mono" />
+          </label>
+        ))}
+      </div>
+      <button type="button" onClick={calc}
+        className="px-3 py-1 rounded-md border border-orange-500/40 bg-orange-500/15 text-xs text-orange-100">Compute</button>
+
+      {result && (
+        <div className="rounded border border-orange-500/20 bg-orange-500/5 p-3 space-y-1">
+          <p className="text-sm">
+            Max home price: <span className="font-mono text-2xl text-orange-300">${result.maxHomePrice.toLocaleString()}</span>
+          </p>
+          <p className="text-xs text-gray-400">Max PITI: ${result.maxPITI.toLocaleString()}/mo</p>
+          <p className={cn(
+            'text-[11px] inline-flex items-center px-2 py-0.5 rounded uppercase mt-1',
+            result.band === 'comfortable' ? 'bg-emerald-500/20 text-emerald-300'
+              : result.band === 'stretching' ? 'bg-amber-500/20 text-amber-300'
+              : 'bg-rose-500/20 text-rose-300',
+          )}>{result.band}</p>
+          <p className="text-[10px] text-gray-500 mt-2">Based on 28% front-end / 36% back-end DTI rule.</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RentBuyTab() {
+  const [vals, setVals] = useState({ price: 500_000, rent: 2500, downPercent: 20, rate: 7, horizonYears: 10, appreciation: 3 });
+  const [result, setResult] = useState<{
+    breakEvenYear: number | null; verdict: string;
+    chartPoints: { year: number; buyNet: number; rentNet: number }[];
+  } | null>(null);
+
+  const calc = async () => {
+    try {
+      const r = await api.post('/api/lens/run', { domain: 'realestate', action: 'calc-rent-vs-buy', input: vals });
+      setResult(((r.data as { result?: typeof result }).result) || null);
+    } catch (e) { console.error(e); }
+  };
+
+  useEffect(() => { calc(); }, []);  // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className="p-3 space-y-3">
+      <div className="grid grid-cols-2 gap-2">
+        {([
+          ['price', 'Buy price'],
+          ['rent', 'Monthly rent'],
+          ['downPercent', 'Down %'],
+          ['rate', 'Mortgage rate %'],
+          ['horizonYears', 'Horizon years'],
+          ['appreciation', 'Appreciation %/yr'],
+        ] as const).map(([k, label]) => (
+          <label key={k} className="flex flex-col gap-1">
+            <span className="text-[10px] uppercase text-gray-500">{label}</span>
+            <input type="number" value={vals[k]}
+              onChange={(e) => setVals({ ...vals, [k]: Number(e.target.value) })}
+              className="px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 font-mono" />
+          </label>
+        ))}
+      </div>
+      <button type="button" onClick={calc}
+        className="px-3 py-1 rounded-md border border-orange-500/40 bg-orange-500/15 text-xs text-orange-100">Compute</button>
+
+      {result && (
+        <div className="rounded border border-orange-500/20 bg-orange-500/5 p-3">
+          <p className="text-sm">{result.verdict}</p>
+          {result.breakEvenYear && (
+            <p className="text-[11px] text-gray-500 mt-1">Break-even: year {result.breakEvenYear}</p>
+          )}
+          <div className="mt-3 border-t border-white/10 pt-2">
+            <div className="grid grid-cols-3 text-[10px] uppercase tracking-wider text-gray-500">
+              <span>Year</span><span className="text-right">Buy net</span><span className="text-right">Rent net</span>
+            </div>
+            {result.chartPoints.map((p) => (
+              <div key={p.year} className="grid grid-cols-3 text-xs font-mono border-t border-white/5 py-0.5">
+                <span className="text-gray-400">{p.year}</span>
+                <span className={cn('text-right', p.buyNet < p.rentNet ? 'text-emerald-300' : 'text-gray-200')}>${p.buyNet.toLocaleString()}</span>
+                <span className="text-right text-gray-200">${p.rentNet.toLocaleString()}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SearchesTab() {
+  const [searches, setSearches] = useState<{ id: string; name: string; alertCadence: string; createdAt: string; filters: Record<string, unknown> }[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [draft, setDraft] = useState({ name: '', alertCadence: 'weekly' as const });
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const r = await api.post('/api/lens/run', { domain: 'realestate', action: 'saved-searches-list', input: {} });
+      setSearches(((r.data as { result?: { searches?: typeof searches } }).result?.searches) || []);
+    } catch (e) { console.error(e); }
+    finally { setLoading(false); }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const save = async () => {
+    try {
+      await api.post('/api/lens/run', { domain: 'realestate', action: 'save-search', input: { ...draft, filters: {} } });
+      setCreating(false); setDraft({ name: '', alertCadence: 'weekly' });
+      await refresh();
+    } catch (e) { console.error(e); }
+  };
+
+  const remove = async (id: string) => {
+    try {
+      await api.post('/api/lens/run', { domain: 'realestate', action: 'delete-search', input: { id } });
+      await refresh();
+    } catch (e) { console.error(e); }
+  };
+
+  return (
+    <div className="p-3 space-y-2">
+      <button type="button" onClick={() => setCreating((v) => !v)}
+        className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md border border-orange-500/30 bg-orange-500/10 text-xs text-orange-200">
+        <Plus className="w-3 h-3" /> New search
+      </button>
+      {creating && (
+        <div className="rounded border border-orange-500/30 bg-orange-500/5 p-3 space-y-2">
+          <input type="text" value={draft.name} onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+            placeholder="Search name (e.g. 3-bed in Austin under $600k)"
+            className="w-full px-2 py-1.5 text-sm bg-black/40 border border-white/10 rounded text-gray-100" />
+          <select value={draft.alertCadence} onChange={(e) => setDraft({ ...draft, alertCadence: e.target.value as typeof draft.alertCadence })}
+            className="px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100">
+            <option value="never">Never alert</option><option value="daily">Daily</option><option value="weekly">Weekly</option><option value="instant">Instant</option>
+          </select>
+          <button type="button" onClick={save} disabled={!draft.name.trim()}
+            className="inline-flex items-center gap-1 px-3 py-1 rounded-md border border-orange-500/40 bg-orange-500/15 text-xs text-orange-100 disabled:opacity-40">
+            <Save className="w-3 h-3" /> Save
+          </button>
+        </div>
+      )}
+      {loading ? <div className="text-center py-8 text-xs text-gray-500"><Loader2 className="w-4 h-4 animate-spin inline mr-2" />Loading…</div> :
+        searches.length === 0 ? <p className="text-center text-xs text-gray-500 py-8">No saved searches.</p> :
+        searches.map((s) => (
+          <div key={s.id} className="rounded border border-white/10 bg-black/20 p-3 group flex items-center justify-between">
+            <div>
+              <p className="text-sm text-gray-100">{s.name}</p>
+              <p className="text-[10px] text-gray-500">{s.alertCadence} alerts · {new Date(s.createdAt).toLocaleDateString()}</p>
+            </div>
+            <button type="button" onClick={() => remove(s.id)}
+              className="p-1 text-gray-600 hover:text-rose-300 opacity-0 group-hover:opacity-100"><Trash2 className="w-3 h-3" /></button>
+          </div>
+        ))
+      }
+    </div>
+  );
+}
+
+export default RealEstateWorkbench;

--- a/server/domains/realestate.js
+++ b/server/domains/realestate.js
@@ -100,4 +100,204 @@ export default function registerRealEstateActions(registerLensAction) {
     const totalRent = units.filter(u => u.tenant).reduce((sum, u) => sum + (u.rentAmount || 0), 0);
     return { ok: true, result: { vacancyRate: rate, occupied, vacant, total: units.length, monthlyRentCollected: totalRent } };
   });
+
+  // ─── 2026 parity — Zillow/Redfin/Trulia/Realtor.com calculators + saved searches ──
+
+  function getREState() {
+    const STATE = globalThis._concordSTATE;
+    if (!STATE) return null;
+    if (!STATE.realestateLens) {
+      STATE.realestateLens = {
+        searches: new Map(), // userId -> Map<id, savedSearch>
+      };
+    }
+    return STATE.realestateLens;
+  }
+  function saveREState() {
+    if (typeof globalThis._concordSaveStateDebounced === "function") {
+      try { globalThis._concordSaveStateDebounced(); } catch (_e) { /* best effort */ }
+    }
+  }
+  function reActor(ctx) { return ctx?.actor?.userId || ctx?.userId || "anon"; }
+  function nextREId(p) { return `${p}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`; }
+
+  // ── Mortgage PITI calculator ──
+
+  registerLensAction("realestate", "calc-mortgage", (_ctx, _artifact, params = {}) => {
+    const price = Number(params.price);
+    const downPercent = Number(params.downPercent ?? 20);
+    const rate = Number(params.rate ?? 7); // percent
+    const termYears = Number(params.termYears ?? 30);
+    const taxRate = Number(params.taxRate ?? 1.1); // percent/yr
+    const insurance = Number(params.insurance ?? 1200); // annual $
+    const hoa = Number(params.hoa ?? 0); // monthly $
+    if (!Number.isFinite(price) || price <= 0) return { ok: false, error: "price must be > 0" };
+    if (downPercent < 0 || downPercent > 100) return { ok: false, error: "downPercent 0..100" };
+    if (rate < 0 || rate > 30) return { ok: false, error: "rate 0..30" };
+    if (termYears <= 0 || termYears > 50) return { ok: false, error: "termYears 1..50" };
+
+    const downPayment = price * downPercent / 100;
+    const loanAmount = price - downPayment;
+    const n = termYears * 12;
+    const r = rate / 100 / 12;
+    const principalAndInterest = r === 0
+      ? loanAmount / n
+      : (loanAmount * r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1);
+    const monthlyTax = (price * taxRate / 100) / 12;
+    const monthlyInsurance = insurance / 12;
+    const ltv = (loanAmount / price) * 100;
+    const monthlyPMI = ltv > 80 ? (loanAmount * 0.005) / 12 : 0; // 0.5%/yr PMI
+    const monthlyTotal = principalAndInterest + monthlyTax + monthlyInsurance + monthlyPMI + hoa;
+    return {
+      ok: true,
+      result: {
+        price, downPayment, loanAmount, termYears, rate, ltvPercent: Math.round(ltv * 100) / 100,
+        monthly: {
+          principalAndInterest: Math.round(principalAndInterest * 100) / 100,
+          tax: Math.round(monthlyTax * 100) / 100,
+          insurance: Math.round(monthlyInsurance * 100) / 100,
+          pmi: Math.round(monthlyPMI * 100) / 100,
+          hoa,
+          total: Math.round(monthlyTotal * 100) / 100,
+        },
+        totalCostOverTerm: Math.round(monthlyTotal * n * 100) / 100,
+        totalInterest: Math.round((principalAndInterest * n - loanAmount) * 100) / 100,
+        formula: "M = P × r(1+r)^n / ((1+r)^n − 1) ; PITI + PMI + HOA",
+      },
+    };
+  });
+
+  // ── Affordability (28/36 DTI rule) ──
+
+  registerLensAction("realestate", "calc-affordability", (_ctx, _artifact, params = {}) => {
+    const grossIncome = Number(params.grossIncome);
+    const monthlyDebts = Number(params.monthlyDebts ?? 0);
+    const downPayment = Number(params.downPayment ?? 0);
+    const rate = Number(params.rate ?? 7);
+    const termYears = Number(params.termYears ?? 30);
+    if (!Number.isFinite(grossIncome) || grossIncome <= 0) return { ok: false, error: "grossIncome must be > 0" };
+    const monthlyGross = grossIncome / 12;
+    const maxFrontEnd = monthlyGross * 0.28; // 28% housing rule
+    const maxBackEnd = monthlyGross * 0.36 - monthlyDebts; // 36% DTI minus debts
+    const maxPITI = Math.min(maxFrontEnd, maxBackEnd);
+    // Reverse mortgage formula to find max loan amount.
+    // Assume 25% of monthly payment goes to taxes/insurance/PMI (rough heuristic).
+    const piEquivalent = maxPITI * 0.75;
+    const n = termYears * 12;
+    const r = rate / 100 / 12;
+    const maxLoan = r === 0 ? piEquivalent * n : piEquivalent * (Math.pow(1 + r, n) - 1) / (r * Math.pow(1 + r, n));
+    const maxHomePrice = maxLoan + downPayment;
+    let band;
+    if (maxPITI < monthlyGross * 0.20) band = "comfortable";
+    else if (maxPITI < monthlyGross * 0.30) band = "stretching";
+    else band = "tight";
+    return {
+      ok: true,
+      result: {
+        monthlyGrossIncome: Math.round(monthlyGross * 100) / 100,
+        maxFrontEnd: Math.round(maxFrontEnd * 100) / 100,
+        maxBackEnd: Math.round(maxBackEnd * 100) / 100,
+        maxPITI: Math.round(maxPITI * 100) / 100,
+        maxLoanAmount: Math.round(maxLoan * 100) / 100,
+        maxHomePrice: Math.round(maxHomePrice * 100) / 100,
+        band,
+        formula: "28% front-end / 36% back-end DTI",
+      },
+    };
+  });
+
+  // ── Rent vs buy break-even ──
+
+  registerLensAction("realestate", "calc-rent-vs-buy", (_ctx, _artifact, params = {}) => {
+    const price = Number(params.price);
+    const rent = Number(params.rent);
+    const downPercent = Number(params.downPercent ?? 20);
+    const rate = Number(params.rate ?? 7);
+    const horizonYears = Math.min(40, Number(params.horizonYears ?? 10));
+    const appreciation = Number(params.appreciation ?? 3); // %/yr
+    const rentInflation = Number(params.rentInflation ?? 3);
+    if (!Number.isFinite(price) || price <= 0) return { ok: false, error: "price must be > 0" };
+    if (!Number.isFinite(rent) || rent <= 0) return { ok: false, error: "rent must be > 0" };
+
+    const downPayment = price * downPercent / 100;
+    const loanAmount = price - downPayment;
+    const n = 30 * 12;
+    const r = rate / 100 / 12;
+    const monthlyPI = (loanAmount * r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1);
+    const monthlyOther = (price * 0.018) / 12; // tax+insurance+maintenance rough
+    const monthlyBuy = monthlyPI + monthlyOther;
+
+    let breakEvenYear = null;
+    let buyCumulative = downPayment;
+    let rentCumulative = 0;
+    let currentRent = rent;
+    let homeValue = price;
+    const points = [];
+    for (let year = 1; year <= horizonYears; year++) {
+      buyCumulative += monthlyBuy * 12;
+      rentCumulative += currentRent * 12;
+      homeValue *= 1 + appreciation / 100;
+      currentRent *= 1 + rentInflation / 100;
+      const buyNet = buyCumulative - (homeValue - loanAmount); // subtract equity
+      points.push({ year, buyNet: Math.round(buyNet), rentNet: Math.round(rentCumulative) });
+      if (breakEvenYear === null && buyNet < rentCumulative) breakEvenYear = year;
+    }
+    return {
+      ok: true,
+      result: {
+        breakEvenYear,
+        monthlyBuyTotal: Math.round(monthlyBuy),
+        monthlyRent: rent,
+        chartPoints: points,
+        verdict: breakEvenYear
+          ? `Buying wins after ${breakEvenYear} years.`
+          : `Renting wins over the ${horizonYears}-year horizon.`,
+      },
+    };
+  });
+
+  // ── Saved searches ──
+
+  registerLensAction("realestate", "saved-searches-list", (ctx, _artifact, _params = {}) => {
+    const s = getREState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = reActor(ctx);
+    const map = s.searches.get(userId);
+    if (!map) return { ok: true, result: { searches: [] } };
+    const searches = Array.from(map.values()).sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    return { ok: true, result: { searches } };
+  });
+
+  registerLensAction("realestate", "save-search", (ctx, _artifact, params = {}) => {
+    const s = getREState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = reActor(ctx);
+    const name = String(params.name || "").trim();
+    if (!name) return { ok: false, error: "name required" };
+    const filters = params.filters && typeof params.filters === "object" ? params.filters : {};
+    const alertCadence = ["never", "daily", "weekly", "instant"].includes(params.alertCadence) ? params.alertCadence : "weekly";
+    const search = {
+      id: nextREId("search"),
+      name: name.slice(0, 80),
+      filters,
+      alertCadence,
+      createdAt: new Date().toISOString(),
+    };
+    if (!s.searches.has(userId)) s.searches.set(userId, new Map());
+    s.searches.get(userId).set(search.id, search);
+    saveREState();
+    return { ok: true, result: { search } };
+  });
+
+  registerLensAction("realestate", "delete-search", (ctx, _artifact, params = {}) => {
+    const s = getREState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = reActor(ctx);
+    const id = String(params.id || "");
+    const map = s.searches.get(userId);
+    if (!map || !map.has(id)) return { ok: false, error: "not found" };
+    map.delete(id);
+    saveREState();
+    return { ok: true, result: { deleted: id } };
+  });
 };

--- a/server/tests/realestate-domain-parity.test.js
+++ b/server/tests/realestate-domain-parity.test.js
@@ -1,0 +1,99 @@
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerActions from "../domains/realestate.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, params = {}) {
+  const fn = ACTIONS.get(`realestate.${name}`);
+  if (!fn) throw new Error(`realestate.${name} not registered`);
+  return fn(ctx, { id: null, data: {}, meta: {} }, params);
+}
+
+before(() => { registerActions(register); });
+beforeEach(() => {
+  globalThis._concordSTATE = { dtus: new Map() };
+  globalThis._concordSaveStateDebounced = () => {};
+  globalThis.fetch = async () => { throw new Error("network disabled"); };
+});
+
+const ctxA = { actor: { userId: "u" }, userId: "u" };
+const ctxB = { actor: { userId: "v" }, userId: "v" };
+
+describe("realestate — mortgage", () => {
+  it("computes PITI for $500k at 7% 30yr 20% down", () => {
+    const r = call("calc-mortgage", ctxA, { price: 500_000, downPercent: 20, rate: 7, termYears: 30, taxRate: 1.1, insurance: 1200, hoa: 0 });
+    assert.equal(r.ok, true);
+    // P&I for $400k at 7% 30yr ≈ $2661
+    assert.ok(Math.abs(r.result.monthly.principalAndInterest - 2661) < 5);
+    assert.equal(r.result.monthly.pmi, 0); // LTV=80%
+  });
+
+  it("adds PMI when LTV > 80%", () => {
+    const r = call("calc-mortgage", ctxA, { price: 500_000, downPercent: 10 });
+    assert.ok(r.result.monthly.pmi > 0);
+  });
+
+  it("rejects invalid rate", () => {
+    const r = call("calc-mortgage", ctxA, { price: 500_000, rate: 50 });
+    assert.equal(r.ok, false);
+  });
+});
+
+describe("realestate — affordability", () => {
+  it("$120k income → max home around $400-500k", () => {
+    const r = call("calc-affordability", ctxA, { grossIncome: 120_000 });
+    assert.equal(r.ok, true);
+    assert.ok(r.result.maxHomePrice > 300_000);
+    assert.ok(r.result.maxHomePrice < 800_000);
+  });
+
+  it("classification band returned", () => {
+    const r = call("calc-affordability", ctxA, { grossIncome: 200_000 });
+    assert.ok(["comfortable", "stretching", "tight"].includes(r.result.band));
+  });
+
+  it("rejects zero income", () => {
+    const r = call("calc-affordability", ctxA, { grossIncome: 0 });
+    assert.equal(r.ok, false);
+  });
+});
+
+describe("realestate — rent vs buy", () => {
+  it("returns chart points + verdict", () => {
+    const r = call("calc-rent-vs-buy", ctxA, { price: 500_000, rent: 2500, horizonYears: 10 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.chartPoints.length, 10);
+    assert.ok(r.result.verdict);
+  });
+
+  it("rejects missing price or rent", () => {
+    const r = call("calc-rent-vs-buy", ctxA, { rent: 1000 });
+    assert.equal(r.ok, false);
+  });
+});
+
+describe("realestate — saved searches", () => {
+  it("create + list", () => {
+    call("save-search", ctxA, { name: "Austin 3BR", alertCadence: "daily" });
+    const r = call("saved-searches-list", ctxA);
+    assert.equal(r.result.searches.length, 1);
+    assert.equal(r.result.searches[0].alertCadence, "daily");
+  });
+
+  it("INVARIANT: scoped per-user", () => {
+    call("save-search", ctxA, { name: "user A" });
+    const b = call("saved-searches-list", ctxB);
+    assert.equal(b.result.searches.length, 0);
+  });
+
+  it("rejects empty name", () => {
+    const r = call("save-search", ctxA, { name: "  " });
+    assert.equal(r.ok, false);
+  });
+
+  it("defaults alertCadence to weekly", () => {
+    const r = call("save-search", ctxA, { name: "x" });
+    assert.equal(r.result.search.alertCadence, "weekly");
+  });
+});


### PR DESCRIPTION
## Summary

Brings the realestate lens to 2026 parity vs **Zillow / Redfin / Trulia / Realtor.com / Compass** on the four highest-impact calculator surfaces. Pure JS math.

### Backend (6 macros)
| Group | Macros |
|---|---|
| Calculator | `calc-mortgage` (PITI + PMI + HOA), `calc-affordability` (28/36 DTI), `calc-rent-vs-buy` (break-even + chart) |
| Searches | `saved-searches-list`, `save-search`, `delete-search` |

### Frontend (1 component, 4 tabs)
Mortgage · Affordability · Rent vs Buy · Saved.

## Test plan
- [x] **12/12 tests passing**
- [x] Mortgage math: P&I for $400k @ 7% 30yr ≈ $2661
- [x] PMI kicks in at LTV > 80%
- [x] Affordability bounds: $120k income → $300k-$800k max
- [x] Per-user scoping for saved searches
- [x] tsc + lint clean

https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_