### PR TITLE
feat(calendar): RFC 5545 iCal export/parse + IANA timezone conversion

### DIFF
--- a/server/domains/calendar.js
+++ b/server/domains/calendar.js
@@ -73,4 +73,219 @@ export default function registerCalendarActions(registerLensAction) {
     const totalMinutes = sorted.reduce((s, t) => s + t.duration, 0);
     return { ok: true, result: { optimizedOrder: sorted.map(t => t.name), morningBlock: morning.map(t => t.name), afternoonBlock: afternoon.map(t => t.name), totalMinutes, totalHours: Math.round(totalMinutes / 60 * 10) / 10, fitsInWorkday: totalMinutes <= 480 } };
   });
+
+  // ── iCalendar (RFC 5545) interop — calendar parity vs Google ───
+  //   Calendar / Apple Calendar / Outlook ────────────────────────
+
+  /**
+   * ical-export — Serializes events to an RFC 5545 ICS document.
+   * Any calendar app (Apple Calendar, Google Calendar, Outlook, Fantastical)
+   * can subscribe to or import this output.
+   *
+   * params: { events: [{ uid?, summary, description?, start, end?, location?, url?, rrule?, organizerEmail?, attendeeEmails?[] }],
+   *           calendarName?: string, calendarTz?: string }
+   *
+   * Returns: { ics: string, eventCount, contentType: "text/calendar" }
+   */
+  registerLensAction("calendar", "ical-export", (_ctx, artifact, params = {}) => {
+    const events = (artifact?.data?.events || params.events || []);
+    if (!Array.isArray(events) || events.length === 0) {
+      return { ok: false, error: "events array required" };
+    }
+    const calendarName = String(params.calendarName || artifact?.title || "Concord Calendar").slice(0, 100);
+    const tz = String(params.calendarTz || "UTC");
+    const lines = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//Concord OS//Calendar Lens//EN",
+      "CALSCALE:GREGORIAN",
+      "METHOD:PUBLISH",
+      `X-WR-CALNAME:${icsEscape(calendarName)}`,
+      `X-WR-TIMEZONE:${icsEscape(tz)}`,
+    ];
+    let validCount = 0;
+    for (const e of events) {
+      const uid = String(e.uid || `${Date.now()}-${Math.random().toString(36).slice(2, 10)}@concord-os`);
+      const summary = String(e.summary || e.name || e.title || "Untitled event");
+      const startMs = new Date(e.start || e.startDate).getTime();
+      if (!Number.isFinite(startMs)) continue;
+      const endMs = e.end || e.endDate
+        ? new Date(e.end || e.endDate).getTime()
+        : startMs + 60 * 60 * 1000;  // default 1h
+      lines.push("BEGIN:VEVENT");
+      lines.push(`UID:${uid}`);
+      lines.push(`DTSTAMP:${icsUtc(new Date())}`);
+      lines.push(`DTSTART:${icsUtc(new Date(startMs))}`);
+      lines.push(`DTEND:${icsUtc(new Date(endMs))}`);
+      lines.push(`SUMMARY:${icsEscape(summary)}`);
+      if (e.description) lines.push(`DESCRIPTION:${icsEscape(String(e.description))}`);
+      if (e.location)    lines.push(`LOCATION:${icsEscape(String(e.location))}`);
+      if (e.url)         lines.push(`URL:${icsEscape(String(e.url))}`);
+      if (e.rrule)       lines.push(`RRULE:${String(e.rrule).replace(/\r?\n/g, " ")}`);
+      if (e.organizerEmail) {
+        lines.push(`ORGANIZER:mailto:${String(e.organizerEmail).replace(/[\r\n,;]/g, "")}`);
+      }
+      const attendees = Array.isArray(e.attendeeEmails) ? e.attendeeEmails : [];
+      for (const a of attendees) {
+        lines.push(`ATTENDEE;ROLE=REQ-PARTICIPANT;RSVP=TRUE:mailto:${String(a).replace(/[\r\n,;]/g, "")}`);
+      }
+      lines.push("END:VEVENT");
+      validCount++;
+    }
+    lines.push("END:VCALENDAR");
+    // RFC 5545 requires CRLF line endings + lines folded at 75 octets.
+    const folded = lines.map(foldIcsLine).join("\r\n") + "\r\n";
+    return {
+      ok: true,
+      result: {
+        ics: folded,
+        eventCount: validCount,
+        calendarName,
+        timezone: tz,
+        contentType: "text/calendar",
+        spec: "RFC 5545",
+      },
+    };
+  });
+
+  /**
+   * ical-parse — Parses an RFC 5545 ICS document into a Concord
+   * events array. Handles line unfolding (CRLF + space continuation),
+   * VEVENT extraction, common property names, and a minimal RRULE
+   * pass-through.
+   *
+   * params: { ics: string } — UTF-8 ICS document
+   */
+  registerLensAction("calendar", "ical-parse", (_ctx, _artifact, params = {}) => {
+    const ics = String(params.ics || "");
+    if (!ics.trim()) return { ok: false, error: "ics string required" };
+    if (!ics.includes("BEGIN:VCALENDAR")) return { ok: false, error: "input is not a VCALENDAR document" };
+    // Unfold lines (RFC 5545 §3.1: continuation lines start with SP or TAB).
+    const unfolded = ics.replace(/\r\n[ \t]/g, "");
+    const rawLines = unfolded.split(/\r?\n/);
+    const events = [];
+    let cur = null;
+    let calendarName = null, timezone = null;
+    for (const line of rawLines) {
+      if (line.startsWith("X-WR-CALNAME:")) calendarName = icsUnescape(line.slice("X-WR-CALNAME:".length));
+      if (line.startsWith("X-WR-TIMEZONE:")) timezone = line.slice("X-WR-TIMEZONE:".length).trim();
+      if (line === "BEGIN:VEVENT") { cur = {}; continue; }
+      if (line === "END:VEVENT") { if (cur) events.push(cur); cur = null; continue; }
+      if (!cur) continue;
+      const sep = line.indexOf(":");
+      if (sep < 0) continue;
+      const keyFull = line.slice(0, sep);
+      const value = line.slice(sep + 1);
+      // Strip iCal parameters (e.g. DTSTART;TZID=America/New_York)
+      const key = keyFull.split(";")[0].toUpperCase();
+      switch (key) {
+        case "UID":          cur.uid = value; break;
+        case "SUMMARY":      cur.summary = icsUnescape(value); break;
+        case "DESCRIPTION":  cur.description = icsUnescape(value); break;
+        case "LOCATION":     cur.location = icsUnescape(value); break;
+        case "URL":          cur.url = value; break;
+        case "DTSTART":      cur.start = parseIcsDate(value); break;
+        case "DTEND":        cur.end = parseIcsDate(value); break;
+        case "RRULE":        cur.rrule = value; break;
+        case "ORGANIZER":    cur.organizerEmail = value.replace(/^mailto:/i, ""); break;
+        case "ATTENDEE":     (cur.attendeeEmails ||= []).push(value.replace(/^mailto:/i, "")); break;
+      }
+    }
+    return {
+      ok: true,
+      result: {
+        events,
+        eventCount: events.length,
+        calendarName, timezone,
+        spec: "RFC 5545",
+      },
+    };
+  });
+
+  /**
+   * timezone-convert — Converts a date/time from one IANA timezone to
+   * another. Uses Node's built-in Intl.DateTimeFormat (no dep).
+   *
+   * params: { isoString, fromTz, toTz }
+   */
+  registerLensAction("calendar", "timezone-convert", (_ctx, _artifact, params = {}) => {
+    const isoString = String(params.isoString || "");
+    const fromTz = String(params.fromTz || "UTC");
+    const toTz = String(params.toTz || "UTC");
+    if (!isoString) return { ok: false, error: "isoString required" };
+    const ms = Date.parse(isoString);
+    if (!Number.isFinite(ms)) return { ok: false, error: "isoString could not be parsed" };
+    // Verify both TZs are valid IANA names.
+    try {
+      new Intl.DateTimeFormat("en-US", { timeZone: fromTz }).format(ms);
+      new Intl.DateTimeFormat("en-US", { timeZone: toTz }).format(ms);
+    } catch (e) {
+      return { ok: false, error: `unknown IANA timezone: ${e.message}` };
+    }
+    const inFromTz = new Intl.DateTimeFormat("en-CA", {
+      timeZone: fromTz, year: "numeric", month: "2-digit", day: "2-digit",
+      hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false,
+    }).format(ms);
+    const inToTz = new Intl.DateTimeFormat("en-CA", {
+      timeZone: toTz, year: "numeric", month: "2-digit", day: "2-digit",
+      hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false,
+    }).format(ms);
+    return {
+      ok: true,
+      result: {
+        sourceIso: isoString,
+        fromTz, toTz,
+        inFromTz, inToTz,
+        epochMs: ms,
+      },
+    };
+  });
+}
+
+// ── iCal helpers (RFC 5545 escaping + date format) ───────────────
+
+function icsEscape(s) {
+  // RFC 5545 §3.3.11 text escaping
+  return String(s)
+    .replace(/\\/g, "\\\\")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,")
+    .replace(/\r?\n/g, "\\n");
+}
+
+function icsUnescape(s) {
+  return String(s)
+    .replace(/\\n/g, "\n")
+    .replace(/\\,/g, ",")
+    .replace(/\\;/g, ";")
+    .replace(/\\\\/g, "\\");
+}
+
+function icsUtc(d) {
+  // RFC 5545 UTC datetime: YYYYMMDDTHHMMSSZ
+  const pad = (n) => String(n).padStart(2, "0");
+  return `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}T${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}Z`;
+}
+
+function foldIcsLine(line) {
+  // RFC 5545 §3.1: lines MUST NOT exceed 75 octets; fold by inserting
+  // CRLF + single space.
+  if (line.length <= 75) return line;
+  let out = line.slice(0, 75);
+  let i = 75;
+  while (i < line.length) {
+    out += "\r\n " + line.slice(i, i + 74);
+    i += 74;
+  }
+  return out;
+}
+
+function parseIcsDate(raw) {
+  // RFC 5545: either YYYYMMDD (date) or YYYYMMDDTHHMMSS(Z) (datetime)
+  const m = raw.match(/^(\d{4})(\d{2})(\d{2})(?:T(\d{2})(\d{2})(\d{2})(Z)?)?$/);
+  if (!m) return raw;  // unrecognized → caller deals with it
+  const [, y, mo, d, h = "00", mi = "00", s = "00", z] = m;
+  return z
+    ? `${y}-${mo}-${d}T${h}:${mi}:${s}Z`
+    : `${y}-${mo}-${d}T${h}:${mi}:${s}`;
 }

--- a/server/tests/calendar-domain-parity.test.js
+++ b/server/tests/calendar-domain-parity.test.js
@@ -1,0 +1,221 @@
+// Contract tests for server/domains/calendar.js — pure-compute helpers
+// plus RFC 5545 iCal interop + IANA timezone conversion.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerCalendarActions from "../domains/calendar.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, artifactOrParams = {}, maybeParams) {
+  const fn = ACTIONS.get(`calendar.${name}`);
+  if (!fn) throw new Error(`calendar.${name} not registered`);
+  const artifact = arguments.length === 4 ? artifactOrParams : { id: null, data: {}, meta: {} };
+  const params = arguments.length === 4 ? (maybeParams || {}) : artifactOrParams;
+  return fn(ctx, artifact, params);
+}
+
+before(() => { registerCalendarActions(register); });
+beforeEach(() => { /* hermetic */ });
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+
+describe("calendar.detectConflicts", () => {
+  it("flags overlapping events with overlap duration", () => {
+    const events = [
+      { name: "A", start: "2026-05-16T10:00:00Z", end: "2026-05-16T11:00:00Z" },
+      { name: "B", start: "2026-05-16T10:30:00Z", end: "2026-05-16T11:30:00Z" },
+    ];
+    const r = call("detectConflicts", ctxA, { data: { events } }, {});
+    assert.equal(r.result.conflictCount, 1);
+    assert.equal(r.result.conflicts[0].overlapMinutes, 30);
+  });
+
+  it("conflictFree when no overlap", () => {
+    const events = [
+      { name: "A", start: "2026-05-16T10:00:00Z", end: "2026-05-16T11:00:00Z" },
+      { name: "B", start: "2026-05-16T12:00:00Z", end: "2026-05-16T13:00:00Z" },
+    ];
+    const r = call("detectConflicts", ctxA, { data: { events } }, {});
+    assert.equal(r.result.conflictFree, true);
+  });
+});
+
+describe("calendar.ical-export (RFC 5545)", () => {
+  it("rejects missing events", () => {
+    const r = call("ical-export", ctxA, {}, {});
+    assert.equal(r.ok, false);
+  });
+
+  it("generates valid VCALENDAR with VEVENT + DTSTART/DTEND/SUMMARY", () => {
+    const events = [
+      { uid: "abc-123@example.com", summary: "Team standup", start: "2026-05-16T15:00:00Z", end: "2026-05-16T15:30:00Z", location: "Zoom" },
+    ];
+    const r = call("ical-export", ctxA, { data: { events } }, { calendarName: "My Calendar" });
+    assert.equal(r.ok, true);
+    assert.match(r.result.ics, /BEGIN:VCALENDAR\r\n/);
+    assert.match(r.result.ics, /VERSION:2\.0\r\n/);
+    assert.match(r.result.ics, /X-WR-CALNAME:My Calendar\r\n/);
+    assert.match(r.result.ics, /BEGIN:VEVENT\r\n/);
+    assert.match(r.result.ics, /UID:abc-123@example\.com\r\n/);
+    assert.match(r.result.ics, /DTSTART:20260516T150000Z\r\n/);
+    assert.match(r.result.ics, /DTEND:20260516T153000Z\r\n/);
+    assert.match(r.result.ics, /SUMMARY:Team standup\r\n/);
+    assert.match(r.result.ics, /LOCATION:Zoom\r\n/);
+    assert.match(r.result.ics, /END:VEVENT\r\n/);
+    assert.match(r.result.ics, /END:VCALENDAR\r\n$/);
+    assert.equal(r.result.eventCount, 1);
+    assert.equal(r.result.spec, "RFC 5545");
+  });
+
+  it("escapes special characters per RFC 5545 §3.3.11", () => {
+    const events = [{
+      summary: "Lunch, then meeting; finally: gym",
+      description: "Line 1\nLine 2",
+      start: "2026-05-16T12:00:00Z",
+    }];
+    const r = call("ical-export", ctxA, { data: { events } }, {});
+    // commas + semicolons escaped, newlines → \n
+    assert.match(r.result.ics, /SUMMARY:Lunch\\, then meeting\\; finally:/);
+    assert.match(r.result.ics, /DESCRIPTION:Line 1\\nLine 2/);
+  });
+
+  it("folds lines longer than 75 octets per RFC 5545 §3.1", () => {
+    const longSummary = "A".repeat(200);
+    const r = call("ical-export", ctxA, { data: { events: [{ summary: longSummary, start: "2026-05-16T10:00:00Z" }] } }, {});
+    // After SUMMARY: marker, folded lines should begin with " "
+    const summaryLine = r.result.ics.split("\r\n").filter((l) => l.startsWith("SUMMARY:") || l.startsWith(" A"));
+    assert.ok(summaryLine.length >= 3); // initial + ≥2 fold continuations
+  });
+
+  it("adds attendees + organizer per RFC 5545", () => {
+    const events = [{
+      summary: "Sync", start: "2026-05-16T10:00:00Z",
+      organizerEmail: "alice@example.com",
+      attendeeEmails: ["bob@example.com", "carol@example.com"],
+    }];
+    const r = call("ical-export", ctxA, { data: { events } }, {});
+    assert.match(r.result.ics, /ORGANIZER:mailto:alice@example\.com\r\n/);
+    assert.match(r.result.ics, /ATTENDEE;ROLE=REQ-PARTICIPANT;RSVP=TRUE:mailto:bob@example\.com\r\n/);
+    assert.match(r.result.ics, /ATTENDEE;ROLE=REQ-PARTICIPANT;RSVP=TRUE:mailto:carol@example\.com\r\n/);
+  });
+
+  it("skips events with invalid start dates rather than aborting", () => {
+    const events = [
+      { summary: "Bad", start: "not-a-date" },
+      { summary: "Good", start: "2026-05-16T10:00:00Z" },
+    ];
+    const r = call("ical-export", ctxA, { data: { events } }, {});
+    assert.equal(r.result.eventCount, 1);
+    assert.match(r.result.ics, /SUMMARY:Good\r\n/);
+  });
+});
+
+describe("calendar.ical-parse (RFC 5545 round-trip)", () => {
+  it("rejects non-VCALENDAR input", () => {
+    assert.equal(call("ical-parse", ctxA, { ics: "not an ics" }).ok, false);
+    assert.equal(call("ical-parse", ctxA, { ics: "" }).ok, false);
+  });
+
+  it("parses a valid VCALENDAR + extracts events", () => {
+    const ics = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//Test//EN",
+      "X-WR-CALNAME:Work",
+      "X-WR-TIMEZONE:America/Los_Angeles",
+      "BEGIN:VEVENT",
+      "UID:evt-1@test",
+      "DTSTAMP:20260516T100000Z",
+      "DTSTART:20260516T150000Z",
+      "DTEND:20260516T160000Z",
+      "SUMMARY:Demo",
+      "DESCRIPTION:Important call",
+      "LOCATION:Conf Room A",
+      "ORGANIZER:mailto:alice@example.com",
+      "ATTENDEE;ROLE=REQ-PARTICIPANT:mailto:bob@example.com",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+    const r = call("ical-parse", ctxA, { ics });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.calendarName, "Work");
+    assert.equal(r.result.timezone, "America/Los_Angeles");
+    assert.equal(r.result.events.length, 1);
+    const e = r.result.events[0];
+    assert.equal(e.uid, "evt-1@test");
+    assert.equal(e.summary, "Demo");
+    assert.equal(e.description, "Important call");
+    assert.equal(e.location, "Conf Room A");
+    assert.equal(e.start, "2026-05-16T15:00:00Z");
+    assert.equal(e.end, "2026-05-16T16:00:00Z");
+    assert.equal(e.organizerEmail, "alice@example.com");
+    assert.deepEqual(e.attendeeEmails, ["bob@example.com"]);
+  });
+
+  it("unfolds continuation lines (RFC 5545 §3.1)", () => {
+    // Per RFC 5545: the leading SP/HT on the continuation line is the
+    // FOLDING marker and is REMOVED during unfolding. The producer is
+    // responsible for placing any space character in the original
+    // content before the line break.
+    const ics = [
+      "BEGIN:VCALENDAR",
+      "BEGIN:VEVENT",
+      "DTSTART:20260516T100000Z",
+      "SUMMARY:This is a very long ",  // trailing space is content
+      " summary that wraps",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+    const r = call("ical-parse", ctxA, { ics });
+    assert.equal(r.result.events[0].summary, "This is a very long summary that wraps");
+  });
+
+  it("round-trip: export then parse preserves UID + SUMMARY + start/end", () => {
+    const original = [{
+      uid: "rt-test@concord", summary: "Round trip",
+      start: "2026-05-16T15:00:00Z", end: "2026-05-16T16:00:00Z",
+      location: "Concord HQ",
+    }];
+    const exported = call("ical-export", ctxA, { data: { events: original } }, {});
+    const parsed = call("ical-parse", ctxA, { ics: exported.result.ics });
+    assert.equal(parsed.result.events.length, 1);
+    const e = parsed.result.events[0];
+    assert.equal(e.uid, "rt-test@concord");
+    assert.equal(e.summary, "Round trip");
+    assert.equal(e.location, "Concord HQ");
+    assert.equal(e.start, "2026-05-16T15:00:00Z");
+    assert.equal(e.end, "2026-05-16T16:00:00Z");
+  });
+});
+
+describe("calendar.timezone-convert (IANA via Intl.DateTimeFormat)", () => {
+  it("rejects missing iso", () => {
+    assert.equal(call("timezone-convert", ctxA, {}).ok, false);
+  });
+
+  it("rejects unknown IANA timezone", () => {
+    const r = call("timezone-convert", ctxA, { isoString: "2026-05-16T15:00:00Z", fromTz: "UTC", toTz: "Mars/Olympus_Mons" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /unknown IANA timezone/);
+  });
+
+  it("converts UTC → America/Los_Angeles correctly (May = PDT, UTC-7)", () => {
+    const r = call("timezone-convert", ctxA, {
+      isoString: "2026-05-16T15:00:00Z",
+      fromTz: "UTC", toTz: "America/Los_Angeles",
+    });
+    assert.equal(r.ok, true);
+    // 15:00 UTC = 08:00 PDT
+    assert.match(r.result.inToTz, /08:00:00$/);
+  });
+
+  it("converts UTC → Asia/Tokyo correctly (JST = UTC+9)", () => {
+    const r = call("timezone-convert", ctxA, {
+      isoString: "2026-05-16T15:00:00Z",
+      fromTz: "UTC", toTz: "Asia/Tokyo",
+    });
+    // 15:00 UTC = 00:00 next day JST
+    assert.match(r.result.inToTz, /2026-05-17,? 00:00:00$/);
+  });
+});


### PR DESCRIPTION
## Summary

Bucket 1 polish on the calendar lens. Adds the missing interop primitives that put calendar parity vs Google Calendar / Apple Calendar / Outlook.

### Backend
- **`ical-export`** — generates RFC 5545 VCALENDAR documents. RFC-compliant text escaping (§3.3.11), CRLF line endings, 75-octet line folding (§3.1). Full event metadata (UID/SUMMARY/DTSTART/DTEND/DESCRIPTION/LOCATION/URL/RRULE/ORGANIZER/ATTENDEE). Skips events with invalid start dates rather than aborting.
- **`ical-parse`** — reverse direction. Unfolds RFC 5545 continuation lines (CRLF + SP/HT marker removed), extracts VEVENT blocks, parses date + datetime forms, strips iCal parameters from property keys.
- **`timezone-convert`** — IANA-aware via Node's built-in `Intl.DateTimeFormat` (no dep). Validates both TZs before converting.

**No new npm dependencies.**

## Test plan

- [x] `node --test server/tests/calendar-domain-parity.test.js` — **16/16 passing**
- [x] Covers: detectConflicts overlap + conflict-free; iCal export shape + CRLF + §3.3.11 escaping + §3.1 line folding + organizer/attendee format + invalid-date skip; iCal parse non-VCALENDAR rejection + line unfolding + round-trip preservation; timezone validation + UTC→PDT + UTC→JST day-rollover

https://claude.ai/code/session_018ucd5N7Hc3K8mNa9p2Lr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_