### PR TITLE
feat(sports/space): real TheSportsDB + ESPN + SpaceX + Launch Library 2

### DIFF
--- a/server/domains/space.js
+++ b/server/domains/space.js
@@ -1,7 +1,97 @@
 // server/domains/space.js
+//
+// Pure-compute orbital mechanics (orbit calc, delta-V budget, launch
+// windows, reentry analysis) plus real free APIs:
+//   • SpaceX r-spacex API: https://api.spacexdata.com/v4 — upcoming
+//     launches, vehicles, launchpads. No API key.
+//   • Launch Library 2 (TheSpaceDevs): https://ll.thespacedevs.com/2.2.0
+//     — universal launch calendar across all providers. Free, no key,
+//     rate-limited (~15 req/hour anonymous).
+
+const SPACEX_BASE = "https://api.spacexdata.com/v4";
+const LAUNCH_LIBRARY_BASE = "https://ll.thespacedevs.com/2.2.0";
+
 export default function registerSpaceActions(registerLensAction) {
   registerLensAction("space", "orbitCalc", (ctx, artifact, _params) => { const data = artifact.data || {}; const altitude = parseFloat(data.altitudeKm) || 400; const radius = 6371 + altitude; const period = 2 * Math.PI * Math.sqrt(Math.pow(radius * 1000, 3) / (6.674e-11 * 5.972e24)) / 60; const velocity = Math.sqrt(6.674e-11 * 5.972e24 / (radius * 1000)) / 1000; return { ok: true, result: { altitudeKm: altitude, orbitalRadiusKm: radius, periodMinutes: Math.round(period * 10) / 10, velocityKmS: Math.round(velocity * 100) / 100, orbitsPerDay: Math.round(1440 / period * 10) / 10, type: altitude < 2000 ? "LEO" : altitude < 35786 ? "MEO" : "GEO", escapeVelocity: `${Math.round(Math.sqrt(2) * velocity * 100) / 100} km/s` } }; });
   registerLensAction("space", "deltaVBudget", (ctx, artifact, _params) => { const maneuvers = artifact.data?.maneuvers || []; if (maneuvers.length === 0) return { ok: true, result: { message: "Add maneuvers with delta-V requirements." } }; const total = maneuvers.reduce((s,m) => s + (parseFloat(m.deltaV) || 0), 0); const analyzed = maneuvers.map(m => ({ maneuver: m.name || m.description, deltaV: parseFloat(m.deltaV) || 0, percentage: total > 0 ? Math.round((parseFloat(m.deltaV) || 0) / total * 100) : 0 })); return { ok: true, result: { maneuvers: analyzed, totalDeltaV: Math.round(total * 10) / 10, unit: "km/s", feasibility: total < 10 ? "achievable-with-chemical" : total < 50 ? "requires-efficient-propulsion" : "requires-advanced-propulsion" } }; });
   registerLensAction("space", "launchWindow", (ctx, artifact, _params) => { const data = artifact.data || {}; const targetOrbit = (data.targetOrbit || "LEO").toUpperCase(); const latitude = parseFloat(data.launchLatitude) || 28.5; const inclination = parseFloat(data.inclination) || latitude; const windowsPerDay = targetOrbit === "GEO" ? 2 : targetOrbit === "LEO" ? Math.round(1440 / (2 * Math.PI * Math.sqrt(Math.pow(6771,3) / (6.674e-11 * 5.972e24)) / 60)) : 1; return { ok: true, result: { targetOrbit, launchLatitude: latitude, orbitalInclination: inclination, windowsPerDay, windowDuration: targetOrbit === "GEO" ? "~1 hour" : "5-10 minutes", nextWindowApprox: "Requires ephemeris data for precise calculation", inclinationPenalty: Math.abs(latitude - inclination) > 5 ? "Dogleg maneuver needed — additional fuel cost" : "Direct ascent possible" } }; });
   registerLensAction("space", "reentryAnalysis", (ctx, artifact, _params) => { const data = artifact.data || {}; const mass = parseFloat(data.massKg) || 1000; const velocity = parseFloat(data.velocityKmS) || 7.8; const angle = parseFloat(data.reentryAngleDeg) || 6; const kineticEnergy = 0.5 * mass * Math.pow(velocity * 1000, 2); const peakG = angle > 3 ? Math.round(angle * 1.5 * 10) / 10 : Math.round(angle * 3 * 10) / 10; const peakTemp = Math.round(1000 + velocity * 200); return { ok: true, result: { massKg: mass, entryVelocity: `${velocity} km/s`, entryAngle: `${angle}°`, kineticEnergyGJ: Math.round(kineticEnergy / 1e9 * 10) / 10, peakDeceleration: `${peakG}g`, peakTemperature: `~${peakTemp}°C`, heatShieldRequired: peakTemp > 1500 ? "ablative" : "ceramic-tile", survivability: angle >= 1 && angle <= 10 ? "nominal-corridor" : angle < 1 ? "skip-off — too shallow" : "structural-failure — too steep" } }; });
+
+  /**
+   * spacex-upcoming — Upcoming SpaceX launches from r-spacex API
+   * (api.spacexdata.com/v4). Free, no API key.
+   */
+  registerLensAction("space", "spacex-upcoming", async (_ctx, _artifact, params = {}) => {
+    const limit = Math.max(1, Math.min(20, Number(params.limit) || 5));
+    try {
+      const r = await fetch(`${SPACEX_BASE}/launches/upcoming`);
+      if (!r.ok) throw new Error(`spacex ${r.status}`);
+      const data = await r.json();
+      const launches = (data || []).slice(0, limit).map((l) => ({
+        id: l.id,
+        name: l.name,
+        flightNumber: l.flight_number,
+        dateUtc: l.date_utc,
+        dateUnix: l.date_unix,
+        precision: l.date_precision,
+        rocketId: l.rocket,
+        launchpadId: l.launchpad,
+        details: l.details,
+        success: l.success,
+        upcoming: l.upcoming,
+        patch: l.links?.patch?.small,
+        webcast: l.links?.webcast,
+        article: l.links?.article,
+        wikipedia: l.links?.wikipedia,
+      }));
+      return {
+        ok: true,
+        result: { launches, count: launches.length, source: "spacexdata-api" },
+      };
+    } catch (e) {
+      return { ok: false, error: `spacex unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * launch-library-upcoming — Universal upcoming launches across all
+   * launch providers (NASA, SpaceX, ULA, ESA, Roscosmos, ISRO, etc.)
+   * via Launch Library 2. Free, no API key, rate-limited 15/hr.
+   */
+  registerLensAction("space", "launch-library-upcoming", async (_ctx, _artifact, params = {}) => {
+    const limit = Math.max(1, Math.min(50, Number(params.limit) || 10));
+    try {
+      const r = await fetch(`${LAUNCH_LIBRARY_BASE}/launch/upcoming/?limit=${limit}&mode=list`);
+      if (!r.ok) {
+        if (r.status === 429) return { ok: false, error: "launch library rate limit exceeded — try again in an hour, or use LL2 API key" };
+        throw new Error(`launch library ${r.status}`);
+      }
+      const data = await r.json();
+      const launches = (data.results || []).map((l) => ({
+        id: l.id,
+        name: l.name,
+        net: l.net,            // No Earlier Than (UTC)
+        windowStart: l.window_start,
+        windowEnd: l.window_end,
+        status: l.status?.name,
+        provider: l.launch_service_provider?.name,
+        rocket: l.rocket?.configuration?.full_name,
+        mission: l.mission?.name,
+        missionDescription: l.mission?.description,
+        missionType: l.mission?.type,
+        orbit: l.mission?.orbit?.name,
+        pad: l.pad?.name,
+        location: l.pad?.location?.name,
+        countryCode: l.pad?.country_code,
+        webcastLive: l.webcast_live,
+        image: l.image,
+      }));
+      return {
+        ok: true,
+        result: { launches, count: launches.length, totalAvailable: data.count, source: "thespacedevs-launch-library" },
+      };
+    } catch (e) {
+      return { ok: false, error: `launch library unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
 }

--- a/server/domains/sports.js
+++ b/server/domains/sports.js
@@ -1,7 +1,151 @@
 // server/domains/sports.js
+//
+// Pure-compute helpers (performance stats, training plan, injury risk,
+// team analysis) plus real free APIs (TheSportsDB for team / league /
+// fixture lookups, ESPN scoreboard for live scores).
+//
+// TheSportsDB free dev key "3"; production may set SPORTSDB_API_KEY.
+// ESPN's public scoreboard endpoint is unkeyed (rate-limited).
+
+const SPORTSDB_BASE = "https://www.thesportsdb.com/api/v1/json";
+const ESPN_SCOREBOARD = "https://site.api.espn.com/apis/site/v2/sports";
+
 export default function registerSportsActions(registerLensAction) {
   registerLensAction("sports", "performanceStats", (ctx, artifact, _params) => { const stats = artifact.data?.stats || []; if (stats.length === 0) return { ok: true, result: { message: "Add performance statistics to analyze." } }; const values = stats.map(s => parseFloat(s.value) || 0); const avg = values.reduce((s,v)=>s+v,0)/values.length; const best = Math.max(...values); const worst = Math.min(...values); const recent5 = values.slice(-5); const trend = recent5.length >= 2 ? (recent5[recent5.length-1] > recent5[0] ? "improving" : "declining") : "insufficient"; return { ok: true, result: { metric: stats[0]?.metric || "performance", average: Math.round(avg*100)/100, best, worst, trend, recentAvg: Math.round(recent5.reduce((s,v)=>s+v,0)/recent5.length*100)/100, consistency: Math.round(Math.sqrt(values.reduce((s,v)=>s+Math.pow(v-avg,2),0)/values.length)*100)/100, dataPoints: values.length } }; });
   registerLensAction("sports", "trainingPlan", (ctx, artifact, _params) => { const data = artifact.data || {}; const sport = (data.sport || "general").toLowerCase(); const level = (data.level || "intermediate").toLowerCase(); const daysPerWeek = parseInt(data.daysPerWeek) || 4; const plans = { running: ["Easy run", "Tempo run", "Intervals", "Long run", "Rest", "Cross-train", "Easy run"], swimming: ["Technique drills", "Speed sets", "Endurance", "Recovery", "Rest", "Open water", "Drills"], cycling: ["Base ride", "Hill repeats", "Tempo", "Long ride", "Rest", "Recovery spin", "Group ride"], general: ["Strength", "Cardio", "HIIT", "Active recovery", "Rest", "Flexibility", "Sport-specific"] }; const template = plans[sport] || plans.general; const schedule = template.slice(0, daysPerWeek).map((workout, i) => ({ day: i+1, workout, intensity: workout.includes("Rest") || workout.includes("Recovery") ? "low" : workout.includes("HIIT") || workout.includes("Interval") ? "high" : "moderate" })); return { ok: true, result: { sport, level, daysPerWeek, schedule, weeklyStructure: { hard: schedule.filter(s => s.intensity === "high").length, moderate: schedule.filter(s => s.intensity === "moderate").length, easy: schedule.filter(s => s.intensity === "low").length }, principle: "Follow 80/20 rule: 80% easy, 20% hard" } }; });
   registerLensAction("sports", "injuryRisk", (ctx, artifact, _params) => { const data = artifact.data || {}; const trainingLoad = parseFloat(data.weeklyHours) || 0; const restDays = parseInt(data.restDaysPerWeek) || 2; const previousInjuries = parseInt(data.previousInjuries) || 0; const age = parseInt(data.age) || 25; const sleep = parseFloat(data.sleepHours) || 7; let risk = 20; if (trainingLoad > 15) risk += 20; if (restDays < 1) risk += 25; if (previousInjuries > 2) risk += 15; if (age > 40) risk += 10; if (sleep < 6) risk += 15; risk = Math.min(100, risk); return { ok: true, result: { riskScore: risk, riskLevel: risk >= 60 ? "high" : risk >= 35 ? "moderate" : "low", factors: { trainingLoad, restDays, previousInjuries, age, sleepHours: sleep }, recommendations: risk >= 40 ? [restDays < 2 ? "Add rest days" : null, sleep < 7 ? "Prioritize 7-9 hours sleep" : null, trainingLoad > 12 ? "Reduce training volume 10-20%" : null, "Include proper warm-up and cool-down"].filter(Boolean) : ["Continue current training — risk is manageable"] } }; });
   registerLensAction("sports", "teamAnalysis", (ctx, artifact, _params) => { const players = artifact.data?.players || []; if (players.length === 0) return { ok: true, result: { message: "Add players with stats to analyze team." } }; const avgAge = Math.round(players.reduce((s,p) => s + (parseInt(p.age) || 25), 0) / players.length * 10) / 10; const positions = {}; for (const p of players) { const pos = p.position || "utility"; positions[pos] = (positions[pos] || 0) + 1; } const avgRating = Math.round(players.reduce((s,p) => s + (parseFloat(p.rating) || 50), 0) / players.length * 10) / 10; return { ok: true, result: { rosterSize: players.length, avgAge, avgRating, positions, topPerformer: players.sort((a,b) => (parseFloat(b.rating) || 0) - (parseFloat(a.rating) || 0))[0]?.name, teamStrength: avgRating >= 70 ? "elite" : avgRating >= 50 ? "competitive" : "developing" } }; });
+
+  // ── Real-data macros (TheSportsDB + ESPN scoreboard) ──
+
+  /**
+   * team-lookup — TheSportsDB team search. Free dev tier (key "3"),
+   * SPORTSDB_API_KEY env for production.
+   * params: { name: string }
+   */
+  registerLensAction("sports", "team-lookup", async (_ctx, _artifact, params = {}) => {
+    const name = String(params.name || "").trim();
+    if (!name) return { ok: false, error: "name required" };
+    const apiKey = process.env.SPORTSDB_API_KEY || "3";
+    try {
+      const r = await fetch(`${SPORTSDB_BASE}/${encodeURIComponent(apiKey)}/searchteams.php?t=${encodeURIComponent(name)}`);
+      if (!r.ok) throw new Error(`thesportsdb ${r.status}`);
+      const data = await r.json();
+      const teams = (data.teams || []).map((t) => ({
+        id: t.idTeam,
+        name: t.strTeam,
+        alternateName: t.strAlternate,
+        sport: t.strSport,
+        league: t.strLeague,
+        leagueId: t.idLeague,
+        country: t.strCountry,
+        formedYear: t.intFormedYear ? parseInt(t.intFormedYear, 10) : null,
+        stadium: t.strStadium,
+        stadiumCapacity: t.intStadiumCapacity ? parseInt(t.intStadiumCapacity, 10) : null,
+        stadiumLocation: t.strStadiumLocation,
+        website: t.strWebsite,
+        badge: t.strTeamBadge,
+        logo: t.strTeamLogo,
+        description: t.strDescriptionEN,
+      }));
+      return {
+        ok: true,
+        result: { teams, count: teams.length, query: name, source: "thesportsdb" },
+      };
+    } catch (e) {
+      return { ok: false, error: `thesportsdb unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * league-table — TheSportsDB league standings (current season).
+   * params: { leagueId: string, season?: "YYYY-YYYY" }
+   */
+  registerLensAction("sports", "league-table", async (_ctx, _artifact, params = {}) => {
+    const leagueId = String(params.leagueId || "").trim();
+    if (!leagueId) return { ok: false, error: "leagueId required (TheSportsDB league ID, e.g. '4328' for EPL)" };
+    const apiKey = process.env.SPORTSDB_API_KEY || "3";
+    const season = params.season ? `&s=${encodeURIComponent(String(params.season))}` : "";
+    try {
+      const r = await fetch(`${SPORTSDB_BASE}/${encodeURIComponent(apiKey)}/lookuptable.php?l=${encodeURIComponent(leagueId)}${season}`);
+      if (!r.ok) throw new Error(`thesportsdb ${r.status}`);
+      const data = await r.json();
+      const table = (data.table || []).map((row) => ({
+        rank: parseInt(row.intRank, 10),
+        teamId: row.idTeam,
+        teamName: row.strTeam,
+        played: parseInt(row.intPlayed, 10),
+        win: parseInt(row.intWin, 10),
+        draw: parseInt(row.intDraw, 10),
+        loss: parseInt(row.intLoss, 10),
+        goalsFor: parseInt(row.intGoalsFor, 10),
+        goalsAgainst: parseInt(row.intGoalsAgainst, 10),
+        goalDifference: parseInt(row.intGoalDifference, 10),
+        points: parseInt(row.intPoints, 10),
+        badge: row.strTeamBadge,
+      }));
+      return {
+        ok: true,
+        result: { table, leagueId, season: params.season || "current", source: "thesportsdb" },
+      };
+    } catch (e) {
+      return { ok: false, error: `thesportsdb unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * scoreboard — ESPN public scoreboard endpoint. No API key required.
+   * params: { sport: nba|nfl|mlb|nhl|soccer, league?: leagueSlug, date?: YYYYMMDD }
+   */
+  registerLensAction("sports", "scoreboard", async (_ctx, _artifact, params = {}) => {
+    const sport = String(params.sport || "").toLowerCase().trim();
+    if (!sport) return { ok: false, error: "sport required (e.g. 'nba', 'nfl', 'mlb', 'nhl', 'soccer')" };
+    const SPORT_TO_PATH = {
+      nba:   "basketball/nba",
+      wnba:  "basketball/wnba",
+      ncaab: "basketball/mens-college-basketball",
+      nfl:   "football/nfl",
+      mlb:   "baseball/mlb",
+      nhl:   "hockey/nhl",
+      soccer: params.league ? `soccer/${params.league}` : "soccer/eng.1",
+    };
+    const path = SPORT_TO_PATH[sport];
+    if (!path) return { ok: false, error: `unsupported sport: ${sport} (try: ${Object.keys(SPORT_TO_PATH).join(", ")})` };
+    const date = params.date && /^\d{8}$/.test(String(params.date)) ? `?dates=${params.date}` : "";
+    try {
+      const r = await fetch(`${ESPN_SCOREBOARD}/${path}/scoreboard${date}`);
+      if (!r.ok) throw new Error(`espn ${r.status}`);
+      const data = await r.json();
+      const events = (data.events || []).map((ev) => {
+        const competition = ev.competitions?.[0] || {};
+        const teams = (competition.competitors || []).map((c) => ({
+          team: c.team?.displayName,
+          abbrev: c.team?.abbreviation,
+          score: c.score ? parseInt(c.score, 10) : null,
+          homeAway: c.homeAway,
+          winner: c.winner,
+          record: c.records?.[0]?.summary,
+        }));
+        return {
+          id: ev.id,
+          name: ev.name,
+          shortName: ev.shortName,
+          date: ev.date,
+          status: ev.status?.type?.description,
+          completed: ev.status?.type?.completed,
+          period: ev.status?.period,
+          clock: ev.status?.displayClock,
+          teams,
+          venue: competition.venue?.fullName,
+          venueCity: competition.venue?.address?.city,
+        };
+      });
+      return {
+        ok: true,
+        result: { events, eventCount: events.length, sport, path, date: params.date || "today", source: "espn-scoreboard" },
+      };
+    } catch (e) {
+      return { ok: false, error: `espn unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
 }

--- a/server/tests/sports-space-domain-parity.test.js
+++ b/server/tests/sports-space-domain-parity.test.js
@@ -1,0 +1,228 @@
+// Contract tests for server/domains/sports.js + server/domains/space.js
+// — pure-compute helpers plus real free APIs (TheSportsDB / ESPN /
+// SpaceX / Launch Library 2).
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerSportsActions from "../domains/sports.js";
+import registerSpaceActions from "../domains/space.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, artifactOrParams = {}, maybeParams) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`${name} not registered`);
+  const artifact = arguments.length === 4 ? artifactOrParams : { id: null, data: {}, meta: {} };
+  const params = arguments.length === 4 ? (maybeParams || {}) : artifactOrParams;
+  return fn(ctx, artifact, params);
+}
+
+before(() => {
+  registerSportsActions(register);
+  registerSpaceActions(register);
+});
+
+beforeEach(() => {
+  globalThis.fetch = async () => { throw new Error("network disabled in tests"); };
+});
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+
+describe("sports.team-lookup (TheSportsDB)", () => {
+  it("rejects missing name", async () => {
+    const r = await call("sports.team-lookup", ctxA, {});
+    assert.equal(r.ok, false);
+  });
+
+  it("hits TheSportsDB + shapes real response", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ({
+          teams: [{
+            idTeam: "133739", strTeam: "Arsenal", strAlternate: "Gunners",
+            strSport: "Soccer", strLeague: "English Premier League", idLeague: "4328",
+            strCountry: "England", intFormedYear: "1886",
+            strStadium: "Emirates Stadium", intStadiumCapacity: "60704",
+            strStadiumLocation: "London", strWebsite: "www.arsenal.com",
+            strTeamBadge: "https://example/arsenal.png",
+            strDescriptionEN: "Arsenal Football Club is a professional football club...",
+          }],
+        }),
+      };
+    };
+    const r = await call("sports.team-lookup", ctxA, { name: "Arsenal" });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /thesportsdb\.com\/api\/v1\/json\/3\/searchteams/);
+    assert.equal(r.result.teams[0].name, "Arsenal");
+    assert.equal(r.result.teams[0].formedYear, 1886);
+    assert.equal(r.result.source, "thesportsdb");
+  });
+
+  it("uses SPORTSDB_API_KEY when set", async () => {
+    process.env.SPORTSDB_API_KEY = "real-key";
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => ({ teams: [] }) };
+    };
+    await call("sports.team-lookup", ctxA, { name: "x" });
+    assert.match(capturedUrl, /\/real-key\/searchteams/);
+    delete process.env.SPORTSDB_API_KEY;
+  });
+});
+
+describe("sports.league-table (TheSportsDB)", () => {
+  it("rejects missing leagueId", async () => {
+    assert.equal((await call("sports.league-table", ctxA, {})).ok, false);
+  });
+
+  it("hits TheSportsDB + parses + sorts", async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        table: [
+          { intRank: "1", idTeam: "133739", strTeam: "Arsenal", intPlayed: "20", intWin: "15", intDraw: "3", intLoss: "2", intGoalsFor: "45", intGoalsAgainst: "15", intGoalDifference: "30", intPoints: "48", strTeamBadge: "x" },
+          { intRank: "2", idTeam: "133602", strTeam: "Liverpool", intPlayed: "20", intWin: "14", intDraw: "4", intLoss: "2", intGoalsFor: "42", intGoalsAgainst: "18", intGoalDifference: "24", intPoints: "46", strTeamBadge: "y" },
+        ],
+      }),
+    });
+    const r = await call("sports.league-table", ctxA, { leagueId: "4328" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.table[0].teamName, "Arsenal");
+    assert.equal(r.result.table[0].points, 48);
+    assert.equal(r.result.source, "thesportsdb");
+  });
+});
+
+describe("sports.scoreboard (ESPN public API)", () => {
+  it("rejects missing sport", async () => {
+    assert.equal((await call("sports.scoreboard", ctxA, {})).ok, false);
+  });
+
+  it("rejects unsupported sport", async () => {
+    const r = await call("sports.scoreboard", ctxA, { sport: "cricket" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /unsupported sport/);
+  });
+
+  it("hits ESPN + parses competitor/score response", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ({
+          events: [{
+            id: "401547651", name: "Lakers @ Warriors",
+            shortName: "LAL @ GSW", date: "2026-05-16T03:00Z",
+            status: { type: { description: "Final", completed: true }, period: 4, displayClock: "0.0" },
+            competitions: [{
+              competitors: [
+                { team: { displayName: "Golden State Warriors", abbreviation: "GSW" }, score: "115", homeAway: "home", winner: true, records: [{ summary: "44-37" }] },
+                { team: { displayName: "Los Angeles Lakers", abbreviation: "LAL" }, score: "108", homeAway: "away", winner: false, records: [{ summary: "47-34" }] },
+              ],
+              venue: { fullName: "Chase Center", address: { city: "San Francisco" } },
+            }],
+          }],
+        }),
+      };
+    };
+    const r = await call("sports.scoreboard", ctxA, { sport: "nba" });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /site\.api\.espn\.com\/apis\/site\/v2\/sports\/basketball\/nba\/scoreboard/);
+    assert.equal(r.result.events[0].teams[0].team, "Golden State Warriors");
+    assert.equal(r.result.events[0].teams[0].score, 115);
+    assert.equal(r.result.events[0].status, "Final");
+    assert.equal(r.result.source, "espn-scoreboard");
+  });
+
+  it("supports date param for historical scores", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => ({ events: [] }) };
+    };
+    await call("sports.scoreboard", ctxA, { sport: "nfl", date: "20240107" });
+    assert.match(capturedUrl, /football\/nfl\/scoreboard\?dates=20240107/);
+  });
+});
+
+describe("space.spacex-upcoming", () => {
+  it("hits SpaceX API + parses launches", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ([{
+          id: "abc123", name: "Crew-9", flight_number: 312,
+          date_utc: "2026-06-01T10:00:00.000Z", date_unix: 1748767200, date_precision: "hour",
+          rocket: "falcon9-id", launchpad: "kennedy-39a",
+          details: "Crew Dragon mission to ISS",
+          success: null, upcoming: true,
+          links: { patch: { small: "https://images.example.org/patch.png" }, webcast: "https://youtu.be/x", wikipedia: "https://en.wikipedia.org/wiki/Crew-9" },
+        }]),
+      };
+    };
+    const r = await call("space.spacex-upcoming", ctxA, { limit: 5 });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /api\.spacexdata\.com\/v4\/launches\/upcoming/);
+    assert.equal(r.result.launches[0].name, "Crew-9");
+    assert.equal(r.result.launches[0].flightNumber, 312);
+    assert.equal(r.result.source, "spacexdata-api");
+  });
+});
+
+describe("space.launch-library-upcoming", () => {
+  it("hits Launch Library 2 + parses cross-provider list", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ({
+          count: 50,
+          results: [{
+            id: "uuid-1", name: "Falcon 9 | Starlink 6-67",
+            net: "2026-06-15T08:30:00Z",
+            window_start: "2026-06-15T08:30:00Z", window_end: "2026-06-15T12:30:00Z",
+            status: { name: "Go for Launch" },
+            launch_service_provider: { name: "SpaceX" },
+            rocket: { configuration: { full_name: "Falcon 9 Block 5" } },
+            mission: { name: "Starlink 6-67", description: "Starlink batch deployment", type: "Communications", orbit: { name: "Low Earth Orbit" } },
+            pad: { name: "Space Launch Complex 40", location: { name: "Cape Canaveral SFS, FL, USA" }, country_code: "USA" },
+            webcast_live: false,
+            image: "https://example.org/launch.jpg",
+          }],
+        }),
+      };
+    };
+    const r = await call("space.launch-library-upcoming", ctxA, { limit: 5 });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /ll\.thespacedevs\.com\/2\.2\.0\/launch\/upcoming/);
+    assert.equal(r.result.launches[0].provider, "SpaceX");
+    assert.equal(r.result.launches[0].rocket, "Falcon 9 Block 5");
+    assert.equal(r.result.totalAvailable, 50);
+    assert.equal(r.result.source, "thespacedevs-launch-library");
+  });
+
+  it("surfaces 429 rate limit clearly", async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 429, json: async () => ({}) });
+    const r = await call("space.launch-library-upcoming", ctxA, {});
+    assert.equal(r.ok, false);
+    assert.match(r.error, /rate limit exceeded/);
+  });
+});
+
+describe("space.orbitCalc (existing pure-math)", () => {
+  it("computes LEO at 400 km", () => {
+    const r = call("space.orbitCalc", ctxA, { data: { altitudeKm: 400 } }, {});
+    assert.equal(r.ok, true);
+    // ISS orbital period ≈ 92 min
+    assert.ok(r.result.periodMinutes > 90 && r.result.periodMinutes < 95);
+    assert.equal(r.result.type, "LEO");
+  });
+});


### PR DESCRIPTION
## Summary

Bucket 1 polish batch: two one-liner domain files (7 LOC each) now have real free-API integrations on top of the existing pure-compute helpers.

### sports
- **`team-lookup`** — TheSportsDB team search (free dev key "3", env override).
- **`league-table`** — TheSportsDB standings + season filter.
- **`scoreboard`** — ESPN public scoreboard API (no key). NBA/WNBA/NCAAB/NFL/MLB/NHL/soccer. Real live scores, team records, venue, period+clock.

### space
- **`spacex-upcoming`** — SpaceX r-spacex API (no key). Falcon/Starship launches with NET, patches, webcast/article links.
- **`launch-library-upcoming`** — Launch Library 2 (no key, 15 req/hr). Cross-provider universal calendar (NASA/SpaceX/ULA/ESA/Roscosmos/ISRO/JAXA/CNSA/Rocket Lab). 429 surfaced as clear "rate limit exceeded".

## Test plan

- [x] `node --test server/tests/sports-space-domain-parity.test.js` — **13/13 passing**
- [x] Covers: TheSportsDB team-lookup + env override + league-table; ESPN scoreboard unsupported-sport rejection + real Lakers/Warriors competitor parsing + date param; SpaceX API parsing; Launch Library 2 cross-provider parsing + 429 surface; ISS-altitude orbitCalc sanity

https://claude.ai/code/session_018ucd5N7Hc3K8mNa9p2Lr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_