### PR TITLE
feat(retail): real Stripe PaymentIntent POS — card tenders verified server-side

### DIFF
--- a/server/domains/retail.js
+++ b/server/domains/retail.js
@@ -505,4 +505,175 @@ export default function registerRetailActions(registerLensAction) {
     const lowStock = Array.from(map.values()).filter((p) => p.stock <= threshold).sort((a, b) => a.stock - b.stock);
     return { ok: true, result: { lowStock, threshold } };
   });
+
+  // ── Stripe POS — real card tender via PaymentIntent ──
+  //
+  // Flow:
+  //   1. cart-create-payment-intent → server-side POST to Stripe
+  //      creates a PaymentIntent for the cart total. Returns
+  //      { clientSecret, paymentIntentId, total }. Frontend uses
+  //      Stripe Elements (or Terminal SDK for in-person readers)
+  //      to confirm with the customer's card.
+  //   2. cart-confirm-paid-with-intent → server verifies the
+  //      PaymentIntent is succeeded, then decrements stock + writes
+  //      the order. Stripe IDs persisted on the order.
+  //   3. Webhook payment_intent.succeeded (server/economy/stripe.js)
+  //      auto-confirms async out-of-band card captures.
+  //
+  // Per "everything must be real": no synthesized auth codes,
+  // no skip-the-network fast path. STRIPE_SECRET_KEY env required.
+
+  async function stripePostRetail(path, formBody) {
+    const stripeKey = process.env.STRIPE_SECRET_KEY;
+    if (!stripeKey) throw new Error("STRIPE_SECRET_KEY not configured");
+    const url = `https://api.stripe.com/v1${path}`;
+    const body = new URLSearchParams(formBody).toString();
+    const r = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${stripeKey}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Stripe-Version": "2025-09-30.acacia",
+      },
+      body,
+    });
+    const data = await r.json();
+    if (!r.ok) throw new Error(`stripe ${path} ${r.status}: ${data?.error?.message || "unknown"}`);
+    return data;
+  }
+
+  async function stripeGetRetail(path) {
+    const stripeKey = process.env.STRIPE_SECRET_KEY;
+    if (!stripeKey) throw new Error("STRIPE_SECRET_KEY not configured");
+    const url = `https://api.stripe.com/v1${path}`;
+    const r = await fetch(url, { headers: { Authorization: `Bearer ${stripeKey}` } });
+    const data = await r.json();
+    if (!r.ok) throw new Error(`stripe ${path} ${r.status}: ${data?.error?.message || "unknown"}`);
+    return data;
+  }
+
+  registerLensAction("retail", "cart-create-payment-intent", async (ctx, _artifact, params = {}) => {
+    const s = getRetailState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = retailActor(ctx);
+    const cartId = String(params.cartId || "");
+    const cart = s.carts.get(userId)?.get(cartId);
+    if (!cart) return { ok: false, error: "cart not found" };
+    if (cart.lines.length === 0) return { ok: false, error: "cart is empty" };
+    if (!process.env.STRIPE_SECRET_KEY) {
+      return { ok: false, error: "Stripe not configured. Set STRIPE_SECRET_KEY env to enable card tenders." };
+    }
+    const taxRate = Number(params.taxRate) || 0;
+    const subtotal = cart.lines.reduce((sum, l) => sum + l.qty * l.unitPrice, 0);
+    const discount = (subtotal * cart.discountPercent) / 100;
+    const subtotalAfter = subtotal - discount;
+    const tax = subtotalAfter * (taxRate / 100);
+    const total = Math.round((subtotalAfter + tax) * 100) / 100;
+    const amountCents = Math.round(total * 100);
+    if (amountCents < 50) return { ok: false, error: "amount below Stripe minimum ($0.50 USD)" };
+
+    try {
+      const formBody = {
+        amount: String(amountCents),
+        currency: "usd",
+        "automatic_payment_methods[enabled]": "true",
+        "metadata[concord_user_id]": userId,
+        "metadata[concord_cart_id]": cartId,
+      };
+      // Reader-driven Terminal: caller passes terminal=true to request
+      // a manual capture flow that the Terminal SDK can complete.
+      if (params.terminal === true) {
+        formBody.capture_method = "manual";
+        formBody["payment_method_types[]"] = "card_present";
+      }
+      const pi = await stripePostRetail("/payment_intents", formBody);
+      // Stash a pending intent on the cart so cart-confirm-paid-with-intent
+      // can correlate without trusting the caller to forward the right id.
+      cart.pendingPaymentIntentId = pi.id;
+      cart.pendingPaymentIntentTotal = total;
+      cart.pendingPaymentIntentTaxRate = taxRate;
+      saveRetailState();
+      return {
+        ok: true,
+        result: {
+          clientSecret: pi.client_secret,
+          paymentIntentId: pi.id,
+          total,
+          subtotal: Math.round(subtotalAfter * 100) / 100,
+          tax: Math.round(tax * 100) / 100,
+          status: pi.status,
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `stripe payment-intent creation failed: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  registerLensAction("retail", "cart-confirm-paid-with-intent", async (ctx, _artifact, params = {}) => {
+    const s = getRetailState();
+    if (!s) return { ok: false, error: "STATE unavailable" };
+    const userId = retailActor(ctx);
+    const cartId = String(params.cartId || "");
+    const cart = s.carts.get(userId)?.get(cartId);
+    if (!cart) return { ok: false, error: "cart not found" };
+    if (!process.env.STRIPE_SECRET_KEY) {
+      return { ok: false, error: "Stripe not configured." };
+    }
+    const paymentIntentId = String(params.paymentIntentId || cart.pendingPaymentIntentId || "");
+    if (!paymentIntentId) return { ok: false, error: "paymentIntentId required" };
+    if (cart.pendingPaymentIntentId && cart.pendingPaymentIntentId !== paymentIntentId) {
+      return { ok: false, error: "paymentIntentId does not match cart's pending intent" };
+    }
+
+    // Verify with Stripe — never trust the client about payment status.
+    let pi;
+    try {
+      pi = await stripeGetRetail(`/payment_intents/${paymentIntentId}`);
+    } catch (e) {
+      return { ok: false, error: `stripe payment-intent fetch failed: ${e instanceof Error ? e.message : String(e)}` };
+    }
+    if (pi.status !== "succeeded") {
+      return { ok: false, error: `payment not succeeded (status=${pi.status}); cannot capture order` };
+    }
+    if (pi.metadata?.concord_user_id !== userId || pi.metadata?.concord_cart_id !== cartId) {
+      return { ok: false, error: "payment-intent metadata mismatch (user/cart)" };
+    }
+
+    const total = cart.pendingPaymentIntentTotal ?? (pi.amount / 100);
+    const taxRate = cart.pendingPaymentIntentTaxRate ?? 0;
+    const subtotal = cart.lines.reduce((sum, l) => sum + l.qty * l.unitPrice, 0);
+    const discount = (subtotal * cart.discountPercent) / 100;
+    const subtotalAfter = subtotal - discount;
+    const tax = subtotalAfter * (taxRate / 100);
+
+    // Decrement stock
+    for (const line of cart.lines) {
+      const product = s.products.get(userId)?.get(line.sku);
+      if (product) product.stock = Math.max(0, product.stock - line.qty);
+    }
+    if (!s.seq.has(userId)) s.seq.set(userId, { order: 1 });
+    const seq = s.seq.get(userId);
+    const order = {
+      id: nextRetailId("ord"),
+      number: `ORD-${String(seq.order).padStart(5, "0")}`,
+      lines: cart.lines,
+      subtotal: Math.round(subtotal * 100) / 100,
+      discount: Math.round(discount * 100) / 100,
+      tax: Math.round(tax * 100) / 100,
+      total: Math.round(total * 100) / 100,
+      tenders: [{ kind: "card", amount: total, provider: "stripe", paymentIntentId, charge: pi.latest_charge || null }],
+      tendered: total,
+      change: 0,
+      stripePaymentIntentId: paymentIntentId,
+      stripePaymentStatus: pi.status,
+      completedAt: nowIsoRet(),
+      paidVia: "stripe",
+    };
+    seq.order++;
+    if (!s.orders.has(userId)) s.orders.set(userId, []);
+    s.orders.get(userId).unshift(order);
+    s.carts.get(userId).delete(cartId);
+    saveRetailState();
+    return { ok: true, result: { order } };
+  });
 };

--- a/server/economy/stripe.js
+++ b/server/economy/stripe.js
@@ -364,6 +364,76 @@ export async function handleWebhook(db, { rawBody, signature, requestId, ip }) {
       break;
     }
 
+    case "payment_intent.succeeded": {
+      // retail.cart-create-payment-intent → Stripe PaymentIntent
+      // captured. Auto-confirm the cart and write the order. The cart's
+      // pendingPaymentIntentId is the correlation key; metadata carries
+      // concord_user_id + concord_cart_id.
+      const pi = event.data.object;
+      const concordUserId = pi?.metadata?.concord_user_id;
+      const concordCartId = pi?.metadata?.concord_cart_id;
+      if (concordUserId && concordCartId) {
+        try {
+          const STATE = globalThis._concordSTATE;
+          const cart = STATE?.retailLens?.carts?.get(concordUserId)?.get(concordCartId);
+          if (cart && cart.pendingPaymentIntentId === pi.id && cart.lines.length > 0) {
+            const taxRate = cart.pendingPaymentIntentTaxRate ?? 0;
+            const subtotal = cart.lines.reduce((sum, l) => sum + l.qty * l.unitPrice, 0);
+            const discount = (subtotal * cart.discountPercent) / 100;
+            const subtotalAfter = subtotal - discount;
+            const tax = subtotalAfter * (taxRate / 100);
+            const total = cart.pendingPaymentIntentTotal ?? (pi.amount / 100);
+            for (const line of cart.lines) {
+              const product = STATE.retailLens.products?.get(concordUserId)?.get(line.sku);
+              if (product) product.stock = Math.max(0, product.stock - line.qty);
+            }
+            if (!STATE.retailLens.seq) STATE.retailLens.seq = new Map();
+            if (!STATE.retailLens.seq.has(concordUserId)) STATE.retailLens.seq.set(concordUserId, { order: 1 });
+            const seq = STATE.retailLens.seq.get(concordUserId);
+            const order = {
+              id: `ord_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`,
+              number: `ORD-${String(seq.order).padStart(5, "0")}`,
+              lines: cart.lines,
+              subtotal: Math.round(subtotal * 100) / 100,
+              discount: Math.round(discount * 100) / 100,
+              tax: Math.round(tax * 100) / 100,
+              total: Math.round(total * 100) / 100,
+              tenders: [{ kind: "card", amount: total, provider: "stripe", paymentIntentId: pi.id, charge: pi.latest_charge || null }],
+              tendered: total,
+              change: 0,
+              stripePaymentIntentId: pi.id,
+              stripePaymentStatus: pi.status,
+              completedAt: nowISO(),
+              paidVia: "stripe",
+              autoConfirmedByWebhook: true,
+            };
+            seq.order++;
+            if (!STATE.retailLens.orders.has(concordUserId)) STATE.retailLens.orders.set(concordUserId, []);
+            STATE.retailLens.orders.get(concordUserId).unshift(order);
+            STATE.retailLens.carts.get(concordUserId).delete(concordCartId);
+            if (typeof globalThis._concordSaveStateDebounced === "function") {
+              try { globalThis._concordSaveStateDebounced(); } catch (_e) { /* best effort */ }
+            }
+            economyAudit(db, {
+              action: "retail_payment_intent_succeeded",
+              userId: concordUserId,
+              amount: total,
+              details: {
+                stripePaymentIntentId: pi.id,
+                concordCartId,
+                orderId: order.id,
+              },
+              requestId,
+              ip,
+            });
+          }
+        } catch (err) {
+          console.error("[Stripe Webhook] payment_intent.succeeded handler failed:", err.message);
+        }
+      }
+      break;
+    }
+
     case "invoice.payment_succeeded": {
       // accounting.invoice-create-payment-link → Stripe Invoice paid.
       // Locate the matching local invoice in STATE.accountingLens and

--- a/server/tests/retail-domain-parity.test.js
+++ b/server/tests/retail-domain-parity.test.js
@@ -116,3 +116,164 @@ describe("retail — orders + low stock", () => {
     assert.equal(r.result.lowStock[0].sku, "LOW");
   });
 });
+
+describe("retail — Stripe PaymentIntent POS (real card tender)", () => {
+  it("cart-create-payment-intent returns error pointing to STRIPE_SECRET_KEY when not set", async () => {
+    delete process.env.STRIPE_SECRET_KEY;
+    call("product-upsert", ctxA, { sku: "P1", name: "x", price: 10, stock: 5 });
+    const c = call("cart-open", ctxA);
+    call("cart-add-line", ctxA, { cartId: c.result.cart.id, sku: "P1", qty: 1 });
+    const r = await call("cart-create-payment-intent", ctxA, { cartId: c.result.cart.id });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /STRIPE_SECRET_KEY|Stripe not configured/);
+  });
+
+  it("cart-create-payment-intent rejects amount below Stripe minimum ($0.50)", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_dummy";
+    call("product-upsert", ctxA, { sku: "P1", name: "x", price: 0.10, stock: 5 });
+    const c = call("cart-open", ctxA);
+    call("cart-add-line", ctxA, { cartId: c.result.cart.id, sku: "P1", qty: 1 });
+    const r = await call("cart-create-payment-intent", ctxA, { cartId: c.result.cart.id });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /below Stripe minimum/);
+    delete process.env.STRIPE_SECRET_KEY;
+  });
+
+  it("cart-create-payment-intent POSTs to Stripe + returns clientSecret + stashes pending id", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_real";
+    const calls = [];
+    globalThis.fetch = async (url, opts) => {
+      calls.push({ url, body: opts?.body });
+      return { ok: true, json: async () => ({ id: "pi_test123", client_secret: "pi_test123_secret_abc", status: "requires_payment_method", amount: 1100 }) };
+    };
+    call("product-upsert", ctxA, { sku: "P1", name: "x", price: 10, stock: 5 });
+    const c = call("cart-open", ctxA);
+    call("cart-add-line", ctxA, { cartId: c.result.cart.id, sku: "P1", qty: 1 });
+    const r = await call("cart-create-payment-intent", ctxA, { cartId: c.result.cart.id, taxRate: 10 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.clientSecret, "pi_test123_secret_abc");
+    assert.equal(r.result.paymentIntentId, "pi_test123");
+    assert.equal(r.result.total, 11);
+    assert.equal(calls.length, 1);
+    assert.match(calls[0].url, /\/payment_intents/);
+    assert.match(calls[0].body, /amount=1100/);
+    assert.match(calls[0].body, /currency=usd/);
+    assert.match(calls[0].body, /metadata%5Bconcord_user_id%5D=u/);
+    // Pending intent persisted on cart
+    const cart = globalThis._concordSTATE.retailLens.carts.get("u").get(c.result.cart.id);
+    assert.equal(cart.pendingPaymentIntentId, "pi_test123");
+    delete process.env.STRIPE_SECRET_KEY;
+  });
+
+  it("cart-create-payment-intent with terminal:true requests manual capture + card_present", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_real";
+    let capturedBody = "";
+    globalThis.fetch = async (_url, opts) => {
+      capturedBody = opts?.body || "";
+      return { ok: true, json: async () => ({ id: "pi_x", client_secret: "x", status: "requires_payment_method", amount: 5000 }) };
+    };
+    call("product-upsert", ctxA, { sku: "P1", name: "x", price: 50, stock: 5 });
+    const c = call("cart-open", ctxA);
+    call("cart-add-line", ctxA, { cartId: c.result.cart.id, sku: "P1", qty: 1 });
+    await call("cart-create-payment-intent", ctxA, { cartId: c.result.cart.id, terminal: true });
+    assert.match(capturedBody, /capture_method=manual/);
+    assert.match(capturedBody, /payment_method_types%5B%5D=card_present/);
+    delete process.env.STRIPE_SECRET_KEY;
+  });
+
+  it("cart-confirm-paid-with-intent verifies server-side + decrements stock + writes order", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_real";
+    let getCalled = false;
+    globalThis.fetch = async (url) => {
+      if (url.includes("/payment_intents") && !getCalled) {
+        // First call: POST create
+        getCalled = true;
+        return { ok: true, json: async () => ({ id: "pi_done", client_secret: "x", status: "requires_payment_method", amount: 2000 }) };
+      }
+      // Second call: GET retrieve, returns succeeded
+      return {
+        ok: true,
+        json: async () => ({
+          id: "pi_done", status: "succeeded", amount: 2000,
+          metadata: { concord_user_id: "u", concord_cart_id: null /* will fill below */ },
+          latest_charge: "ch_test789",
+        }),
+      };
+    };
+    call("product-upsert", ctxA, { sku: "P1", name: "x", price: 20, stock: 10 });
+    const c = call("cart-open", ctxA);
+    const cartId = c.result.cart.id;
+    call("cart-add-line", ctxA, { cartId, sku: "P1", qty: 1 });
+    // Override fetch so the GET returns the right cartId in metadata
+    globalThis.fetch = async (url, opts) => {
+      if (opts?.method === "POST" || (!opts?.method && url.endsWith("/payment_intents"))) {
+        return { ok: true, json: async () => ({ id: "pi_done", client_secret: "x", status: "requires_payment_method", amount: 2000 }) };
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          id: "pi_done", status: "succeeded", amount: 2000,
+          metadata: { concord_user_id: "u", concord_cart_id: cartId },
+          latest_charge: "ch_test789",
+        }),
+      };
+    };
+    await call("cart-create-payment-intent", ctxA, { cartId });
+    const r = await call("cart-confirm-paid-with-intent", ctxA, { cartId, paymentIntentId: "pi_done" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.order.paidVia, "stripe");
+    assert.equal(r.result.order.stripePaymentIntentId, "pi_done");
+    assert.equal(r.result.order.tenders[0].kind, "card");
+    // Stock decremented
+    const product = globalThis._concordSTATE.retailLens.products.get("u").get("P1");
+    assert.equal(product.stock, 9);
+    // Cart cleared
+    assert.equal(globalThis._concordSTATE.retailLens.carts.get("u").has(cartId), false);
+    delete process.env.STRIPE_SECRET_KEY;
+  });
+
+  it("cart-confirm-paid-with-intent refuses when Stripe says not-succeeded", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_real";
+    globalThis.fetch = async (url, opts) => {
+      if (opts?.method === "POST" || (!opts?.method && url.endsWith("/payment_intents"))) {
+        return { ok: true, json: async () => ({ id: "pi_unpaid", client_secret: "x", status: "requires_payment_method", amount: 2000 }) };
+      }
+      return { ok: true, json: async () => ({ id: "pi_unpaid", status: "requires_action", metadata: {} }) };
+    };
+    call("product-upsert", ctxA, { sku: "P1", name: "x", price: 20, stock: 10 });
+    const c = call("cart-open", ctxA);
+    call("cart-add-line", ctxA, { cartId: c.result.cart.id, sku: "P1", qty: 1 });
+    await call("cart-create-payment-intent", ctxA, { cartId: c.result.cart.id });
+    const r = await call("cart-confirm-paid-with-intent", ctxA, { cartId: c.result.cart.id, paymentIntentId: "pi_unpaid" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /payment not succeeded/);
+    // Stock NOT decremented
+    assert.equal(globalThis._concordSTATE.retailLens.products.get("u").get("P1").stock, 10);
+    delete process.env.STRIPE_SECRET_KEY;
+  });
+
+  it("cart-confirm-paid-with-intent rejects metadata mismatch (anti-tamper)", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_real";
+    globalThis.fetch = async (url, opts) => {
+      if (opts?.method === "POST" || (!opts?.method && url.endsWith("/payment_intents"))) {
+        return { ok: true, json: async () => ({ id: "pi_x", client_secret: "x", status: "requires_payment_method", amount: 2000 }) };
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          id: "pi_x", status: "succeeded",
+          // metadata says it belongs to a different user / cart!
+          metadata: { concord_user_id: "v", concord_cart_id: "other_cart" },
+        }),
+      };
+    };
+    call("product-upsert", ctxA, { sku: "P1", name: "x", price: 20, stock: 10 });
+    const c = call("cart-open", ctxA);
+    call("cart-add-line", ctxA, { cartId: c.result.cart.id, sku: "P1", qty: 1 });
+    await call("cart-create-payment-intent", ctxA, { cartId: c.result.cart.id });
+    const r = await call("cart-confirm-paid-with-intent", ctxA, { cartId: c.result.cart.id, paymentIntentId: "pi_x" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /metadata mismatch/);
+    delete process.env.STRIPE_SECRET_KEY;
+  });
+});


### PR DESCRIPTION
## Summary

Continuation of **Bucket 2 Gap D — real payments**. `retail.cart-tender` previously accepted any tender kind (cash, card) without actually processing the card. This wires the real card path: Stripe PaymentIntent + Elements/Terminal SDK confirmation + **server-side verification before order capture**.

### Backend
- **`cart-create-payment-intent`** — env-gated by `STRIPE_SECRET_KEY`. POST `/payment_intents` with amount in cents, `currency:usd`, metadata carrying `concord_user_id` + `concord_cart_id`. Stashes the pending intent id on the cart so confirm cannot be spoofed. Returns `{ clientSecret, paymentIntentId, total }` for the frontend Stripe Elements / Terminal SDK to confirm.
  - `terminal:true` switches to `capture_method=manual` + `payment_method_types=card_present` for in-person reader flows.
- **`cart-confirm-paid-with-intent`** — re-fetches the PI from Stripe (NEVER trusts the client about payment status), checks `status === "succeeded"`, verifies metadata `concord_user_id` + `concord_cart_id` match the calling context (anti-tamper), then decrements stock + writes the order with Stripe IDs persisted.
- Existing `cart-tender` (cash path) untouched.
- `server/economy/stripe.js` — extended `handleWebhook` with `payment_intent.succeeded` case. Async card captures (e.g. webhook arrives before client confirms) auto-confirm the cart and write the order via the same path. Order flagged `autoConfirmedByWebhook:true` for audit.

## Test plan

- [x] `node --test server/tests/retail-domain-parity.test.js` — **18/18 passing** (7 new cases)
- [x] cart-create-payment-intent: env-gate, $0.50 minimum, real POST shape (URL-encoded form fields), pending intent persists on cart, `terminal:true` triggers `capture_method=manual` + `card_present`
- [x] cart-confirm-paid-with-intent: happy path (order + stock decrement + cart clear); rejects when Stripe says not-succeeded (stock NOT decremented); rejects metadata mismatch (anti-tamper)
- [ ] **UI flow** requires Stripe.js Elements on the frontend (follow-up). Webhook smoke needs Stripe CLI `stripe listen` — not testable here per CLAUDE.md

https://claude.ai/code/session_018ucd5N7Hc3K8mNa9p2Lr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_