### PR TITLE
feat(payment): Stripe Elements frontend wire-up — retail POS + healthcare copay + accounting payment links

### DIFF
--- a/concord-frontend/components/accounting/AccountingWorkbench.tsx
+++ b/concord-frontend/components/accounting/AccountingWorkbench.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import {
-  X, Loader2, BookOpen, TrendingUp, Landmark, Calculator, Receipt, Plus, Save, Trash2, Check, AlertTriangle, FileText,
+  X, Loader2, BookOpen, TrendingUp, Landmark, Calculator, Receipt, Plus, Save, Trash2, Check, AlertTriangle, FileText, Link as LinkIcon,
 } from 'lucide-react';
 import { api } from '@/lib/api/client';
 import { cn } from '@/lib/utils';
@@ -729,6 +729,28 @@ function AgingTab() {
     } catch (e) { console.error(e); }
   };
 
+  const [linkPrompt, setLinkPrompt] = useState<string | null>(null);
+  const [linkEmail, setLinkEmail] = useState('');
+  const [linkResult, setLinkResult] = useState<{ url: string; pdf: string } | null>(null);
+  const [linkError, setLinkError] = useState<string | null>(null);
+
+  const sendPaymentLink = async () => {
+    if (!linkPrompt) return;
+    setLinkError(null); setLinkResult(null);
+    try {
+      const res = await api.post('/api/lens/run', {
+        domain: 'accounting', action: 'invoice-create-payment-link',
+        input: { id: linkPrompt, customerEmail: linkEmail.trim() },
+      });
+      const data = res.data as { ok?: boolean; error?: string; result?: { hostedUrl?: string; pdfUrl?: string } };
+      if (data.ok && data.result?.hostedUrl) {
+        setLinkResult({ url: data.result.hostedUrl, pdf: data.result.pdfUrl || '' });
+      } else {
+        setLinkError(data.error || 'Failed to create payment link');
+      }
+    } catch (e) { setLinkError((e as Error).message); }
+  };
+
   const fmt = (n: number) => n.toFixed(2);
 
   return (
@@ -813,6 +835,14 @@ function AgingTab() {
                     <span className="font-mono text-gray-200">${fmt(inv.total)}</span>
                     <button
                       type="button"
+                      onClick={() => { setLinkPrompt(inv.id); setLinkEmail(''); setLinkResult(null); setLinkError(null); }}
+                      className="px-2 py-0.5 rounded border border-cyan-500/30 bg-cyan-500/10 text-[10px] text-cyan-200 opacity-0 group-hover:opacity-100 inline-flex items-center gap-1"
+                      title="Send Stripe payment link"
+                    >
+                      <LinkIcon className="w-3 h-3" /> Pay link
+                    </button>
+                    <button
+                      type="button"
                       onClick={() => markPaid(inv.id)}
                       className="px-2 py-0.5 rounded border border-emerald-500/30 bg-emerald-500/10 text-[10px] text-emerald-200 opacity-0 group-hover:opacity-100"
                     >
@@ -824,6 +854,52 @@ function AgingTab() {
             )}
           </div>
         ))
+      )}
+
+      {linkPrompt && (
+        <div className="rounded-lg border border-cyan-500/30 bg-cyan-500/5 p-3 space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-cyan-200">Send Stripe payment link</span>
+            <button type="button" onClick={() => setLinkPrompt(null)} className="text-zinc-500 hover:text-zinc-300">
+              <X className="w-3 h-3" />
+            </button>
+          </div>
+          {!linkResult ? (
+            <>
+              <input
+                type="email" autoFocus placeholder="Customer email"
+                value={linkEmail}
+                onChange={(e) => setLinkEmail(e.target.value)}
+                className="w-full px-2 py-1.5 text-sm bg-black/40 border border-white/10 rounded text-gray-100"
+              />
+              <button
+                type="button" onClick={sendPaymentLink}
+                disabled={!linkEmail.includes('@')}
+                className="w-full px-3 py-1.5 rounded border border-cyan-500/40 bg-cyan-500/15 text-xs text-cyan-100 disabled:opacity-40"
+              >Create hosted invoice link</button>
+              {linkError && <p className="text-xs text-rose-300">{linkError}</p>}
+            </>
+          ) : (
+            <div className="space-y-2">
+              <p className="text-xs text-emerald-300">✓ Hosted invoice created</p>
+              <a href={linkResult.url} target="_blank" rel="noopener noreferrer"
+                className="block text-xs text-cyan-200 underline break-all">{linkResult.url}</a>
+              <div className="flex gap-2">
+                <button type="button"
+                  onClick={() => { void navigator.clipboard?.writeText(linkResult.url); }}
+                  className="flex-1 px-2 py-1 rounded border border-cyan-500/30 bg-cyan-500/5 text-xs text-cyan-200">
+                  Copy link
+                </button>
+                {linkResult.pdf && (
+                  <a href={linkResult.pdf} target="_blank" rel="noopener noreferrer"
+                    className="flex-1 px-2 py-1 rounded border border-zinc-700 bg-zinc-900 text-xs text-zinc-200 text-center">
+                    Open PDF
+                  </a>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
       )}
     </div>
   );

--- a/concord-frontend/components/healthcare/AppointmentScheduler.tsx
+++ b/concord-frontend/components/healthcare/AppointmentScheduler.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Calendar, Search, Loader2, Video, MapPin } from 'lucide-react';
+import { Calendar, Search, Loader2, Video, MapPin, CreditCard } from 'lucide-react';
 import { api } from '@/lib/api/client';
 import { cn } from '@/lib/utils';
+import { StripePaymentForm } from '@/components/payment/StripePaymentForm';
 
 export interface Provider {
   id: string;
@@ -33,7 +34,10 @@ export function AppointmentScheduler() {
   const [selectedProvider, setSelectedProvider] = useState<Provider | null>(null);
   const [slots, setSlots] = useState<AppointmentSlot[]>([]);
   const [bookingId, setBookingId] = useState<string | null>(null);
-  const [confirmed, setConfirmed] = useState<{ providerId: string; slot: AppointmentSlot } | null>(null);
+  const [confirmed, setConfirmed] = useState<{ providerId: string; slot: AppointmentSlot; appointmentId?: string; copayUsd?: number } | null>(null);
+  const [copayUsd, setCopayUsd] = useState<string>('');
+  const [copayIntent, setCopayIntent] = useState<{ clientSecret: string; copayUsd: number } | null>(null);
+  const [copayMessage, setCopayMessage] = useState<string | null>(null);
 
   useEffect(() => { search(); }, []);
 
@@ -63,13 +67,40 @@ export function AppointmentScheduler() {
     if (!selectedProvider) return;
     setBookingId(slot.date + slot.time);
     try {
-      await api.post('/api/lens/run', {
+      const copayNum = Number(copayUsd);
+      const res = await api.post('/api/lens/run', {
         domain: 'healthcare', action: 'appointment-book',
-        input: { providerId: selectedProvider.id, date: slot.date, time: slot.time, kind: slot.kind },
+        input: {
+          providerId: selectedProvider.id, date: slot.date, time: slot.time, kind: slot.kind,
+          copayUsd: Number.isFinite(copayNum) && copayNum > 0 ? copayNum : undefined,
+        },
       });
-      setConfirmed({ providerId: selectedProvider.id, slot });
+      const appt = (res.data as { result?: { appointment?: { id: string; copayUsd?: number } } }).result?.appointment;
+      setConfirmed({ providerId: selectedProvider.id, slot, appointmentId: appt?.id, copayUsd: appt?.copayUsd });
     } catch (e) { console.error('[Book] failed', e); }
     finally { setBookingId(null); }
+  }
+
+  async function chargeCopay() {
+    if (!confirmed?.appointmentId) return;
+    setCopayMessage(null);
+    try {
+      const res = await api.post('/api/lens/run', {
+        domain: 'healthcare', action: 'appointment-charge-copay',
+        input: { appointmentId: confirmed.appointmentId },
+      });
+      const data = res.data as { ok?: boolean; error?: string; result?: { clientSecret: string; copayUsd: number } };
+      if (data.ok && data.result) {
+        setCopayIntent({ clientSecret: data.result.clientSecret, copayUsd: data.result.copayUsd });
+      } else {
+        setCopayMessage(data.error || 'Co-pay charge unavailable');
+      }
+    } catch (e) { setCopayMessage((e as Error).message); }
+  }
+
+  function onCopaySuccess() {
+    setCopayMessage('✓ Co-pay paid');
+    setCopayIntent(null);
   }
 
   // Group slots by date
@@ -130,16 +161,46 @@ export function AppointmentScheduler() {
           {!selectedProvider ? (
             <div className="text-xs text-gray-500 italic text-center py-10">Select a provider to see availability.</div>
           ) : confirmed ? (
-            <div className="bg-green-500/10 border border-green-500/40 rounded p-4 text-center">
-              <Calendar className="w-8 h-8 text-green-400 mx-auto mb-2" />
-              <h3 className="text-sm font-bold text-green-300 mb-1">Appointment booked!</h3>
-              <p className="text-xs text-gray-300">{selectedProvider.name} · {confirmed.slot.date} at {confirmed.slot.time}</p>
-              <p className="text-[10px] text-gray-500 mt-1">{confirmed.slot.kind === 'telehealth' ? 'Video call link will be sent before visit' : 'In-person'}</p>
+            <div className="space-y-3">
+              <div className="bg-green-500/10 border border-green-500/40 rounded p-4 text-center">
+                <Calendar className="w-8 h-8 text-green-400 mx-auto mb-2" />
+                <h3 className="text-sm font-bold text-green-300 mb-1">Appointment booked!</h3>
+                <p className="text-xs text-gray-300">{selectedProvider.name} · {confirmed.slot.date} at {confirmed.slot.time}</p>
+                <p className="text-[10px] text-gray-500 mt-1">{confirmed.slot.kind === 'telehealth' ? 'Video call link will be sent before visit' : 'In-person'}</p>
+              </div>
+              {confirmed.copayUsd && confirmed.copayUsd > 0 && !copayIntent && (
+                <button
+                  type="button"
+                  onClick={chargeCopay}
+                  className="w-full inline-flex items-center justify-center gap-2 px-3 py-2 rounded border border-cyan-500/40 bg-cyan-500/15 text-sm text-cyan-100"
+                >
+                  <CreditCard className="w-4 h-4" /> Pay ${confirmed.copayUsd.toFixed(2)} co-pay
+                </button>
+              )}
+              {copayIntent && (
+                <StripePaymentForm
+                  clientSecret={copayIntent.clientSecret}
+                  amountUsd={copayIntent.copayUsd}
+                  description="Visit co-pay"
+                  onSuccess={onCopaySuccess}
+                  onCancel={() => setCopayIntent(null)}
+                />
+              )}
+              {copayMessage && <p className="text-[11px] text-emerald-300 text-center">{copayMessage}</p>}
             </div>
           ) : (
             <div className="space-y-3">
               <div className="text-sm font-medium text-white">{selectedProvider.name}</div>
               <div className="text-xs text-gray-400">{selectedProvider.specialty} · {selectedProvider.practice}</div>
+              <div className="rounded border border-zinc-700 bg-zinc-900/60 p-2">
+                <label className="text-[10px] uppercase tracking-wider text-zinc-500">Co-pay (USD, optional)</label>
+                <input
+                  type="number" min={0} step="0.01" placeholder="0.00"
+                  value={copayUsd}
+                  onChange={(e) => setCopayUsd(e.target.value)}
+                  className="mt-1 w-full bg-zinc-950 border border-zinc-700 rounded px-2 py-1 text-xs text-zinc-100 font-mono"
+                />
+              </div>
               {Object.entries(slotsByDate).slice(0, 10).map(([date, daySlots]) => (
                 <div key={date}>
                   <div className="text-[10px] uppercase tracking-wider text-gray-500 mb-1">

--- a/concord-frontend/components/payment/StripePaymentForm.tsx
+++ b/concord-frontend/components/payment/StripePaymentForm.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+/**
+ * StripePaymentForm — reusable Stripe Elements payment confirmation
+ * surface for retail POS / healthcare copay / any future PaymentIntent
+ * flow.
+ *
+ * Lifecycle:
+ *   1. Caller obtains a clientSecret from a server macro (e.g.
+ *      retail.cart-create-payment-intent → returns clientSecret).
+ *   2. Mount <StripePaymentForm clientSecret={...} onSuccess={...} />.
+ *   3. Form loads Stripe.js from CDN, mounts the Payment Element,
+ *      and shows a Pay button.
+ *   4. On submit: stripe.confirmPayment with redirect:'if_required'.
+ *      Cards that need 3DS auto-redirect; cards that don't return
+ *      immediately and the form calls onSuccess({paymentIntentId}).
+ *   5. Caller's onSuccess handler typically POSTs the corresponding
+ *      confirm macro server-side (e.g. retail.cart-confirm-paid-with-intent)
+ *      which re-fetches the PaymentIntent from Stripe and captures
+ *      the order. The form does NOT trust client-side success alone.
+ *
+ * Requires NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY env at build time.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { loadStripeJs, type StripeJsGlobal, type StripeElementsGroup } from '@/lib/stripe/load-stripe-js';
+
+export interface StripePaymentFormProps {
+  clientSecret: string;
+  amountUsd: number;
+  description?: string;
+  onSuccess: (result: { paymentIntentId: string }) => void;
+  onCancel?: () => void;
+  submitLabel?: string;
+  className?: string;
+}
+
+export function StripePaymentForm({
+  clientSecret,
+  amountUsd,
+  description,
+  onSuccess,
+  onCancel,
+  submitLabel,
+  className,
+}: StripePaymentFormProps) {
+  const [status, setStatus] = useState<'loading' | 'ready' | 'submitting' | 'success' | 'error'>('loading');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const stripeRef = useRef<StripeJsGlobal | null>(null);
+  const elementsRef = useRef<StripeElementsGroup | null>(null);
+  const elementMountRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const publishableKey = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
+      if (!publishableKey) {
+        if (!cancelled) {
+          setStatus('error');
+          setErrorMessage('NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY env not configured.');
+        }
+        return;
+      }
+      const stripe = await loadStripeJs(publishableKey);
+      if (cancelled) return;
+      if (!stripe) {
+        setStatus('error');
+        setErrorMessage('Stripe.js failed to load. Check your network + ad-blocker.');
+        return;
+      }
+      stripeRef.current = stripe;
+      const elements = stripe.elements({
+        clientSecret,
+        appearance: {
+          theme: 'night',
+          variables: {
+            colorPrimary: '#06b6d4',
+            colorBackground: '#0c0c0d',
+            colorText: '#f4f4f5',
+            colorDanger: '#f43f5e',
+            fontFamily: 'ui-sans-serif, system-ui, sans-serif',
+            borderRadius: '8px',
+          },
+        },
+      });
+      elementsRef.current = elements;
+      const paymentElement = elements.create('payment', { layout: 'tabs' });
+      if (elementMountRef.current) {
+        paymentElement.mount(elementMountRef.current);
+        if (!cancelled) setStatus('ready');
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [clientSecret]);
+
+  async function handleSubmit(ev: React.FormEvent) {
+    ev.preventDefault();
+    const stripe = stripeRef.current;
+    const elements = elementsRef.current;
+    if (!stripe || !elements) return;
+    setStatus('submitting');
+    setErrorMessage(null);
+    try {
+      const { error, paymentIntent } = await stripe.confirmPayment({
+        elements,
+        // if_required: cards that don't need 3DS skip the redirect and
+        // return synchronously. Cards that DO need 3DS redirect away;
+        // when the user comes back, the page-level PaymentIntent status
+        // check should run (caller's responsibility).
+        redirect: 'if_required',
+      });
+      if (error) {
+        setStatus('error');
+        setErrorMessage(error.message || 'Payment failed. Please try again.');
+        return;
+      }
+      if (paymentIntent && paymentIntent.status === 'succeeded') {
+        setStatus('success');
+        onSuccess({ paymentIntentId: paymentIntent.id });
+      } else {
+        setStatus('error');
+        setErrorMessage(`Payment status: ${paymentIntent?.status || 'unknown'} — please try again.`);
+      }
+    } catch (e) {
+      setStatus('error');
+      setErrorMessage(e instanceof Error ? e.message : 'Unexpected payment error.');
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className={className ?? 'space-y-4'}>
+      <div className="rounded-xl border border-zinc-700 bg-zinc-900/80 p-4">
+        <div className="mb-3 flex items-baseline justify-between">
+          <span className="text-xs text-zinc-400 uppercase tracking-wider">{description ?? 'Payment'}</span>
+          <span className="text-lg font-semibold text-zinc-100">${amountUsd.toFixed(2)}</span>
+        </div>
+        <div ref={elementMountRef} aria-label="Stripe payment element" />
+        {status === 'loading' && <p className="mt-3 text-xs text-zinc-500">Loading secure payment form…</p>}
+      </div>
+      {errorMessage && (
+        <div className="rounded-lg border border-rose-700/50 bg-rose-950/40 px-3 py-2 text-sm text-rose-200">
+          {errorMessage}
+        </div>
+      )}
+      <div className="flex gap-2">
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={status === 'submitting'}
+            className="flex-1 rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-zinc-300 hover:bg-zinc-800 disabled:opacity-50"
+          >Cancel</button>
+        )}
+        <button
+          type="submit"
+          disabled={status !== 'ready'}
+          className="flex-1 rounded-lg bg-cyan-500 px-4 py-2 text-sm font-medium text-cyan-950 hover:bg-cyan-400 disabled:opacity-50"
+        >
+          {status === 'submitting' ? 'Processing…' :
+           status === 'success' ? '✓ Paid' :
+           submitLabel ?? `Pay $${amountUsd.toFixed(2)}`}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/concord-frontend/components/retail/RetailWorkbench.tsx
+++ b/concord-frontend/components/retail/RetailWorkbench.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { X, Loader2, ShoppingCart, Package, Receipt, AlertTriangle, Plus, Trash2, Save, DollarSign } from 'lucide-react';
+import { X, Loader2, ShoppingCart, Package, Receipt, AlertTriangle, Plus, Trash2, Save, DollarSign, CreditCard } from 'lucide-react';
 import { api } from '@/lib/api/client';
 import { cn } from '@/lib/utils';
+import { StripePaymentForm } from '@/components/payment/StripePaymentForm';
 
 export interface Product {
   sku: string;
@@ -80,6 +81,7 @@ function POSTab() {
   const [totals, setTotals] = useState<{ subtotal: number; tax: number; total: number; itemCount: number } | null>(null);
   const [tenderAmount, setTenderAmount] = useState('');
   const [message, setMessage] = useState<string | null>(null);
+  const [cardIntent, setCardIntent] = useState<{ clientSecret: string; paymentIntentId: string; total: number } | null>(null);
 
   const refreshProducts = useCallback(async () => {
     try {
@@ -139,6 +141,40 @@ function POSTab() {
     } catch (e) { setMessage((e as Error).message); }
   };
 
+  const tenderWithCard = async () => {
+    if (!cartId) return;
+    try {
+      const r = await api.post('/api/lens/run', {
+        domain: 'retail', action: 'cart-create-payment-intent',
+        input: { cartId, taxRate: 8 },
+      });
+      const data = r.data as { ok?: boolean; error?: string; result?: { clientSecret: string; paymentIntentId: string; total: number } };
+      if (data.ok && data.result) {
+        setCardIntent({ clientSecret: data.result.clientSecret, paymentIntentId: data.result.paymentIntentId, total: data.result.total });
+      } else {
+        setMessage(data.error || 'Card payment unavailable');
+      }
+    } catch (e) { setMessage((e as Error).message); }
+  };
+
+  const onCardSuccess = async ({ paymentIntentId }: { paymentIntentId: string }) => {
+    if (!cartId) return;
+    try {
+      const r = await api.post('/api/lens/run', {
+        domain: 'retail', action: 'cart-confirm-paid-with-intent',
+        input: { cartId, paymentIntentId },
+      });
+      const data = r.data as { ok?: boolean; error?: string; result?: { order?: { number: string } } };
+      if (data.ok) {
+        setMessage(`✓ Card payment captured · ${data.result?.order?.number}`);
+        await openCart();
+        setCardIntent(null);
+      } else {
+        setMessage(data.error || 'Capture failed (payment may need manual reconcile)');
+      }
+    } catch (e) { setMessage((e as Error).message); }
+  };
+
   return (
     <div className="grid grid-cols-2 gap-2 p-3 h-full">
       <div className="space-y-1 overflow-y-auto">
@@ -181,10 +217,25 @@ function POSTab() {
             placeholder="Tender" className="flex-1 px-2 py-1.5 text-xs bg-black/40 border border-white/10 rounded text-gray-100 font-mono" />
           <button type="button" onClick={tender} disabled={!tenderAmount}
             className="px-3 py-1 rounded-md border border-rose-500/40 bg-rose-500/15 text-xs text-rose-100 disabled:opacity-40">
-            <DollarSign className="w-3 h-3 inline" /> Tender
+            <DollarSign className="w-3 h-3 inline" /> Cash
+          </button>
+          <button type="button" onClick={tenderWithCard} disabled={!totals || totals.total <= 0}
+            className="px-3 py-1 rounded-md border border-cyan-500/40 bg-cyan-500/15 text-xs text-cyan-100 disabled:opacity-40">
+            <CreditCard className="w-3 h-3 inline" /> Card
           </button>
         </div>
         {message && <p className="text-[11px] text-emerald-300 mt-2">{message}</p>}
+        {cardIntent && (
+          <div className="mt-3 border-t border-white/10 pt-3">
+            <StripePaymentForm
+              clientSecret={cardIntent.clientSecret}
+              amountUsd={cardIntent.total}
+              description="Cart checkout"
+              onSuccess={onCardSuccess}
+              onCancel={() => setCardIntent(null)}
+            />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/concord-frontend/lib/stripe/load-stripe-js.ts
+++ b/concord-frontend/lib/stripe/load-stripe-js.ts
@@ -1,0 +1,97 @@
+/**
+ * Stripe.js loader — script-injection pattern, no @stripe/stripe-js
+ * npm dependency. Loads the official Stripe.js from js.stripe.com/v3,
+ * memoizes by publishable key.
+ *
+ * Why no @stripe/stripe-js? It's a thin wrapper over this same script
+ * tag, and adding it would trigger the "new top-level dependency"
+ * escalation per CLAUDE.md. The Stripe.js global API is stable and
+ * directly callable without the wrapper.
+ *
+ * Usage:
+ *   const stripe = await loadStripeJs(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!);
+ *   const elements = stripe.elements({ clientSecret });
+ *   const paymentElement = elements.create('payment');
+ *   paymentElement.mount('#payment-element');
+ */
+
+const STRIPE_V3_SRC = 'https://js.stripe.com/v3/';
+
+interface StripeJsGlobal {
+  // Minimal subset of Stripe.js v3 API we use. The real Stripe global
+  // has many more methods; we only type the ones the form touches.
+  elements: (opts: { clientSecret?: string; appearance?: object }) => StripeElementsGroup;
+  confirmPayment: (opts: {
+    elements: StripeElementsGroup;
+    confirmParams?: { return_url?: string };
+    redirect?: 'always' | 'if_required';
+  }) => Promise<{ error?: { type: string; message?: string; code?: string }; paymentIntent?: { id: string; status: string } }>;
+  retrievePaymentIntent: (clientSecret: string) => Promise<{ paymentIntent?: { id: string; status: string }; error?: { message?: string } }>;
+}
+
+interface StripeElementsGroup {
+  create: (kind: 'payment' | 'card', options?: object) => StripeElement;
+  getElement: (kind: 'payment' | 'card') => StripeElement | null;
+}
+
+interface StripeElement {
+  mount: (selectorOrNode: string | HTMLElement) => void;
+  unmount: () => void;
+  destroy: () => void;
+  on: (event: string, handler: (ev: unknown) => void) => void;
+}
+
+declare global {
+  interface Window {
+    Stripe?: (publishableKey: string) => StripeJsGlobal;
+  }
+}
+
+// Module-level cache keyed by publishable key. loadStripeJs is safe
+// to call concurrently — the second caller awaits the same promise.
+const stripeByKey = new Map<string, Promise<StripeJsGlobal | null>>();
+
+let scriptInjectPromise: Promise<void> | null = null;
+
+function injectStripeScript(): Promise<void> {
+  if (typeof window === 'undefined') return Promise.reject(new Error('Stripe.js only loads in the browser'));
+  if (window.Stripe) return Promise.resolve();
+  if (scriptInjectPromise) return scriptInjectPromise;
+
+  scriptInjectPromise = new Promise<void>((resolve, reject) => {
+    // Reuse an existing script tag (e.g. from a prior page navigation)
+    const existing = document.querySelector(`script[src="${STRIPE_V3_SRC}"]`);
+    if (existing) {
+      if (window.Stripe) return resolve();
+      existing.addEventListener('load', () => resolve(), { once: true });
+      existing.addEventListener('error', () => reject(new Error('Stripe.js failed to load')), { once: true });
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = STRIPE_V3_SRC;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error('Stripe.js failed to load'));
+    document.head.appendChild(script);
+  });
+  return scriptInjectPromise;
+}
+
+export async function loadStripeJs(publishableKey: string): Promise<StripeJsGlobal | null> {
+  if (!publishableKey) return null;
+  const cached = stripeByKey.get(publishableKey);
+  if (cached) return cached;
+  const promise = (async () => {
+    try {
+      await injectStripeScript();
+      if (!window.Stripe) return null;
+      return window.Stripe(publishableKey);
+    } catch (_e) {
+      return null;
+    }
+  })();
+  stripeByKey.set(publishableKey, promise);
+  return promise;
+}
+
+export type { StripeJsGlobal, StripeElementsGroup, StripeElement };


### PR DESCRIPTION
## Summary

Closes the UI loop on the four Bucket 2 Gap D Stripe paths shipped backend-only in PRs #457 / #459 / #460 / #461.

### New shared infrastructure
- `lib/stripe/load-stripe-js.ts` — Stripe.js loader via CDN script-injection, memoized per-publishable-key. **No new npm dependency** (avoids `@stripe/stripe-js` since it's a thin wrapper over the same script tag; per CLAUDE.md "escalate before adding new top-level deps" we use the inline pattern).
- `components/payment/StripePaymentForm.tsx` — reusable Elements payment surface with Concord's dark theme. `redirect:'if_required'` so non-3DS cards return synchronously; 3DS-required cards auto-redirect.

### Wire-ups
- **Retail POS** — new "Card" button beside "Cash". `cart-create-payment-intent` → `StripePaymentForm` → `cart-confirm-paid-with-intent` (server re-fetches PI, writes order; never trusts client).
- **Healthcare** — optional `copayUsd` input in slot-picker; persists when booking. Confirmed view shows "Pay $X co-pay" → `appointment-charge-copay` → `StripePaymentForm`.
- **Accounting** — new "Pay link" button per open invoice. Email prompt → `invoice-create-payment-link` → shows `hosted_invoice_url` + PDF link + copy-to-clipboard. No Elements needed (Stripe hosts the page).

### Deferred
- **Crypto swap-execute**: `swap-route` returns a signable transaction blob, but broadcasting it needs wallet-connect signing (different stack from Stripe.js). Separate PR.

## Test plan

- [x] `tsc --noEmit` — 0 errors (clean type-check)
- [ ] E2E payment smoke needs real Stripe test keys + browser — not testable in this environment per CLAUDE.md

### Env required
- `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` (build time) — retail + healthcare flows
- `STRIPE_SECRET_KEY` (server-side, already wired) — all four

https://claude.ai/code/session_018ucd5N7Hc3K8mNa9p2Lr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_