### PR TITLE
paper: real arXiv export API — no more SAMPLE_PAPERS

### DIFF
--- a/server/domains/paper.js
+++ b/server/domains/paper.js
@@ -87,16 +87,68 @@ export default function registerPaperActions(registerLensAction) {
     return { ok: true, result: { oldStats: { lines: oldLines.length, words: oldWords.length, chars: oldChars }, newStats: { lines: newLines.length, words: newWords.length, chars: newChars }, diff: { linesAdded: added.length, linesRemoved: removed.length, linesUnchanged: unchanged.length, wordDelta: newWords.length - oldWords.length, charDelta: newChars - oldChars }, changeRate: Math.round(((added.length + removed.length) / Math.max(1, oldLines.length)) * 100), addedPreview: added.slice(0, 10), removedPreview: removed.slice(0, 10) } };
   });
 
-  // ─── Parity-sprint ──
-  registerLensAction("paper", "search", (_ctx, _artifact, params = {}) => {
-    const query = String(params.query || "").trim().toLowerCase();
+  // ─── Real paper search via arXiv (free, no key) ──
+  //
+  // arXiv export API: http://export.arxiv.org/api/query — returns Atom XML
+  // with title, summary, authors, published date, primary category, links
+  // to PDF/abstract. Covers physics, math, CS, biology, finance, statistics,
+  // economics. Comprehensive academic preprint repository.
+
+  function parseArxivAtom(xml) {
+    // Lightweight Atom parser — extracts <entry> blocks
+    const entries = [];
+    const entryMatches = xml.match(/<entry>[\s\S]*?<\/entry>/g) || [];
+    for (const entryXml of entryMatches) {
+      const get = (tag) => {
+        const m = entryXml.match(new RegExp(`<${tag}>([\\s\\S]*?)<\\/${tag}>`));
+        return m ? m[1].trim() : "";
+      };
+      const id = get("id");
+      const arxivId = id.replace(/^http(s)?:\/\/arxiv\.org\/abs\//, "").trim();
+      const authors = [];
+      const authorMatches = entryXml.match(/<author>[\s\S]*?<\/author>/g) || [];
+      for (const am of authorMatches) {
+        const n = am.match(/<name>([\s\S]*?)<\/name>/);
+        if (n) authors.push(n[1].trim());
+      }
+      const linkPdf = entryXml.match(/<link[^>]+title="pdf"[^>]+href="([^"]+)"/);
+      entries.push({
+        id: arxivId,
+        title: get("title").replace(/\s+/g, " "),
+        abstract: get("summary").replace(/\s+/g, " "),
+        authors,
+        published: get("published"),
+        updated: get("updated"),
+        url: id,
+        pdfUrl: linkPdf ? linkPdf[1] : null,
+        primaryCategory: (entryXml.match(/<arxiv:primary_category[^>]+term="([^"]+)"/) || [, null])[1],
+      });
+    }
+    return entries;
+  }
+
+  registerLensAction("paper", "search", async (_ctx, _artifact, params = {}) => {
+    const query = String(params.query || "").trim();
     if (!query) return { ok: false, error: "query required" };
-    const matched = SAMPLE_PAPERS.filter(p =>
-      p.title.toLowerCase().includes(query) ||
-      p.abstract.toLowerCase().includes(query) ||
-      p.authors.some(a => a.toLowerCase().includes(query))
-    ).slice(0, 20);
-    return { ok: true, result: { papers: matched.length > 0 ? matched : SAMPLE_PAPERS.slice(0, 5), query } };
+    const limit = Math.max(1, Math.min(50, Number(params.limit) || 20));
+    try {
+      const url = `http://export.arxiv.org/api/query?search_query=${encodeURIComponent("all:" + query)}&start=0&max_results=${limit}&sortBy=relevance`;
+      const r = await globalThis.fetch(url);
+      if (!r.ok) return { ok: false, error: `arxiv ${r.status}` };
+      const xml = await r.text();
+      const papers = parseArxivAtom(xml);
+      return {
+        ok: true,
+        result: {
+          papers,
+          query,
+          count: papers.length,
+          source: "arXiv export API",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `arxiv search failed: ${e?.message || "network"}` };
+    }
   });
 
   registerLensAction("paper", "summarize", async (ctx, _artifact, params = {}) => {
@@ -123,13 +175,8 @@ export default function registerPaperActions(registerLensAction) {
   });
 }
 
-const SAMPLE_PAPERS = [
-  { id: "1706.03762", title: "Attention Is All You Need", authors: ["Vaswani", "Shazeer", "Parmar"], journal: "NeurIPS", year: 2017, doi: "10.5555/3295222.3295349", abstract: "We propose a new simple network architecture, the Transformer, based solely on attention mechanisms…", citationCount: 92340, openAccess: true },
-  { id: "1810.04805", title: "BERT: Pre-training of Deep Bidirectional Transformers", authors: ["Devlin", "Chang", "Lee", "Toutanova"], journal: "NAACL", year: 2018, abstract: "We introduce a new language representation model called BERT…", citationCount: 78410, openAccess: true },
-  { id: "2005.14165", title: "Language Models are Few-Shot Learners", authors: ["Brown", "Mann"], journal: "NeurIPS", year: 2020, abstract: "Recent work has demonstrated substantial gains on many NLP tasks by pre-training on a large corpus of text…", citationCount: 35210, openAccess: true },
-  { id: "1512.03385", title: "Deep Residual Learning for Image Recognition", authors: ["He", "Zhang", "Ren", "Sun"], journal: "CVPR", year: 2016, abstract: "We present a residual learning framework to ease the training of substantially deeper networks…", citationCount: 145200, openAccess: true },
-  { id: "1409.0473", title: "Neural Machine Translation by Jointly Learning to Align and Translate", authors: ["Bahdanau", "Cho", "Bengio"], journal: "ICLR", year: 2015, abstract: "Neural machine translation is a recently proposed approach to machine translation…", citationCount: 28500, openAccess: true },
-  { id: "1502.03167", title: "Batch Normalization", authors: ["Ioffe", "Szegedy"], journal: "ICML", year: 2015, abstract: "Training Deep Neural Networks is complicated by internal covariate shift…", citationCount: 56200, openAccess: true },
-  { id: "1406.2661", title: "Generative Adversarial Networks", authors: ["Goodfellow"], journal: "NeurIPS", year: 2014, abstract: "We propose a new framework for estimating generative models via an adversarial process…", citationCount: 71200, openAccess: true },
-  { id: "2103.00020", title: "CLIP: Learning Transferable Visual Models From Natural Language Supervision", authors: ["Radford", "Kim", "Hallacy"], journal: "ICML", year: 2021, abstract: "State-of-the-art computer vision systems are trained to predict a fixed set of predetermined object categories…", citationCount: 13400, openAccess: true },
-];
+// Note: prior versions held a SAMPLE_PAPERS array of 8 hand-curated ML
+// preprints used to back paper-search. Per the "everything must be real"
+// directive, that table has been removed — paper.search now hits the
+// arXiv export API directly (free, no key, full preprint repository
+// covering physics, math, CS, biology, finance, statistics, economics).

--- a/server/tests/paper-domain-parity.test.js
+++ b/server/tests/paper-domain-parity.test.js
@@ -1,0 +1,80 @@
+// Tier-2 contract test for paper-search → real arXiv export API.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerPaperActions from "../domains/paper.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, params = {}) {
+  const fn = ACTIONS.get(`paper.${name}`);
+  if (!fn) throw new Error(`paper.${name} not registered`);
+  return fn(ctx, { id: null, data: {}, meta: {} }, params);
+}
+
+before(() => { registerPaperActions(register); });
+beforeEach(() => {
+  globalThis._concordSTATE = { dtus: new Map() };
+  globalThis._concordSaveStateDebounced = () => {};
+  globalThis.fetch = async () => { throw new Error("network disabled"); };
+});
+
+const ctx = { actor: { userId: "u" }, userId: "u" };
+
+describe("paper.search (arXiv live)", () => {
+  it("rejects empty query", async () => {
+    const r = await call("search", ctx, { query: "" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /query required/);
+  });
+
+  it("returns error when network is disabled (hermetic test)", async () => {
+    const r = await call("search", ctx, { query: "attention is all you need" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /failed|network/);
+  });
+
+  it("parses arXiv Atom XML response", async () => {
+    globalThis.fetch = async (url) => {
+      assert.match(url, /export\.arxiv\.org\/api\/query/);
+      assert.match(url, /search_query=all%3Aattention/);
+      return {
+        ok: true,
+        text: async () => `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+  <entry>
+    <id>http://arxiv.org/abs/1706.03762v5</id>
+    <updated>2017-12-06T19:32:32Z</updated>
+    <published>2017-06-12T17:57:34Z</published>
+    <title>Attention Is All You Need</title>
+    <summary>The dominant sequence transduction models are based on complex recurrent or convolutional neural networks…</summary>
+    <author><name>Ashish Vaswani</name></author>
+    <author><name>Noam Shazeer</name></author>
+    <link title="pdf" href="http://arxiv.org/pdf/1706.03762v5"/>
+    <arxiv:primary_category term="cs.CL"/>
+  </entry>
+</feed>`,
+      };
+    };
+    const r = await call("search", ctx, { query: "attention" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.source, "arXiv export API");
+    assert.equal(r.result.papers.length, 1);
+    assert.equal(r.result.papers[0].title, "Attention Is All You Need");
+    assert.equal(r.result.papers[0].authors.length, 2);
+    assert.equal(r.result.papers[0].authors[0], "Ashish Vaswani");
+    assert.equal(r.result.papers[0].id, "1706.03762v5");
+    assert.equal(r.result.papers[0].primaryCategory, "cs.CL");
+    assert.match(r.result.papers[0].pdfUrl, /pdf\/1706\.03762/);
+  });
+
+  it("returns empty array (not fake fallback) when no matches", async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      text: async () => `<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"></feed>`,
+    });
+    const r = await call("search", ctx, { query: "asdfqwerzxcv" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.papers.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the `SAMPLE_PAPERS` array of 8 hand-curated ML preprints with live arXiv export API fetches.

`paper.search` now async-fetches `export.arxiv.org/api/query` (free, no key, full preprint repository). Lightweight Atom XML parser extracts: arxiv ID, title, abstract, all authors, dates, primary category, abstract URL, PDF URL.

## Test plan
- [x] **4/4 tests passing** (new test file)
- [x] Empty-query rejection
- [x] Atom XML parsing (with multi-author + PDF link extraction)
- [x] Empty-results returns `[]` not fake fallback

https://claude.ai/code/session_01DHcvDveKnNtEXdKngvJdzp

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_