### PR TITLE
science lens: OriginPro/Igor/MATLAB/Jupyter parity — descriptive, t-test, correlation

### DIFF
--- a/concord-frontend/app/lenses/science/page.tsx
+++ b/concord-frontend/app/lenses/science/page.tsx
@@ -49,6 +49,7 @@ import { RealtimeDataPanel } from '@/components/lens/RealtimeDataPanel';
 import { LensFeaturePanel } from '@/components/lens/LensFeaturePanel';
 import { LensFeedPanel } from '@/components/feeds/LensFeedPanel';
 import LiveFeed, { adaptToLiveFeedArticles } from '@/components/lens/LiveFeed';
+import ScienceWorkbench from '@/components/science/ScienceWorkbench';
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -360,6 +361,7 @@ export default function ScienceLensPage() {
 
   const [showFeatures, setShowFeatures] = useState(true);
   const [mode, setMode] = useState<ModeTab>('Dashboard');
+  const [workbenchOpen, setWorkbenchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [showEditor, setShowEditor] = useState(false);
@@ -2176,6 +2178,17 @@ export default function ScienceLensPage() {
     
       {/* Sprint 17 production-grade polish sentinels — accessibility-only, never visually displayed */}
       <a href="#science-skip" className="sr-only focus:not-sr-only focus:ring-2 focus:ring-amber-500 focus:outline-none">Skip to science content</a>
+
+      {/* 2026 parity workbench — descriptive stats / t-test / correlation */}
+      <button
+        type="button"
+        onClick={() => setWorkbenchOpen(true)}
+        className="fixed bottom-6 right-6 z-30 inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-teal-500 hover:bg-teal-400 text-teal-50 shadow-2xl text-sm font-medium"
+        title="Science Workbench — descriptive stats, t-test, correlation/regression"
+      >
+        Science Workbench
+      </button>
+      <ScienceWorkbench open={workbenchOpen} onClose={() => setWorkbenchOpen(false)} />
     </LensShell>
   );
 }

--- a/concord-frontend/components/science/ScienceWorkbench.tsx
+++ b/concord-frontend/components/science/ScienceWorkbench.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { X, Loader2, BarChart3, Sigma, Activity, TrendingUp } from 'lucide-react';
+import { api } from '@/lib/api/client';
+import { cn } from '@/lib/utils';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+type Tab = 'descriptive' | 'ttest' | 'correlation';
+
+export function ScienceWorkbench({ open, onClose }: Props) {
+  const [tab, setTab] = useState<Tab>('descriptive');
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-y-0 right-0 w-[620px] max-w-[100vw] z-40 bg-[#0d1117] border-l border-teal-500/20 shadow-2xl overflow-hidden flex flex-col">
+      <header className="px-4 py-3 border-b border-white/10 flex items-center justify-between bg-gradient-to-r from-teal-950/40 to-transparent">
+        <div className="flex items-center gap-2">
+          <Sigma className="w-4 h-4 text-teal-400" />
+          <span className="text-sm font-semibold text-gray-200">Science Workbench</span>
+        </div>
+        <button type="button" onClick={onClose} className="p-1 rounded-md hover:bg-white/5 text-gray-400" aria-label="Close">
+          <X className="w-4 h-4" />
+        </button>
+      </header>
+
+      <nav className="px-3 py-2 border-b border-white/10 flex items-center gap-1">
+        {([
+          { id: 'descriptive', label: 'Descriptive', icon: BarChart3 },
+          { id: 'ttest',       label: 't-test',      icon: Activity },
+          { id: 'correlation', label: 'Correlation', icon: TrendingUp },
+        ] as const).map((t) => {
+          const Icon = t.icon;
+          const active = tab === t.id;
+          return (
+            <button key={t.id} type="button" onClick={() => setTab(t.id)}
+              className={cn(
+                'inline-flex items-center gap-1.5 px-2.5 py-1 text-xs rounded transition',
+                active
+                  ? 'bg-teal-500/15 text-teal-200 border border-teal-500/40'
+                  : 'text-gray-400 hover:text-gray-200 border border-transparent',
+              )}>
+              <Icon className="w-3 h-3" /> {t.label}
+            </button>
+          );
+        })}
+      </nav>
+
+      <div className="flex-1 overflow-y-auto">
+        {tab === 'descriptive' && <DescriptiveTab />}
+        {tab === 'ttest' && <TTestTab />}
+        {tab === 'correlation' && <CorrelationTab />}
+      </div>
+    </div>
+  );
+}
+
+function parseDataInput(s: string): number[] {
+  return s.split(/[,\s]+/).map(Number).filter(Number.isFinite);
+}
+
+function DescriptiveTab() {
+  const [data, setData] = useState('1, 2, 3, 4, 5, 6, 7, 8, 9, 10');
+  const [result, setResult] = useState<{
+    n: number; mean: number; median: number; sd: number; variance: number;
+    min: number; max: number; q1: number; q3: number; iqr: number; sum: number;
+  } | null>(null);
+
+  const calc = async () => {
+    try {
+      const r = await api.post('/api/lens/run', {
+        domain: 'science', action: 'stats-descriptive',
+        input: { data: parseDataInput(data) },
+      });
+      setResult(((r.data as { result?: typeof result }).result) || null);
+    } catch (e) { console.error(e); }
+  };
+
+  useEffect(() => { calc(); }, []);  // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className="p-3 space-y-3">
+      <textarea value={data} onChange={(e) => setData(e.target.value)} rows={3}
+        placeholder="comma or space separated numbers"
+        className="w-full px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 font-mono resize-none" />
+      <button type="button" onClick={calc}
+        className="px-3 py-1 rounded-md border border-teal-500/40 bg-teal-500/15 text-xs text-teal-100">Compute</button>
+
+      {result && (
+        <div className="rounded border border-teal-500/20 bg-teal-500/5 p-3 grid grid-cols-3 gap-3 text-xs">
+          {Object.entries(result).map(([k, v]) => (
+            <div key={k}>
+              <span className="text-gray-500 uppercase text-[10px]">{k}</span>
+              <p className="font-mono text-gray-100">{v}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TTestTab() {
+  const [kind, setKind] = useState<'one-sample' | 'two-sample'>('two-sample');
+  const [a, setA] = useState('5, 7, 8, 4, 6, 9, 5, 7');
+  const [b, setB] = useState('10, 12, 11, 14, 13, 11, 12, 13');
+  const [mu, setMu] = useState('5');
+  const [result, setResult] = useState<{
+    kind: string; t: number; df: number; pValue: number;
+    significantAt05?: boolean; meanA?: number; meanB?: number;
+  } | null>(null);
+
+  const calc = async () => {
+    try {
+      const input: Record<string, unknown> = { kind, a: parseDataInput(a) };
+      if (kind === 'two-sample') input.b = parseDataInput(b);
+      else input.mu = Number(mu);
+      const r = await api.post('/api/lens/run', { domain: 'science', action: 'stats-ttest', input });
+      setResult(((r.data as { result?: typeof result }).result) || null);
+    } catch (e) { console.error(e); }
+  };
+
+  return (
+    <div className="p-3 space-y-3">
+      <select value={kind} onChange={(e) => setKind(e.target.value as typeof kind)}
+        className="px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100">
+        <option value="one-sample">One-sample (vs μ)</option>
+        <option value="two-sample">Two-sample Welch&apos;s</option>
+      </select>
+
+      <textarea value={a} onChange={(e) => setA(e.target.value)} rows={2}
+        placeholder="Sample A (comma/space separated)"
+        className="w-full px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 font-mono resize-none" />
+
+      {kind === 'two-sample' ? (
+        <textarea value={b} onChange={(e) => setB(e.target.value)} rows={2}
+          placeholder="Sample B"
+          className="w-full px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 font-mono resize-none" />
+      ) : (
+        <input type="number" value={mu} onChange={(e) => setMu(e.target.value)} placeholder="μ"
+          className="w-full px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 font-mono" />
+      )}
+
+      <button type="button" onClick={calc}
+        className="px-3 py-1 rounded-md border border-teal-500/40 bg-teal-500/15 text-xs text-teal-100">Run t-test</button>
+
+      {result && (
+        <div className="rounded border border-teal-500/20 bg-teal-500/5 p-3 space-y-1 text-sm">
+          <p>t = <span className="font-mono text-gray-100">{result.t}</span></p>
+          <p>df = <span className="font-mono text-gray-100">{result.df}</span></p>
+          <p>p-value = <span className={cn('font-mono', result.pValue < 0.05 ? 'text-emerald-300' : 'text-gray-400')}>{result.pValue}</span></p>
+          {result.meanA !== undefined && <p className="text-[11px] text-gray-500">means: A={result.meanA}, B={result.meanB}</p>}
+          {result.significantAt05 !== undefined && (
+            <p className={cn('text-[11px] uppercase font-bold', result.significantAt05 ? 'text-emerald-300' : 'text-gray-500')}>
+              {result.significantAt05 ? '✓ Significant @ α=0.05' : 'Not significant @ α=0.05'}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CorrelationTab() {
+  const [x, setX] = useState('1, 2, 3, 4, 5, 6, 7, 8, 9, 10');
+  const [y, setY] = useState('2.1, 3.9, 6.2, 8.0, 10.1, 11.8, 14.0, 16.2, 18.1, 20.0');
+  const [result, setResult] = useState<{
+    n: number; pearsonR: number; rSquared: number; pValue: number;
+    slope: number; intercept: number; equation: string; significantAt05: boolean;
+  } | null>(null);
+
+  const calc = async () => {
+    try {
+      const r = await api.post('/api/lens/run', {
+        domain: 'science', action: 'stats-correlation',
+        input: { x: parseDataInput(x), y: parseDataInput(y) },
+      });
+      setResult(((r.data as { result?: typeof result }).result) || null);
+    } catch (e) { console.error(e); }
+  };
+
+  useEffect(() => { calc(); }, []);  // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className="p-3 space-y-3">
+      <textarea value={x} onChange={(e) => setX(e.target.value)} rows={2}
+        placeholder="X values"
+        className="w-full px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 font-mono resize-none" />
+      <textarea value={y} onChange={(e) => setY(e.target.value)} rows={2}
+        placeholder="Y values"
+        className="w-full px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 font-mono resize-none" />
+      <button type="button" onClick={calc}
+        className="px-3 py-1 rounded-md border border-teal-500/40 bg-teal-500/15 text-xs text-teal-100">Compute</button>
+
+      {result && (
+        <div className="rounded border border-teal-500/20 bg-teal-500/5 p-3 space-y-1 text-sm">
+          <p>Pearson r = <span className="font-mono text-2xl text-teal-300">{result.pearsonR}</span></p>
+          <p>R² = <span className="font-mono text-gray-100">{result.rSquared}</span></p>
+          <p>p-value = <span className={cn('font-mono', result.pValue < 0.05 ? 'text-emerald-300' : 'text-gray-400')}>{result.pValue}</span></p>
+          <p className="text-[11px] text-gray-500">{result.equation}</p>
+          <p className={cn('text-[11px] uppercase font-bold', result.significantAt05 ? 'text-emerald-300' : 'text-gray-500')}>
+            {result.significantAt05 ? '✓ Significant @ α=0.05' : 'Not significant @ α=0.05'}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ScienceWorkbench;

--- a/server/domains/science.js
+++ b/server/domains/science.js
@@ -261,4 +261,264 @@ export default function registerScienceActions(registerLensAction) {
     }
     return { ok: true, result: { clusters, totalObservations: geoObs.length, radiusKm: radius } };
   });
+
+  // ─── 2026 parity — OriginPro/Igor/MATLAB/Jupyter/Prism analytics ──
+  //
+  // Pure JS stats: descriptive stats, t-test, correlation, linear regression,
+  // and a typed data-table store. No external deps.
+
+  function getScienceState() {
+    const STATE = globalThis._concordSTATE;
+    if (!STATE) return null;
+    if (!STATE.scienceLens) {
+      STATE.scienceLens = {
+        datasets: new Map(), // userId -> Map<id, dataset>
+      };
+    }
+    return STATE.scienceLens;
+  }
+  function saveScienceState() {
+    if (typeof globalThis._concordSaveStateDebounced === "function") {
+      try { globalThis._concordSaveStateDebounced(); } catch (_e) { /* best effort */ }
+    }
+  }
+  function sciActor(ctx) { return ctx?.actor?.userId || ctx?.userId || "anon"; }
+  function nextSciId(p) { return `${p}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`; }
+
+  // ── Stat helpers ──
+
+  function mean(arr) { return arr.reduce((a, b) => a + b, 0) / arr.length; }
+  function variance(arr, sample = true) {
+    const m = mean(arr);
+    return arr.reduce((s, x) => s + (x - m) ** 2, 0) / (sample ? (arr.length - 1) : arr.length);
+  }
+  function stddev(arr, sample = true) { return Math.sqrt(variance(arr, sample)); }
+  function median(arr) {
+    const s = [...arr].sort((a, b) => a - b);
+    const n = s.length;
+    return n % 2 === 0 ? (s[n / 2 - 1] + s[n / 2]) / 2 : s[Math.floor(n / 2)];
+  }
+  function percentile(arr, p) {
+    const s = [...arr].sort((a, b) => a - b);
+    const k = (s.length - 1) * (p / 100);
+    const f = Math.floor(k);
+    const c = Math.ceil(k);
+    return f === c ? s[f] : s[f] + (s[c] - s[f]) * (k - f);
+  }
+
+  // Student's t CDF approximation (sufficient for p-value reporting at common alphas).
+  function tCDF(t, df) {
+    // Use Abramowitz & Stegun approximation via the inverse normal for high df.
+    if (df > 100) {
+      // Approximates Z
+      const z = t;
+      return 0.5 + 0.5 * erf(z / Math.SQRT2);
+    }
+    // Iterative beta function approximation
+    const x = df / (df + t * t);
+    return 1 - 0.5 * incompleteBeta(x, df / 2, 0.5);
+  }
+  function erf(x) {
+    const a1 = 0.254829592, a2 = -0.284496736, a3 = 1.421413741, a4 = -1.453152027, a5 = 1.061405429, p = 0.3275911;
+    const sign = x < 0 ? -1 : 1;
+    x = Math.abs(x);
+    const t = 1 / (1 + p * x);
+    const y = 1 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * Math.exp(-x * x);
+    return sign * y;
+  }
+  function incompleteBeta(x, a, b) {
+    // Simple series approximation
+    if (x <= 0) return 0;
+    if (x >= 1) return 1;
+    const bt = Math.exp(lnGamma(a + b) - lnGamma(a) - lnGamma(b) + a * Math.log(x) + b * Math.log(1 - x));
+    if (x < (a + 1) / (a + b + 2)) {
+      return bt * betacf(x, a, b) / a;
+    }
+    return 1 - bt * betacf(1 - x, b, a) / b;
+  }
+  function lnGamma(z) {
+    const g = 7;
+    const c = [0.99999999999980993, 676.5203681218851, -1259.1392167224028, 771.32342877765313, -176.61502916214059, 12.507343278686905, -0.13857109526572012, 9.9843695780195716e-6, 1.5056327351493116e-7];
+    if (z < 0.5) return Math.log(Math.PI / Math.sin(Math.PI * z)) - lnGamma(1 - z);
+    z -= 1;
+    let x = c[0];
+    for (let i = 1; i < g + 2; i++) x += c[i] / (z + i);
+    const t = z + g + 0.5;
+    return 0.5 * Math.log(2 * Math.PI) + (z + 0.5) * Math.log(t) - t + Math.log(x);
+  }
+  function betacf(x, a, b) {
+    const MAX_IT = 100;
+    const EPS = 3e-7;
+    let qab = a + b, qap = a + 1, qam = a - 1, c = 1, d = 1 - qab * x / qap;
+    if (Math.abs(d) < 1e-30) d = 1e-30;
+    d = 1 / d;
+    let h = d;
+    for (let m = 1; m <= MAX_IT; m++) {
+      const m2 = 2 * m;
+      let aa = m * (b - m) * x / ((qam + m2) * (a + m2));
+      d = 1 + aa * d;
+      if (Math.abs(d) < 1e-30) d = 1e-30;
+      c = 1 + aa / c;
+      if (Math.abs(c) < 1e-30) c = 1e-30;
+      d = 1 / d;
+      h *= d * c;
+      aa = -(a + m) * (qab + m) * x / ((a + m2) * (qap + m2));
+      d = 1 + aa * d;
+      if (Math.abs(d) < 1e-30) d = 1e-30;
+      c = 1 + aa / c;
+      if (Math.abs(c) < 1e-30) c = 1e-30;
+      d = 1 / d;
+      const del = d * c;
+      h *= del;
+      if (Math.abs(del - 1) < EPS) break;
+    }
+    return h;
+  }
+
+  // ── Descriptive statistics ──
+
+  registerLensAction("science", "stats-descriptive", (_ctx, _artifact, params = {}) => {
+    const data = Array.isArray(params.data) ? params.data.map(Number).filter((x) => Number.isFinite(x)) : [];
+    if (data.length === 0) return { ok: false, error: "data array required (numeric)" };
+    if (data.length === 1) return { ok: false, error: "need >= 2 values for variance/sd" };
+    return {
+      ok: true,
+      result: {
+        n: data.length,
+        mean: Math.round(mean(data) * 10000) / 10000,
+        median: Math.round(median(data) * 10000) / 10000,
+        sd: Math.round(stddev(data) * 10000) / 10000,
+        variance: Math.round(variance(data) * 10000) / 10000,
+        min: Math.min(...data),
+        max: Math.max(...data),
+        q1: Math.round(percentile(data, 25) * 10000) / 10000,
+        q3: Math.round(percentile(data, 75) * 10000) / 10000,
+        iqr: Math.round((percentile(data, 75) - percentile(data, 25)) * 10000) / 10000,
+        sum: data.reduce((a, b) => a + b, 0),
+      },
+    };
+  });
+
+  // ── t-test (one-sample, two-sample independent) ──
+
+  registerLensAction("science", "stats-ttest", (_ctx, _artifact, params = {}) => {
+    const kind = String(params.kind || "two-sample");
+    if (!["one-sample", "two-sample"].includes(kind)) return { ok: false, error: "kind must be one-sample | two-sample" };
+    const a = Array.isArray(params.a) ? params.a.map(Number).filter(Number.isFinite) : [];
+    if (a.length < 2) return { ok: false, error: "sample a needs >= 2 values" };
+    if (kind === "one-sample") {
+      const mu = Number(params.mu);
+      if (!Number.isFinite(mu)) return { ok: false, error: "mu required for one-sample" };
+      const m = mean(a);
+      const sd = stddev(a);
+      const se = sd / Math.sqrt(a.length);
+      const t = (m - mu) / se;
+      const df = a.length - 1;
+      const p = 2 * (1 - tCDF(Math.abs(t), df));
+      return { ok: true, result: { kind, t: Math.round(t * 10000) / 10000, df, pValue: Math.round(p * 100000) / 100000, sampleMean: m, mu } };
+    }
+    // Two-sample (Welch's t-test, doesn't assume equal variance)
+    const b = Array.isArray(params.b) ? params.b.map(Number).filter(Number.isFinite) : [];
+    if (b.length < 2) return { ok: false, error: "sample b needs >= 2 values" };
+    const m1 = mean(a), m2 = mean(b);
+    const v1 = variance(a), v2 = variance(b);
+    const n1 = a.length, n2 = b.length;
+    const se = Math.sqrt(v1 / n1 + v2 / n2);
+    const t = (m1 - m2) / se;
+    const df = (v1 / n1 + v2 / n2) ** 2 / ((v1 / n1) ** 2 / (n1 - 1) + (v2 / n2) ** 2 / (n2 - 1));
+    const p = 2 * (1 - tCDF(Math.abs(t), df));
+    return {
+      ok: true,
+      result: {
+        kind: "two-sample-welch", t: Math.round(t * 10000) / 10000, df: Math.round(df * 100) / 100,
+        pValue: Math.round(p * 100000) / 100000,
+        meanA: Math.round(m1 * 10000) / 10000, meanB: Math.round(m2 * 10000) / 10000,
+        nA: n1, nB: n2,
+        significantAt05: p < 0.05,
+      },
+    };
+  });
+
+  // ── Pearson correlation + linear regression ──
+
+  registerLensAction("science", "stats-correlation", (_ctx, _artifact, params = {}) => {
+    const x = Array.isArray(params.x) ? params.x.map(Number).filter(Number.isFinite) : [];
+    const y = Array.isArray(params.y) ? params.y.map(Number).filter(Number.isFinite) : [];
+    if (x.length !== y.length) return { ok: false, error: "x and y must be same length" };
+    if (x.length < 3) return { ok: false, error: "need >= 3 paired values" };
+    const mx = mean(x), my = mean(y);
+    let num = 0, dx = 0, dy = 0;
+    for (let i = 0; i < x.length; i++) {
+      num += (x[i] - mx) * (y[i] - my);
+      dx += (x[i] - mx) ** 2;
+      dy += (y[i] - my) ** 2;
+    }
+    const r = num / Math.sqrt(dx * dy);
+    // t-test on r: t = r * sqrt((n-2)/(1-r²)), df = n-2
+    const t = r * Math.sqrt((x.length - 2) / (1 - r * r));
+    const df = x.length - 2;
+    const p = 2 * (1 - tCDF(Math.abs(t), df));
+    // Linear regression y = a + bx
+    const slope = num / dx;
+    const intercept = my - slope * mx;
+    return {
+      ok: true,
+      result: {
+        n: x.length,
+        pearsonR: Math.round(r * 10000) / 10000,
+        rSquared: Math.round(r * r * 10000) / 10000,
+        pValue: Math.round(p * 100000) / 100000,
+        slope: Math.round(slope * 10000) / 10000,
+        intercept: Math.round(intercept * 10000) / 10000,
+        equation: `y = ${slope.toFixed(4)}x + ${intercept.toFixed(4)}`,
+        significantAt05: p < 0.05,
+      },
+    };
+  });
+
+  // ── Dataset storage (per-user) ──
+
+  registerLensAction("science", "dataset-save", (ctx, _artifact, params = {}) => {
+    const s = getScienceState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = sciActor(ctx);
+    const name = String(params.name || "").trim();
+    if (!name) return { ok: false, error: "name required" };
+    if (name.length > 80) return { ok: false, error: "name too long" };
+    const columns = Array.isArray(params.columns) ? params.columns : [];
+    if (columns.length === 0) return { ok: false, error: "columns array required" };
+    const rows = Array.isArray(params.rows) ? params.rows : [];
+    if (rows.length > 10_000) return { ok: false, error: "rows max 10000" };
+    const dataset = {
+      id: nextSciId("ds"),
+      name, columns, rows,
+      createdAt: new Date().toISOString(),
+    };
+    if (!s.datasets.has(userId)) s.datasets.set(userId, new Map());
+    s.datasets.get(userId).set(dataset.id, dataset);
+    saveScienceState();
+    return { ok: true, result: { dataset } };
+  });
+
+  registerLensAction("science", "dataset-list", (ctx, _artifact, _params = {}) => {
+    const s = getScienceState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = sciActor(ctx);
+    const map = s.datasets.get(userId);
+    if (!map) return { ok: true, result: { datasets: [] } };
+    const datasets = Array.from(map.values()).map(({ rows, ...meta }) => ({ ...meta, rowCount: rows.length }));
+    return { ok: true, result: { datasets } };
+  });
+
+  registerLensAction("science", "dataset-delete", (ctx, _artifact, params = {}) => {
+    const s = getScienceState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = sciActor(ctx);
+    const id = String(params.id || "");
+    const map = s.datasets.get(userId);
+    if (!map || !map.has(id)) return { ok: false, error: "not found" };
+    map.delete(id);
+    saveScienceState();
+    return { ok: true, result: { deleted: id } };
+  });
 };

--- a/server/tests/science-domain-parity.test.js
+++ b/server/tests/science-domain-parity.test.js
@@ -1,0 +1,132 @@
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerActions from "../domains/science.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, params = {}) {
+  const fn = ACTIONS.get(`science.${name}`);
+  if (!fn) throw new Error(`science.${name} not registered`);
+  return fn(ctx, { id: null, data: {}, meta: {} }, params);
+}
+
+before(() => { registerActions(register); });
+beforeEach(() => {
+  globalThis._concordSTATE = { dtus: new Map() };
+  globalThis._concordSaveStateDebounced = () => {};
+  globalThis.fetch = async () => { throw new Error("network disabled"); };
+});
+
+const ctxA = { actor: { userId: "u" }, userId: "u" };
+const ctxB = { actor: { userId: "v" }, userId: "v" };
+
+describe("science — descriptive stats", () => {
+  it("computes mean=5.5 median=5.5 for 1..10", () => {
+    const r = call("stats-descriptive", ctxA, { data: [1,2,3,4,5,6,7,8,9,10] });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.n, 10);
+    assert.equal(r.result.mean, 5.5);
+    assert.equal(r.result.median, 5.5);
+    assert.equal(r.result.min, 1);
+    assert.equal(r.result.max, 10);
+  });
+
+  it("computes correct sd for [2,4,4,4,5,5,7,9] = 2.138", () => {
+    const r = call("stats-descriptive", ctxA, { data: [2,4,4,4,5,5,7,9] });
+    assert.ok(Math.abs(r.result.sd - 2.138) < 0.01);
+  });
+
+  it("rejects empty data", () => {
+    const r = call("stats-descriptive", ctxA, { data: [] });
+    assert.equal(r.ok, false);
+  });
+
+  it("rejects single value (no variance possible)", () => {
+    const r = call("stats-descriptive", ctxA, { data: [42] });
+    assert.equal(r.ok, false);
+  });
+});
+
+describe("science — t-test", () => {
+  it("two-sample t-test detects significant difference", () => {
+    const r = call("stats-ttest", ctxA, {
+      kind: "two-sample",
+      a: [5,7,8,4,6,9,5,7],
+      b: [10,12,11,14,13,11,12,13],
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.significantAt05, true);
+    assert.ok(Math.abs(r.result.t) > 2);
+  });
+
+  it("two-sample t-test does not flag identical means", () => {
+    const r = call("stats-ttest", ctxA, {
+      kind: "two-sample",
+      a: [5, 5, 5, 5, 5],
+      b: [5, 5, 5, 5, 5],
+    });
+    // Both stddevs are 0 — undefined t, but should not crash
+    assert.equal(r.ok, true);
+  });
+
+  it("one-sample t-test", () => {
+    const r = call("stats-ttest", ctxA, {
+      kind: "one-sample",
+      a: [10, 12, 11, 13, 14, 12, 11],
+      mu: 12,
+    });
+    assert.equal(r.ok, true);
+    assert.ok(Math.abs(r.result.sampleMean - 11.857) < 0.01);
+  });
+
+  it("rejects sample with < 2 values", () => {
+    const r = call("stats-ttest", ctxA, { kind: "two-sample", a: [5], b: [1,2,3] });
+    assert.equal(r.ok, false);
+  });
+});
+
+describe("science — correlation + linear regression", () => {
+  it("perfect linear y=2x correlation r ≈ 1", () => {
+    const r = call("stats-correlation", ctxA, {
+      x: [1,2,3,4,5,6,7,8,9,10],
+      y: [2,4,6,8,10,12,14,16,18,20],
+    });
+    assert.equal(r.ok, true);
+    assert.ok(Math.abs(r.result.pearsonR - 1) < 0.001);
+    assert.ok(Math.abs(r.result.slope - 2) < 0.001);
+    assert.ok(Math.abs(r.result.intercept) < 0.001);
+  });
+
+  it("negative correlation y=-x → r ≈ -1", () => {
+    const r = call("stats-correlation", ctxA, {
+      x: [1, 2, 3, 4, 5],
+      y: [-1, -2, -3, -4, -5],
+    });
+    assert.ok(Math.abs(r.result.pearsonR + 1) < 0.001);
+  });
+
+  it("rejects mismatched lengths", () => {
+    const r = call("stats-correlation", ctxA, { x: [1, 2, 3], y: [1, 2] });
+    assert.equal(r.ok, false);
+  });
+
+  it("rejects fewer than 3 pairs", () => {
+    const r = call("stats-correlation", ctxA, { x: [1, 2], y: [1, 2] });
+    assert.equal(r.ok, false);
+  });
+});
+
+describe("science — dataset storage", () => {
+  it("save + list", () => {
+    call("dataset-save", ctxA, { name: "Test", columns: ["x", "y"], rows: [[1, 2], [3, 4]] });
+    const r = call("dataset-list", ctxA);
+    assert.equal(r.result.datasets.length, 1);
+    assert.equal(r.result.datasets[0].rowCount, 2);
+  });
+
+  it("INVARIANT: scoped per-user", () => {
+    call("dataset-save", ctxA, { name: "a-only", columns: ["x"], rows: [[1]] });
+    const b = call("dataset-list", ctxB);
+    assert.equal(b.result.datasets.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary

Brings the science lens to 2026 parity vs **OriginPro / Igor Pro / MATLAB / Jupyter / RStudio / Prism / JMP / SciDAVis**. Pure JS stats, no external deps.

### Backend (6 macros + helpers)
| Group | Macros |
|---|---|
| Descriptive | `stats-descriptive` (n, mean, median, sd, variance, min, max, q1, q3, iqr, sum) |
| t-test | `stats-ttest` (one-sample, two-sample Welch's) |
| Correlation | `stats-correlation` (Pearson r + R² + linear regression + p-value) |
| Dataset | `dataset-save`, `dataset-list`, `dataset-delete` (per-user) |

Helpers: lnGamma + incomplete beta + Student's t CDF (production-grade for common alphas).

### Frontend (1 component, 3 tabs)
Descriptive · t-test · Correlation.

## Test plan
- [x] **14/14 tests passing**
- [x] Mean 1..10 = 5.5; sd [2,4,4,4,5,5,7,9] ≈ 2.138
- [x] Perfect y=2x → r ≈ 1.000, slope ≈ 2.000; y=-x → r ≈ -1
- [x] Two-sample t-test detects significant difference
- [x] Per-user dataset scoping
- [x] tsc + lint clean

https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_