### PR TITLE
feat(whiteboard): real-time multiplayer collab — shared boards + cursors + votes

### DIFF
--- a/concord-frontend/hooks/useSocket.ts
+++ b/concord-frontend/hooks/useSocket.ts
@@ -87,8 +87,11 @@ const FORWARDED_EVENTS: SocketEvent[] = [
   'app:published',
   // Music / studio
   'music:toggle',
-  // Whiteboard
+  // Whiteboard (legacy + real-time multiplayer)
   'whiteboard:updated',
+  'whiteboard:scene-update',
+  'whiteboard:cursor',
+  'whiteboard:vote-cast',
   // Resonance
   'resonance:update',
   // Platform presence

--- a/concord-frontend/hooks/useWhiteboardCollab.ts
+++ b/concord-frontend/hooks/useWhiteboardCollab.ts
@@ -1,0 +1,184 @@
+/**
+ * useWhiteboardCollab — real-time multiplayer for shared whiteboards.
+ *
+ * Subscribes to socket.io events scoped to `whiteboard:${boardId}` and
+ * exposes:
+ *   - peerCursors: live cursor positions of other participants
+ *   - voteCounts: aggregated per-element vote tally
+ *   - broadcastScene(scene): debounced scene push (last-write-wins)
+ *   - broadcastCursor(x, y): rate-limited cursor ping
+ *   - castVote(elementId): toggle a vote on an element
+ *
+ * Lifecycle:
+ *   - On mount: POST /api/lens/run whiteboard.join-shared
+ *   - On unmount: POST /api/lens/run whiteboard.leave-shared
+ *
+ * The hook is purely additive — it doesn't replace the local Canvas
+ * state, it mirrors remote scene-updates into a `remoteScene` accumulator
+ * that the host component can choose to merge on conflict.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { api } from '@/lib/api/client';
+import { onEvent } from '@/lib/realtime/event-bus';
+
+export interface PeerCursor {
+  userId: string;
+  x: number;
+  y: number;
+  lastSeenMs: number;
+}
+
+export interface WhiteboardCollabState {
+  peerCursors: Record<string, PeerCursor>;
+  voteCounts: Record<string, number>;
+  remoteScene: unknown | null;
+  remoteSceneUpdateCount: number;
+}
+
+interface UseWhiteboardCollabOpts {
+  boardId: string | null;
+  enabled?: boolean;
+  cursorThrottleMs?: number;
+  sceneDebounceMs?: number;
+  cursorStaleMs?: number;
+}
+
+export function useWhiteboardCollab({
+  boardId,
+  enabled = true,
+  cursorThrottleMs = 60,
+  sceneDebounceMs = 200,
+  cursorStaleMs = 4000,
+}: UseWhiteboardCollabOpts) {
+  const [state, setState] = useState<WhiteboardCollabState>({
+    peerCursors: {},
+    voteCounts: {},
+    remoteScene: null,
+    remoteSceneUpdateCount: 0,
+  });
+
+  const lastCursorPushRef = useRef(0);
+  const sceneDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingSceneRef = useRef<unknown | null>(null);
+
+  // Join on mount, leave on unmount.
+  useEffect(() => {
+    if (!enabled || !boardId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await api.post('/api/lens/run', {
+          domain: 'whiteboard', action: 'join-shared', input: { id: boardId },
+        });
+        if (cancelled) return;
+        const remoteScene = res.data?.result?.board?.scene;
+        if (remoteScene) {
+          setState((prev) => ({ ...prev, remoteScene, remoteSceneUpdateCount: prev.remoteSceneUpdateCount + 1 }));
+        }
+      } catch (_e) { /* join is best-effort */ }
+    })();
+    return () => {
+      cancelled = true;
+      api.post('/api/lens/run', {
+        domain: 'whiteboard', action: 'leave-shared', input: { id: boardId },
+      }).catch(() => { /* leave is best-effort */ });
+    };
+  }, [boardId, enabled]);
+
+  // Subscribe to realtime events. Filter by boardId.
+  useEffect(() => {
+    if (!enabled || !boardId) return;
+    const offScene = onEvent('whiteboard:scene-update', (payload: unknown) => {
+      const p = payload as { boardId?: string; userId?: string; elementCount?: number };
+      if (p.boardId !== boardId) return;
+      // The event itself carries metadata only; re-fetch the full scene.
+      // We do this lazily — the next remote-driven render can call
+      // whiteboard.join-shared again to pull the latest scene.
+      // For now we increment a counter so callers can re-fetch.
+      setState((prev) => ({ ...prev, remoteSceneUpdateCount: prev.remoteSceneUpdateCount + 1 }));
+    });
+    const offCursor = onEvent('whiteboard:cursor', (payload: unknown) => {
+      const p = payload as { boardId?: string; userId?: string; x?: number; y?: number };
+      if (p.boardId !== boardId || typeof p.userId !== 'string' || typeof p.x !== 'number' || typeof p.y !== 'number') return;
+      setState((prev) => ({
+        ...prev,
+        peerCursors: {
+          ...prev.peerCursors,
+          [p.userId!]: { userId: p.userId!, x: p.x!, y: p.y!, lastSeenMs: Date.now() },
+        },
+      }));
+    });
+    const offVote = onEvent('whiteboard:vote-cast', (payload: unknown) => {
+      const p = payload as { boardId?: string; elementId?: string; voteCount?: number };
+      if (p.boardId !== boardId || typeof p.elementId !== 'string' || typeof p.voteCount !== 'number') return;
+      setState((prev) => ({
+        ...prev,
+        voteCounts: { ...prev.voteCounts, [p.elementId!]: p.voteCount! },
+      }));
+    });
+    return () => {
+      offScene?.();
+      offCursor?.();
+      offVote?.();
+    };
+  }, [boardId, enabled]);
+
+  // GC stale peer cursors.
+  useEffect(() => {
+    if (!enabled) return;
+    const i = setInterval(() => {
+      setState((prev) => {
+        const now = Date.now();
+        const fresh: Record<string, PeerCursor> = {};
+        let changed = false;
+        for (const [id, c] of Object.entries(prev.peerCursors)) {
+          if (now - c.lastSeenMs < cursorStaleMs) fresh[id] = c;
+          else changed = true;
+        }
+        return changed ? { ...prev, peerCursors: fresh } : prev;
+      });
+    }, 1000);
+    return () => clearInterval(i);
+  }, [enabled, cursorStaleMs]);
+
+  // Debounced scene push.
+  const broadcastScene = useCallback((scene: unknown) => {
+    if (!boardId || !enabled) return;
+    pendingSceneRef.current = scene;
+    if (sceneDebounceRef.current) clearTimeout(sceneDebounceRef.current);
+    sceneDebounceRef.current = setTimeout(() => {
+      const payload = pendingSceneRef.current;
+      pendingSceneRef.current = null;
+      sceneDebounceRef.current = null;
+      api.post('/api/lens/run', {
+        domain: 'whiteboard', action: 'broadcast-scene',
+        input: { id: boardId, scene: payload },
+      }).catch(() => { /* best effort */ });
+    }, sceneDebounceMs);
+  }, [boardId, enabled, sceneDebounceMs]);
+
+  // Rate-limited cursor push.
+  const broadcastCursor = useCallback((x: number, y: number) => {
+    if (!boardId || !enabled) return;
+    const now = Date.now();
+    if (now - lastCursorPushRef.current < cursorThrottleMs) return;
+    lastCursorPushRef.current = now;
+    api.post('/api/lens/run', {
+      domain: 'whiteboard', action: 'broadcast-cursor',
+      input: { id: boardId, x, y },
+    }).catch(() => { /* best effort */ });
+  }, [boardId, enabled, cursorThrottleMs]);
+
+  const castVote = useCallback(async (elementId: string) => {
+    if (!boardId || !enabled) return;
+    try {
+      await api.post('/api/lens/run', {
+        domain: 'whiteboard', action: 'shared-vote-cast',
+        input: { id: boardId, elementId },
+      });
+    } catch (_e) { /* best effort */ }
+  }, [boardId, enabled]);
+
+  return { ...state, broadcastScene, broadcastCursor, castVote };
+}

--- a/concord-frontend/lib/realtime/socket.ts
+++ b/concord-frontend/lib/realtime/socket.ts
@@ -162,8 +162,12 @@ export type SocketEvent =
   | 'app:published'
   // Music / studio
   | 'music:toggle'
-  // Whiteboard
+  // Whiteboard (legacy)
   | 'whiteboard:updated'
+  // Whiteboard real-time multiplayer (server/domains/whiteboard.js broadcast-scene / broadcast-cursor / shared-vote-cast)
+  | 'whiteboard:scene-update'
+  | 'whiteboard:cursor'
+  | 'whiteboard:vote-cast'
   // Creative Registry & Royalties
   | 'creative_registry:update'
   | 'marketplace:purchase'

--- a/server/domains/whiteboard.js
+++ b/server/domains/whiteboard.js
@@ -112,12 +112,11 @@ export default function registerWhiteboardActions(registerLensAction) {
   function getWhiteboardState() {
     const STATE = globalThis._concordSTATE;
     if (!STATE) return null;
-    if (!STATE.whiteboardLens) {
-      STATE.whiteboardLens = {
-        boards: new Map(),       // userId -> Map<id, board>
-        votes:  new Map(),       // userId -> Map<boardId, Map<elementId, Map<voterId, true>>>
-      };
-    }
+    if (!STATE.whiteboardLens) STATE.whiteboardLens = {};
+    if (!STATE.whiteboardLens.boards)        STATE.whiteboardLens.boards        = new Map(); // userId -> Map<id, board>
+    if (!STATE.whiteboardLens.votes)         STATE.whiteboardLens.votes         = new Map(); // userId -> Map<boardId, Map<elementId, Set<voterId>>>
+    if (!STATE.whiteboardLens.sharedBoards)  STATE.whiteboardLens.sharedBoards  = new Map(); // boardId -> { id, title, scene, ownerId, participants: Set<userId>, createdAt, updatedAt }
+    if (!STATE.whiteboardLens.sharedVotes)   STATE.whiteboardLens.sharedVotes   = new Map(); // boardId -> Map<elementId, Set<voterId>>
     return STATE.whiteboardLens;
   }
   function saveWhiteboardState() {
@@ -277,6 +276,185 @@ export default function registerWhiteboardActions(registerLensAction) {
     const userId = wbActor(ctx);
     const boardId = String(params.boardId || "");
     const boardVotes = s.votes.get(userId)?.get(boardId);
+    if (!boardVotes) return { ok: true, result: { tally: [], total: 0 } };
+    const tally = Array.from(boardVotes.entries())
+      .map(([elementId, voters]) => ({ elementId, count: voters.size }))
+      .sort((a, b) => b.count - a.count);
+    const total = tally.reduce((s2, t) => s2 + t.count, 0);
+    return { ok: true, result: { tally, total } };
+  });
+
+  // ── Shared boards (real-time multiplayer collab) ──
+  //
+  // Per-user boards above (board-save/load/list/delete) remain the
+  // private workspace. A shared board lives in STATE.whiteboardLens
+  // .sharedBoards and is identified by its `id` — any participant
+  // can read/write its scene, with last-write-wins semantics and
+  // realtime broadcast via socket.io to room `whiteboard:${id}`.
+  // Votes on shared boards are aggregated across all participants
+  // (not per-user as on private boards).
+
+  function sharedBoardSummary(b) {
+    return {
+      id: b.id, title: b.title, ownerId: b.ownerId,
+      participants: Array.from(b.participants || []),
+      participantCount: (b.participants && b.participants.size) || 0,
+      elementCount: Array.isArray(b.scene?.elements) ? b.scene.elements.length : 0,
+      createdAt: b.createdAt, updatedAt: b.updatedAt,
+    };
+  }
+
+  registerLensAction("whiteboard", "share-board", (ctx, _artifact, params = {}) => {
+    const s = getWhiteboardState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = wbActor(ctx);
+    // Either promote an existing private board, or create a new
+    // shared board outright (params.scene + params.title).
+    let scene, title, sourcePrivateId;
+    if (params.id) {
+      sourcePrivateId = String(params.id);
+      const ownerMap = s.boards.get(userId);
+      const priv = ownerMap?.get(sourcePrivateId);
+      if (!priv) return { ok: false, error: "private board not found" };
+      scene = priv.scene; title = priv.title;
+    } else {
+      scene = params.scene && typeof params.scene === "object" ? params.scene : { elements: [], appState: {} };
+      title = String(params.title || "Untitled shared board").slice(0, 80);
+    }
+    const sharedId = String(params.sharedId || `shared_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`);
+    const board = {
+      id: sharedId, title, scene, ownerId: userId,
+      participants: new Set([userId]),
+      createdAt: nowIsoWb(), updatedAt: nowIsoWb(),
+      sourcePrivateId,
+    };
+    s.sharedBoards.set(sharedId, board);
+    saveWhiteboardState();
+    return { ok: true, result: { board: sharedBoardSummary(board) } };
+  });
+
+  registerLensAction("whiteboard", "shared-list", (ctx, _artifact, _params = {}) => {
+    const s = getWhiteboardState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = wbActor(ctx);
+    const boards = [];
+    for (const b of s.sharedBoards.values()) {
+      if (b.participants?.has(userId)) boards.push(sharedBoardSummary(b));
+    }
+    boards.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+    return { ok: true, result: { boards } };
+  });
+
+  registerLensAction("whiteboard", "join-shared", (ctx, _artifact, params = {}) => {
+    const s = getWhiteboardState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = wbActor(ctx);
+    const id = String(params.id || "");
+    const b = s.sharedBoards.get(id);
+    if (!b) return { ok: false, error: "shared board not found" };
+    if (!b.participants) b.participants = new Set();
+    b.participants.add(userId);
+    saveWhiteboardState();
+    return { ok: true, result: { board: { ...sharedBoardSummary(b), scene: b.scene } } };
+  });
+
+  registerLensAction("whiteboard", "leave-shared", (ctx, _artifact, params = {}) => {
+    const s = getWhiteboardState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = wbActor(ctx);
+    const id = String(params.id || "");
+    const b = s.sharedBoards.get(id);
+    if (!b) return { ok: false, error: "shared board not found" };
+    b.participants?.delete(userId);
+    saveWhiteboardState();
+    return { ok: true, result: { id, remainingParticipants: b.participants?.size || 0 } };
+  });
+
+  // broadcast-scene — persist + realtime fan-out via the io that
+  // server.js stashes on globalThis._concordREALTIME (best-effort;
+  // no realtime in tests means the macro still updates STATE).
+  registerLensAction("whiteboard", "broadcast-scene", (ctx, _artifact, params = {}) => {
+    const s = getWhiteboardState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = wbActor(ctx);
+    const id = String(params.id || "");
+    const b = s.sharedBoards.get(id);
+    if (!b) return { ok: false, error: "shared board not found" };
+    if (!b.participants?.has(userId)) return { ok: false, error: "not a participant" };
+    if (!params.scene || typeof params.scene !== "object") return { ok: false, error: "scene required" };
+    b.scene = params.scene;
+    b.updatedAt = nowIsoWb();
+    saveWhiteboardState();
+    const REALTIME = globalThis._concordREALTIME;
+    try {
+      REALTIME?.io?.to(`whiteboard:${id}`).emit("whiteboard:scene-update", {
+        boardId: id, userId, elementCount: Array.isArray(params.scene.elements) ? params.scene.elements.length : 0,
+        ts: Date.now(),
+      });
+    } catch (_e) { /* realtime is best-effort */ }
+    return { ok: true, result: { id, updatedAt: b.updatedAt } };
+  });
+
+  // broadcast-cursor — ephemeral, not persisted; pure realtime ping
+  // so other participants see a live cursor. Position is { x, y } in
+  // board coordinates.
+  registerLensAction("whiteboard", "broadcast-cursor", (ctx, _artifact, params = {}) => {
+    const s = getWhiteboardState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = wbActor(ctx);
+    const id = String(params.id || "");
+    const b = s.sharedBoards.get(id);
+    if (!b) return { ok: false, error: "shared board not found" };
+    if (!b.participants?.has(userId)) return { ok: false, error: "not a participant" };
+    const x = Number(params.x);
+    const y = Number(params.y);
+    if (!isFinite(x) || !isFinite(y)) return { ok: false, error: "x, y required" };
+    const REALTIME = globalThis._concordREALTIME;
+    try {
+      REALTIME?.io?.to(`whiteboard:${id}`).emit("whiteboard:cursor", {
+        boardId: id, userId, x, y, ts: Date.now(),
+      });
+    } catch (_e) { /* best effort */ }
+    return { ok: true, result: { id, userId, x, y } };
+  });
+
+  // ── Shared-board voting (aggregated across all participants) ──
+
+  registerLensAction("whiteboard", "shared-vote-cast", (ctx, _artifact, params = {}) => {
+    const s = getWhiteboardState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = wbActor(ctx);
+    const id = String(params.id || params.boardId || "");
+    const elementId = String(params.elementId || "");
+    const b = s.sharedBoards.get(id);
+    if (!b) return { ok: false, error: "shared board not found" };
+    if (!b.participants?.has(userId)) return { ok: false, error: "not a participant" };
+    if (!elementId) return { ok: false, error: "elementId required" };
+    if (!s.sharedVotes.has(id)) s.sharedVotes.set(id, new Map());
+    const boardVotes = s.sharedVotes.get(id);
+    if (!boardVotes.has(elementId)) boardVotes.set(elementId, new Set());
+    boardVotes.get(elementId).add(userId);
+    saveWhiteboardState();
+    const REALTIME = globalThis._concordREALTIME;
+    try {
+      REALTIME?.io?.to(`whiteboard:${id}`).emit("whiteboard:vote-cast", {
+        boardId: id, elementId, voterId: userId,
+        voteCount: boardVotes.get(elementId).size,
+        ts: Date.now(),
+      });
+    } catch (_e) { /* best effort */ }
+    return { ok: true, result: { boardId: id, elementId, voteCount: boardVotes.get(elementId).size } };
+  });
+
+  registerLensAction("whiteboard", "shared-vote-tally", (ctx, _artifact, params = {}) => {
+    const s = getWhiteboardState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = wbActor(ctx);
+    const id = String(params.id || params.boardId || "");
+    const b = s.sharedBoards.get(id);
+    if (!b) return { ok: false, error: "shared board not found" };
+    if (!b.participants?.has(userId)) return { ok: false, error: "not a participant" };
+    const boardVotes = s.sharedVotes.get(id);
     if (!boardVotes) return { ok: true, result: { tally: [], total: 0 } };
     const tally = Array.from(boardVotes.entries())
       .map(([elementId, voters]) => ({ elementId, count: voters.size }))

--- a/server/lib/event-shapes.js
+++ b/server/lib/event-shapes.js
@@ -222,6 +222,25 @@ export const EVENT_SHAPES = Object.freeze({
       "factionPhase",
     ],
   },
+
+  // ── Whiteboard realtime collaboration ─────────────────────────────
+  // Emitted by server/domains/whiteboard.js broadcast-scene /
+  // broadcast-cursor / shared-vote-cast macros. Scoped to
+  // socket.io room `whiteboard:${boardId}` so only participants
+  // receive events. Multi-cursor + last-write-wins scene sync
+  // makes the whiteboard lens true real-time multiplayer.
+  "whiteboard:scene-update": {
+    required: ["boardId", "userId", "elementCount"],
+    optional: [],
+  },
+  "whiteboard:cursor": {
+    required: ["boardId", "userId", "x", "y"],
+    optional: [],
+  },
+  "whiteboard:vote-cast": {
+    required: ["boardId", "elementId", "voterId", "voteCount"],
+    optional: [],
+  },
 });
 
 /**

--- a/server/tests/whiteboard-domain-parity.test.js
+++ b/server/tests/whiteboard-domain-parity.test.js
@@ -103,3 +103,130 @@ describe("whiteboard — voting", () => {
     assert.equal(b.result.tally.length, 0);
   });
 });
+
+describe("whiteboard — shared boards (real-time multiplayer)", () => {
+  function captureRealtimeEmits() {
+    const events = [];
+    globalThis._concordREALTIME = {
+      io: {
+        to: (room) => ({
+          emit: (name, payload) => events.push({ room, name, payload }),
+        }),
+      },
+    };
+    return events;
+  }
+
+  it("share-board creates a new shared board owned by the caller", () => {
+    const r = call("share-board", ctxA, { title: "Team retro", scene: { elements: [{ id: "e1" }] } });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.board.ownerId, "u");
+    assert.equal(r.result.board.participants[0], "u");
+    assert.equal(r.result.board.elementCount, 1);
+  });
+
+  it("share-board promotes an existing private board (carries scene + title)", () => {
+    const priv = call("board-save", ctxA, { title: "My idea", scene: { elements: [{ id: "x" }, { id: "y" }] } });
+    const r = call("share-board", ctxA, { id: priv.result.board.id });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.board.title, "My idea");
+    assert.equal(r.result.board.elementCount, 2);
+  });
+
+  it("join-shared adds participant + returns scene; leave-shared removes them", () => {
+    const created = call("share-board", ctxA, { title: "Collab", scene: { elements: [] } });
+    const sid = created.result.board.id;
+    const join = call("join-shared", ctxB, { id: sid });
+    assert.equal(join.ok, true);
+    assert.equal(join.result.board.participantCount, 2);
+    assert.ok(join.result.board.scene);
+    const leave = call("leave-shared", ctxB, { id: sid });
+    assert.equal(leave.ok, true);
+    assert.equal(leave.result.remainingParticipants, 1);
+  });
+
+  it("shared-list shows boards the caller participates in (not all boards)", () => {
+    const aBoard = call("share-board", ctxA, { title: "A's board" }).result.board.id;
+    call("share-board", ctxB, { title: "B's board" }); // userB created, userA not invited
+    const listA = call("shared-list", ctxA, {});
+    assert.equal(listA.result.boards.length, 1);
+    assert.equal(listA.result.boards[0].id, aBoard);
+  });
+
+  it("broadcast-scene persists scene + fans out to socket.io room", () => {
+    const events = captureRealtimeEmits();
+    const sid = call("share-board", ctxA, { title: "X" }).result.board.id;
+    call("join-shared", ctxB, { id: sid });
+    const r = call("broadcast-scene", ctxA, { id: sid, scene: { elements: [{ id: "e1" }, { id: "e2" }] } });
+    assert.equal(r.ok, true);
+    // Persisted scene visible to other participants
+    const reJoin = call("join-shared", ctxB, { id: sid });
+    assert.equal(reJoin.result.board.scene.elements.length, 2);
+    // Realtime fan-out
+    const e = events.find((ev) => ev.name === "whiteboard:scene-update");
+    assert.ok(e);
+    assert.equal(e.room, `whiteboard:${sid}`);
+    assert.equal(e.payload.boardId, sid);
+    assert.equal(e.payload.userId, "u");
+    assert.equal(e.payload.elementCount, 2);
+  });
+
+  it("broadcast-scene rejects non-participants", () => {
+    const sid = call("share-board", ctxA, { title: "X" }).result.board.id;
+    const r = call("broadcast-scene", ctxB, { id: sid, scene: { elements: [] } });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /not a participant/);
+  });
+
+  it("broadcast-cursor emits ephemeral cursor event (no scene persist)", () => {
+    const events = captureRealtimeEmits();
+    const sid = call("share-board", ctxA, { title: "X" }).result.board.id;
+    call("join-shared", ctxB, { id: sid });
+    const r = call("broadcast-cursor", ctxB, { id: sid, x: 120, y: 240 });
+    assert.equal(r.ok, true);
+    const e = events.find((ev) => ev.name === "whiteboard:cursor");
+    assert.ok(e);
+    assert.equal(e.payload.x, 120);
+    assert.equal(e.payload.userId, "v");
+  });
+
+  it("broadcast-cursor rejects non-numeric coords", () => {
+    const sid = call("share-board", ctxA, { title: "X" }).result.board.id;
+    const r = call("broadcast-cursor", ctxA, { id: sid, x: "nope" });
+    assert.equal(r.ok, false);
+  });
+
+  it("shared-vote-cast aggregates across participants (not per-user)", () => {
+    const events = captureRealtimeEmits();
+    const sid = call("share-board", ctxA, { title: "X" }).result.board.id;
+    call("join-shared", ctxB, { id: sid });
+    call("shared-vote-cast", ctxA, { id: sid, elementId: "e1" });
+    call("shared-vote-cast", ctxB, { id: sid, elementId: "e1" });
+    // Both users see the same tally (vote aggregated, not per-user as in private boards)
+    const tallyA = call("shared-vote-tally", ctxA, { id: sid });
+    const tallyB = call("shared-vote-tally", ctxB, { id: sid });
+    assert.equal(tallyA.result.tally[0].count, 2);
+    assert.deepEqual(tallyA.result.tally, tallyB.result.tally);
+    // Realtime fan-out: two events should fire, the second carrying voteCount 2
+    const voteEvents = events.filter((ev) => ev.name === "whiteboard:vote-cast");
+    assert.equal(voteEvents.length, 2);
+    assert.equal(voteEvents[1].payload.voteCount, 2);
+  });
+
+  it("shared-vote-cast dedupes same voter on same element", () => {
+    const sid = call("share-board", ctxA, { title: "X" }).result.board.id;
+    call("shared-vote-cast", ctxA, { id: sid, elementId: "e1" });
+    call("shared-vote-cast", ctxA, { id: sid, elementId: "e1" });
+    const tally = call("shared-vote-tally", ctxA, { id: sid });
+    assert.equal(tally.result.tally[0].count, 1);
+  });
+
+  it("realtime emit failure does not throw (best-effort)", () => {
+    globalThis._concordREALTIME = {
+      io: { to: () => ({ emit: () => { throw new Error("socket dead"); } }) },
+    };
+    const sid = call("share-board", ctxA, { title: "X" }).result.board.id;
+    const r = call("broadcast-scene", ctxA, { id: sid, scene: { elements: [] } });
+    assert.equal(r.ok, true);
+  });
+});


### PR DESCRIPTION
## Summary

First slice of **Bucket 2 Gap C — Real-time multiplayer**. Wires multi-user collaboration on the whiteboard lens (multi-cursor was deferred from PR #441).

### Backend
- `server/domains/whiteboard.js`: new `sharedBoards` + `sharedVotes` substrate. 7 new macros: `share-board`, `shared-list`, `join-shared`, `leave-shared`, `broadcast-scene`, `broadcast-cursor`, `shared-vote-cast`, `shared-vote-tally`. Last-write-wins on scene updates; votes aggregated across all participants.
- `server/lib/event-shapes.js`: registered three new event shapes (`whiteboard:scene-update`, `whiteboard:cursor`, `whiteboard:vote-cast`). Room scope: `whiteboard:${boardId}`.

### Frontend
- `concord-frontend/hooks/useWhiteboardCollab.ts`: React hook that joins on mount, leaves on unmount, subscribes to the three new events, exposes `peerCursors` / `voteCounts` / `remoteScene` + `broadcastScene` (200ms debounced), `broadcastCursor` (60ms throttled), `castVote`. Realtime emit failures are best-effort.
- `SocketEvent` union + `FORWARDED_EVENTS` extended with the new events.

## Test plan

- [x] `node --test server/tests/whiteboard-domain-parity.test.js` — **23/23 passing** (11 new cases covering shared substrate)
- [x] `npx tsc --noEmit` — 0 errors
- [ ] **UI multi-cursor smoke** requires two browser sessions on the dev server — not testable in this environment per CLAUDE.md "Type checking and test suites verify code correctness, not feature correctness"

https://claude.ai/code/session_018ucd5N7Hc3K8mNa9p2Lr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_