### PR TITLE
persistence: Bucket 2 Gap A — persist all 26 STATE.&lt;lens&gt;Lens stores across restart

### DIFF
--- a/server/lib/lens-state-persistence.js
+++ b/server/lib/lens-state-persistence.js
@@ -1,0 +1,84 @@
+// server/lib/lens-state-persistence.js
+//
+// Bucket 2 Gap A — persistent backing for the 26 STATE.<lens>Lens stores.
+//
+// Background: every domain file under server/domains/ that ships a workbench
+// drawer stores per-user data under STATE.<lens>Lens = { ...: Map<userId, X> }
+// where X ∈ Map | Set | Array | object. Before this module existed, the
+// snapshot in server.js#_serializeState() never included these keys, so a
+// hard restart wiped every user's saved projects/prompts/notes/journal/etc.
+//
+// This module exports two helpers plumbed into the existing snapshot
+// mechanism (server.js _serializeState/_hydrateState). No new SQLite tables
+// needed — the existing state_snapshots table already holds the JSON blob.
+
+// Canonical list of lens state keys. Add new entries here when a new
+// lens domain file ships its own STATE.<x>Lens store.
+export const LENS_STATE_KEYS = Object.freeze([
+  "accountingLens", "agricultureLens", "aviationLens", "bioLens",
+  "chatLens", "cryptoLens", "ecoLens", "educationLens",
+  "financeLens", "fitnessLens", "foodLens", "govLens",
+  "healthLens", "insLens", "legalLens", "logLens",
+  "marketsLens", "messageLens", "realestateLens", "researchLens",
+  "retailLens", "scienceLens", "studioLens", "tradesLens",
+  "whiteboardLens", "worldLens",
+]);
+
+function serializeValue(v) {
+  if (v instanceof Map) {
+    return {
+      __type: "Map",
+      entries: Array.from(v.entries()).map(([k, vv]) => [k, serializeValue(vv)]),
+    };
+  }
+  if (v instanceof Set) {
+    return { __type: "Set", values: Array.from(v) };
+  }
+  // Arrays of plain objects + plain objects pass through (JSON-safe).
+  return v;
+}
+
+function deserializeValue(v) {
+  if (v && typeof v === "object" && v.__type === "Map" && Array.isArray(v.entries)) {
+    return new Map(v.entries.map(([k, vv]) => [k, deserializeValue(vv)]));
+  }
+  if (v && typeof v === "object" && v.__type === "Set" && Array.isArray(v.values)) {
+    return new Set(v.values);
+  }
+  return v;
+}
+
+// Walk every registered lens key on STATE, serialize nested Map/Set into
+// JSON-safe envelopes. Returns a plain object suitable for JSON.stringify.
+export function serializeLensState(STATE) {
+  if (!STATE || typeof STATE !== "object") return {};
+  const out = {};
+  for (const key of LENS_STATE_KEYS) {
+    const lens = STATE[key];
+    if (!lens || typeof lens !== "object") continue;
+    const lensOut = {};
+    for (const [field, val] of Object.entries(lens)) {
+      lensOut[field] = serializeValue(val);
+    }
+    out[key] = lensOut;
+  }
+  return out;
+}
+
+// Inverse: take the persisted blob and restore STATE.<lens>Lens with
+// proper Map/Set instances. Unknown lens keys are silently ignored
+// (forward-compat — old snapshots may carry lens keys that were renamed
+// or removed; we don't want a single malformed entry to block startup).
+export function hydrateLensState(STATE, persisted) {
+  if (!STATE || typeof STATE !== "object") return;
+  if (!persisted || typeof persisted !== "object") return;
+  for (const key of LENS_STATE_KEYS) {
+    const lensPersisted = persisted[key];
+    if (!lensPersisted || typeof lensPersisted !== "object") continue;
+    const lensOut = {};
+    for (const [field, val] of Object.entries(lensPersisted)) {
+      lensOut[field] = deserializeValue(val);
+    }
+    STATE[key] = lensOut;
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -96,6 +96,7 @@ registerHeartbeat("fauna-spawner", {
 // Frequency 4 (~60s) = visibly responsive without churning the DB.
 import { runCreatureFlockCycle } from "./emergent/creature-flock-cycle.js";
 import { LruMap, LruSet } from "./lib/lru-map.js";
+import { serializeLensState, hydrateLensState, LENS_STATE_KEYS } from "./lib/lens-state-persistence.js";
 registerHeartbeat("creature-flock-cycle", {
   frequency: 4,
   handler: runCreatureFlockCycle,
@@ -8366,6 +8367,11 @@ function _serializeState() {
       councilQueue: (STATE.globalThread?.councilQueue || []).slice(-500),
       acceptedContributions: (STATE.globalThread?.acceptedContributions || []).slice(-200),
     },
+    // Per-lens user state (chatLens / worldLens / accountingLens / etc.).
+    // Bucket 2 Gap A fix: was in-memory only until this snapshot was
+    // extended; hard restarts lost user data. Generic helper in
+    // server/lib/lens-state-persistence.js handles nested Map/Set.
+    lensState: serializeLensState(STATE),
     // Excluded from save: _caches, _derivedIndexes, _repairCaches, _styleVectors (transient)
   };
 }
@@ -8525,6 +8531,11 @@ function _hydrateState(obj) {
       acceptedContributions: Array.isArray(obj.globalThread.acceptedContributions) ? obj.globalThread.acceptedContributions : [],
     };
   }
+
+  // Per-lens user state (chatLens / worldLens / accountingLens / etc.).
+  // Bucket 2 Gap A: hydrates the 26 STATE.<lens>Lens stores from the
+  // snapshot so user data survives restart.
+  if (obj.lensState) hydrateLensState(STATE, obj.lensState);
 }
 
 
@@ -70548,4 +70559,8 @@ export const __TEST__ = Object.freeze({
   verifyCitationIntegrity,
   registerInCreativeRegistry,
   entityExploreCreativeGlobal,
+  // Bucket 2 Gap A — lens state persistence helpers (test surface)
+  serializeLensState,
+  hydrateLensState,
+  LENS_STATE_KEYS,
 });

--- a/server/tests/lens-state-persistence.test.js
+++ b/server/tests/lens-state-persistence.test.js
@@ -1,0 +1,197 @@
+// Tier-2 contract test for Bucket 2 Gap A — lens state persistence.
+//
+// The 26 STATE.<lens>Lens stores are written to in-memory Maps by the
+// domain files. Before this fix the global JSON snapshot didn't include
+// them, so a server restart wiped every user's projects/prompts/saved
+// searches/journal entries/etc.
+//
+// This test imports the standalone helpers (server.js is too heavyweight
+// to load in tests; the helpers live in their own lib for testability).
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  LENS_STATE_KEYS,
+  serializeLensState,
+  hydrateLensState,
+} from "../lib/lens-state-persistence.js";
+
+let STATE;
+function freshState() {
+  STATE = {};
+}
+
+describe("lens state persistence — Bucket 2 Gap A", () => {
+  beforeEach(() => { freshState(); });
+
+  it("exposes 26 lens state keys", () => {
+    assert.equal(LENS_STATE_KEYS.length, 26);
+    assert.ok(LENS_STATE_KEYS.includes("chatLens"));
+    assert.ok(LENS_STATE_KEYS.includes("worldLens"));
+    assert.ok(LENS_STATE_KEYS.includes("accountingLens"));
+  });
+
+  it("serializes empty STATE to empty object", () => {
+    assert.deepEqual(serializeLensState(STATE), {});
+  });
+
+  it("serializes null STATE safely", () => {
+    assert.deepEqual(serializeLensState(null), {});
+    assert.deepEqual(serializeLensState(undefined), {});
+  });
+
+  it("roundtrips a flat Map<userId, Map<id, obj>> structure", () => {
+    STATE.chatLens = {
+      projects: new Map([
+        ["user_a", new Map([["proj_1", { id: "proj_1", name: "Alpha" }]])],
+        ["user_b", new Map([["proj_2", { id: "proj_2", name: "Beta" }]])],
+      ]),
+    };
+    const persisted = serializeLensState(STATE);
+    freshState();
+    hydrateLensState(STATE, persisted);
+
+    assert.ok(STATE.chatLens.projects instanceof Map);
+    assert.ok(STATE.chatLens.projects.get("user_a") instanceof Map);
+    assert.equal(STATE.chatLens.projects.get("user_a").get("proj_1").name, "Alpha");
+    assert.equal(STATE.chatLens.projects.get("user_b").get("proj_2").name, "Beta");
+  });
+
+  it("roundtrips Map<userId, Map>", () => {
+    STATE.bioLens = {
+      sequences: new Map([
+        ["user_a", new Map([["seq_1", { id: "seq_1", sequence: "ATGC" }]])],
+      ]),
+    };
+    STATE.researchLens = {
+      notes: new Map(),
+      dailyByDate: new Map([
+        ["user_a", new Map([["2026-05-16", "note_xyz"]])],
+      ]),
+    };
+    const persisted = serializeLensState(STATE);
+    freshState();
+    hydrateLensState(STATE, persisted);
+
+    assert.equal(STATE.bioLens.sequences.get("user_a").get("seq_1").sequence, "ATGC");
+    assert.equal(STATE.researchLens.dailyByDate.get("user_a").get("2026-05-16"), "note_xyz");
+  });
+
+  it("roundtrips Map<userId, Set>", () => {
+    // worldLens.pinnedQuests uses Set<questId>
+    STATE.worldLens = {
+      pinnedQuests: new Map([
+        ["user_a", new Set(["q1", "q2", "q3"])],
+      ]),
+    };
+    const persisted = serializeLensState(STATE);
+    freshState();
+    hydrateLensState(STATE, persisted);
+
+    assert.ok(STATE.worldLens.pinnedQuests.get("user_a") instanceof Set);
+    assert.ok(STATE.worldLens.pinnedQuests.get("user_a").has("q2"));
+    assert.equal(STATE.worldLens.pinnedQuests.get("user_a").size, 3);
+  });
+
+  it("roundtrips Map<userId, Array<obj>> (e.g. journal entries)", () => {
+    STATE.accountingLens = {
+      journal: new Map([
+        ["user_a", [
+          { id: "je_1", number: "JE-00001", lines: [{ accountId: "acct_1000", debit: 100, credit: 0 }] },
+          { id: "je_2", number: "JE-00002", lines: [] },
+        ]],
+      ]),
+    };
+    const persisted = serializeLensState(STATE);
+    freshState();
+    hydrateLensState(STATE, persisted);
+
+    assert.ok(Array.isArray(STATE.accountingLens.journal.get("user_a")));
+    assert.equal(STATE.accountingLens.journal.get("user_a").length, 2);
+    assert.equal(STATE.accountingLens.journal.get("user_a")[0].number, "JE-00001");
+  });
+
+  it("roundtrips deeply nested Map<userId, Map<msgId, Map<emoji, count>>>", () => {
+    // messageLens.reactions uses three-level nesting
+    STATE.messageLens = {
+      reactions: new Map([
+        ["user_a", new Map([
+          ["msg_1", new Map([["👍", 3], ["❤️", 1]])],
+        ])],
+      ]),
+    };
+    const persisted = serializeLensState(STATE);
+    freshState();
+    hydrateLensState(STATE, persisted);
+
+    const userMap = STATE.messageLens.reactions.get("user_a");
+    assert.ok(userMap instanceof Map);
+    const msgMap = userMap.get("msg_1");
+    assert.ok(msgMap instanceof Map);
+    assert.equal(msgMap.get("👍"), 3);
+    assert.equal(msgMap.get("❤️"), 1);
+  });
+
+  it("INVARIANT: per-user scoping survives the cycle (user A's data doesn't leak to user B)", () => {
+    STATE.chatLens = {
+      projects: new Map([
+        ["user_a", new Map([["proj_secret", { name: "user A only" }]])],
+      ]),
+    };
+    const persisted = serializeLensState(STATE);
+    freshState();
+    hydrateLensState(STATE, persisted);
+
+    assert.equal(STATE.chatLens.projects.has("user_b"), false);
+    assert.ok(STATE.chatLens.projects.get("user_a").has("proj_secret"));
+  });
+
+  it("hydrate ignores unknown lens keys (forward-compat)", () => {
+    hydrateLensState(STATE, { futureLensThatDoesntExistYet: { foo: "bar" } });
+    // No throw. STATE.futureLensThatDoesntExistYet is not set because
+    // it's not in LENS_STATE_KEYS — that's the safety guarantee.
+    assert.equal(STATE.futureLensThatDoesntExistYet, undefined);
+  });
+
+  it("hydrate handles null/undefined gracefully", () => {
+    assert.doesNotThrow(() => hydrateLensState(STATE, null));
+    assert.doesNotThrow(() => hydrateLensState(STATE, undefined));
+    assert.doesNotThrow(() => hydrateLensState(STATE, {}));
+    assert.doesNotThrow(() => hydrateLensState(null, {}));
+  });
+
+  it("serialize handles a lens with mixed field types (Map + Array + plain object)", () => {
+    STATE.tradesLens = {
+      jobs: new Map([["user_a", new Map([["job_1", { id: "job_1" }]])]]),
+      seq: new Map([["user_a", { job: 5, invoice: 3 }]]),
+      // Hypothetical plain array field
+      events: [{ kind: "audit", at: "2026-05-16" }],
+    };
+    const persisted = serializeLensState(STATE);
+    freshState();
+    hydrateLensState(STATE, persisted);
+
+    assert.equal(STATE.tradesLens.jobs.get("user_a").get("job_1").id, "job_1");
+    assert.equal(STATE.tradesLens.seq.get("user_a").job, 5);
+    assert.deepEqual(STATE.tradesLens.events, [{ kind: "audit", at: "2026-05-16" }]);
+  });
+
+  it("snapshot is JSON-safe (can round-trip through JSON.stringify/parse)", () => {
+    STATE.chatLens = {
+      projects: new Map([
+        ["user_a", new Map([["proj_1", { name: "Alpha", emoji: "🚀" }]])],
+      ]),
+    };
+    STATE.worldLens = {
+      pinnedQuests: new Map([["user_a", new Set(["q1", "q2"])]]),
+    };
+
+    const persisted = serializeLensState(STATE);
+    const jsonRoundtrip = JSON.parse(JSON.stringify(persisted));
+    freshState();
+    hydrateLensState(STATE, jsonRoundtrip);
+
+    assert.equal(STATE.chatLens.projects.get("user_a").get("proj_1").emoji, "🚀");
+    assert.ok(STATE.worldLens.pinnedQuests.get("user_a").has("q1"));
+  });
+});


### PR DESCRIPTION
## Summary

**Bucket 2 Gap A from the handoff plan.** Persists all 26 `STATE.<lens>Lens` stores added across the parity sprint so a server restart no longer wipes user data.

Before: the global snapshot in `server.js#_serializeState()` didn't include lens state keys, so every user's saved projects/prompts/notes/journal/contracts/invoices/etc. were in-memory only. Hard restart = data loss.

After: snapshot now writes a `lensState` blob; hydrate restores Map/Set instances on boot. No new SQLite tables needed — extends the existing `state_snapshots` mechanism.

### Files
- **NEW** `server/lib/lens-state-persistence.js` — standalone for testability (server.js is too heavyweight to import in tests)
  - `LENS_STATE_KEYS` — canonical list of 26 lens keys
  - `serializeLensState(STATE)` — nested Map/Set → JSON-safe envelopes
  - `hydrateLensState(STATE, persisted)` — inverse
- **EDIT** `server.js#_serializeState` — write `lensState` key
- **EDIT** `server.js#_hydrateState` — restore from `obj.lensState`
- **NEW** `server/tests/lens-state-persistence.test.js` — 13 contract tests

## Test plan
- [x] **13/13 tests passing**
- [x] Roundtrip: flat Map<userId, Map<id, obj>>, Map<userId, Set>, Map<userId, Array>, three-level nesting
- [x] Per-user scoping invariant survives the cycle
- [x] JSON.stringify roundtrip (snapshot is JSON-safe)
- [x] Null/undefined safety
- [x] Forward-compat: unknown lens keys silently ignored

## Plan context

First PR of Bucket 2 per the handoff plan. Remaining Bucket 2 gaps:
- Gap B: **real third-party data feeds** (NO sample data per user directive — every lens must use real APIs; sprint-era seed/synthesized data needs a real-feed pass)
- Gap C: real-time multiplayer (Y.js/WebRTC over existing socket.io)
- Gap D: Stripe payments

https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_