### PR TITLE
feat(healthcare): real Stripe co-pay charging for appointments

### DIFF
--- a/server/domains/healthcare.js
+++ b/server/domains/healthcare.js
@@ -575,14 +575,105 @@ export default function registerHealthcareActions(registerLensAction) {
     const kind = ["telehealth", "in_person"].includes(params.kind) ? params.kind : "in_person";
     if (!providerId || !date || !time) return { ok: false, error: "providerId, date, time required" };
     if (!state.appointments.has(userId)) state.appointments.set(userId, []);
+    const copayUsd = Number(params.copayUsd);
     const appt = {
       id: `appt_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
       providerId, date, time, kind,
+      copayUsd: Number.isFinite(copayUsd) && copayUsd > 0 ? Math.round(copayUsd * 100) / 100 : 0,
+      copayStatus: "unpaid",
       status: "booked", bookedAt: new Date().toISOString(),
     };
     state.appointments.get(userId).push(appt);
     saveStateIfAvailable();
     return { ok: true, result: { appointment: appt } };
+  });
+
+  /**
+   * appointment-charge-copay — Stripe PaymentIntent for the appointment
+   * co-pay. Returns { clientSecret, paymentIntentId } so the patient-
+   * portal frontend can confirm via Stripe Elements. The webhook
+   * (server/economy/stripe.js payment_intent.succeeded) marks the
+   * appointment copayStatus:'paid' on capture.
+   *
+   * Per "everything must be real" directive: real Stripe API call,
+   * env-gated by STRIPE_SECRET_KEY, no synthetic copay processor.
+   */
+  registerLensAction("healthcare", "appointment-charge-copay", async (ctx, _artifact, params = {}) => {
+    const state = getHealthState(); if (!state) return { ok: false, error: "STATE unavailable" };
+    const userId = ctx?.actor?.userId || ctx?.userId || "anon";
+    const apptId = String(params.appointmentId || params.id || "");
+    if (!apptId) return { ok: false, error: "appointmentId required" };
+    const list = state.appointments.get(userId) || [];
+    const appt = list.find((a) => a.id === apptId);
+    if (!appt) return { ok: false, error: "appointment not found" };
+    if (appt.copayStatus === "paid") return { ok: false, error: "copay already paid" };
+    if (!appt.copayUsd || appt.copayUsd <= 0) return { ok: false, error: "appointment has no copay amount" };
+
+    if (!process.env.STRIPE_SECRET_KEY) {
+      return {
+        ok: false,
+        error: "Stripe not configured. Set STRIPE_SECRET_KEY env to enable co-pay charges.",
+      };
+    }
+    const amountCents = Math.round(appt.copayUsd * 100);
+    if (amountCents < 50) return { ok: false, error: "copay below Stripe minimum ($0.50 USD)" };
+
+    try {
+      const url = `https://api.stripe.com/v1/payment_intents`;
+      const body = new URLSearchParams({
+        amount: String(amountCents),
+        currency: "usd",
+        "automatic_payment_methods[enabled]": "true",
+        description: `Co-pay for appointment ${appt.id} (${appt.date} ${appt.time})`,
+        "metadata[concord_user_id]": userId,
+        "metadata[concord_appointment_id]": appt.id,
+        "metadata[concord_purpose]": "healthcare_copay",
+      }).toString();
+      const r = await fetch(url, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${process.env.STRIPE_SECRET_KEY}`,
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Stripe-Version": "2025-09-30.acacia",
+        },
+        body,
+      });
+      const data = await r.json();
+      if (!r.ok) throw new Error(`${r.status}: ${data?.error?.message || "unknown"}`);
+      appt.copayStatus = "pending";
+      appt.stripePaymentIntentId = data.id;
+      saveStateIfAvailable();
+      return {
+        ok: true,
+        result: {
+          clientSecret: data.client_secret,
+          paymentIntentId: data.id,
+          copayUsd: appt.copayUsd,
+          status: data.status,
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `stripe copay intent failed: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * appointment-list — lists appointments for the caller, sorted by date
+   * desc. Supports optional status filter (booked|completed|cancelled|all)
+   * and copay filter (unpaid|pending|paid|all).
+   */
+  registerLensAction("healthcare", "appointment-list", (ctx, _artifact, params = {}) => {
+    const state = getHealthState(); if (!state) return { ok: false, error: "STATE unavailable" };
+    const userId = ctx?.actor?.userId || ctx?.userId || "anon";
+    const status = ["booked", "completed", "cancelled", "all"].includes(params.status) ? params.status : "all";
+    const copayStatus = ["unpaid", "pending", "paid", "all"].includes(params.copayStatus) ? params.copayStatus : "all";
+    const list = state.appointments.get(userId) || [];
+    const filtered = list.filter((a) => {
+      if (status !== "all" && a.status !== status) return false;
+      if (copayStatus !== "all" && (a.copayStatus || "unpaid") !== copayStatus) return false;
+      return true;
+    }).slice().sort((a, b) => `${b.date} ${b.time}`.localeCompare(`${a.date} ${a.time}`));
+    return { ok: true, result: { appointments: filtered } };
   });
 
   /**

--- a/server/economy/stripe.js
+++ b/server/economy/stripe.js
@@ -365,13 +365,49 @@ export async function handleWebhook(db, { rawBody, signature, requestId, ip }) {
     }
 
     case "payment_intent.succeeded": {
-      // retail.cart-create-payment-intent → Stripe PaymentIntent
-      // captured. Auto-confirm the cart and write the order. The cart's
-      // pendingPaymentIntentId is the correlation key; metadata carries
-      // concord_user_id + concord_cart_id.
+      // Two purposes route through PaymentIntent succeeded today:
+      //   1. retail.cart-create-payment-intent → cart capture
+      //   2. healthcare.appointment-charge-copay → copay paid
+      // Disambiguated by metadata.concord_purpose ("healthcare_copay")
+      // or by presence of concord_cart_id vs concord_appointment_id.
       const pi = event.data.object;
       const concordUserId = pi?.metadata?.concord_user_id;
       const concordCartId = pi?.metadata?.concord_cart_id;
+      const concordAppointmentId = pi?.metadata?.concord_appointment_id;
+      const concordPurpose = pi?.metadata?.concord_purpose;
+
+      if (concordUserId && (concordAppointmentId || concordPurpose === "healthcare_copay")) {
+        try {
+          const STATE = globalThis._concordSTATE;
+          const list = STATE?.healthLens?.appointments?.get(concordUserId) || [];
+          const appt = list.find((a) => a.id === concordAppointmentId || a.stripePaymentIntentId === pi.id);
+          if (appt) {
+            appt.copayStatus = "paid";
+            appt.copayPaidAt = nowISO();
+            appt.stripePaymentIntentId = pi.id;
+            appt.stripeChargeId = pi.latest_charge || null;
+            if (typeof globalThis._concordSaveStateDebounced === "function") {
+              try { globalThis._concordSaveStateDebounced(); } catch (_e) { /* best effort */ }
+            }
+          }
+          economyAudit(db, {
+            action: "healthcare_copay_paid",
+            userId: concordUserId,
+            amount: pi.amount ? pi.amount / 100 : 0,
+            details: {
+              stripePaymentIntentId: pi.id,
+              concordAppointmentId,
+              matchFound: !!appt,
+            },
+            requestId,
+            ip,
+          });
+        } catch (err) {
+          console.error("[Stripe Webhook] healthcare copay handler failed:", err.message);
+        }
+        break;
+      }
+
       if (concordUserId && concordCartId) {
         try {
           const STATE = globalThis._concordSTATE;

--- a/server/tests/healthcare-domain-parity.test.js
+++ b/server/tests/healthcare-domain-parity.test.js
@@ -187,3 +187,100 @@ describe("regression: pre-existing analytical macros still work", () => {
     assert.ok(ACTIONS.size > 12);
   });
 });
+
+describe("healthcare.appointment-charge-copay (real Stripe)", () => {
+  it("rejects when STRIPE_SECRET_KEY env not set", async () => {
+    delete process.env.STRIPE_SECRET_KEY;
+    const booked = call("appointment-book", ctxA, { providerId: "p1", date: "2026-06-01", time: "10:00", copayUsd: 30 });
+    const r = await call("appointment-charge-copay", ctxA, { appointmentId: booked.result.appointment.id });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /STRIPE_SECRET_KEY|Stripe not configured/);
+  });
+
+  it("rejects when appointment has no copay amount", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_dummy";
+    const booked = call("appointment-book", ctxA, { providerId: "p1", date: "2026-06-01", time: "10:00" });
+    const r = await call("appointment-charge-copay", ctxA, { appointmentId: booked.result.appointment.id });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /no copay amount/);
+    delete process.env.STRIPE_SECRET_KEY;
+  });
+
+  it("creates a Stripe PaymentIntent for the copay (real API shape)", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_real";
+    let captured;
+    globalThis.fetch = async (url, opts) => {
+      captured = { url, body: opts?.body };
+      return {
+        ok: true,
+        json: async () => ({ id: "pi_copay123", client_secret: "pi_copay123_secret_xyz", status: "requires_payment_method", amount: 3000 }),
+      };
+    };
+    const booked = call("appointment-book", ctxA, { providerId: "p1", date: "2026-06-01", time: "10:00", copayUsd: 30 });
+    const r = await call("appointment-charge-copay", ctxA, { appointmentId: booked.result.appointment.id });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.clientSecret, "pi_copay123_secret_xyz");
+    assert.equal(r.result.paymentIntentId, "pi_copay123");
+    assert.equal(r.result.copayUsd, 30);
+    assert.match(captured.url, /\/payment_intents/);
+    assert.match(captured.body, /amount=3000/);
+    assert.match(captured.body, /metadata%5Bconcord_purpose%5D=healthcare_copay/);
+    assert.match(captured.body, /metadata%5Bconcord_user_id%5D=user_a/);
+    // appointment now in pending status
+    const list = globalThis._concordSTATE.healthLens.appointments.get("user_a");
+    assert.equal(list[0].copayStatus, "pending");
+    assert.equal(list[0].stripePaymentIntentId, "pi_copay123");
+    delete process.env.STRIPE_SECRET_KEY;
+  });
+
+  it("rejects double-charging an already-paid copay", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_real";
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({ id: "pi_xx", client_secret: "x", status: "requires_payment_method", amount: 3000 }),
+    });
+    const booked = call("appointment-book", ctxA, { providerId: "p1", date: "2026-06-01", time: "10:00", copayUsd: 30 });
+    await call("appointment-charge-copay", ctxA, { appointmentId: booked.result.appointment.id });
+    // Simulate webhook flipping to paid
+    globalThis._concordSTATE.healthLens.appointments.get("user_a")[0].copayStatus = "paid";
+    const r2 = await call("appointment-charge-copay", ctxA, { appointmentId: booked.result.appointment.id });
+    assert.equal(r2.ok, false);
+    assert.match(r2.error, /already paid/);
+    delete process.env.STRIPE_SECRET_KEY;
+  });
+
+  it("surfaces real Stripe error messages on API failure", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_bad";
+    globalThis.fetch = async () => ({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: { message: "Invalid API Key" } }),
+    });
+    const booked = call("appointment-book", ctxA, { providerId: "p1", date: "2026-06-01", time: "10:00", copayUsd: 30 });
+    const r = await call("appointment-charge-copay", ctxA, { appointmentId: booked.result.appointment.id });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /Invalid API Key|stripe/i);
+    delete process.env.STRIPE_SECRET_KEY;
+  });
+});
+
+describe("healthcare.appointment-list", () => {
+  it("lists appointments scoped per-user, sorted date desc", () => {
+    call("appointment-book", ctxA, { providerId: "p1", date: "2026-05-01", time: "09:00" });
+    call("appointment-book", ctxA, { providerId: "p1", date: "2026-06-01", time: "10:00" });
+    const r = call("appointment-list", ctxA, {});
+    assert.equal(r.result.appointments.length, 2);
+    assert.equal(r.result.appointments[0].date, "2026-06-01");
+  });
+
+  it("filters by copayStatus", () => {
+    const a = call("appointment-book", ctxA, { providerId: "p1", date: "2026-06-01", time: "10:00", copayUsd: 25 });
+    const b = call("appointment-book", ctxA, { providerId: "p1", date: "2026-06-02", time: "11:00", copayUsd: 25 });
+    // Mark first one paid
+    globalThis._concordSTATE.healthLens.appointments.get("user_a")
+      .find((x) => x.id === a.result.appointment.id).copayStatus = "paid";
+    void b;
+    assert.equal(call("appointment-list", ctxA, { copayStatus: "paid" }).result.appointments.length, 1);
+    assert.equal(call("appointment-list", ctxA, { copayStatus: "unpaid" }).result.appointments.length, 1);
+  });
+});


### PR DESCRIPTION
## Summary

Continuation of **Bucket 2 Gap D — real payments**. `healthcare.appointment-book` previously recorded an appointment with no payment hook — patients couldn't pay the co-pay through the lens. This wires real Stripe PaymentIntent co-pay charging tied to the appointment record.

### Backend
- `appointment-book` extended with optional `copayUsd` param; persists `copayStatus:'unpaid'` alongside the appointment.
- **`appointment-charge-copay`** — env-gated by `STRIPE_SECRET_KEY`. POST `/payment_intents` with amount in cents + `metadata.concord_user_id` + `concord_appointment_id` + `concord_purpose='healthcare_copay'`. Refuses double-charge, missing copay amount, amounts < $0.50, surfaces real Stripe error messages.
- **`appointment-list`** — filterable by `status` (booked|completed|cancelled) and `copayStatus` (unpaid|pending|paid), sorted by date desc.
- `server/economy/stripe.js` — `payment_intent.succeeded` webhook disambiguates between retail cart capture and healthcare copay via `metadata.concord_purpose`. Healthcare branch flips `appt.copayStatus='paid'` + records `stripeChargeId`, logs via `economyAudit('healthcare_copay_paid')`.

## Test plan

- [x] `node --test server/tests/healthcare-domain-parity.test.js` — **24/24 passing** (7 new cases)
- [x] env-gate, no-copay rejection, real PaymentIntent POST shape with copay-specific metadata, double-charge rejection, Stripe 401 error surface, appointment-list per-user scoping + copay filter
- [ ] UI flow needs Stripe.js Elements in the patient portal (follow-up)

https://claude.ai/code/session_018ucd5N7Hc3K8mNa9p2Lr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_