### PR TITLE
feat(cooking): real USDA FoodData Central — 600k+ ingredient nutrition lookup

### DIFF
--- a/server/domains/cooking.js
+++ b/server/domains/cooking.js
@@ -1,4 +1,13 @@
 // server/domains/cooking.js
+//
+// Pure-compute recipe helpers (scale, nutrition estimate, meal plan,
+// substitution) plus real USDA FoodData Central integration for
+// authoritative nutrient data across 600,000+ foods (SR Legacy +
+// Branded Foods + FNDDS). Free; NASA_FDC_API_KEY env optional
+// (falls back to DEMO_KEY rate-limited 1000/hr per IP).
+
+const FDC_BASE = "https://api.nal.usda.gov/fdc/v1";
+
 export default function registerCookingActions(registerLensAction) {
   registerLensAction("cooking", "scaleRecipe", (ctx, artifact, _params) => {
     const data = artifact.data || {};
@@ -40,5 +49,119 @@ export default function registerCookingActions(registerLensAction) {
     const subs = { butter: [{ sub: "Coconut oil", ratio: "1:1" }, { sub: "Applesauce", ratio: "1:0.5", note: "For baking, reduces fat" }], egg: [{ sub: "Flax egg (1 tbsp ground flax + 3 tbsp water)", ratio: "1 egg" }, { sub: "Mashed banana", ratio: "1/4 cup per egg" }], milk: [{ sub: "Oat milk", ratio: "1:1" }, { sub: "Almond milk", ratio: "1:1" }], flour: [{ sub: "Almond flour", ratio: "1:1", note: "Gluten-free, denser" }, { sub: "Oat flour", ratio: "1:1" }], sugar: [{ sub: "Honey", ratio: "1:0.75", note: "Reduce liquid by 2 tbsp" }, { sub: "Maple syrup", ratio: "1:0.75" }], cream: [{ sub: "Coconut cream", ratio: "1:1" }, { sub: "Cashew cream", ratio: "1:1" }] };
     const match = Object.keys(subs).find(k => ingredient.includes(k));
     return { ok: true, result: { ingredient, substitutions: match ? subs[match] : [{ sub: "No common substitutions found", ratio: "N/A" }], found: !!match } };
+  });
+
+  /**
+   * usda-search — Search USDA FoodData Central for ingredients by name.
+   * Returns matches with FDC IDs the caller can pass to usda-nutrition.
+   * Free; NASA_FDC_API_KEY env optional (DEMO_KEY fallback).
+   *
+   * params: { query: string, dataType?: "Branded"|"Survey (FNDDS)"|"Foundation"|"SR Legacy", pageSize?: 1-50 }
+   */
+  registerLensAction("cooking", "usda-search", async (_ctx, _artifact, params = {}) => {
+    const query = String(params.query || "").trim();
+    if (!query) return { ok: false, error: "query required" };
+    if (query.length < 2) return { ok: false, error: "query must be ≥ 2 characters" };
+    const apiKey = process.env.NASA_FDC_API_KEY || process.env.FDC_API_KEY || "DEMO_KEY";
+    const pageSize = Math.max(1, Math.min(50, Number(params.pageSize) || 10));
+    const dataType = params.dataType ? `&dataType=${encodeURIComponent(String(params.dataType))}` : "";
+    try {
+      const r = await fetch(`${FDC_BASE}/foods/search?api_key=${encodeURIComponent(apiKey)}&query=${encodeURIComponent(query)}&pageSize=${pageSize}${dataType}`);
+      if (!r.ok) {
+        if (r.status === 429) return { ok: false, error: "FDC rate limit exceeded — set FDC_API_KEY env (free at api.data.gov/signup)" };
+        throw new Error(`fdc ${r.status}`);
+      }
+      const data = await r.json();
+      const foods = (data.foods || []).map((f) => ({
+        fdcId: f.fdcId,
+        description: f.description,
+        dataType: f.dataType,
+        brandOwner: f.brandOwner,
+        brandName: f.brandName,
+        gtinUpc: f.gtinUpc,
+        servingSize: f.servingSize,
+        servingSizeUnit: f.servingSizeUnit,
+        score: f.score,
+        publishedDate: f.publishedDate,
+      }));
+      return {
+        ok: true,
+        result: {
+          foods, count: foods.length,
+          totalHits: data.totalHits,
+          currentPage: data.currentPage,
+          totalPages: data.totalPages,
+          source: "usda-fooddata-central",
+          usingDemoKey: apiKey === "DEMO_KEY",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `fdc unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * usda-nutrition — Full nutrient profile by FDC ID. Returns calories,
+   * macros (protein/carbs/fat/fiber/sugar), vitamins, minerals, and
+   * the full nutrient list per 100g (or per serving for branded foods).
+   *
+   * params: { fdcId: number }
+   */
+  registerLensAction("cooking", "usda-nutrition", async (_ctx, _artifact, params = {}) => {
+    const fdcId = Number(params.fdcId);
+    if (!Number.isFinite(fdcId) || fdcId <= 0) return { ok: false, error: "fdcId required (integer from usda-search)" };
+    const apiKey = process.env.NASA_FDC_API_KEY || process.env.FDC_API_KEY || "DEMO_KEY";
+    try {
+      const r = await fetch(`${FDC_BASE}/food/${fdcId}?api_key=${encodeURIComponent(apiKey)}`);
+      if (r.status === 404) return { ok: false, error: `FDC ID not found: ${fdcId}` };
+      if (!r.ok) {
+        if (r.status === 429) return { ok: false, error: "FDC rate limit exceeded — set FDC_API_KEY env" };
+        throw new Error(`fdc ${r.status}`);
+      }
+      const food = await r.json();
+      // Build a {nutrientName: { amount, unit }} dict
+      const nutrients = {};
+      for (const n of food.foodNutrients || []) {
+        const name = n.nutrient?.name || n.nutrientName;
+        if (!name) continue;
+        nutrients[name] = {
+          amount: n.amount ?? n.value ?? null,
+          unit: n.nutrient?.unitName || n.unitName,
+        };
+      }
+      // Pull out the headline values
+      const pick = (k) => nutrients[k]?.amount ?? null;
+      return {
+        ok: true,
+        result: {
+          fdcId: food.fdcId,
+          description: food.description,
+          dataType: food.dataType,
+          brandOwner: food.brandOwner,
+          servingSize: food.servingSize,
+          servingSizeUnit: food.servingSizeUnit,
+          householdServingFullText: food.householdServingFullText,
+          headline: {
+            caloriesKcal: pick("Energy"),
+            proteinG: pick("Protein"),
+            totalFatG: pick("Total lipid (fat)"),
+            saturatedFatG: pick("Fatty acids, total saturated"),
+            carbsG: pick("Carbohydrate, by difference"),
+            fiberG: pick("Fiber, total dietary"),
+            sugarG: pick("Sugars, total including NLEA"),
+            sodiumMg: pick("Sodium, Na"),
+            calciumMg: pick("Calcium, Ca"),
+            ironMg: pick("Iron, Fe"),
+            potassiumMg: pick("Potassium, K"),
+            vitaminCMg: pick("Vitamin C, total ascorbic acid"),
+          },
+          nutrients,
+          source: "usda-fooddata-central",
+          usingDemoKey: apiKey === "DEMO_KEY",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `fdc unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
   });
 }

--- a/server/tests/cooking-domain-parity.test.js
+++ b/server/tests/cooking-domain-parity.test.js
@@ -1,0 +1,173 @@
+// Contract tests for server/domains/cooking.js — pure-compute recipe
+// helpers + real USDA FoodData Central integration.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerCookingActions from "../domains/cooking.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, artifactOrParams = {}, maybeParams) {
+  const fn = ACTIONS.get(`cooking.${name}`);
+  if (!fn) throw new Error(`cooking.${name} not registered`);
+  const artifact = arguments.length === 4 ? artifactOrParams : { id: null, data: {}, meta: {} };
+  const params = arguments.length === 4 ? (maybeParams || {}) : artifactOrParams;
+  return fn(ctx, artifact, params);
+}
+
+before(() => { registerCookingActions(register); });
+
+beforeEach(() => {
+  globalThis.fetch = async () => { throw new Error("network disabled in tests"); };
+  delete process.env.FDC_API_KEY;
+  delete process.env.NASA_FDC_API_KEY;
+});
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+
+describe("cooking.scaleRecipe", () => {
+  it("doubles a 4-serving recipe to 8 servings", () => {
+    const r = call("scaleRecipe", ctxA, {
+      data: { servings: 4, targetServings: 8, ingredients: [{ name: "flour", quantity: "2", unit: "cups" }] },
+    }, {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.scaleFactor, 2);
+    assert.match(r.result.ingredients[0].scaled, /^4 cups$/);
+  });
+});
+
+describe("cooking.substitution", () => {
+  it("returns common butter substitutions", () => {
+    const r = call("substitution", ctxA, { data: { ingredient: "unsalted butter" } }, {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.found, true);
+    assert.ok(r.result.substitutions.some((s) => s.sub.toLowerCase().includes("coconut")));
+  });
+});
+
+describe("cooking.usda-search (USDA FoodData Central)", () => {
+  it("rejects empty query", async () => {
+    const r = await call("usda-search", ctxA, {});
+    assert.equal(r.ok, false);
+  });
+
+  it("rejects query shorter than 2 chars", async () => {
+    const r = await call("usda-search", ctxA, { query: "a" });
+    assert.equal(r.ok, false);
+  });
+
+  it("hits FDC + parses real response", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ({
+          totalHits: 142, currentPage: 1, totalPages: 15,
+          foods: [{
+            fdcId: 173410, description: "Cheese, cheddar",
+            dataType: "SR Legacy", publishedDate: "2019-04-01",
+            score: 850.0,
+          }, {
+            fdcId: 1097518, description: "Cheese, cheddar, sharp, sliced",
+            dataType: "Branded", brandOwner: "Sargento", brandName: "Sargento",
+            gtinUpc: "046100000557",
+            servingSize: 28, servingSizeUnit: "g",
+            score: 720.5,
+          }],
+        }),
+      };
+    };
+    const r = await call("usda-search", ctxA, { query: "cheddar" });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /api\.nal\.usda\.gov\/fdc\/v1\/foods\/search/);
+    assert.match(capturedUrl, /api_key=DEMO_KEY/);
+    assert.match(capturedUrl, /query=cheddar/);
+    assert.equal(r.result.foods.length, 2);
+    assert.equal(r.result.foods[0].fdcId, 173410);
+    assert.equal(r.result.foods[1].brandOwner, "Sargento");
+    assert.equal(r.result.totalHits, 142);
+    assert.equal(r.result.source, "usda-fooddata-central");
+    assert.equal(r.result.usingDemoKey, true);
+  });
+
+  it("uses FDC_API_KEY env when set", async () => {
+    process.env.FDC_API_KEY = "real-fdc-key";
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => ({ foods: [] }) };
+    };
+    const r = await call("usda-search", ctxA, { query: "apple" });
+    assert.match(capturedUrl, /api_key=real-fdc-key/);
+    assert.equal(r.result.usingDemoKey, false);
+  });
+
+  it("supports dataType filter", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => ({ foods: [] }) };
+    };
+    await call("usda-search", ctxA, { query: "apple", dataType: "SR Legacy" });
+    assert.match(capturedUrl, /dataType=SR%20Legacy/);
+  });
+
+  it("surfaces 429 rate limit with helpful key-setup pointer", async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 429, json: async () => ({}) });
+    const r = await call("usda-search", ctxA, { query: "apple" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /rate limit exceeded.*FDC_API_KEY/);
+  });
+});
+
+describe("cooking.usda-nutrition (USDA FoodData Central)", () => {
+  it("rejects missing fdcId", async () => {
+    const r = await call("usda-nutrition", ctxA, {});
+    assert.equal(r.ok, false);
+  });
+
+  it("rejects non-positive fdcId", async () => {
+    assert.equal((await call("usda-nutrition", ctxA, { fdcId: 0 })).ok, false);
+    assert.equal((await call("usda-nutrition", ctxA, { fdcId: -1 })).ok, false);
+  });
+
+  it("hits FDC + parses headline + full nutrient list", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ({
+          fdcId: 173410, description: "Cheese, cheddar", dataType: "SR Legacy",
+          foodNutrients: [
+            { nutrient: { name: "Energy", unitName: "KCAL" }, amount: 403 },
+            { nutrient: { name: "Protein", unitName: "G" }, amount: 22.87 },
+            { nutrient: { name: "Total lipid (fat)", unitName: "G" }, amount: 33.31 },
+            { nutrient: { name: "Carbohydrate, by difference", unitName: "G" }, amount: 3.09 },
+            { nutrient: { name: "Calcium, Ca", unitName: "MG" }, amount: 721 },
+            { nutrient: { name: "Sodium, Na", unitName: "MG" }, amount: 643 },
+            { nutrient: { name: "Iron, Fe", unitName: "MG" }, amount: 0.16 },
+          ],
+        }),
+      };
+    };
+    const r = await call("usda-nutrition", ctxA, { fdcId: 173410 });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /\/fdc\/v1\/food\/173410/);
+    assert.equal(r.result.description, "Cheese, cheddar");
+    assert.equal(r.result.headline.caloriesKcal, 403);
+    assert.equal(r.result.headline.proteinG, 22.87);
+    assert.equal(r.result.headline.calciumMg, 721);
+    // full nutrient dict has all 7 entries
+    assert.equal(Object.keys(r.result.nutrients).length, 7);
+    assert.equal(r.result.source, "usda-fooddata-central");
+  });
+
+  it("returns clear 404 when FDC ID doesn't exist", async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 404, json: async () => ({}) });
+    const r = await call("usda-nutrition", ctxA, { fdcId: 9999999 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /FDC ID not found/);
+  });
+});


### PR DESCRIPTION
## Summary

Bucket 1 polish on cooking lens. Previously had a 10-ingredient hardcoded nutrition table (real values but tiny coverage); now adds two real-data macros hitting **USDA FoodData Central** (authoritative US nutrition database with 600,000+ foods — SR Legacy + Branded Foods + FNDDS + Foundation).

### Backend
- **`usda-search`** — ingredient search by name. Returns FDC IDs, brand owner, GTIN/UPC, serving size, data type. Free; `NASA_FDC_API_KEY` / `FDC_API_KEY` env optional (DEMO_KEY fallback, 1000 req/hr). `dataType` filter supported.
- **`usda-nutrition`** — full nutrient profile by FDC ID. Headline values (calories, macros, fiber, sugar, sodium, calcium, iron, K, vitamin C) + full nutrient dict (50+ vitamins/minerals/amino acids).

## Test plan

- [x] `node --test server/tests/cooking-domain-parity.test.js` — **12/12 passing**
- [x] Covers: scaleRecipe scaling factor, substitution lookup; usda-search query validation + real FDC response shape + env override + dataType filter + 429 with helpful pointer; usda-nutrition fdcId validation + real cheddar parsing + 404 for unknown ID

https://claude.ai/code/session_018ucd5N7Hc3K8mNa9p2Lr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_