### PR TITLE
retail lens: Shopify/Square/Stripe POS parity — register, catalog, orders, low stock

### DIFF
--- a/concord-frontend/app/lenses/retail/page.tsx
+++ b/concord-frontend/app/lenses/retail/page.tsx
@@ -72,6 +72,7 @@ import { DTUExportButton } from '@/components/lens/DTUExportButton';
 import { RealtimeDataPanel } from '@/components/lens/RealtimeDataPanel';
 import { LensFeaturePanel } from '@/components/lens/LensFeaturePanel';
 import LiveFeed from '@/components/lens/LiveFeed';
+import RetailWorkbench from '@/components/retail/RetailWorkbench';
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -246,6 +247,7 @@ export default function RetailLensPage() {
   const { latestData: realtimeData, isLive, lastUpdated, insights } = useRealtimeLens('retail');
 
   const [mode, setMode] = useState<ModeTab>('Products');
+  const [workbenchOpen, setWorkbenchOpen] = useState(false);
 
 
   // Lens-scoped keyboard commands (auto-wired by codemod).
@@ -2002,6 +2004,17 @@ export default function RetailLensPage() {
     
       {/* Sprint 17 production-grade polish sentinels — accessibility-only, never visually displayed */}
       <a href="#retail-skip" className="sr-only focus:not-sr-only focus:ring-2 focus:ring-amber-500 focus:outline-none">Skip to retail content</a>
+
+      {/* 2026 parity workbench — POS register / catalog / orders / low stock */}
+      <button
+        type="button"
+        onClick={() => setWorkbenchOpen(true)}
+        className="fixed bottom-6 right-6 z-30 inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-rose-500 hover:bg-rose-400 text-rose-50 shadow-2xl text-sm font-medium"
+        title="Retail Workbench — POS register, catalog, orders, low stock"
+      >
+        Retail Workbench
+      </button>
+      <RetailWorkbench open={workbenchOpen} onClose={() => setWorkbenchOpen(false)} />
     </LensShell>
   );
 }

--- a/concord-frontend/components/retail/RetailWorkbench.tsx
+++ b/concord-frontend/components/retail/RetailWorkbench.tsx
@@ -1,0 +1,332 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { X, Loader2, ShoppingCart, Package, Receipt, AlertTriangle, Plus, Trash2, Save, DollarSign } from 'lucide-react';
+import { api } from '@/lib/api/client';
+import { cn } from '@/lib/utils';
+
+export interface Product {
+  sku: string;
+  name: string;
+  price: number;
+  stock: number;
+  category: string;
+  barcode: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+type Tab = 'pos' | 'catalog' | 'orders' | 'lowstock';
+
+export function RetailWorkbench({ open, onClose }: Props) {
+  const [tab, setTab] = useState<Tab>('pos');
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-y-0 right-0 w-[660px] max-w-[100vw] z-40 bg-[#0d1117] border-l border-rose-500/20 shadow-2xl overflow-hidden flex flex-col">
+      <header className="px-4 py-3 border-b border-white/10 flex items-center justify-between bg-gradient-to-r from-rose-950/40 to-transparent">
+        <div className="flex items-center gap-2">
+          <ShoppingCart className="w-4 h-4 text-rose-400" />
+          <span className="text-sm font-semibold text-gray-200">Retail Workbench</span>
+        </div>
+        <button type="button" onClick={onClose} className="p-1 rounded-md hover:bg-white/5 text-gray-400" aria-label="Close">
+          <X className="w-4 h-4" />
+        </button>
+      </header>
+
+      <nav className="px-3 py-2 border-b border-white/10 flex items-center gap-1">
+        {([
+          { id: 'pos',      label: 'POS',         icon: ShoppingCart },
+          { id: 'catalog',  label: 'Catalog',     icon: Package },
+          { id: 'orders',   label: 'Orders',      icon: Receipt },
+          { id: 'lowstock', label: 'Low stock',   icon: AlertTriangle },
+        ] as const).map((t) => {
+          const Icon = t.icon;
+          const active = tab === t.id;
+          return (
+            <button key={t.id} type="button" onClick={() => setTab(t.id)}
+              className={cn(
+                'inline-flex items-center gap-1.5 px-2.5 py-1 text-xs rounded transition',
+                active
+                  ? 'bg-rose-500/15 text-rose-200 border border-rose-500/40'
+                  : 'text-gray-400 hover:text-gray-200 border border-transparent',
+              )}>
+              <Icon className="w-3 h-3" /> {t.label}
+            </button>
+          );
+        })}
+      </nav>
+
+      <div className="flex-1 overflow-y-auto">
+        {tab === 'pos' && <POSTab />}
+        {tab === 'catalog' && <CatalogTab />}
+        {tab === 'orders' && <OrdersTab />}
+        {tab === 'lowstock' && <LowStockTab />}
+      </div>
+    </div>
+  );
+}
+
+function POSTab() {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [cartId, setCartId] = useState<string | null>(null);
+  const [cart, setCart] = useState<{ lines: { sku: string; name: string; unitPrice: number; qty: number }[] } | null>(null);
+  const [totals, setTotals] = useState<{ subtotal: number; tax: number; total: number; itemCount: number } | null>(null);
+  const [tenderAmount, setTenderAmount] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+
+  const refreshProducts = useCallback(async () => {
+    try {
+      const r = await api.post('/api/lens/run', { domain: 'retail', action: 'product-list', input: {} });
+      setProducts(((r.data as { result?: { products?: Product[] } }).result?.products) || []);
+    } catch (e) { console.error(e); }
+  }, []);
+
+  const openCart = useCallback(async () => {
+    try {
+      const r = await api.post('/api/lens/run', { domain: 'retail', action: 'cart-open', input: {} });
+      const c = (r.data as { result?: { cart?: { id: string; lines: [] } } }).result?.cart;
+      if (c) {
+        setCartId(c.id);
+        setCart({ lines: c.lines });
+      }
+    } catch (e) { console.error(e); }
+  }, []);
+
+  useEffect(() => { refreshProducts(); openCart(); }, [refreshProducts, openCart]);
+
+  const addToCart = async (sku: string) => {
+    if (!cartId) return;
+    try {
+      const r = await api.post('/api/lens/run', { domain: 'retail', action: 'cart-add-line', input: { cartId, sku, qty: 1 } });
+      const c = (r.data as { result?: { cart?: typeof cart } }).result?.cart;
+      if (c) setCart(c);
+      computeTotal();
+    } catch (e) { console.error(e); }
+  };
+
+  const computeTotal = async () => {
+    if (!cartId) return;
+    try {
+      const r = await api.post('/api/lens/run', { domain: 'retail', action: 'cart-total', input: { cartId, taxRate: 8 } });
+      setTotals(((r.data as { result?: typeof totals }).result) || null);
+    } catch (e) { console.error(e); }
+  };
+
+  useEffect(() => { computeTotal(); }, [cart]);  // eslint-disable-line react-hooks/exhaustive-deps
+
+  const tender = async () => {
+    if (!cartId) return;
+    try {
+      const r = await api.post('/api/lens/run', {
+        domain: 'retail', action: 'cart-tender',
+        input: { cartId, taxRate: 8, tenders: [{ kind: 'cash', amount: Number(tenderAmount) }] },
+      });
+      const data = r.data as { ok?: boolean; error?: string; result?: { order?: { number: string; change: number } } };
+      if (data.ok) {
+        setMessage(`✓ ${data.result?.order?.number} · change $${data.result?.order?.change}`);
+        await openCart();
+        setTenderAmount('');
+      } else {
+        setMessage(data.error || 'Failed');
+      }
+    } catch (e) { setMessage((e as Error).message); }
+  };
+
+  return (
+    <div className="grid grid-cols-2 gap-2 p-3 h-full">
+      <div className="space-y-1 overflow-y-auto">
+        <p className="text-[10px] uppercase text-gray-500 mb-1">Tap to add</p>
+        {products.length === 0 ? <p className="text-xs text-gray-500">No products. Add some in Catalog tab.</p> :
+          products.map((p) => (
+            <button key={p.sku} type="button" onClick={() => addToCart(p.sku)}
+              className="w-full text-left rounded border border-white/10 bg-black/20 hover:bg-rose-500/10 p-2">
+              <p className="text-sm text-gray-100">{p.name}</p>
+              <div className="flex justify-between text-[11px]">
+                <span className="font-mono text-rose-300">${p.price}</span>
+                <span className="text-gray-500">{p.stock} in stock</span>
+              </div>
+            </button>
+          ))
+        }
+      </div>
+
+      <div className="border-l border-white/10 pl-3 flex flex-col">
+        <p className="text-[10px] uppercase text-gray-500 mb-1">Cart</p>
+        <div className="flex-1 overflow-y-auto">
+          {cart?.lines.length === 0 ? <p className="text-xs text-gray-500">Empty.</p> :
+            cart?.lines.map((l) => (
+              <div key={l.sku} className="flex justify-between text-xs py-1 border-b border-white/5">
+                <span className="text-gray-200">{l.qty}× {l.name}</span>
+                <span className="font-mono text-gray-300">${(l.qty * l.unitPrice).toFixed(2)}</span>
+              </div>
+            ))
+          }
+        </div>
+        {totals && (
+          <div className="mt-2 border-t border-white/10 pt-2 text-xs space-y-0.5 font-mono">
+            <div className="flex justify-between"><span className="text-gray-500">Subtotal</span><span>${totals.subtotal}</span></div>
+            <div className="flex justify-between"><span className="text-gray-500">Tax (8%)</span><span>${totals.tax}</span></div>
+            <div className="flex justify-between font-bold text-lg"><span>Total</span><span className="text-rose-300">${totals.total}</span></div>
+          </div>
+        )}
+        <div className="mt-2 flex gap-2">
+          <input type="number" value={tenderAmount} onChange={(e) => setTenderAmount(e.target.value)}
+            placeholder="Tender" className="flex-1 px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 font-mono" />
+          <button type="button" onClick={tender} disabled={!tenderAmount}
+            className="px-3 py-1 rounded-md border border-rose-500/40 bg-rose-500/15 text-xs text-rose-100 disabled:opacity-40">
+            <DollarSign className="w-3 h-3 inline" /> Tender
+          </button>
+        </div>
+        {message && <p className="text-[11px] text-emerald-300 mt-2">{message}</p>}
+      </div>
+    </div>
+  );
+}
+
+function CatalogTab() {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [draft, setDraft] = useState({ sku: '', name: '', price: 0, stock: 0, category: '', barcode: '' });
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const r = await api.post('/api/lens/run', { domain: 'retail', action: 'product-list', input: {} });
+      setProducts(((r.data as { result?: { products?: Product[] } }).result?.products) || []);
+    } catch (e) { console.error(e); }
+    finally { setLoading(false); }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const save = async () => {
+    try {
+      await api.post('/api/lens/run', { domain: 'retail', action: 'product-upsert', input: draft });
+      setCreating(false); setDraft({ sku: '', name: '', price: 0, stock: 0, category: '', barcode: '' });
+      await refresh();
+    } catch (e) { console.error(e); }
+  };
+
+  const remove = async (sku: string) => {
+    try {
+      await api.post('/api/lens/run', { domain: 'retail', action: 'product-delete', input: { sku } });
+      await refresh();
+    } catch (e) { console.error(e); }
+  };
+
+  return (
+    <div className="p-3 space-y-2">
+      <button type="button" onClick={() => setCreating((v) => !v)}
+        className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md border border-rose-500/30 bg-rose-500/10 text-xs text-rose-200">
+        <Plus className="w-3 h-3" /> Add product
+      </button>
+      {creating && (
+        <div className="rounded border border-rose-500/30 bg-rose-500/5 p-3 space-y-2">
+          <div className="grid grid-cols-2 gap-2">
+            <input type="text" value={draft.sku} onChange={(e) => setDraft({ ...draft, sku: e.target.value })}
+              placeholder="SKU" maxLength={32}
+              className="px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 font-mono" />
+            <input type="text" value={draft.name} onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+              placeholder="Product name"
+              className="px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100" />
+          </div>
+          <div className="grid grid-cols-3 gap-2">
+            <input type="number" value={draft.price} step="0.01" onChange={(e) => setDraft({ ...draft, price: Number(e.target.value) })}
+              placeholder="Price" className="px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 font-mono" />
+            <input type="number" value={draft.stock} onChange={(e) => setDraft({ ...draft, stock: Number(e.target.value) })}
+              placeholder="Stock" className="px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 font-mono" />
+            <input type="text" value={draft.category} onChange={(e) => setDraft({ ...draft, category: e.target.value })}
+              placeholder="Category" className="px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100" />
+          </div>
+          <button type="button" onClick={save} disabled={!draft.sku.trim() || !draft.name.trim()}
+            className="inline-flex items-center gap-1 px-3 py-1 rounded-md border border-rose-500/40 bg-rose-500/15 text-xs text-rose-100 disabled:opacity-40">
+            <Save className="w-3 h-3" /> Save
+          </button>
+        </div>
+      )}
+      {loading ? <div className="text-center py-8 text-xs text-gray-500"><Loader2 className="w-4 h-4 animate-spin inline mr-2" />Loading…</div> :
+        products.map((p) => (
+          <div key={p.sku} className="rounded border border-white/10 bg-black/20 p-3 flex items-center justify-between group">
+            <div>
+              <p className="text-sm text-gray-100">{p.name} <code className="text-[10px] text-gray-500 ml-2">{p.sku}</code></p>
+              <p className="text-[11px] text-gray-500">${p.price} · {p.stock} in stock · {p.category || 'uncategorized'}</p>
+            </div>
+            <button type="button" onClick={() => remove(p.sku)}
+              className="p-1 text-gray-600 hover:text-rose-300 opacity-0 group-hover:opacity-100"><Trash2 className="w-3 h-3" /></button>
+          </div>
+        ))
+      }
+    </div>
+  );
+}
+
+function OrdersTab() {
+  const [orders, setOrders] = useState<{ id: string; number: string; total: number; itemCount?: number; completedAt: string; lines: { sku: string; name: string; qty: number }[] }[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const r = await api.post('/api/lens/run', { domain: 'retail', action: 'orders-list', input: {} });
+        setOrders(((r.data as { result?: { orders?: typeof orders } }).result?.orders) || []);
+      } catch (e) { console.error(e); }
+    })();
+  }, []);
+
+  return (
+    <div className="p-3 space-y-2">
+      {orders.length === 0 ? <p className="text-center text-xs text-gray-500 py-8">No orders yet. Use POS to ring one up.</p> :
+        orders.map((o) => (
+          <div key={o.id} className="rounded border border-white/10 bg-black/20 p-3">
+            <div className="flex justify-between">
+              <span className="font-mono text-rose-300">{o.number}</span>
+              <span className="font-mono text-gray-100">${o.total}</span>
+            </div>
+            <p className="text-[10px] text-gray-500 mt-1">{new Date(o.completedAt).toLocaleString()}</p>
+            <p className="text-[11px] text-gray-400 mt-1">{o.lines.map((l) => `${l.qty}× ${l.name}`).join(', ')}</p>
+          </div>
+        ))
+      }
+    </div>
+  );
+}
+
+function LowStockTab() {
+  const [items, setItems] = useState<Product[]>([]);
+  const [threshold] = useState(5);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const r = await api.post('/api/lens/run', { domain: 'retail', action: 'low-stock', input: { threshold } });
+        setItems(((r.data as { result?: { lowStock?: Product[] } }).result?.lowStock) || []);
+      } catch (e) { console.error(e); }
+    })();
+  }, [threshold]);
+
+  return (
+    <div className="p-3 space-y-2">
+      <p className="text-[11px] text-gray-500">Products with stock ≤ {threshold}</p>
+      {items.length === 0 ? <p className="text-center text-xs text-emerald-300 py-8">✓ All stock above threshold.</p> :
+        items.map((p) => (
+          <div key={p.sku} className="rounded border border-amber-500/20 bg-amber-500/5 p-3 flex justify-between">
+            <div>
+              <p className="text-sm text-gray-100">{p.name}</p>
+              <p className="text-[11px] text-gray-500">{p.sku}</p>
+            </div>
+            <span className="font-mono text-amber-300 text-lg">{p.stock}</span>
+          </div>
+        ))
+      }
+    </div>
+  );
+}
+
+export default RetailWorkbench;

--- a/server/domains/retail.js
+++ b/server/domains/retail.js
@@ -299,4 +299,210 @@ export default function registerRetailActions(registerLensAction) {
 
     return { ok: true, result: report };
   });
+
+  // ─── 2026 parity — Shopify/Square/Stripe POS / Lightspeed parity ──
+
+  function getRetailState() {
+    const STATE = globalThis._concordSTATE;
+    if (!STATE) return null;
+    if (!STATE.retailLens) {
+      STATE.retailLens = {
+        products: new Map(),  // userId -> Map<sku, product>
+        orders:   new Map(),  // userId -> Array<order>
+        carts:    new Map(),  // userId -> Map<cartId, cart>
+        seq:      new Map(),  // userId -> { order: 1 }
+      };
+    }
+    return STATE.retailLens;
+  }
+  function saveRetailState() {
+    if (typeof globalThis._concordSaveStateDebounced === "function") {
+      try { globalThis._concordSaveStateDebounced(); } catch (_e) { /* best effort */ }
+    }
+  }
+  function retailActor(ctx) { return ctx?.actor?.userId || ctx?.userId || "anon"; }
+  function nextRetailId(p) { return `${p}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`; }
+  function nowIsoRet() { return new Date().toISOString(); }
+
+  // ── Product catalog ──
+
+  registerLensAction("retail", "product-list", (ctx, _artifact, _params = {}) => {
+    const s = getRetailState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = retailActor(ctx);
+    const map = s.products.get(userId);
+    if (!map) return { ok: true, result: { products: [] } };
+    const products = Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name));
+    return { ok: true, result: { products } };
+  });
+
+  registerLensAction("retail", "product-upsert", (ctx, _artifact, params = {}) => {
+    const s = getRetailState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = retailActor(ctx);
+    const sku = String(params.sku || "").trim();
+    if (!sku) return { ok: false, error: "sku required" };
+    if (sku.length > 32) return { ok: false, error: "sku too long" };
+    const name = String(params.name || "").trim();
+    if (!name) return { ok: false, error: "name required" };
+    const price = Number(params.price);
+    if (!Number.isFinite(price) || price < 0) return { ok: false, error: "price must be >= 0" };
+    const stock = Number(params.stock);
+    if (!Number.isFinite(stock) || stock < 0) return { ok: false, error: "stock must be >= 0" };
+    if (!s.products.has(userId)) s.products.set(userId, new Map());
+    const existing = s.products.get(userId).get(sku);
+    const product = {
+      sku, name, price,
+      stock,
+      category: String(params.category || "").slice(0, 40),
+      barcode: String(params.barcode || "").slice(0, 32),
+      updatedAt: nowIsoRet(),
+      createdAt: existing?.createdAt || nowIsoRet(),
+    };
+    s.products.get(userId).set(sku, product);
+    saveRetailState();
+    return { ok: true, result: { product } };
+  });
+
+  registerLensAction("retail", "product-delete", (ctx, _artifact, params = {}) => {
+    const s = getRetailState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = retailActor(ctx);
+    const sku = String(params.sku || "");
+    if (!sku) return { ok: false, error: "sku required" };
+    const map = s.products.get(userId);
+    if (!map || !map.has(sku)) return { ok: false, error: "not found" };
+    map.delete(sku);
+    saveRetailState();
+    return { ok: true, result: { deleted: sku } };
+  });
+
+  // ── Cart + checkout ──
+
+  registerLensAction("retail", "cart-open", (ctx, _artifact, _params = {}) => {
+    const s = getRetailState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = retailActor(ctx);
+    const cart = { id: nextRetailId("cart"), lines: [], discountPercent: 0, openedAt: nowIsoRet() };
+    if (!s.carts.has(userId)) s.carts.set(userId, new Map());
+    s.carts.get(userId).set(cart.id, cart);
+    saveRetailState();
+    return { ok: true, result: { cart } };
+  });
+
+  registerLensAction("retail", "cart-add-line", (ctx, _artifact, params = {}) => {
+    const s = getRetailState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = retailActor(ctx);
+    const cartId = String(params.cartId || "");
+    const sku = String(params.sku || "");
+    const qty = Number(params.qty) || 1;
+    if (!cartId || !sku) return { ok: false, error: "cartId and sku required" };
+    if (qty <= 0) return { ok: false, error: "qty must be > 0" };
+    const cart = s.carts.get(userId)?.get(cartId);
+    if (!cart) return { ok: false, error: "cart not found" };
+    const product = s.products.get(userId)?.get(sku);
+    if (!product) return { ok: false, error: `product not found: ${sku}` };
+    const existing = cart.lines.find((l) => l.sku === sku);
+    if (existing) existing.qty += qty;
+    else cart.lines.push({ sku, name: product.name, unitPrice: product.price, qty });
+    saveRetailState();
+    return { ok: true, result: { cart } };
+  });
+
+  registerLensAction("retail", "cart-total", (ctx, _artifact, params = {}) => {
+    const s = getRetailState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = retailActor(ctx);
+    const cartId = String(params.cartId || "");
+    const cart = s.carts.get(userId)?.get(cartId);
+    if (!cart) return { ok: false, error: "cart not found" };
+    const taxRate = Number(params.taxRate) || 0;
+    const subtotal = cart.lines.reduce((sum, l) => sum + l.qty * l.unitPrice, 0);
+    const discount = (subtotal * cart.discountPercent) / 100;
+    const subtotalAfterDiscount = subtotal - discount;
+    const tax = subtotalAfterDiscount * (taxRate / 100);
+    const total = subtotalAfterDiscount + tax;
+    return {
+      ok: true,
+      result: {
+        subtotal: Math.round(subtotal * 100) / 100,
+        discount: Math.round(discount * 100) / 100,
+        subtotalAfterDiscount: Math.round(subtotalAfterDiscount * 100) / 100,
+        tax: Math.round(tax * 100) / 100,
+        total: Math.round(total * 100) / 100,
+        lineCount: cart.lines.length,
+        itemCount: cart.lines.reduce((s, l) => s + l.qty, 0),
+      },
+    };
+  });
+
+  registerLensAction("retail", "cart-tender", (ctx, _artifact, params = {}) => {
+    const s = getRetailState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = retailActor(ctx);
+    const cartId = String(params.cartId || "");
+    const cart = s.carts.get(userId)?.get(cartId);
+    if (!cart) return { ok: false, error: "cart not found" };
+    if (cart.lines.length === 0) return { ok: false, error: "cart is empty" };
+    const taxRate = Number(params.taxRate) || 0;
+    const tenders = Array.isArray(params.tenders) ? params.tenders : [];
+    if (tenders.length === 0) return { ok: false, error: "tenders required (e.g. [{kind:'cash', amount:100}])" };
+    // Compute total
+    const subtotal = cart.lines.reduce((sum, l) => sum + l.qty * l.unitPrice, 0);
+    const discount = (subtotal * cart.discountPercent) / 100;
+    const subtotalAfter = subtotal - discount;
+    const tax = subtotalAfter * (taxRate / 100);
+    const total = Math.round((subtotalAfter + tax) * 100) / 100;
+    const tendered = tenders.reduce((s, t) => s + Number(t.amount || 0), 0);
+    if (tendered < total - 0.01) return { ok: false, error: `insufficient tender: ${tendered.toFixed(2)} < ${total.toFixed(2)}` };
+    const change = Math.round((tendered - total) * 100) / 100;
+    // Decrement stock
+    for (const line of cart.lines) {
+      const product = s.products.get(userId)?.get(line.sku);
+      if (product) product.stock = Math.max(0, product.stock - line.qty);
+    }
+    if (!s.seq.has(userId)) s.seq.set(userId, { order: 1 });
+    const seq = s.seq.get(userId);
+    const order = {
+      id: nextRetailId("ord"),
+      number: `ORD-${String(seq.order).padStart(5, "0")}`,
+      lines: cart.lines,
+      subtotal: Math.round(subtotal * 100) / 100,
+      discount: Math.round(discount * 100) / 100,
+      tax: Math.round(tax * 100) / 100,
+      total,
+      tenders,
+      tendered: Math.round(tendered * 100) / 100,
+      change,
+      completedAt: nowIsoRet(),
+    };
+    seq.order++;
+    if (!s.orders.has(userId)) s.orders.set(userId, []);
+    s.orders.get(userId).unshift(order);
+    s.carts.get(userId).delete(cartId);
+    saveRetailState();
+    return { ok: true, result: { order } };
+  });
+
+  registerLensAction("retail", "orders-list", (ctx, _artifact, _params = {}) => {
+    const s = getRetailState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = retailActor(ctx);
+    const orders = s.orders.get(userId) || [];
+    return { ok: true, result: { orders: orders.slice(0, 100) } };
+  });
+
+  // ── Inventory low-stock report ──
+
+  registerLensAction("retail", "low-stock", (ctx, _artifact, params = {}) => {
+    const s = getRetailState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = retailActor(ctx);
+    const threshold = Number(params.threshold) || 5;
+    const map = s.products.get(userId);
+    if (!map) return { ok: true, result: { lowStock: [] } };
+    const lowStock = Array.from(map.values()).filter((p) => p.stock <= threshold).sort((a, b) => a.stock - b.stock);
+    return { ok: true, result: { lowStock, threshold } };
+  });
 };

--- a/server/tests/retail-domain-parity.test.js
+++ b/server/tests/retail-domain-parity.test.js
@@ -1,0 +1,118 @@
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerActions from "../domains/retail.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, params = {}) {
+  const fn = ACTIONS.get(`retail.${name}`);
+  if (!fn) throw new Error(`retail.${name} not registered`);
+  return fn(ctx, { id: null, data: {}, meta: {} }, params);
+}
+
+before(() => { registerActions(register); });
+beforeEach(() => {
+  globalThis._concordSTATE = { dtus: new Map() };
+  globalThis._concordSaveStateDebounced = () => {};
+  globalThis.fetch = async () => { throw new Error("network disabled"); };
+});
+
+const ctxA = { actor: { userId: "u" }, userId: "u" };
+const ctxB = { actor: { userId: "v" }, userId: "v" };
+
+describe("retail — product catalog", () => {
+  it("upsert + list", () => {
+    call("product-upsert", ctxA, { sku: "ABC123", name: "Widget", price: 9.99, stock: 50 });
+    const r = call("product-list", ctxA);
+    assert.equal(r.result.products.length, 1);
+    assert.equal(r.result.products[0].sku, "ABC123");
+  });
+
+  it("INVARIANT: products scoped per-user", () => {
+    call("product-upsert", ctxA, { sku: "X", name: "a-only", price: 1, stock: 1 });
+    const b = call("product-list", ctxB);
+    assert.equal(b.result.products.length, 0);
+  });
+
+  it("rejects negative price", () => {
+    const r = call("product-upsert", ctxA, { sku: "X", name: "x", price: -1, stock: 0 });
+    assert.equal(r.ok, false);
+  });
+
+  it("delete removes", () => {
+    call("product-upsert", ctxA, { sku: "X", name: "x", price: 1, stock: 1 });
+    call("product-delete", ctxA, { sku: "X" });
+    assert.equal(call("product-list", ctxA).result.products.length, 0);
+  });
+});
+
+describe("retail — POS flow", () => {
+  beforeEach(() => {
+    call("product-upsert", ctxA, { sku: "WIDGET", name: "Widget", price: 10, stock: 5 });
+    call("product-upsert", ctxA, { sku: "GADGET", name: "Gadget", price: 25, stock: 3 });
+  });
+
+  it("open cart, add line, total, tender", () => {
+    const c = call("cart-open", ctxA);
+    const cartId = c.result.cart.id;
+    call("cart-add-line", ctxA, { cartId, sku: "WIDGET", qty: 2 });
+    call("cart-add-line", ctxA, { cartId, sku: "GADGET", qty: 1 });
+    const total = call("cart-total", ctxA, { cartId, taxRate: 10 });
+    // subtotal = 20+25 = 45, tax 10% = 4.5, total = 49.5
+    assert.equal(total.result.subtotal, 45);
+    assert.equal(total.result.tax, 4.5);
+    assert.equal(total.result.total, 49.5);
+    const tender = call("cart-tender", ctxA, { cartId, taxRate: 10, tenders: [{ kind: "cash", amount: 50 }] });
+    assert.equal(tender.ok, true);
+    assert.equal(tender.result.order.change, 0.5);
+  });
+
+  it("rejects insufficient tender", () => {
+    const c = call("cart-open", ctxA);
+    call("cart-add-line", ctxA, { cartId: c.result.cart.id, sku: "WIDGET", qty: 1 });
+    const r = call("cart-tender", ctxA, { cartId: c.result.cart.id, tenders: [{ kind: "cash", amount: 5 }] });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /insufficient/);
+  });
+
+  it("rejects unknown product", () => {
+    const c = call("cart-open", ctxA);
+    const r = call("cart-add-line", ctxA, { cartId: c.result.cart.id, sku: "BOGUS", qty: 1 });
+    assert.equal(r.ok, false);
+  });
+
+  it("rejects empty cart tender", () => {
+    const c = call("cart-open", ctxA);
+    const r = call("cart-tender", ctxA, { cartId: c.result.cart.id, tenders: [{ kind: "cash", amount: 100 }] });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /empty/);
+  });
+
+  it("decrements stock on tender", () => {
+    const c = call("cart-open", ctxA);
+    call("cart-add-line", ctxA, { cartId: c.result.cart.id, sku: "WIDGET", qty: 3 });
+    call("cart-tender", ctxA, { cartId: c.result.cart.id, tenders: [{ kind: "cash", amount: 100 }] });
+    const list = call("product-list", ctxA);
+    const widget = list.result.products.find((p) => p.sku === "WIDGET");
+    assert.equal(widget.stock, 2); // started at 5, sold 3
+  });
+});
+
+describe("retail — orders + low stock", () => {
+  it("orders-list returns completed orders", () => {
+    call("product-upsert", ctxA, { sku: "X", name: "x", price: 5, stock: 10 });
+    const c = call("cart-open", ctxA);
+    call("cart-add-line", ctxA, { cartId: c.result.cart.id, sku: "X", qty: 1 });
+    call("cart-tender", ctxA, { cartId: c.result.cart.id, tenders: [{ kind: "cash", amount: 10 }] });
+    const r = call("orders-list", ctxA);
+    assert.equal(r.result.orders.length, 1);
+  });
+
+  it("low-stock returns items below threshold", () => {
+    call("product-upsert", ctxA, { sku: "LOW", name: "low", price: 1, stock: 2 });
+    call("product-upsert", ctxA, { sku: "HIGH", name: "high", price: 1, stock: 100 });
+    const r = call("low-stock", ctxA, { threshold: 5 });
+    assert.equal(r.result.lowStock.length, 1);
+    assert.equal(r.result.lowStock[0].sku, "LOW");
+  });
+});


### PR DESCRIPTION
## Summary

Brings the retail lens to 2026 parity vs **Shopify POS / Square / Stripe Terminal / Lightspeed / Toast / Clover / Erply** on the four core POS surfaces.

### Backend (9 macros)
| Group | Macros |
|---|---|
| Catalog | `product-list`, `product-upsert`, `product-delete` |
| Cart/POS | `cart-open`, `cart-add-line`, `cart-total`, `cart-tender` (multi-tender + insufficient guard + auto stock decrement) |
| Orders | `orders-list` |
| Inventory | `low-stock` |

### Frontend (1 component, 4 tabs)
POS (tile grid + cart + tender) · Catalog · Orders · Low stock.

## Test plan
- [x] **11/11 tests passing**
- [x] POS flow end-to-end: cart → lines → total w/ tax → tender → order
- [x] Insufficient-tender rejected, unknown-product rejected, empty-cart rejected
- [x] Auto stock-decrement on tender
- [x] Per-user scoping; tsc + lint clean

https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_