### PR TITLE
fix(finance/crypto/eco/logistics): remove remaining sample data — real or empty

### DIFF
--- a/server/domains/crypto.js
+++ b/server/domains/crypto.js
@@ -389,25 +389,12 @@ export default function registerCryptoActions(registerLensAction) {
       }) : [];
       return { ok: true, result: { id, candles, count: candles.length, days, source: "coingecko" } };
     } catch (e) {
-      // Synthesise a deterministic candle series so the chart stays useful
-      // when offline. Seeded by id so the demo is stable across reloads.
-      const seed = hashString(id);
-      const now = Math.floor(Date.now() / 1000);
-      const candles = [];
-      let last = 100 + (seed % 50);
-      for (let i = days; i >= 0; i--) {
-        const t = now - i * 86400;
-        const drift = ((seed >> i) & 7) - 3.5;
-        const open = last;
-        const close = Math.max(0.01, open + drift);
-        const high = Math.max(open, close) + Math.abs(drift) * 0.5;
-        const low = Math.min(open, close) - Math.abs(drift) * 0.5;
-        candles.push({ time: t, open, high, low, close, volume: Math.round(1000 + (seed % 500) * i / days) });
-        last = close;
-      }
+      // Per "everything must be real" directive: no synthetic candle fallback.
+      // CoinGecko is the real source; if it's unreachable, surface the error
+      // so the UI can show a proper retry/offline state.
       return {
-        ok: true,
-        result: { id, candles, count: candles.length, days, source: "fallback", message: e instanceof Error ? e.message : "synthetic series" },
+        ok: false,
+        error: `coingecko unreachable: ${e instanceof Error ? e.message : String(e)}`,
       };
     }
   });

--- a/server/domains/eco.js
+++ b/server/domains/eco.js
@@ -543,10 +543,9 @@ export default function registerEcoActions(registerLensAction) {
         },
       };
     } catch (e) {
-      return {
-        ok: true,
-        result: synthesizeWeatherFallback(lat, lng, e),
-      };
+      // Per "everything must be real" directive: no synthetic week fallback.
+      // Open-Meteo is the real source; surface the network error.
+      return { ok: false, error: `open-meteo unreachable: ${e instanceof Error ? e.message : String(e)}` };
     }
   });
 
@@ -825,39 +824,6 @@ function extractJson(text) {
   const last = body.lastIndexOf("}");
   if (first < 0 || last <= first) return null;
   try { return JSON.parse(body.slice(first, last + 1)); } catch { return null; }
-}
-
-function synthesizeWeatherFallback(lat, lng, err) {
-  // Deterministic-ish synthetic week so the UI stays useful when Open-Meteo unreachable
-  const seasonAmp = 10;
-  const base = 18 - Math.abs(lat) * 0.3;
-  const daily = Array.from({ length: 7 }, (_, i) => ({
-    date: new Date(Date.now() + i * 86400000).toISOString().slice(0, 10),
-    high: base + 8 + Math.sin(i / 2) * seasonAmp / 2,
-    low: base - 2 + Math.sin(i / 2) * seasonAmp / 2,
-    precipitationMm: i % 3 === 0 ? 2.5 : 0,
-    precipitationProbability: i % 3 === 0 ? 60 : 10,
-    windSpeedMax: 18 + i,
-    weatherCode: i % 3 === 0 ? 61 : i % 2 === 0 ? 2 : 0,
-    uvIndex: 5,
-  }));
-  return {
-    current: {
-      temperature: base + 5, feelsLike: base + 4, humidity: 60,
-      windSpeed: 12, windDirection: 270, precipitationMm: 0,
-      weatherCode: 1, isDay: true,
-    },
-    daily,
-    hourly: Array.from({ length: 24 }, (_, i) => ({
-      time: new Date(Date.now() + i * 3600000).toISOString(),
-      temperature: base + 3 + Math.sin(i / 4) * 3,
-      precipitationMm: 0,
-      humidity: 60,
-    })),
-    location: { lat, lng, label: "fallback" },
-    alerts: [],
-    error: err instanceof Error ? err.message : String(err),
-  };
 }
 
 const CLIMATE_ACTIONS_LIBRARY = [

--- a/server/domains/finance.js
+++ b/server/domains/finance.js
@@ -165,31 +165,39 @@ export default function registerFinanceActions(registerLensAction) {
   });
 
   /**
-   * net-worth-history — Snapshot trajectory; seeds 12 months of synthetic
-   * snapshots if the user has none, so the chart is never empty for demo.
+   * net-worth-history — User's real net-worth snapshot trajectory.
+   * Returns empty array if the user hasn't logged any snapshots yet
+   * (per "everything must be real" directive — no synthetic seeding).
    */
   registerLensAction("finance", "net-worth-history", (ctx, _artifact, params = {}) => {
     const state = getFinState(); if (!state) return { ok: false, error: "STATE unavailable" };
     const userId = ctx?.actor?.userId || ctx?.userId || "anon";
-    if (!state.snapshots.has(userId) || state.snapshots.get(userId).length === 0) {
-      state.snapshots.set(userId, synthSnapshots(userId));
-    }
     const all = state.snapshots.get(userId) || [];
     const range = String(params.range || "1Y");
     const filtered = filterByRange(all, range);
-    return { ok: true, result: { snapshots: filtered, range, total: all.length } };
+    return {
+      ok: true,
+      result: {
+        snapshots: filtered, range, total: all.length,
+        notes: all.length === 0 ? "No snapshots logged yet. Add a snapshot via finance.snapshot-record to start tracking net worth over time." : undefined,
+      },
+    };
   });
 
   /**
    * investment-checkup — Empower-style allocation drift + concentration +
-   * fee benchmarking + Health Score.
+   * fee benchmarking + Health Score. Returns error if user has no holdings
+   * (per "everything must be real" directive — no SAMPLE_PORTFOLIO).
    */
   registerLensAction("finance", "investment-checkup", (ctx, _artifact, _params = {}) => {
     const state = getFinState(); if (!state) return { ok: false, error: "STATE unavailable" };
     const userId = ctx?.actor?.userId || ctx?.userId || "anon";
-    let holdings = state.holdings.get(userId);
+    const holdings = state.holdings.get(userId);
     if (!holdings || holdings.length === 0) {
-      holdings = SAMPLE_PORTFOLIO;
+      return {
+        ok: false,
+        error: "no holdings — add positions via finance.holdings-add first (real portfolio data only, no sample)",
+      };
     }
     const totalValue = holdings.reduce((s, h) => s + h.value, 0);
 
@@ -528,47 +536,12 @@ Generate the summary.`;
 
 // ─── helpers ──────────────────────────────────────────────────────────
 
-function synthSnapshots(userId) {
-  const seed = hashString(userId);
-  const snapshots = [];
-  const start = new Date();
-  start.setMonth(start.getMonth() - 36);
-  let cash = 8000 + (seed % 5000);
-  let invest = 50000 + (seed % 30000);
-  let real = 0;
-  let crypto = 2000 + (seed % 1500);
-  let liab = 18000 - (seed % 8000);
-  for (let i = 0; i < 36; i++) {
-    const d = new Date(start); d.setMonth(d.getMonth() + i);
-    cash += 200 + ((seed >> i) & 7) * 30;
-    invest = invest * (1 + (((seed >> i) & 31) - 14) / 200);
-    crypto = crypto * (1 + (((seed >> i) & 31) - 12) / 100);
-    liab = Math.max(0, liab - 250);
-    snapshots.push({
-      date: d.toISOString().slice(0, 10),
-      cash: Math.round(cash), investments: Math.round(invest),
-      realEstate: real, crypto: Math.round(crypto),
-      liabilities: Math.round(liab),
-      total: Math.round(cash + invest + real + crypto - liab),
-    });
-  }
-  return snapshots;
-}
-
 function filterByRange(snapshots, range) {
   const now = Date.now();
   const days = range === "1M" ? 30 : range === "6M" ? 180 : range === "1Y" ? 365 : range === "5Y" ? 365 * 5 : Infinity;
   return snapshots.filter(s => (now - new Date(s.date).getTime()) / 86400000 <= days);
 }
 
-const SAMPLE_PORTFOLIO = [
-  { symbol: "VTI", value: 28000, assetClass: "equity_us", sector: "Diversified", expenseRatio: 0.0003, feeCategory: "total_market" },
-  { symbol: "VXUS", value: 11000, assetClass: "equity_intl", sector: "International", expenseRatio: 0.0008, feeCategory: "total_intl" },
-  { symbol: "BND", value: 13000, assetClass: "bonds", sector: "Bonds", expenseRatio: 0.0005, feeCategory: "total_bond" },
-  { symbol: "VNQ", value: 4000, assetClass: "reits", sector: "Real Estate", expenseRatio: 0.0007, feeCategory: "reit" },
-  { symbol: "AAPL", value: 9000, assetClass: "equity_us", sector: "Technology", expenseRatio: 0, feeCategory: "stock" },
-  { symbol: "Cash", value: 3000, assetClass: "cash", sector: "Cash" },
-];
 
 function seedSubscriptions() {
   const now = Date.now();

--- a/server/domains/logistics.js
+++ b/server/domains/logistics.js
@@ -607,21 +607,19 @@ export default function registerLogisticsActions(registerLensAction) {
   });
 
   registerLensAction("logistics", "inventory-list", (_ctx, _artifact, _params = {}) => {
-    const items = SAMPLE_SKUS.map((s, i) => {
-      const seed = hashStringLog(s.sku);
-      const quantity = seed % 200;
-      const reorderPoint = 30 + (seed % 50);
-      const weeklyVelocity = 5 + (seed % 25);
-      return {
-        id: `inv_${i}`,
-        sku: s.sku, name: s.name, category: s.category,
-        quantity, reorderPoint,
-        bin: `${String.fromCharCode(65 + (seed % 6))}-${String((seed >> 3) % 99 + 1).padStart(2, "0")}-${seed % 9 + 1}`,
-        weeklyVelocity,
-        daysOfStock: weeklyVelocity > 0 ? (quantity / weeklyVelocity) * 7 : 999,
-      };
-    });
-    return { ok: true, result: { items } };
+    // Per "everything must be real" directive: inventory comes from the
+    // user's real catalog (managed via retail.product-* or warehouse
+    // intake macros). No SAMPLE_SKUS seed. Returns empty + setup hint
+    // until a real inventory feed is wired (warehouse WMS export,
+    // Shopify catalog sync, or per-user warehouse macros).
+    return {
+      ok: true,
+      result: {
+        items: [],
+        source: "empty",
+        notes: "No inventory loaded. Wire a real warehouse feed (WMS export, Shopify catalog sync, or per-user logistics.warehouse-* macros) to populate.",
+      },
+    };
   });
 };
 
@@ -631,21 +629,3 @@ function hashStringLog(s) {
   return Math.abs(h);
 }
 
-const SAMPLE_SKUS = [
-  { sku: "WIDGET-001", name: "Standard Widget", category: "Hardware" },
-  { sku: "WIDGET-002", name: "Premium Widget", category: "Hardware" },
-  { sku: "BOX-LG-01", name: "Large Shipping Box", category: "Packaging" },
-  { sku: "BOX-MD-01", name: "Medium Shipping Box", category: "Packaging" },
-  { sku: "TAPE-001", name: "Packing Tape Roll", category: "Packaging" },
-  { sku: "LABEL-100", name: "Shipping Labels 100ct", category: "Packaging" },
-  { sku: "PAD-001", name: "Bubble Wrap Padding", category: "Packaging" },
-  { sku: "TOOL-WR-1", name: "Wrench Set", category: "Tools" },
-  { sku: "TOOL-DR-1", name: "Cordless Drill", category: "Tools" },
-  { sku: "WIRE-12G", name: "12-gauge Wire 100ft", category: "Materials" },
-  { sku: "WIRE-14G", name: "14-gauge Wire 100ft", category: "Materials" },
-  { sku: "PVC-2IN-10", name: "PVC Pipe 2in × 10ft", category: "Materials" },
-  { sku: "PAINT-WH-1G", name: "White Paint 1gal", category: "Materials" },
-  { sku: "PRIMER-1G", name: "Primer 1gal", category: "Materials" },
-  { sku: "SCREWS-100", name: "Wood Screws 100ct", category: "Hardware" },
-  { sku: "BOLTS-50", name: "Hex Bolts 1/4in 50ct", category: "Hardware" },
-];

--- a/server/tests/crypto-domain-parity.test.js
+++ b/server/tests/crypto-domain-parity.test.js
@@ -56,29 +56,40 @@ describe("crypto.search-tokens", () => {
   });
 });
 
-describe("crypto.token-candles", () => {
-  it("returns a deterministic synthetic candle series when CoinGecko unreachable", async () => {
-    const r1 = await call("token-candles", ctxA, { id: "bitcoin", days: 14 });
-    assert.equal(r1.ok, true);
-    assert.equal(r1.result.source, "fallback");
-    assert.ok(r1.result.candles.length >= 14);
-    for (const c of r1.result.candles) {
-      assert.ok(c.high >= c.low, `candle high ${c.high} must be >= low ${c.low}`);
-      assert.ok(c.high >= c.open && c.high >= c.close, "high must dominate");
-      assert.ok(c.low <= c.open && c.low <= c.close, "low must be dominated");
-      assert.ok(c.close > 0);
-    }
-    // Determinism: same id + days produce the same close-price trajectory
-    const r2 = await call("token-candles", ctxA, { id: "bitcoin", days: 14 });
-    assert.deepEqual(
-      r1.result.candles.map(c => c.close),
-      r2.result.candles.map(c => c.close),
-    );
+describe("crypto.token-candles (real CoinGecko, no fallback)", () => {
+  it("returns error shape when CoinGecko unreachable (no synthetic fallback)", async () => {
+    const r = await call("token-candles", ctxA, { id: "bitcoin", days: 14 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /coingecko unreachable|network/);
   });
 
-  it("clamps days to [1, 365]", async () => {
+  it("parses CoinGecko candle + volume response", async () => {
+    globalThis.fetch = async (url) => {
+      if (url.includes("/ohlc")) {
+        return { ok: true, json: async () => ([
+          [1700000000000, 35000, 35500, 34800, 35200],
+          [1700086400000, 35200, 35400, 35000, 35300],
+        ]) };
+      }
+      // market_chart for volumes
+      return { ok: true, json: async () => ({ total_volumes: [[1700000000000, 1_000_000], [1700086400000, 1_200_000]] }) };
+    };
+    const r = await call("token-candles", ctxA, { id: "bitcoin", days: 14 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.source, "coingecko");
+    assert.equal(r.result.candles.length, 2);
+    assert.equal(r.result.candles[0].open, 35000);
+    assert.equal(r.result.candles[0].volume, 1_000_000);
+  });
+
+  it("clamps days to [1, 365] even when network is mocked", async () => {
+    globalThis.fetch = async (url) => {
+      // Verify days was clamped to 365 in the URL
+      assert.match(url, /days=365/);
+      return { ok: true, json: async () => [] };
+    };
     const r = await call("token-candles", ctxA, { id: "ethereum", days: 99999 });
-    assert.ok(r.result.candles.length <= 366);
+    assert.equal(r.ok, true);
   });
 });
 

--- a/server/tests/eco-domain-parity.test.js
+++ b/server/tests/eco-domain-parity.test.js
@@ -32,15 +32,37 @@ const ctxA = { actor: { userId: userA }, userId: userA };
 const ctxB = { actor: { userId: userB }, userId: userB };
 
 describe("eco.weather-forecast", () => {
-  it("returns the deterministic fallback forecast when Open-Meteo unreachable", async () => {
+  it("returns error shape when Open-Meteo unreachable (no synthetic fallback)", async () => {
+    const r = await call("weather-forecast", ctxA, { lat: 37.7, lng: -122.4 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /open-meteo unreachable/);
+  });
+
+  it("parses Open-Meteo response when fetch succeeds", async () => {
+    globalThis.fetch = async (url) => {
+      assert.match(url, /api\.open-meteo\.com\/v1\/forecast/);
+      assert.match(url, /latitude=37\.7/);
+      return {
+        ok: true,
+        json: async () => ({
+          current: { temperature_2m: 18, relative_humidity_2m: 60, apparent_temperature: 17, is_day: 1, precipitation: 0, weather_code: 1, wind_speed_10m: 5, wind_direction_10m: 180 },
+          hourly: { time: [], temperature_2m: [], precipitation: [], relative_humidity_2m: [] },
+          daily: {
+            time: ["2026-05-16","2026-05-17","2026-05-18","2026-05-19","2026-05-20","2026-05-21","2026-05-22"],
+            weather_code: [1,1,2,3,1,2,1],
+            temperature_2m_max: [22,23,21,20,22,24,23],
+            temperature_2m_min: [12,13,11,10,12,14,13],
+            precipitation_sum: [0,0,1,2,0,0,0],
+            precipitation_probability_max: [10,5,30,60,5,10,5],
+            wind_speed_10m_max: [12,10,8,15,9,11,10],
+            uv_index_max: [6,7,5,4,7,8,7],
+          },
+        }),
+      };
+    };
     const r = await call("weather-forecast", ctxA, { lat: 37.7, lng: -122.4 });
     assert.equal(r.ok, true);
-    assert.ok(r.result.daily.length === 7);
-    for (const d of r.result.daily) {
-      assert.ok(typeof d.high === "number");
-      assert.ok(typeof d.low === "number");
-      assert.ok(d.high >= d.low);
-    }
+    assert.equal(r.result.daily.length, 7);
     assert.equal(r.result.location.lat, 37.7);
   });
 

--- a/server/tests/finance-domain-parity.test.js
+++ b/server/tests/finance-domain-parity.test.js
@@ -48,18 +48,12 @@ describe("finance.envelopes-* + monthly-income", () => {
   });
 });
 
-describe("finance.net-worth-history", () => {
-  it("seeds synthetic snapshots when none exist", () => {
+describe("finance.net-worth-history (real user snapshots only)", () => {
+  it("returns empty array + setup hint when no snapshots logged", () => {
     const r = call("net-worth-history", ctxA, { range: "1Y" });
     assert.equal(r.ok, true);
-    assert.ok(r.result.snapshots.length > 0);
-    for (const s of r.result.snapshots) {
-      assert.ok(typeof s.cash === "number");
-      assert.ok(typeof s.total === "number");
-      // Total may differ by ±1 due to per-component rounding in the synthetic seeder.
-      const expected = s.cash + s.investments + s.realEstate + s.crypto - s.liabilities;
-      assert.ok(Math.abs(s.total - expected) <= 2, `total ${s.total} vs sum ${expected}`);
-    }
+    assert.equal(r.result.snapshots.length, 0);
+    assert.match(r.result.notes, /No snapshots logged/);
   });
 
   it("manual snapshot persists and feeds history", () => {
@@ -72,18 +66,11 @@ describe("finance.net-worth-history", () => {
   });
 });
 
-describe("finance.investment-checkup", () => {
-  it("returns allocation drift + concentration + fees + score for sample portfolio", () => {
+describe("finance.investment-checkup (real holdings required)", () => {
+  it("returns error when user has no holdings (no SAMPLE_PORTFOLIO fallback)", () => {
     const r = call("investment-checkup", ctxA, {});
-    assert.equal(r.ok, true);
-    assert.ok(Array.isArray(r.result.allocation));
-    assert.equal(r.result.allocation.length, 5);
-    for (const a of r.result.allocation) {
-      assert.ok(typeof a.current === "number");
-      assert.ok(["buy", "sell", "hold"].includes(a.rebalanceAction));
-    }
-    assert.ok(r.result.score >= 0 && r.result.score <= 100);
-    assert.ok(r.result.totalAnnualFeeUsd >= 0);
+    assert.equal(r.ok, false);
+    assert.match(r.error, /no holdings/);
   });
 });
 

--- a/server/tests/logistics-domain-parity.test.js
+++ b/server/tests/logistics-domain-parity.test.js
@@ -53,14 +53,12 @@ describe("logistics.route-optimize", () => {
 });
 
 describe("logistics.inventory-list", () => {
-  it("returns deterministic SKU set with low/out flags computable", () => {
+  it("returns empty + setup hint when no real inventory feed is wired (no SAMPLE_SKUS fallback)", () => {
     const r = call("inventory-list", ctxA, {});
     assert.equal(r.ok, true);
-    assert.ok(r.result.items.length >= 10);
-    for (const i of r.result.items) {
-      assert.ok(i.sku && i.name);
-      assert.ok(typeof i.quantity === "number");
-    }
+    assert.deepEqual(r.result.items, []);
+    assert.equal(r.result.source, "empty");
+    assert.match(r.result.notes, /warehouse feed|WMS|Shopify/);
   });
 });
 


### PR DESCRIPTION
## Summary

Per the **"everything must be real"** directive, removes four remaining sample-data fallbacks across these four domains:

- **finance** — drops `synthSnapshots` (12-month synthetic generator) + `SAMPLE_PORTFOLIO`. `net-worth-history` returns empty + setup hint; `investment-checkup` returns error pointing to `finance.holdings-add`.
- **crypto** — `token-candles` returns `ok:false` with `"coingecko unreachable: …"` on network failure instead of synthesizing OHLC candles.
- **eco** — `weather-forecast` returns `ok:false` with `"open-meteo unreachable: …"` on network failure; `synthesizeWeatherFallback` deleted.
- **logistics** — `inventory-list` returns empty + setup hint pointing to WMS export / Shopify catalog sync / per-user warehouse macros instead of the 10-SKU `SAMPLE_SKUS` table.

## Test plan

- [x] `node --test server/tests/{finance,crypto,eco,logistics}-domain-parity.test.js` — **65/65 passing**
- [x] Test reshape:
  - finance: empty-array + setup-hint, no-holdings error
  - crypto: error shape on unreachable + new mocked-fetch tests for real CoinGecko response shape + clamp-days
  - eco: error shape on unreachable + new mocked-fetch test for real Open-Meteo response
  - logistics: empty + setup hint
- [x] Smoke check: no other test file references `SAMPLE_SKUS`, `SAMPLE_PORTFOLIO`, `synthSnapshots`, or `synthesizeWeatherFallback`

https://claude.ai/code/session_018ucd5N7Hc3K8mNa9p2Lr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_