### PR TITLE
whiteboard lens: Miro/FigJam/Excalidraw parity — boards, 6 templates, voting

### DIFF
--- a/concord-frontend/app/lenses/whiteboard/page.tsx
+++ b/concord-frontend/app/lenses/whiteboard/page.tsx
@@ -48,6 +48,7 @@ import { RealtimeDataPanel } from '@/components/lens/RealtimeDataPanel';
 import { DTUDetailView } from '@/components/dtu/DTUDetailView';
 import { useRunArtifact } from '@/lib/hooks/use-lens-artifacts';
 import { Zap } from 'lucide-react';
+import WhiteboardWorkbench from '@/components/whiteboard/WhiteboardWorkbench';
 
 /* ---------- types ---------- */
 type BoardMode = 'canvas' | 'moodboard' | 'arrangement';
@@ -153,6 +154,7 @@ export default function WhiteboardLensPage() {
 
   /* board list state */
   const [showCreate, setShowCreate] = useState(false);
+  const [workbenchOpen, setWorkbenchOpen] = useState(false);
   const [selectedWbId, setSelectedWbId] = useState<string | null>(null);
   const [boardMode, setBoardMode] = useState<BoardMode>('canvas');
   const [showModeMenu, setShowModeMenu] = useState(false);
@@ -1662,6 +1664,16 @@ export default function WhiteboardLensPage() {
         />
       )}
     </div>
+    {/* 2026 parity workbench — boards, templates, voting */}
+    <button
+      type="button"
+      onClick={() => setWorkbenchOpen(true)}
+      className="fixed bottom-6 right-6 z-30 inline-flex items-center gap-2 px-4 py-2.5 rounded-full bg-sky-500 hover:bg-sky-400 text-sky-50 shadow-2xl text-sm font-medium"
+      title="Whiteboard Workbench — boards, 6 templates (SWOT/retro/journey/mindmap/crazy8s/brainstorm), voting"
+    >
+      Whiteboard Workbench
+    </button>
+    <WhiteboardWorkbench open={workbenchOpen} onClose={() => setWorkbenchOpen(false)} />
     </LensShell>
   );
 }

--- a/concord-frontend/components/whiteboard/WhiteboardWorkbench.tsx
+++ b/concord-frontend/components/whiteboard/WhiteboardWorkbench.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { X, Loader2, Square, BookOpen, ThumbsUp, Trash2, Save, Plus } from 'lucide-react';
+import { api } from '@/lib/api/client';
+import { cn } from '@/lib/utils';
+
+export interface Template {
+  id: string;
+  name: string;
+  elementCount: number;
+}
+
+export interface Board {
+  id: string;
+  title: string;
+  elementCount?: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+type Tab = 'boards' | 'templates' | 'voting';
+
+export function WhiteboardWorkbench({ open, onClose }: Props) {
+  const [tab, setTab] = useState<Tab>('boards');
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-y-0 right-0 w-[560px] max-w-[100vw] z-40 bg-[#0d1117] border-l border-sky-500/20 shadow-2xl overflow-hidden flex flex-col">
+      <header className="px-4 py-3 border-b border-white/10 flex items-center justify-between bg-gradient-to-r from-sky-950/40 to-transparent">
+        <div className="flex items-center gap-2">
+          <Square className="w-4 h-4 text-sky-400" />
+          <span className="text-sm font-semibold text-gray-200">Whiteboard Workbench</span>
+        </div>
+        <button type="button" onClick={onClose} className="p-1 rounded-md hover:bg-white/5 text-gray-400" aria-label="Close">
+          <X className="w-4 h-4" />
+        </button>
+      </header>
+
+      <nav className="px-3 py-2 border-b border-white/10 flex items-center gap-1">
+        {([
+          { id: 'boards',    label: 'Boards',    icon: Square },
+          { id: 'templates', label: 'Templates', icon: BookOpen },
+          { id: 'voting',    label: 'Voting',    icon: ThumbsUp },
+        ] as const).map((t) => {
+          const Icon = t.icon;
+          const active = tab === t.id;
+          return (
+            <button key={t.id} type="button" onClick={() => setTab(t.id)}
+              className={cn(
+                'inline-flex items-center gap-1.5 px-2.5 py-1 text-xs rounded transition',
+                active
+                  ? 'bg-sky-500/15 text-sky-200 border border-sky-500/40'
+                  : 'text-gray-400 hover:text-gray-200 border border-transparent',
+              )}>
+              <Icon className="w-3 h-3" /> {t.label}
+            </button>
+          );
+        })}
+      </nav>
+
+      <div className="flex-1 overflow-y-auto">
+        {tab === 'boards' && <BoardsTab />}
+        {tab === 'templates' && <TemplatesTab />}
+        {tab === 'voting' && <VotingTab />}
+      </div>
+    </div>
+  );
+}
+
+function BoardsTab() {
+  const [boards, setBoards] = useState<Board[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [title, setTitle] = useState('');
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const r = await api.post('/api/lens/run', { domain: 'whiteboard', action: 'board-list', input: {} });
+      setBoards(((r.data as { result?: { boards?: Board[] } }).result?.boards) || []);
+    } catch (e) { console.error(e); }
+    finally { setLoading(false); }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const save = async () => {
+    try {
+      await api.post('/api/lens/run', { domain: 'whiteboard', action: 'board-save', input: { title, scene: { elements: [], appState: {} } } });
+      setCreating(false); setTitle('');
+      await refresh();
+    } catch (e) { console.error(e); }
+  };
+
+  const remove = async (id: string) => {
+    if (!window.confirm('Delete board?')) return;
+    try {
+      await api.post('/api/lens/run', { domain: 'whiteboard', action: 'board-delete', input: { id } });
+      await refresh();
+    } catch (e) { console.error(e); }
+  };
+
+  return (
+    <div className="p-3 space-y-2">
+      <button type="button" onClick={() => setCreating((v) => !v)}
+        className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md border border-sky-500/30 bg-sky-500/10 text-xs text-sky-200">
+        <Plus className="w-3 h-3" /> New board
+      </button>
+      {creating && (
+        <div className="rounded border border-sky-500/30 bg-sky-500/5 p-3 space-y-2">
+          <input type="text" value={title} onChange={(e) => setTitle(e.target.value)}
+            placeholder="Board title" maxLength={80}
+            className="w-full px-2 py-1.5 text-sm bg-black/40 border border-white/10 rounded text-gray-100" />
+          <button type="button" onClick={save} disabled={!title.trim()}
+            className="inline-flex items-center gap-1 px-3 py-1 rounded-md border border-sky-500/40 bg-sky-500/15 text-xs text-sky-100 disabled:opacity-40">
+            <Save className="w-3 h-3" /> Create
+          </button>
+        </div>
+      )}
+      {loading ? <div className="text-center py-8 text-xs text-gray-500"><Loader2 className="w-4 h-4 animate-spin inline mr-2" />Loading…</div> :
+        boards.length === 0 ? <p className="text-center text-xs text-gray-500 py-8">No boards. Create one or load a template.</p> :
+        boards.map((b) => (
+          <div key={b.id} className="rounded border border-white/10 bg-black/20 p-3 group flex items-start justify-between">
+            <div>
+              <p className="text-sm font-medium text-gray-100">{b.title}</p>
+              <p className="text-[10px] text-gray-500">{b.elementCount} elements · {new Date(b.updatedAt).toLocaleDateString()}</p>
+            </div>
+            <button type="button" onClick={() => remove(b.id)}
+              className="p-1 text-gray-600 hover:text-rose-300 opacity-0 group-hover:opacity-100"><Trash2 className="w-3 h-3" /></button>
+          </div>
+        ))
+      }
+    </div>
+  );
+}
+
+function TemplatesTab() {
+  const [templates, setTemplates] = useState<Template[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const r = await api.post('/api/lens/run', { domain: 'whiteboard', action: 'templates-list', input: {} });
+        setTemplates(((r.data as { result?: { templates?: Template[] } }).result?.templates) || []);
+      } catch (e) { console.error(e); }
+    })();
+  }, []);
+
+  const apply = async (id: string, name: string) => {
+    try {
+      const t = await api.post('/api/lens/run', { domain: 'whiteboard', action: 'template-load', input: { id } });
+      const template = ((t.data as { result?: { template?: { elements: unknown[] } } }).result?.template);
+      if (!template) return;
+      await api.post('/api/lens/run', {
+        domain: 'whiteboard', action: 'board-save',
+        input: { title: name, scene: { elements: template.elements, appState: {} } },
+      });
+      alert(`Created "${name}" board from template`);
+    } catch (e) { console.error(e); }
+  };
+
+  return (
+    <div className="p-3 space-y-2">
+      <p className="text-[11px] text-gray-500">Click a template to create a new board.</p>
+      {templates.map((t) => (
+        <button key={t.id} type="button" onClick={() => apply(t.id, t.name)}
+          className="w-full text-left rounded border border-white/10 bg-black/20 p-3 hover:bg-white/5">
+          <p className="text-sm font-medium text-gray-100">{t.name}</p>
+          <p className="text-[11px] text-gray-500">{t.elementCount} starter elements</p>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function VotingTab() {
+  const [boardId, setBoardId] = useState('');
+  const [elementId, setElementId] = useState('');
+  const [tally, setTally] = useState<{ elementId: string; count: number }[]>([]);
+  const [total, setTotal] = useState(0);
+
+  const refresh = async () => {
+    if (!boardId) return;
+    try {
+      const r = await api.post('/api/lens/run', { domain: 'whiteboard', action: 'vote-tally', input: { boardId } });
+      const data = (r.data as { result?: { tally?: typeof tally; total?: number } }).result;
+      setTally(data?.tally || []);
+      setTotal(data?.total || 0);
+    } catch (e) { console.error(e); }
+  };
+
+  const vote = async () => {
+    if (!boardId || !elementId) return;
+    try {
+      await api.post('/api/lens/run', { domain: 'whiteboard', action: 'vote-cast', input: { boardId, elementId } });
+      await refresh();
+    } catch (e) { console.error(e); }
+  };
+
+  return (
+    <div className="p-3 space-y-3">
+      <p className="text-[11px] text-gray-500">Cast votes on board elements. Dedupes per voter per element.</p>
+      <div className="grid grid-cols-2 gap-2">
+        <input type="text" value={boardId} onChange={(e) => setBoardId(e.target.value)}
+          placeholder="boardId" className="px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 font-mono" />
+        <input type="text" value={elementId} onChange={(e) => setElementId(e.target.value)}
+          placeholder="elementId" className="px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 font-mono" />
+      </div>
+      <div className="flex gap-2">
+        <button type="button" onClick={vote} disabled={!boardId || !elementId}
+          className="px-3 py-1 rounded-md border border-sky-500/40 bg-sky-500/15 text-xs text-sky-100 disabled:opacity-40">
+          <ThumbsUp className="w-3 h-3 inline" /> Vote
+        </button>
+        <button type="button" onClick={refresh} disabled={!boardId}
+          className="px-3 py-1 rounded-md border border-white/10 text-xs text-gray-400 disabled:opacity-40">
+          Tally
+        </button>
+      </div>
+
+      {tally.length > 0 && (
+        <div className="rounded border border-sky-500/20 bg-sky-500/5 p-3">
+          <p className="text-[10px] uppercase text-gray-500 mb-2">{total} total votes</p>
+          {tally.map((t) => (
+            <div key={t.elementId} className="flex justify-between text-xs font-mono py-1 border-b border-white/5">
+              <span className="text-gray-300 truncate">{t.elementId}</span>
+              <span className="text-sky-300">×{t.count}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default WhiteboardWorkbench;

--- a/server/domains/whiteboard.js
+++ b/server/domains/whiteboard.js
@@ -106,4 +106,182 @@ export default function registerWhiteboardActions(registerLensAction) {
     manifest.forEach(m => { byLayer[m.layer] = (byLayer[m.layer] || 0) + 1; });
     return { ok: true, result: { totalElements: elements.length, canvas: { x: minX, y: minY, width: Math.round(canvasWidth), height: Math.round(canvasHeight), aspectRatio: canvasHeight > 0 ? `${Math.round(canvasWidth / canvasHeight * 100) / 100}:1` : "N/A" }, layers: Object.entries(byLayer).map(([name, count]) => ({ name, elementCount: count })), exportFormats: ["PNG", "SVG", "PDF", "JSON"], manifest: manifest.slice(0, 50), recommendations: [canvasWidth > 4000 || canvasHeight > 4000 ? "Large canvas — consider splitting for high-res export" : null, elements.length > 200 ? "Many elements — SVG export recommended over raster" : null].filter(Boolean) } };
   });
+
+  // ─── 2026 parity — Miro/FigJam/Excalidraw/Mural ──
+
+  function getWhiteboardState() {
+    const STATE = globalThis._concordSTATE;
+    if (!STATE) return null;
+    if (!STATE.whiteboardLens) {
+      STATE.whiteboardLens = {
+        boards: new Map(),       // userId -> Map<id, board>
+        votes:  new Map(),       // userId -> Map<boardId, Map<elementId, Map<voterId, true>>>
+      };
+    }
+    return STATE.whiteboardLens;
+  }
+  function saveWhiteboardState() {
+    if (typeof globalThis._concordSaveStateDebounced === "function") {
+      try { globalThis._concordSaveStateDebounced(); } catch (_e) { /* best effort */ }
+    }
+  }
+  function wbActor(ctx) { return ctx?.actor?.userId || ctx?.userId || "anon"; }
+  function nextWbId(p) { return `${p}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`; }
+  function nowIsoWb() { return new Date().toISOString(); }
+
+  // ── Templates (6 starters) ──
+
+  const TEMPLATES = {
+    swot: {
+      name: "SWOT analysis",
+      elements: [
+        { kind: "frame", label: "Strengths",     x: 0,   y: 0,   w: 400, h: 300 },
+        { kind: "frame", label: "Weaknesses",    x: 400, y: 0,   w: 400, h: 300 },
+        { kind: "frame", label: "Opportunities", x: 0,   y: 300, w: 400, h: 300 },
+        { kind: "frame", label: "Threats",       x: 400, y: 300, w: 400, h: 300 },
+      ],
+    },
+    retro: {
+      name: "Sprint retrospective",
+      elements: [
+        { kind: "frame", label: "Start",    x: 0,   y: 0, w: 300, h: 500 },
+        { kind: "frame", label: "Stop",     x: 300, y: 0, w: 300, h: 500 },
+        { kind: "frame", label: "Continue", x: 600, y: 0, w: 300, h: 500 },
+      ],
+    },
+    journey: {
+      name: "Customer journey map",
+      elements: [
+        { kind: "frame", label: "Awareness",     x: 0,   y: 0, w: 240, h: 400 },
+        { kind: "frame", label: "Consideration", x: 240, y: 0, w: 240, h: 400 },
+        { kind: "frame", label: "Purchase",      x: 480, y: 0, w: 240, h: 400 },
+        { kind: "frame", label: "Retention",     x: 720, y: 0, w: 240, h: 400 },
+        { kind: "frame", label: "Advocacy",      x: 960, y: 0, w: 240, h: 400 },
+      ],
+    },
+    mindmap: {
+      name: "Mind map",
+      elements: [
+        { kind: "ellipse", label: "Central topic", x: 400, y: 200, w: 200, h: 100 },
+      ],
+    },
+    crazy8s: {
+      name: "Crazy 8s (8-cell sketch grid)",
+      elements: Array.from({ length: 8 }, (_, i) => ({
+        kind: "rectangle",
+        label: `Idea ${i + 1}`,
+        x: (i % 4) * 250,
+        y: Math.floor(i / 4) * 200,
+        w: 240,
+        h: 190,
+      })),
+    },
+    brainstorm: {
+      name: "Brainstorm cluster",
+      elements: [
+        { kind: "frame", label: "Ideas",     x: 0,   y: 0, w: 400, h: 600 },
+        { kind: "frame", label: "Themes",    x: 400, y: 0, w: 400, h: 600 },
+        { kind: "frame", label: "Next steps", x: 800, y: 0, w: 400, h: 600 },
+      ],
+    },
+  };
+
+  registerLensAction("whiteboard", "templates-list", (_ctx, _artifact, _params = {}) => {
+    return { ok: true, result: { templates: Object.entries(TEMPLATES).map(([id, t]) => ({ id, name: t.name, elementCount: t.elements.length })) } };
+  });
+
+  registerLensAction("whiteboard", "template-load", (_ctx, _artifact, params = {}) => {
+    const id = String(params.id || "");
+    const t = TEMPLATES[id];
+    if (!t) return { ok: false, error: `unknown template: ${id}` };
+    return { ok: true, result: { template: { id, ...t } } };
+  });
+
+  // ── Board snapshots (per-user persistence) ──
+
+  registerLensAction("whiteboard", "board-list", (ctx, _artifact, _params = {}) => {
+    const s = getWhiteboardState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = wbActor(ctx);
+    const map = s.boards.get(userId);
+    if (!map) return { ok: true, result: { boards: [] } };
+    const boards = Array.from(map.values())
+      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+      .map(({ scene, ...meta }) => ({ ...meta, elementCount: Array.isArray(scene?.elements) ? scene.elements.length : 0 }));
+    return { ok: true, result: { boards } };
+  });
+
+  registerLensAction("whiteboard", "board-save", (ctx, _artifact, params = {}) => {
+    const s = getWhiteboardState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = wbActor(ctx);
+    const id = params.id ? String(params.id) : nextWbId("board");
+    const title = String(params.title || "Untitled board").slice(0, 80);
+    const scene = params.scene && typeof params.scene === "object" ? params.scene : { elements: [], appState: {} };
+    if (!s.boards.has(userId)) s.boards.set(userId, new Map());
+    const existing = s.boards.get(userId).get(id);
+    const board = {
+      id, title, scene,
+      createdAt: existing?.createdAt || nowIsoWb(),
+      updatedAt: nowIsoWb(),
+    };
+    s.boards.get(userId).set(id, board);
+    saveWhiteboardState();
+    return { ok: true, result: { board } };
+  });
+
+  registerLensAction("whiteboard", "board-load", (ctx, _artifact, params = {}) => {
+    const s = getWhiteboardState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = wbActor(ctx);
+    const id = String(params.id || "");
+    const map = s.boards.get(userId);
+    if (!map || !map.has(id)) return { ok: false, error: "not found" };
+    return { ok: true, result: { board: map.get(id) } };
+  });
+
+  registerLensAction("whiteboard", "board-delete", (ctx, _artifact, params = {}) => {
+    const s = getWhiteboardState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = wbActor(ctx);
+    const id = String(params.id || "");
+    const map = s.boards.get(userId);
+    if (!map || !map.has(id)) return { ok: false, error: "not found" };
+    map.delete(id);
+    saveWhiteboardState();
+    return { ok: true, result: { deleted: id } };
+  });
+
+  // ── Voting sessions ──
+
+  registerLensAction("whiteboard", "vote-cast", (ctx, _artifact, params = {}) => {
+    const s = getWhiteboardState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = wbActor(ctx);
+    const boardId = String(params.boardId || "");
+    const elementId = String(params.elementId || "");
+    if (!boardId || !elementId) return { ok: false, error: "boardId and elementId required" };
+    if (!s.votes.has(userId)) s.votes.set(userId, new Map());
+    const boardVotes = s.votes.get(userId);
+    if (!boardVotes.has(boardId)) boardVotes.set(boardId, new Map());
+    const elementVotes = boardVotes.get(boardId);
+    if (!elementVotes.has(elementId)) elementVotes.set(elementId, new Set());
+    elementVotes.get(elementId).add(userId);
+    saveWhiteboardState();
+    return { ok: true, result: { boardId, elementId, voteCount: elementVotes.get(elementId).size } };
+  });
+
+  registerLensAction("whiteboard", "vote-tally", (ctx, _artifact, params = {}) => {
+    const s = getWhiteboardState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = wbActor(ctx);
+    const boardId = String(params.boardId || "");
+    const boardVotes = s.votes.get(userId)?.get(boardId);
+    if (!boardVotes) return { ok: true, result: { tally: [], total: 0 } };
+    const tally = Array.from(boardVotes.entries())
+      .map(([elementId, voters]) => ({ elementId, count: voters.size }))
+      .sort((a, b) => b.count - a.count);
+    const total = tally.reduce((s2, t) => s2 + t.count, 0);
+    return { ok: true, result: { tally, total } };
+  });
 }

--- a/server/tests/whiteboard-domain-parity.test.js
+++ b/server/tests/whiteboard-domain-parity.test.js
@@ -1,0 +1,105 @@
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerActions from "../domains/whiteboard.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, params = {}) {
+  const fn = ACTIONS.get(`whiteboard.${name}`);
+  if (!fn) throw new Error(`whiteboard.${name} not registered`);
+  return fn(ctx, { id: null, data: {}, meta: {} }, params);
+}
+
+before(() => { registerActions(register); });
+beforeEach(() => {
+  globalThis._concordSTATE = { dtus: new Map() };
+  globalThis._concordSaveStateDebounced = () => {};
+  globalThis.fetch = async () => { throw new Error("network disabled"); };
+});
+
+const ctxA = { actor: { userId: "u" }, userId: "u" };
+const ctxB = { actor: { userId: "v" }, userId: "v" };
+
+describe("whiteboard — templates", () => {
+  it("lists 6 starter templates", () => {
+    const r = call("templates-list", {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.templates.length, 6);
+    assert.ok(r.result.templates.some((t) => t.id === "swot"));
+  });
+
+  it("template-load returns elements", () => {
+    const r = call("template-load", {}, { id: "swot" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.template.elements.length, 4);
+  });
+
+  it("rejects unknown template", () => {
+    const r = call("template-load", {}, { id: "bogus" });
+    assert.equal(r.ok, false);
+  });
+});
+
+describe("whiteboard — boards", () => {
+  it("save + list", () => {
+    call("board-save", ctxA, { title: "My board", scene: { elements: [{ id: "a" }, { id: "b" }] } });
+    const r = call("board-list", ctxA);
+    assert.equal(r.result.boards.length, 1);
+    assert.equal(r.result.boards[0].elementCount, 2);
+  });
+
+  it("INVARIANT: boards scoped per-user", () => {
+    call("board-save", ctxA, { title: "a-only", scene: { elements: [] } });
+    const b = call("board-list", ctxB);
+    assert.equal(b.result.boards.length, 0);
+  });
+
+  it("save with same id updates", () => {
+    const c1 = call("board-save", ctxA, { title: "v1", scene: { elements: [] } });
+    const id = c1.result.board.id;
+    call("board-save", ctxA, { id, title: "v2", scene: { elements: [{ id: "a" }] } });
+    const loaded = call("board-load", ctxA, { id });
+    assert.equal(loaded.result.board.title, "v2");
+    assert.equal(loaded.result.board.scene.elements.length, 1);
+  });
+
+  it("delete removes", () => {
+    const c = call("board-save", ctxA, { title: "tmp", scene: {} });
+    call("board-delete", ctxA, { id: c.result.board.id });
+    assert.equal(call("board-list", ctxA).result.boards.length, 0);
+  });
+});
+
+describe("whiteboard — voting", () => {
+  it("vote-cast increments tally", () => {
+    call("vote-cast", ctxA, { boardId: "b1", elementId: "e1" });
+    const r = call("vote-tally", ctxA, { boardId: "b1" });
+    assert.equal(r.result.tally[0].count, 1);
+  });
+
+  it("dedupes votes from same user on same element", () => {
+    call("vote-cast", ctxA, { boardId: "b1", elementId: "e1" });
+    call("vote-cast", ctxA, { boardId: "b1", elementId: "e1" });
+    const r = call("vote-tally", ctxA, { boardId: "b1" });
+    // Same voter casting twice on same element = single vote
+    assert.equal(r.result.tally[0].count, 1);
+  });
+
+  it("tally sorted by count desc", () => {
+    call("vote-cast", ctxA, { boardId: "b1", elementId: "e1" });
+    call("vote-cast", ctxA, { boardId: "b1", elementId: "e2" });
+    const r = call("vote-tally", ctxA, { boardId: "b1" });
+    assert.equal(r.result.tally.length, 2);
+  });
+
+  it("rejects missing boardId or elementId", () => {
+    const r = call("vote-cast", ctxA, { boardId: "b1" });
+    assert.equal(r.ok, false);
+  });
+
+  it("INVARIANT: votes scoped per-user", () => {
+    call("vote-cast", ctxA, { boardId: "b1", elementId: "e1" });
+    const b = call("vote-tally", ctxB, { boardId: "b1" });
+    assert.equal(b.result.tally.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary

Brings the whiteboard lens to 2026 parity vs **Miro / FigJam / Excalidraw / Mural / Whimsical / Lucidchart / Conceptboard / Drawio** on three surfaces: persistent boards, starter templates, facilitator voting.

**Multi-cursor real-time collaboration explicitly deferred** — requires Y.js/CRDT layer.

### Backend (8 macros)
| Group | Macros |
|---|---|
| Templates | `templates-list`, `template-load` (6 starters: SWOT/retro/journey/mindmap/crazy8s/brainstorm) |
| Boards | `board-list`, `board-save`, `board-load`, `board-delete` |
| Voting | `vote-cast` (per-voter dedupe), `vote-tally` (sorted desc) |

### Frontend (1 component, 3 tabs)
Boards · Templates · Voting.

## Test plan
- [x] **12/12 tests passing**
- [x] Template integrity (SWOT = 4 frames; total 6)
- [x] Board upsert by id
- [x] **Vote-dedup invariant**: same voter twice on same element = 1 count
- [x] Per-user scoping; tsc + lint clean

🎉 **Final lens (17/17) of the per-lens parity sprint.**

https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_