### PR TITLE
feat(message): multi-device realtime sync via per-user socket.io room

### DIFF
--- a/concord-frontend/hooks/useSocket.ts
+++ b/concord-frontend/hooks/useSocket.ts
@@ -92,6 +92,11 @@ const FORWARDED_EVENTS: SocketEvent[] = [
   'whiteboard:scene-update',
   'whiteboard:cursor',
   'whiteboard:vote-cast',
+  // Message lens multi-device sync
+  'message:saved',
+  'message:unsaved',
+  'message:reacted',
+  'message:voice-registered',
   // Resonance
   'resonance:update',
   // Platform presence

--- a/concord-frontend/lib/realtime/socket.ts
+++ b/concord-frontend/lib/realtime/socket.ts
@@ -168,6 +168,11 @@ export type SocketEvent =
   | 'whiteboard:scene-update'
   | 'whiteboard:cursor'
   | 'whiteboard:vote-cast'
+  // Message lens multi-device sync (server/domains/message.js, room user:${userId})
+  | 'message:saved'
+  | 'message:unsaved'
+  | 'message:reacted'
+  | 'message:voice-registered'
   // Creative Registry & Royalties
   | 'creative_registry:update'
   | 'marketplace:purchase'

--- a/server/domains/message.js
+++ b/server/domains/message.js
@@ -27,6 +27,17 @@ export default function registerMessageActions(registerLensAction) {
   function nextMsgId(p) { return `${p}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`; }
   function nowIsoMsg() { return new Date().toISOString(); }
 
+  // Multi-device sync: emit to the per-user room so a star/react/voice
+  // on one device flips instantly on every other device the user has
+  // open. The DM substrate already broadcasts the messages themselves;
+  // this is purely the lens-scoped layer (saves / reactions / voice).
+  function emitToUserRoom(userId, name, payload) {
+    const REALTIME = globalThis._concordREALTIME;
+    try {
+      REALTIME?.io?.to(`user:${userId}`).emit(name, { userId, ...payload, ts: Date.now() });
+    } catch (_e) { /* best effort */ }
+  }
+
   // ── Saved (starred) messages ──
 
   registerLensAction("message", "saved-list", (ctx, _artifact, _params = {}) => {
@@ -60,6 +71,7 @@ export default function registerMessageActions(registerLensAction) {
     };
     s.saved.get(userId).set(messageId, entry);
     saveMessageState();
+    emitToUserRoom(userId, "message:saved", { messageId, threadId, entry });
     return { ok: true, result: { entry } };
   });
 
@@ -73,6 +85,7 @@ export default function registerMessageActions(registerLensAction) {
     if (!map || !map.has(messageId)) return { ok: false, error: "not saved" };
     map.delete(messageId);
     saveMessageState();
+    emitToUserRoom(userId, "message:unsaved", { messageId });
     return { ok: true, result: { unsaved: messageId } };
   });
 
@@ -148,7 +161,9 @@ export default function registerMessageActions(registerLensAction) {
     const reactMap = userMap.get(messageId);
     reactMap.set(emoji, (reactMap.get(emoji) || 0) + 1);
     saveMessageState();
-    return { ok: true, result: { messageId, emoji, count: reactMap.get(emoji) } };
+    const count = reactMap.get(emoji);
+    emitToUserRoom(userId, "message:reacted", { messageId, emoji, count });
+    return { ok: true, result: { messageId, emoji, count } };
   });
 
   registerLensAction("message", "unreact", (ctx, _artifact, params = {}) => {
@@ -167,7 +182,9 @@ export default function registerMessageActions(registerLensAction) {
     if (next <= 0) reactMap.delete(emoji);
     else reactMap.set(emoji, next);
     saveMessageState();
-    return { ok: true, result: { messageId, emoji, count: reactMap.get(emoji) || 0 } };
+    const count = reactMap.get(emoji) || 0;
+    emitToUserRoom(userId, "message:reacted", { messageId, emoji, count });
+    return { ok: true, result: { messageId, emoji, count } };
   });
 
   registerLensAction("message", "reactions-for", (ctx, _artifact, params = {}) => {
@@ -203,6 +220,7 @@ export default function registerMessageActions(registerLensAction) {
     if (!s.voice.has(userId)) s.voice.set(userId, new Map());
     s.voice.get(userId).set(messageId, meta);
     saveMessageState();
+    emitToUserRoom(userId, "message:voice-registered", { messageId, durationMs });
     return { ok: true, result: { meta } };
   });
 

--- a/server/lib/event-shapes.js
+++ b/server/lib/event-shapes.js
@@ -241,6 +241,27 @@ export const EVENT_SHAPES = Object.freeze({
     required: ["boardId", "elementId", "voterId", "voteCount"],
     optional: [],
   },
+
+  // ── Message lens multi-device sync ────────────────────────────────
+  // Emitted by server/domains/message.js to room `user:${userId}` so
+  // a save/react/voice action on one device flips instantly on every
+  // other device the same user has open.
+  "message:saved": {
+    required: ["userId", "messageId"],
+    optional: ["threadId", "entry"],
+  },
+  "message:unsaved": {
+    required: ["userId", "messageId"],
+    optional: [],
+  },
+  "message:reacted": {
+    required: ["userId", "messageId", "emoji", "count"],
+    optional: [],
+  },
+  "message:voice-registered": {
+    required: ["userId", "messageId", "durationMs"],
+    optional: [],
+  },
 });
 
 /**

--- a/server/tests/message-domain-parity.test.js
+++ b/server/tests/message-domain-parity.test.js
@@ -147,3 +147,79 @@ describe("message — STATE unavailable path", () => {
     assert.equal(r.ok, false);
   });
 });
+
+describe("message — multi-device realtime sync (per-user room fan-out)", () => {
+  function captureRealtimeEmits() {
+    const events = [];
+    globalThis._concordREALTIME = {
+      io: { to: (room) => ({ emit: (name, payload) => events.push({ room, name, payload }) }) },
+    };
+    return events;
+  }
+
+  it("save-message emits message:saved to user:${userId} room only", () => {
+    const events = captureRealtimeEmits();
+    const r = call("save-message", ctxA, { messageId: "m1", threadId: "t1", sender: "alice", body: "hi" });
+    assert.equal(r.ok, true);
+    const e = events.find((ev) => ev.name === "message:saved");
+    assert.ok(e);
+    assert.equal(e.room, "user:user_a");
+    // userId injected by emitToUserRoom
+    assert.equal(e.payload.userId, "user_a");
+    assert.equal(e.payload.messageId, "m1");
+    assert.equal(e.payload.threadId, "t1");
+  });
+
+  it("unsave-message emits message:unsaved", () => {
+    call("save-message", ctxA, { messageId: "m1", body: "hi" });
+    const events = captureRealtimeEmits();
+    call("unsave-message", ctxA, { messageId: "m1" });
+    const e = events.find((ev) => ev.name === "message:unsaved");
+    assert.ok(e);
+    assert.equal(e.payload.messageId, "m1");
+  });
+
+  it("react emits message:reacted with current count", () => {
+    const events = captureRealtimeEmits();
+    call("react", ctxA, { messageId: "m1", emoji: "👍" });
+    call("react", ctxA, { messageId: "m1", emoji: "👍" });
+    const reactEvents = events.filter((ev) => ev.name === "message:reacted");
+    assert.equal(reactEvents.length, 2);
+    assert.equal(reactEvents[1].payload.count, 2);
+    assert.equal(reactEvents[1].payload.emoji, "👍");
+  });
+
+  it("unreact emits message:reacted with decremented count", () => {
+    call("react", ctxA, { messageId: "m1", emoji: "👍" });
+    call("react", ctxA, { messageId: "m1", emoji: "👍" });
+    const events = captureRealtimeEmits();
+    call("unreact", ctxA, { messageId: "m1", emoji: "👍" });
+    const e = events.find((ev) => ev.name === "message:reacted");
+    assert.ok(e);
+    assert.equal(e.payload.count, 1);
+  });
+
+  it("voice-register emits message:voice-registered", () => {
+    const events = captureRealtimeEmits();
+    call("voice-register", ctxA, { messageId: "m1", durationMs: 1500 });
+    const e = events.find((ev) => ev.name === "message:voice-registered");
+    assert.ok(e);
+    assert.equal(e.payload.durationMs, 1500);
+  });
+
+  it("realtime emit failure does not throw (best-effort)", () => {
+    globalThis._concordREALTIME = {
+      io: { to: () => ({ emit: () => { throw new Error("socket dead"); } }) },
+    };
+    const r = call("save-message", ctxA, { messageId: "m1", body: "hi" });
+    assert.equal(r.ok, true);
+  });
+
+  it("INVARIANT: emits use user:${userId} as the room (per-user scoping, not per-thread)", () => {
+    const events = captureRealtimeEmits();
+    call("save-message", ctxA, { messageId: "m1", body: "x" });
+    call("save-message", ctxB, { messageId: "m2", body: "y" });
+    const rooms = events.filter((ev) => ev.name === "message:saved").map((ev) => ev.room);
+    assert.deepEqual(rooms.sort(), ["user:user_a", "user:user_b"]);
+  });
+});


### PR DESCRIPTION
## Summary

Continuation of **Bucket 2 Gap C — real-time multiplayer**. The message lens previously piggybacked the existing DM substrate but added no realtime of its own — a star/react/voice-register on one device wouldn't reflect on another device the same user had open. This wires that gap.

### Backend
- `server/domains/message.js` — `emitToUserRoom` helper broadcasts to room `user:${userId}` via `globalThis._concordREALTIME.io`. Best-effort. `save-message` / `unsave-message` / `react` / `unreact` / `voice-register` each emit one event on the per-user room after persisting.
- `server/lib/event-shapes.js` — 4 new shapes: `message:saved`, `message:unsaved`, `message:reacted`, `message:voice-registered`.

### Frontend
- `SocketEvent` union + `FORWARDED_EVENTS` extended.

## Test plan

- [x] `node --test server/tests/message-domain-parity.test.js` — **25/25 passing** (7 new cases)
- [x] Per-user room INVARIANT: two different users get two different rooms (`user:user_a` vs `user:user_b`), never bleed across
- [x] Realtime emit failure isolated (try/catch in `emitToUserRoom`)

https://claude.ai/code/session_018ucd5N7Hc3K8mNa9p2Lr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_