### PR TITLE
research lens: Notion/Roam/Obsidian parity — notes, daily, search, templates, backlinks

### DIFF
--- a/concord-frontend/app/lenses/research/page.tsx
+++ b/concord-frontend/app/lenses/research/page.tsx
@@ -47,6 +47,7 @@ import LiveFeed, { adaptToLiveFeedArticles } from '@/components/lens/LiveFeed';
 import { VisionAnalyzeButton } from '@/components/common/VisionAnalyzeButton';
 import { PullToSubstrate } from '@/components/lens/PullToSubstrate';
 import { FeedBanner } from '@/components/lens/FeedBanner';
+import ResearchWorkbench from '@/components/research/ResearchWorkbench';
 
 interface DTUResult {
   id: string;
@@ -86,6 +87,7 @@ export default function ResearchLensPage() {
 
   const [query, setQuery] = useState('');
   const [domainFilter, setDomainFilter] = useState('');
+  const [workbenchOpen, setWorkbenchOpen] = useState(false);
   const [tierFilter, setTierFilter] = useState('');
   const [sortBy, setSortBy] = useState<'relevance' | 'date' | 'tier'>('date');
   const [selectedDtu, setSelectedDtu] = useState<DTUResult | null>(null);
@@ -884,6 +886,16 @@ export default function ResearchLensPage() {
         )}
       </div>
     </div>
+    {/* 2026 parity workbench — notes, daily journal, search, templates */}
+    <button
+      type="button"
+      onClick={() => setWorkbenchOpen(true)}
+      className="fixed bottom-6 right-6 z-30 inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-fuchsia-500 hover:bg-fuchsia-400 text-fuchsia-50 shadow-2xl text-sm font-medium"
+      title="Research Workbench — notes, daily journal, search, templates, backlinks"
+    >
+      Research Workbench
+    </button>
+    <ResearchWorkbench open={workbenchOpen} onClose={() => setWorkbenchOpen(false)} />
     </LensShell>
   );
 }

--- a/concord-frontend/components/research/ResearchWorkbench.tsx
+++ b/concord-frontend/components/research/ResearchWorkbench.tsx
@@ -1,0 +1,325 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  X, Loader2, FileText, Calendar, Search, BookOpen, Save, Trash2, Plus, ArrowLeft,
+} from 'lucide-react';
+import { api } from '@/lib/api/client';
+import { cn } from '@/lib/utils';
+
+export interface Note {
+  id: string;
+  title: string;
+  body: string;
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
+  preview?: string;
+}
+
+export interface Template { id: string; title: string; body: string; }
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+type Tab = 'notes' | 'daily' | 'search' | 'templates';
+
+export function ResearchWorkbench({ open, onClose }: Props) {
+  const [tab, setTab] = useState<Tab>('notes');
+  const [activeNoteId, setActiveNoteId] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-y-0 right-0 w-[640px] max-w-[100vw] z-40 bg-[#0d1117] border-l border-fuchsia-500/20 shadow-2xl overflow-hidden flex flex-col">
+      <header className="px-4 py-3 border-b border-white/10 flex items-center justify-between bg-gradient-to-r from-fuchsia-950/40 to-transparent">
+        <div className="flex items-center gap-2">
+          <FileText className="w-4 h-4 text-fuchsia-400" />
+          <span className="text-sm font-semibold text-gray-200">Research Workbench</span>
+        </div>
+        <button type="button" onClick={onClose} className="p-1 rounded-md hover:bg-white/5 text-gray-400" aria-label="Close">
+          <X className="w-4 h-4" />
+        </button>
+      </header>
+
+      <nav className="px-3 py-2 border-b border-white/10 flex items-center gap-1">
+        {([
+          { id: 'notes',     label: 'Notes',     icon: FileText },
+          { id: 'daily',     label: 'Daily',     icon: Calendar },
+          { id: 'search',    label: 'Search',    icon: Search },
+          { id: 'templates', label: 'Templates', icon: BookOpen },
+        ] as const).map((t) => {
+          const Icon = t.icon;
+          const active = tab === t.id;
+          return (
+            <button key={t.id} type="button" onClick={() => { setTab(t.id); setActiveNoteId(null); }}
+              className={cn(
+                'inline-flex items-center gap-1.5 px-2.5 py-1 text-xs rounded transition',
+                active
+                  ? 'bg-fuchsia-500/15 text-fuchsia-200 border border-fuchsia-500/40'
+                  : 'text-gray-400 hover:text-gray-200 border border-transparent',
+              )}>
+              <Icon className="w-3 h-3" /> {t.label}
+            </button>
+          );
+        })}
+      </nav>
+
+      <div className="flex-1 overflow-y-auto">
+        {tab === 'notes' && (activeNoteId ? <NoteEditor noteId={activeNoteId} onBack={() => setActiveNoteId(null)} /> : <NotesTab onOpen={setActiveNoteId} />)}
+        {tab === 'daily' && <DailyTab />}
+        {tab === 'search' && <SearchTab onOpen={(id) => { setActiveNoteId(id); setTab('notes'); }} />}
+        {tab === 'templates' && <TemplatesTab />}
+      </div>
+    </div>
+  );
+}
+
+function NotesTab({ onOpen }: { onOpen: (id: string) => void }) {
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [draft, setDraft] = useState({ title: '', body: '' });
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const r = await api.post('/api/lens/run', { domain: 'research', action: 'notes-list', input: {} });
+      setNotes(((r.data as { result?: { notes?: Note[] } }).result?.notes) || []);
+    } catch (e) { console.error(e); }
+    finally { setLoading(false); }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const save = async () => {
+    try {
+      await api.post('/api/lens/run', { domain: 'research', action: 'note-create', input: draft });
+      setCreating(false); setDraft({ title: '', body: '' });
+      await refresh();
+    } catch (e) { console.error(e); }
+  };
+
+  const remove = async (id: string) => {
+    if (!window.confirm('Delete this note?')) return;
+    try {
+      await api.post('/api/lens/run', { domain: 'research', action: 'note-delete', input: { id } });
+      await refresh();
+    } catch (e) { console.error(e); }
+  };
+
+  return (
+    <div className="p-3 space-y-2">
+      <button type="button" onClick={() => setCreating((v) => !v)}
+        className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md border border-fuchsia-500/30 bg-fuchsia-500/10 text-xs text-fuchsia-200">
+        <Plus className="w-3 h-3" /> New note
+      </button>
+      {creating && (
+        <div className="rounded border border-fuchsia-500/30 bg-fuchsia-500/5 p-3 space-y-2">
+          <input type="text" value={draft.title} onChange={(e) => setDraft({ ...draft, title: e.target.value })}
+            placeholder="Title" maxLength={200}
+            className="w-full px-2 py-1.5 text-sm bg-black/40 border border-white/10 rounded text-gray-100" />
+          <textarea value={draft.body} onChange={(e) => setDraft({ ...draft, body: e.target.value })}
+            placeholder="Body — supports [[wikilinks]] for backlinks" rows={6}
+            className="w-full px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 font-mono resize-none" />
+          <button type="button" onClick={save} disabled={!draft.title.trim()}
+            className="inline-flex items-center gap-1 px-3 py-1 rounded-md border border-fuchsia-500/40 bg-fuchsia-500/15 text-xs text-fuchsia-100 disabled:opacity-40">
+            <Save className="w-3 h-3" /> Save
+          </button>
+        </div>
+      )}
+      {loading ? <div className="text-center py-8 text-xs text-gray-500"><Loader2 className="w-4 h-4 animate-spin inline mr-2" />Loading…</div> :
+        notes.length === 0 ? <p className="text-center text-xs text-gray-500 py-8">No notes yet.</p> :
+        notes.map((n) => (
+          <div key={n.id} className="rounded border border-white/10 bg-black/20 p-3 group hover:bg-white/5">
+            <div className="flex items-start justify-between gap-2">
+              <button type="button" onClick={() => onOpen(n.id)} className="flex-1 text-left min-w-0">
+                <p className="text-sm font-medium text-gray-100 truncate">{n.title}</p>
+                <p className="text-[11px] text-gray-500 mt-1 line-clamp-2">{n.preview}</p>
+                {n.tags.length > 0 && (
+                  <div className="flex gap-1 mt-1.5">
+                    {n.tags.map((t) => <span key={t} className="text-[9px] px-1.5 py-0.5 rounded bg-white/5 text-gray-400">{t}</span>)}
+                  </div>
+                )}
+              </button>
+              <button type="button" onClick={() => remove(n.id)}
+                className="p-1 text-gray-600 hover:text-rose-300 opacity-0 group-hover:opacity-100"><Trash2 className="w-3 h-3" /></button>
+            </div>
+          </div>
+        ))
+      }
+    </div>
+  );
+}
+
+function NoteEditor({ noteId, onBack }: { noteId: string; onBack: () => void }) {
+  const [note, setNote] = useState<Note | null>(null);
+  const [backlinks, setBacklinks] = useState<{ noteId: string; noteTitle: string; context: string }[]>([]);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState({ title: '', body: '' });
+
+  const refresh = useCallback(async () => {
+    try {
+      const r = await api.post('/api/lens/run', { domain: 'research', action: 'note-get', input: { id: noteId } });
+      const n = ((r.data as { result?: { note?: Note } }).result?.note) || null;
+      setNote(n);
+      if (n) {
+        setDraft({ title: n.title, body: n.body });
+        // Look up backlinks to this title
+        const b = await api.post('/api/lens/run', { domain: 'research', action: 'backlinks-for', input: { title: n.title } });
+        setBacklinks(((b.data as { result?: { backlinks?: typeof backlinks } }).result?.backlinks) || []);
+      }
+    } catch (e) { console.error(e); }
+  }, [noteId]);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const save = async () => {
+    try {
+      await api.post('/api/lens/run', { domain: 'research', action: 'note-update', input: { id: noteId, ...draft } });
+      setEditing(false);
+      await refresh();
+    } catch (e) { console.error(e); }
+  };
+
+  if (!note) return <div className="text-center py-8 text-xs text-gray-500"><Loader2 className="w-4 h-4 animate-spin inline mr-2" />Loading…</div>;
+
+  return (
+    <div className="p-3 space-y-3">
+      <div className="flex items-center justify-between">
+        <button type="button" onClick={onBack} className="inline-flex items-center gap-1 text-xs text-gray-400 hover:text-gray-200">
+          <ArrowLeft className="w-3 h-3" /> Back
+        </button>
+        <button type="button" onClick={() => editing ? save() : setEditing(true)}
+          className="px-3 py-1 rounded-md border border-fuchsia-500/40 bg-fuchsia-500/15 text-xs text-fuchsia-100">
+          {editing ? 'Save' : 'Edit'}
+        </button>
+      </div>
+
+      {editing ? (
+        <>
+          <input type="text" value={draft.title} onChange={(e) => setDraft({ ...draft, title: e.target.value })}
+            className="w-full px-2 py-1.5 text-sm bg-black/40 border border-white/10 rounded text-gray-100" />
+          <textarea value={draft.body} onChange={(e) => setDraft({ ...draft, body: e.target.value })} rows={16}
+            className="w-full px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 font-mono resize-none" />
+        </>
+      ) : (
+        <>
+          <h3 className="text-lg font-semibold text-gray-100">{note.title}</h3>
+          <pre className="text-xs text-gray-200 whitespace-pre-wrap font-mono">{note.body}</pre>
+        </>
+      )}
+
+      {backlinks.length > 0 && (
+        <div className="border-t border-white/10 pt-3">
+          <p className="text-[10px] uppercase tracking-wider text-gray-500 mb-2">Backlinks ({backlinks.length})</p>
+          {backlinks.map((b) => (
+            <div key={b.noteId} className="rounded border border-white/10 bg-black/20 p-2 mb-1">
+              <p className="text-xs text-fuchsia-300">{b.noteTitle}</p>
+              <p className="text-[11px] text-gray-500 mt-0.5">…{b.context}…</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DailyTab() {
+  const [note, setNote] = useState<Note | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const r = await api.post('/api/lens/run', { domain: 'research', action: 'daily-note', input: {} });
+        setNote(((r.data as { result?: { note?: Note } }).result?.note) || null);
+      } catch (e) { console.error(e); }
+      finally { setLoading(false); }
+    })();
+  }, []);
+
+  if (loading) return <div className="text-center py-8 text-xs text-gray-500"><Loader2 className="w-4 h-4 animate-spin inline mr-2" />Loading…</div>;
+  if (!note) return <p className="text-xs text-gray-500 p-4">Could not load daily note.</p>;
+
+  return (
+    <div className="p-3 space-y-2">
+      <p className="text-[10px] text-gray-500">Auto-created daily note. Edit via Notes tab.</p>
+      <h3 className="text-lg font-semibold text-gray-100">{note.title}</h3>
+      <pre className="text-xs text-gray-200 whitespace-pre-wrap font-mono border border-white/10 rounded p-3 bg-black/20">{note.body}</pre>
+    </div>
+  );
+}
+
+function SearchTab({ onOpen }: { onOpen: (id: string) => void }) {
+  const [query, setQuery] = useState('');
+  const [hits, setHits] = useState<{ id: string; title: string; score: number; preview: string }[]>([]);
+
+  const search = async () => {
+    if (query.trim().length < 2) return;
+    try {
+      const r = await api.post('/api/lens/run', { domain: 'research', action: 'notes-search', input: { query } });
+      setHits(((r.data as { result?: { hits?: typeof hits } }).result?.hits) || []);
+    } catch (e) { console.error(e); }
+  };
+
+  return (
+    <div className="p-3 space-y-3">
+      <div className="flex gap-2">
+        <input type="text" value={query} onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') search(); }}
+          placeholder="Search notes"
+          className="flex-1 px-2 py-1.5 text-sm bg-black/40 border border-white/10 rounded text-gray-100" />
+        <button type="button" onClick={search}
+          className="px-3 py-1 rounded-md border border-fuchsia-500/40 bg-fuchsia-500/15 text-xs text-fuchsia-100">Go</button>
+      </div>
+      {hits.map((h) => (
+        <button key={h.id} type="button" onClick={() => onOpen(h.id)}
+          className="w-full text-left rounded border border-white/10 bg-black/20 p-3 hover:bg-white/5">
+          <p className="text-sm font-medium text-gray-100">{h.title}</p>
+          <p className="text-[11px] text-gray-500 line-clamp-2">{h.preview}</p>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function TemplatesTab() {
+  const [templates, setTemplates] = useState<Template[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const r = await api.post('/api/lens/run', { domain: 'research', action: 'templates-list', input: {} });
+        setTemplates(((r.data as { result?: { templates?: Template[] } }).result?.templates) || []);
+      } catch (e) { console.error(e); }
+    })();
+  }, []);
+
+  const apply = async (id: string) => {
+    try {
+      const r = await api.post('/api/lens/run', { domain: 'research', action: 'template-apply', input: { id } });
+      const t = ((r.data as { result?: { template?: Template } }).result?.template);
+      if (!t) return;
+      await api.post('/api/lens/run', { domain: 'research', action: 'note-create', input: { title: t.title, body: t.body } });
+      alert(`Created note from ${t.title} template`);
+    } catch (e) { console.error(e); }
+  };
+
+  return (
+    <div className="p-3 space-y-2">
+      <p className="text-[11px] text-gray-500">Click a template to create a new note from it.</p>
+      {templates.map((t) => (
+        <button key={t.id} type="button" onClick={() => apply(t.id)}
+          className="w-full text-left rounded border border-white/10 bg-black/20 p-3 hover:bg-white/5">
+          <p className="text-sm font-medium text-gray-100">{t.title}</p>
+          <pre className="text-[10px] text-gray-500 line-clamp-3 whitespace-pre-wrap font-mono mt-1">{t.body}</pre>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default ResearchWorkbench;

--- a/server/domains/research.js
+++ b/server/domains/research.js
@@ -323,4 +323,214 @@ export default function registerResearchActions(registerLensAction) {
       },
     };
   });
+
+  // ─── 2026 parity — Notion/Roam/Obsidian/Logseq second-brain ──
+
+  function getResearchState() {
+    const STATE = globalThis._concordSTATE;
+    if (!STATE) return null;
+    if (!STATE.researchLens) {
+      STATE.researchLens = {
+        notes: new Map(),         // userId -> Map<noteId, note>
+        dailyByDate: new Map(),   // userId -> Map<YYYY-MM-DD, noteId>
+      };
+    }
+    return STATE.researchLens;
+  }
+  function saveResearchState() {
+    if (typeof globalThis._concordSaveStateDebounced === "function") {
+      try { globalThis._concordSaveStateDebounced(); } catch (_e) { /* best effort */ }
+    }
+  }
+  function researchActor(ctx) { return ctx?.actor?.userId || ctx?.userId || "anon"; }
+  function nextResId(p) { return `${p}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`; }
+  function nowIsoRes() { return new Date().toISOString(); }
+  function todayIso() { return nowIsoRes().slice(0, 10); }
+
+  const TEMPLATES = {
+    meeting:       { title: "Meeting notes",       body: "## Date\n\n## Attendees\n\n## Agenda\n\n## Decisions\n\n## Action items\n- [ ] " },
+    weekly_review: { title: "Weekly review",       body: "## What I shipped\n\n## What I learned\n\n## What's stuck\n\n## Next week priorities\n- [ ] " },
+    book_note:     { title: "Book note",           body: "## Title\n## Author\n## Why I read it\n\n## Key ideas\n\n## Quotes\n\n## My take" },
+    paper_note:    { title: "Paper note",          body: "## Citation\n## TL;DR\n\n## Methods\n\n## Findings\n\n## Critique\n\n## Cited references" },
+    project_brief: { title: "Project brief",       body: "## Goal\n\n## Success criteria\n\n## Out of scope\n\n## Open questions\n\n## Plan" },
+    decision_log:  { title: "Decision log",        body: "## Decision\n\n## Context\n\n## Options considered\n\n## Chosen path\n\n## Tradeoffs" },
+  };
+
+  // ── Notes CRUD ──
+
+  registerLensAction("research", "note-create", (ctx, _artifact, params = {}) => {
+    const s = getResearchState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = researchActor(ctx);
+    const title = String(params.title || "").trim();
+    if (!title) return { ok: false, error: "title required" };
+    if (title.length > 200) return { ok: false, error: "title too long (max 200)" };
+    const body = String(params.body || "");
+    if (body.length > 100_000) return { ok: false, error: "body too long (max 100000)" };
+    const tags = Array.isArray(params.tags) ? params.tags.slice(0, 20).map(String) : [];
+    const note = {
+      id: nextResId("note"),
+      title, body, tags,
+      createdAt: nowIsoRes(),
+      updatedAt: nowIsoRes(),
+    };
+    if (!s.notes.has(userId)) s.notes.set(userId, new Map());
+    s.notes.get(userId).set(note.id, note);
+    saveResearchState();
+    return { ok: true, result: { note } };
+  });
+
+  registerLensAction("research", "note-update", (ctx, _artifact, params = {}) => {
+    const s = getResearchState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = researchActor(ctx);
+    const id = String(params.id || "");
+    if (!id) return { ok: false, error: "id required" };
+    const map = s.notes.get(userId);
+    if (!map || !map.has(id)) return { ok: false, error: "not found" };
+    const n = map.get(id);
+    if (typeof params.title === "string") n.title = params.title.trim().slice(0, 200);
+    if (typeof params.body === "string") n.body = params.body.slice(0, 100_000);
+    if (Array.isArray(params.tags)) n.tags = params.tags.slice(0, 20).map(String);
+    n.updatedAt = nowIsoRes();
+    saveResearchState();
+    return { ok: true, result: { note: n } };
+  });
+
+  registerLensAction("research", "note-delete", (ctx, _artifact, params = {}) => {
+    const s = getResearchState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = researchActor(ctx);
+    const id = String(params.id || "");
+    if (!id) return { ok: false, error: "id required" };
+    const map = s.notes.get(userId);
+    if (!map || !map.has(id)) return { ok: false, error: "not found" };
+    map.delete(id);
+    saveResearchState();
+    return { ok: true, result: { deleted: id } };
+  });
+
+  registerLensAction("research", "notes-list", (ctx, _artifact, _params = {}) => {
+    const s = getResearchState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = researchActor(ctx);
+    const map = s.notes.get(userId);
+    if (!map) return { ok: true, result: { notes: [] } };
+    const notes = Array.from(map.values())
+      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+      .map(({ body, ...rest }) => ({ ...rest, preview: body.slice(0, 200) }));
+    return { ok: true, result: { notes } };
+  });
+
+  registerLensAction("research", "note-get", (ctx, _artifact, params = {}) => {
+    const s = getResearchState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = researchActor(ctx);
+    const id = String(params.id || "");
+    if (!id) return { ok: false, error: "id required" };
+    const map = s.notes.get(userId);
+    if (!map || !map.has(id)) return { ok: false, error: "not found" };
+    return { ok: true, result: { note: map.get(id) } };
+  });
+
+  // ── Daily journal ──
+
+  registerLensAction("research", "daily-note", (ctx, _artifact, params = {}) => {
+    const s = getResearchState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = researchActor(ctx);
+    const date = String(params.date || todayIso());
+    if (!s.dailyByDate.has(userId)) s.dailyByDate.set(userId, new Map());
+    const dailyMap = s.dailyByDate.get(userId);
+    let noteId = dailyMap.get(date);
+    if (!noteId) {
+      // Create new daily note
+      if (!s.notes.has(userId)) s.notes.set(userId, new Map());
+      const note = {
+        id: nextResId("daily"),
+        title: `Daily — ${date}`,
+        body: `# ${date}\n\n## What I'm working on today\n\n## Notes\n\n## Tomorrow`,
+        tags: ["daily"],
+        createdAt: nowIsoRes(),
+        updatedAt: nowIsoRes(),
+      };
+      s.notes.get(userId).set(note.id, note);
+      dailyMap.set(date, note.id);
+      saveResearchState();
+      return { ok: true, result: { note, created: true } };
+    }
+    const note = s.notes.get(userId).get(noteId);
+    return { ok: true, result: { note, created: false } };
+  });
+
+  // ── Templates ──
+
+  registerLensAction("research", "templates-list", (_ctx, _artifact, _params = {}) => {
+    return { ok: true, result: { templates: Object.entries(TEMPLATES).map(([id, t]) => ({ id, ...t })) } };
+  });
+
+  registerLensAction("research", "template-apply", (_ctx, _artifact, params = {}) => {
+    const id = String(params.id || "");
+    const t = TEMPLATES[id];
+    if (!t) return { ok: false, error: `unknown template: ${id}` };
+    return { ok: true, result: { template: { id, ...t } } };
+  });
+
+  // ── Backlinks (mentions of [[note title]]) ──
+
+  registerLensAction("research", "backlinks-for", (ctx, _artifact, params = {}) => {
+    const s = getResearchState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = researchActor(ctx);
+    const title = String(params.title || "").trim();
+    if (!title) return { ok: false, error: "title required" };
+    const wikiRef = `[[${title}]]`;
+    const map = s.notes.get(userId);
+    if (!map) return { ok: true, result: { backlinks: [] } };
+    const hits = [];
+    for (const n of map.values()) {
+      if (n.title === title) continue;
+      if (n.body.includes(wikiRef)) {
+        // Find context around the mention
+        const idx = n.body.indexOf(wikiRef);
+        const start = Math.max(0, idx - 80);
+        const end = Math.min(n.body.length, idx + wikiRef.length + 80);
+        hits.push({
+          noteId: n.id,
+          noteTitle: n.title,
+          context: n.body.slice(start, end),
+        });
+      }
+    }
+    return { ok: true, result: { backlinks: hits, count: hits.length } };
+  });
+
+  // ── Note search (full-text) ──
+
+  registerLensAction("research", "notes-search", (ctx, _artifact, params = {}) => {
+    const s = getResearchState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = researchActor(ctx);
+    const query = String(params.query || "").trim().toLowerCase();
+    if (!query) return { ok: false, error: "query required" };
+    if (query.length < 2) return { ok: false, error: "query too short" };
+    const map = s.notes.get(userId);
+    if (!map) return { ok: true, result: { hits: [] } };
+    const terms = query.split(/\s+/).filter(Boolean);
+    const hits = [];
+    for (const n of map.values()) {
+      const titleLower = n.title.toLowerCase();
+      const bodyLower = n.body.toLowerCase();
+      let score = 0;
+      for (const t of terms) {
+        if (titleLower.includes(t)) score += 5;
+        if (bodyLower.includes(t)) score += 1;
+      }
+      if (score > 0) {
+        hits.push({ id: n.id, title: n.title, score, preview: n.body.slice(0, 200), updatedAt: n.updatedAt });
+      }
+    }
+    hits.sort((a, b) => b.score - a.score);
+    return { ok: true, result: { hits: hits.slice(0, 50), count: hits.length } };
+  });
 }

--- a/server/tests/research-domain-parity.test.js
+++ b/server/tests/research-domain-parity.test.js
@@ -1,0 +1,134 @@
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerActions from "../domains/research.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, params = {}) {
+  const fn = ACTIONS.get(`research.${name}`);
+  if (!fn) throw new Error(`research.${name} not registered`);
+  return fn(ctx, { id: null, data: {}, meta: {} }, params);
+}
+
+before(() => { registerActions(register); });
+beforeEach(() => {
+  globalThis._concordSTATE = { dtus: new Map() };
+  globalThis._concordSaveStateDebounced = () => {};
+  globalThis.fetch = async () => { throw new Error("network disabled"); };
+});
+
+const ctxA = { actor: { userId: "u" }, userId: "u" };
+const ctxB = { actor: { userId: "v" }, userId: "v" };
+
+describe("research — notes CRUD", () => {
+  it("creates and lists a note", () => {
+    const c = call("note-create", ctxA, { title: "First", body: "Hello world" });
+    assert.equal(c.ok, true);
+    const l = call("notes-list", ctxA);
+    assert.equal(l.result.notes.length, 1);
+    assert.equal(l.result.notes[0].title, "First");
+  });
+
+  it("INVARIANT: notes scoped per-user", () => {
+    call("note-create", ctxA, { title: "a-only", body: "x" });
+    const b = call("notes-list", ctxB);
+    assert.equal(b.result.notes.length, 0);
+  });
+
+  it("update modifies title and body", () => {
+    const c = call("note-create", ctxA, { title: "old", body: "old body" });
+    const u = call("note-update", ctxA, { id: c.result.note.id, title: "new", body: "new body" });
+    assert.equal(u.result.note.title, "new");
+    assert.equal(u.result.note.body, "new body");
+  });
+
+  it("delete removes", () => {
+    const c = call("note-create", ctxA, { title: "tmp", body: "x" });
+    call("note-delete", ctxA, { id: c.result.note.id });
+    const l = call("notes-list", ctxA);
+    assert.equal(l.result.notes.length, 0);
+  });
+
+  it("rejects oversized title", () => {
+    const r = call("note-create", ctxA, { title: "x".repeat(201), body: "y" });
+    assert.equal(r.ok, false);
+  });
+});
+
+describe("research — daily note", () => {
+  it("auto-creates daily note for today", () => {
+    const r = call("daily-note", ctxA);
+    assert.equal(r.ok, true);
+    assert.equal(r.result.created, true);
+    assert.match(r.result.note.title, /^Daily — /);
+  });
+
+  it("subsequent call returns same daily note", () => {
+    const r1 = call("daily-note", ctxA);
+    const r2 = call("daily-note", ctxA);
+    assert.equal(r1.result.note.id, r2.result.note.id);
+    assert.equal(r2.result.created, false);
+  });
+
+  it("different date creates different note", () => {
+    const r1 = call("daily-note", ctxA, { date: "2026-01-01" });
+    const r2 = call("daily-note", ctxA, { date: "2026-01-02" });
+    assert.notEqual(r1.result.note.id, r2.result.note.id);
+  });
+});
+
+describe("research — backlinks", () => {
+  it("finds [[wikilinks]] in other notes", () => {
+    call("note-create", ctxA, { title: "Source", body: "main body" });
+    call("note-create", ctxA, { title: "Linker", body: "I reference [[Source]] here" });
+    const r = call("backlinks-for", ctxA, { title: "Source" });
+    assert.equal(r.result.backlinks.length, 1);
+    assert.equal(r.result.backlinks[0].noteTitle, "Linker");
+    assert.ok(r.result.backlinks[0].context.includes("[[Source]]"));
+  });
+
+  it("excludes self-references", () => {
+    call("note-create", ctxA, { title: "Self", body: "I am [[Self]]" });
+    const r = call("backlinks-for", ctxA, { title: "Self" });
+    assert.equal(r.result.backlinks.length, 0);
+  });
+});
+
+describe("research — templates", () => {
+  it("lists 6 templates", () => {
+    const r = call("templates-list", {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.templates.length, 6);
+  });
+
+  it("apply returns named template", () => {
+    const r = call("template-apply", {}, { id: "meeting" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.template.id, "meeting");
+    assert.match(r.result.template.title, /meeting/i);
+  });
+
+  it("rejects unknown template id", () => {
+    const r = call("template-apply", {}, { id: "bogus" });
+    assert.equal(r.ok, false);
+  });
+});
+
+describe("research — search", () => {
+  beforeEach(() => {
+    call("note-create", ctxA, { title: "Pasta recipes", body: "spaghetti and carbonara" });
+    call("note-create", ctxA, { title: "Rocket science", body: "propellant mixture for spaghetti-thrust engines" });
+  });
+
+  it("scores title matches higher than body", () => {
+    const r = call("notes-search", ctxA, { query: "spaghetti" });
+    assert.ok(r.result.hits.length >= 1);
+    // Title hits get +5, body hits +1
+    assert.ok(r.result.hits[0].score >= 1);
+  });
+
+  it("rejects short query", () => {
+    const r = call("notes-search", ctxA, { query: "x" });
+    assert.equal(r.ok, false);
+  });
+});


### PR DESCRIPTION
## Summary

Brings the research lens to 2026 parity vs **Notion / Roam / Obsidian / Logseq / RemNote / Tana / Capacities / Mem**. The Roam triumvirate — bidirectional [[wikilinks]] + daily journal + block-level transclusion-style backlinks.

### Backend (9 macros)
| Group | Macros |
|---|---|
| Notes | `note-create`, `note-update`, `note-delete`, `notes-list`, `note-get` |
| Daily | `daily-note` (idempotent per date) |
| Templates | `templates-list`, `template-apply` (6 starter templates) |
| Backlinks | `backlinks-for` (scans for [[title]] mentions) |
| Search | `notes-search` (multi-term, title-weighted) |

### Frontend (1 component, 4 tabs)
Notes (list + inline editor) · Daily (auto today) · Search · Templates.

## Test plan
- [x] **15/15 tests passing**
- [x] CRUD + per-user scoping
- [x] Daily-note idempotency per date
- [x] Backlinks find [[wikilinks]] and exclude self-refs
- [x] Templates: 6 starter, list + apply
- [x] tsc + lint clean

https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_