### PR TITLE
feat(astronomy): real NASA APOD + ISS location + NeoWs near-earth objects

### DIFF
--- a/server/domains/astronomy.js
+++ b/server/domains/astronomy.js
@@ -1,6 +1,15 @@
 // server/domains/astronomy.js
-// Domain actions for astronomy: celestial position calculation, magnitude estimation,
-// observation planning, light travel time, orbital mechanics.
+// Domain actions for astronomy: celestial position, observation planning,
+// orbital mechanics, plus real-data NASA APIs (APOD, ISS location, near-earth-object lookup).
+//
+// Free data sources:
+//   • NASA APOD (Astronomy Picture of the Day): api.nasa.gov/planetary/apod
+//     Optional NASA_API_KEY env; falls back to DEMO_KEY (rate-limited to 30/hr).
+//   • Where Is The ISS At: api.wheretheiss.at/v1/satellites/25544 — no key needed.
+//   • NASA NeoWs (Near Earth Objects): api.nasa.gov/neo/rest/v1/feed — uses NASA_API_KEY.
+
+const NASA_API_BASE = "https://api.nasa.gov";
+const ISS_API_BASE = "https://api.wheretheiss.at/v1/satellites/25544";
 
 export default function registerAstronomyActions(registerLensAction) {
   registerLensAction("astronomy", "celestialPosition", (ctx, artifact, _params) => {
@@ -54,5 +63,130 @@ export default function registerAstronomyActions(registerLensAction) {
     const aphelion = semiMajorAU * (1 + eccentricity);
     const orbitalVelocity = 29.78 / Math.sqrt(semiMajorAU); // km/s, simplified
     return { ok: true, result: { object: data.name || artifact.title, semiMajorAxisAU: semiMajorAU, eccentricity, periodYears: Math.round(periodYears * 1000) / 1000, periodDays: Math.round(periodYears * 365.25 * 10) / 10, perihelionAU: Math.round(perihelion * 1000) / 1000, aphelionAU: Math.round(aphelion * 1000) / 1000, avgOrbitalVelocityKmS: Math.round(orbitalVelocity * 10) / 10, orbitType: eccentricity < 0.05 ? "nearly-circular" : eccentricity < 0.5 ? "elliptical" : "highly-eccentric" } };
+  });
+
+  /**
+   * apod — Astronomy Picture of the Day from NASA.
+   * Free; NASA_API_KEY env optional (falls back to DEMO_KEY).
+   * params: { date?: "YYYY-MM-DD" — defaults to today }
+   */
+  registerLensAction("astronomy", "apod", async (_ctx, _artifact, params = {}) => {
+    const apiKey = process.env.NASA_API_KEY || "DEMO_KEY";
+    const date = params.date ? `&date=${encodeURIComponent(String(params.date))}` : "";
+    const url = `${NASA_API_BASE}/planetary/apod?api_key=${encodeURIComponent(apiKey)}${date}`;
+    try {
+      const r = await fetch(url);
+      if (!r.ok) throw new Error(`nasa apod ${r.status}`);
+      const data = await r.json();
+      return {
+        ok: true,
+        result: {
+          date: data.date,
+          title: data.title,
+          explanation: data.explanation,
+          mediaType: data.media_type,
+          url: data.url,
+          hdurl: data.hdurl || null,
+          copyright: data.copyright || null,
+          source: "nasa-apod",
+          usingDemoKey: apiKey === "DEMO_KEY",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `nasa apod unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * iss-current-location — Real-time International Space Station
+   * latitude/longitude/altitude/velocity. Free, no API key.
+   */
+  registerLensAction("astronomy", "iss-current-location", async (_ctx, _artifact, _params = {}) => {
+    try {
+      const r = await fetch(ISS_API_BASE);
+      if (!r.ok) throw new Error(`iss api ${r.status}`);
+      const data = await r.json();
+      return {
+        ok: true,
+        result: {
+          satelliteId: data.id,
+          name: data.name,
+          latitude: data.latitude,
+          longitude: data.longitude,
+          altitudeKm: data.altitude,
+          velocityKmH: data.velocity,
+          visibility: data.visibility,
+          footprintKm: data.footprint,
+          solarLatitude: data.solar_lat,
+          solarLongitude: data.solar_lon,
+          timestamp: data.timestamp,
+          daynum: data.daynum,
+          units: data.units,
+          source: "wheretheiss.at",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `iss api unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * near-earth-objects — NASA NeoWs feed of asteroids/comets passing
+   * close to Earth in a given date range (max 7 days).
+   * Requires NASA_API_KEY (DEMO_KEY rate-limited).
+   * params: { startDate: "YYYY-MM-DD", endDate?: "YYYY-MM-DD" }
+   */
+  registerLensAction("astronomy", "near-earth-objects", async (_ctx, _artifact, params = {}) => {
+    const startDate = String(params.startDate || new Date().toISOString().slice(0, 10));
+    const endDate = String(params.endDate || startDate);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(startDate) || !/^\d{4}-\d{2}-\d{2}$/.test(endDate)) {
+      return { ok: false, error: "startDate / endDate must be YYYY-MM-DD" };
+    }
+    const apiKey = process.env.NASA_API_KEY || "DEMO_KEY";
+    const url = `${NASA_API_BASE}/neo/rest/v1/feed?start_date=${startDate}&end_date=${endDate}&api_key=${encodeURIComponent(apiKey)}`;
+    try {
+      const r = await fetch(url);
+      if (!r.ok) throw new Error(`neows ${r.status}`);
+      const data = await r.json();
+      const objects = [];
+      for (const [date, list] of Object.entries(data.near_earth_objects || {})) {
+        for (const obj of list) {
+          const approach = obj.close_approach_data?.[0];
+          objects.push({
+            id: obj.id,
+            name: obj.name,
+            absoluteMagnitude: obj.absolute_magnitude_h,
+            estimatedDiameterMeters: {
+              min: obj.estimated_diameter?.meters?.estimated_diameter_min,
+              max: obj.estimated_diameter?.meters?.estimated_diameter_max,
+            },
+            potentiallyHazardous: obj.is_potentially_hazardous_asteroid,
+            sentryObject: obj.is_sentry_object || false,
+            approach: approach ? {
+              date,
+              relativeVelocityKmH: parseFloat(approach.relative_velocity?.kilometers_per_hour),
+              missDistanceKm: parseFloat(approach.miss_distance?.kilometers),
+              missDistanceLunar: parseFloat(approach.miss_distance?.lunar),
+              orbitingBody: approach.orbiting_body,
+            } : null,
+            nasaJplUrl: obj.nasa_jpl_url,
+          });
+        }
+      }
+      objects.sort((a, b) => (a.approach?.missDistanceKm || Infinity) - (b.approach?.missDistanceKm || Infinity));
+      return {
+        ok: true,
+        result: {
+          startDate, endDate,
+          objects,
+          count: objects.length,
+          hazardousCount: objects.filter((o) => o.potentiallyHazardous).length,
+          source: "nasa-neows",
+          usingDemoKey: apiKey === "DEMO_KEY",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `neows unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
   });
 }

--- a/server/tests/astronomy-domain-parity.test.js
+++ b/server/tests/astronomy-domain-parity.test.js
@@ -1,0 +1,225 @@
+// Contract tests for server/domains/astronomy.js — pure-math macros
+// plus real NASA / wheretheiss.at API integrations.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerAstronomyActions from "../domains/astronomy.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, artifactOrParams = {}, maybeParams) {
+  const fn = ACTIONS.get(`astronomy.${name}`);
+  if (!fn) throw new Error(`astronomy.${name} not registered`);
+  const artifact = arguments.length === 4 ? artifactOrParams : { id: null, data: {}, meta: {} };
+  const params = arguments.length === 4 ? (maybeParams || {}) : artifactOrParams;
+  return fn(ctx, artifact, params);
+}
+
+before(() => { registerAstronomyActions(register); });
+
+beforeEach(() => {
+  globalThis.fetch = async () => { throw new Error("network disabled in tests"); };
+});
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+
+describe("astronomy.celestialPosition (pure math)", () => {
+  it("computes altitude/azimuth for a star", () => {
+    const r = call("celestialPosition", ctxA, {
+      data: { rightAscension: 6.7525, declination: -16.7161, latitude: 40.7, longitude: -74, name: "Sirius" },
+    }, {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.object, "Sirius");
+    assert.ok(typeof r.result.altitude === "number");
+    assert.ok(typeof r.result.azimuth === "number");
+    assert.ok(r.result.azimuth >= 0 && r.result.azimuth < 360);
+  });
+});
+
+describe("astronomy.orbitalMechanics (Kepler's third law)", () => {
+  it("computes Earth's orbital period as ≈ 1 year", () => {
+    const r = call("orbitalMechanics", ctxA, {
+      data: { name: "Earth", semiMajorAxis: 1, eccentricity: 0.0167, centralMass: 1 },
+    }, {});
+    assert.equal(r.ok, true);
+    assert.ok(Math.abs(r.result.periodYears - 1) < 0.01);
+    assert.equal(r.result.orbitType, "nearly-circular");
+  });
+
+  it("computes Halley's comet as highly-eccentric", () => {
+    const r = call("orbitalMechanics", ctxA, {
+      data: { name: "Halley", semiMajorAxis: 17.8, eccentricity: 0.967, centralMass: 1 },
+    }, {});
+    assert.equal(r.result.orbitType, "highly-eccentric");
+    // Halley's period ≈ 75.3 years
+    assert.ok(Math.abs(r.result.periodYears - 75.3) < 1);
+  });
+});
+
+describe("astronomy.apod (NASA Astronomy Picture of the Day)", () => {
+  it("hits NASA APOD and parses real response", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ({
+          date: "2026-05-16",
+          title: "The Pillars of Creation",
+          explanation: "M16 imaged by JWST...",
+          media_type: "image",
+          url: "https://apod.nasa.gov/apod/image/2305/Pillars_JWST_960.jpg",
+          hdurl: "https://apod.nasa.gov/apod/image/2305/Pillars_JWST_4000.jpg",
+          copyright: "NASA, ESA, CSA, STScI",
+        }),
+      };
+    };
+    const r = await call("apod", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /api\.nasa\.gov\/planetary\/apod/);
+    assert.match(capturedUrl, /api_key=DEMO_KEY/);
+    assert.equal(r.result.title, "The Pillars of Creation");
+    assert.equal(r.result.mediaType, "image");
+    assert.equal(r.result.source, "nasa-apod");
+    assert.equal(r.result.usingDemoKey, true);
+  });
+
+  it("uses NASA_API_KEY env when set", async () => {
+    process.env.NASA_API_KEY = "real-key-abc";
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => ({ date: "2026-05-16", title: "x", explanation: "y", media_type: "image", url: "z" }) };
+    };
+    const r = await call("apod", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /api_key=real-key-abc/);
+    assert.equal(r.result.usingDemoKey, false);
+    delete process.env.NASA_API_KEY;
+  });
+
+  it("passes date param when supplied", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => ({ date: "2024-01-01", title: "x", explanation: "y", media_type: "image", url: "z" }) };
+    };
+    await call("apod", ctxA, { date: "2024-01-01" });
+    assert.match(capturedUrl, /date=2024-01-01/);
+  });
+
+  it("surfaces NASA API errors verbatim", async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 503, json: async () => ({}) });
+    const r = await call("apod", ctxA, {});
+    assert.equal(r.ok, false);
+    assert.match(r.error, /nasa apod unreachable.*503/);
+  });
+});
+
+describe("astronomy.iss-current-location (wheretheiss.at)", () => {
+  it("hits the ISS API and shapes the response", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ({
+          id: 25544, name: "iss",
+          latitude: 47.5,  longitude: -122.3,
+          altitude: 420.5, velocity: 27580.2,
+          visibility: "daylight",
+          footprint: 4490.5,
+          solar_lat: 22.5, solar_lon: 180,
+          timestamp: 1715882400, daynum: 2460441.5,
+          units: "kilometers",
+        }),
+      };
+    };
+    const r = await call("iss-current-location", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /api\.wheretheiss\.at\/v1\/satellites\/25544/);
+    assert.equal(r.result.satelliteId, 25544);
+    assert.equal(r.result.altitudeKm, 420.5);
+    assert.equal(r.result.velocityKmH, 27580.2);
+    assert.equal(r.result.source, "wheretheiss.at");
+  });
+
+  it("surfaces ISS API failures", async () => {
+    const r = await call("iss-current-location", ctxA, {});
+    assert.equal(r.ok, false);
+    assert.match(r.error, /iss api unreachable/);
+  });
+});
+
+describe("astronomy.near-earth-objects (NASA NeoWs)", () => {
+  it("rejects malformed date", async () => {
+    const r = await call("near-earth-objects", ctxA, { startDate: "yesterday" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /YYYY-MM-DD/);
+  });
+
+  it("hits NeoWs and parses real response shape", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ({
+          near_earth_objects: {
+            "2026-05-16": [{
+              id: "3542519", name: "(2010 PK9)",
+              nasa_jpl_url: "https://ssd.jpl.nasa.gov/...",
+              absolute_magnitude_h: 19.1,
+              estimated_diameter: { meters: { estimated_diameter_min: 290.6, estimated_diameter_max: 650.0 } },
+              is_potentially_hazardous_asteroid: true,
+              is_sentry_object: false,
+              close_approach_data: [{
+                relative_velocity: { kilometers_per_hour: "63552.6" },
+                miss_distance: { kilometers: "5482310.4", lunar: "14.26" },
+                orbiting_body: "Earth",
+              }],
+            }, {
+              id: "1234567", name: "(2024 X1)",
+              absolute_magnitude_h: 25.0,
+              estimated_diameter: { meters: { estimated_diameter_min: 10, estimated_diameter_max: 25 } },
+              is_potentially_hazardous_asteroid: false,
+              close_approach_data: [{
+                relative_velocity: { kilometers_per_hour: "30000" },
+                miss_distance: { kilometers: "500000", lunar: "1.3" },
+                orbiting_body: "Earth",
+              }],
+            }],
+          },
+        }),
+      };
+    };
+    const r = await call("near-earth-objects", ctxA, { startDate: "2026-05-16" });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /api\.nasa\.gov\/neo\/rest\/v1\/feed/);
+    assert.match(capturedUrl, /start_date=2026-05-16/);
+    assert.equal(r.result.count, 2);
+    assert.equal(r.result.hazardousCount, 1);
+    // Sorted by miss distance ascending — closer one (500k km) first
+    assert.equal(r.result.objects[0].name, "(2024 X1)");
+    assert.equal(r.result.objects[1].name, "(2010 PK9)");
+    assert.equal(r.result.source, "nasa-neows");
+  });
+
+  it("defaults to today when startDate not supplied", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => ({ near_earth_objects: {} }) };
+    };
+    await call("near-earth-objects", ctxA, {});
+    const today = new Date().toISOString().slice(0, 10);
+    assert.match(capturedUrl, new RegExp(`start_date=${today}`));
+  });
+
+  it("surfaces NeoWs failures verbatim", async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 429, json: async () => ({}) });
+    const r = await call("near-earth-objects", ctxA, { startDate: "2026-05-16" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /neows unreachable.*429/);
+  });
+});


### PR DESCRIPTION
## Summary

Bucket 1 polish pass on the astronomy lens. Adds three real-data macros on top of the existing pure-math set (`celestialPosition`, `planObservation`, `lightTravelTime`, `orbitalMechanics`).

### New macros
- **`apod`** — NASA Astronomy Picture of the Day. `NASA_API_KEY` optional (`DEMO_KEY` fallback, rate-limited 30/hr). Returns title, explanation, url/hdurl, mediaType, copyright. Optional `date` param.
- **`iss-current-location`** — Real-time ISS lat/lon/altitude/velocity/visibility/footprint via `api.wheretheiss.at` — **no API key required**.
- **`near-earth-objects`** — NASA NeoWs feed. Asteroids/comets with estimated diameter, `potentiallyHazardous` flag, close-approach data (relative velocity, miss distance in km + lunar distances). Sorted by miss distance.

## Test plan

- [x] `node --test server/tests/astronomy-domain-parity.test.js` — **13/13 passing**
- [x] Existing pure-math: Sirius altitude/azimuth, Earth orbital period ≈ 1 year, Halley highly-eccentric
- [x] APOD: DEMO_KEY default + env override + date param + 503 error surface
- [x] ISS: real response parsing + network error surface
- [x] NeoWs: date validation + real response shape + sorted-by-miss-distance INVARIANT + hazardous count + 429 error surface

https://claude.ai/code/session_018ucd5N7Hc3K8mNa9p2Lr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_