### PR TITLE
feat(music): real MusicBrainz integration — artist/release/ISRC lookup

### DIFF
--- a/server/domains/music.js
+++ b/server/domains/music.js
@@ -1,4 +1,29 @@
 // server/domains/music.js
+//
+// Pure-compute music-theory helpers (BPM, key detect via
+// Krumhansl-Schmuckler, chord progression match, setlist planner)
+// plus real MusicBrainz metadata (artists, releases, recordings).
+//
+// MusicBrainz is the authoritative open-source music metadata DB.
+// Free, no API key — but ToS REQUIRES a contact User-Agent header.
+// Set MUSICBRAINZ_CONTACT to a contact email/URL for production
+// usage; we use a fallback identifying Concord OS for dev.
+
+const MB_BASE = "https://musicbrainz.org/ws/2";
+
+function mbUserAgent() {
+  const contact = process.env.MUSICBRAINZ_CONTACT || "https://concord-os.org";
+  return `Concord-OS/1.0 ( ${contact} )`;
+}
+
+async function mbFetch(path) {
+  const url = `${MB_BASE}${path}${path.includes("?") ? "&" : "?"}fmt=json`;
+  const r = await fetch(url, { headers: { "User-Agent": mbUserAgent(), Accept: "application/json" } });
+  if (r.status === 503) throw new Error("musicbrainz rate limited (1 req/sec) — back off and retry");
+  if (!r.ok) throw new Error(`musicbrainz ${r.status}`);
+  return r.json();
+}
+
 export default function registerMusicActions(registerLensAction) {
   registerLensAction("music", "bpmAnalyze", (ctx, artifact, _params) => {
     const beats = artifact.data?.beats || artifact.data?.timestamps || [];
@@ -89,5 +114,105 @@ export default function registerMusicActions(registerLensAction) {
     const totalDuration = processed.reduce((s, t) => s + t.duration, 0);
     const avgBpm = Math.round(processed.reduce((s, t) => s + t.bpm, 0) / n);
     return { ok: true, result: { suggestedOrder: setlist.map(t => t.title), totalDuration: Math.round(totalDuration), totalMinutes: Math.round(totalDuration / 60), trackCount: n, avgBpm, energyCurve: setlist.map(t => ({ title: t.title, energy: t.energy, bpm: t.bpm })), peakMoment: peak.title, opener: opener.title, closer: closer.title } };
+  });
+
+  // ── MusicBrainz (real metadata) ──
+
+  /**
+   * mb-search-artist — Fuzzy artist search via MusicBrainz.
+   * params: { query: string, limit?: 1-100 }
+   */
+  registerLensAction("music", "mb-search-artist", async (_ctx, _artifact, params = {}) => {
+    const query = String(params.query || "").trim();
+    if (!query) return { ok: false, error: "query required" };
+    if (query.length < 2) return { ok: false, error: "query must be ≥ 2 characters" };
+    const limit = Math.max(1, Math.min(100, Number(params.limit) || 10));
+    try {
+      const data = await mbFetch(`/artist?query=${encodeURIComponent(query)}&limit=${limit}`);
+      const artists = (data.artists || []).map((a) => ({
+        mbid: a.id,
+        name: a.name,
+        sortName: a["sort-name"],
+        type: a.type,
+        country: a.country,
+        beginArea: a["begin-area"]?.name,
+        lifeSpan: a["life-span"] ? { begin: a["life-span"].begin, end: a["life-span"].end, ended: a["life-span"].ended } : null,
+        disambiguation: a.disambiguation,
+        score: a.score,
+        tags: (a.tags || []).map((t) => t.name),
+      }));
+      return {
+        ok: true,
+        result: { artists, count: artists.length, totalCount: data.count, source: "musicbrainz" },
+      };
+    } catch (e) {
+      return { ok: false, error: `musicbrainz unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * mb-artist-releases — Lookup an artist's releases (albums/EPs/singles)
+   * by their MBID. Returns releases with type, date, country, formats.
+   */
+  registerLensAction("music", "mb-artist-releases", async (_ctx, _artifact, params = {}) => {
+    const mbid = String(params.mbid || "").trim();
+    if (!mbid) return { ok: false, error: "mbid required (MusicBrainz artist UUID from mb-search-artist)" };
+    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(mbid)) {
+      return { ok: false, error: "mbid must be a MusicBrainz UUID" };
+    }
+    const limit = Math.max(1, Math.min(100, Number(params.limit) || 25));
+    try {
+      const data = await mbFetch(`/release?artist=${mbid}&limit=${limit}&inc=release-groups`);
+      const releases = (data.releases || []).map((r) => ({
+        mbid: r.id,
+        title: r.title,
+        date: r.date,
+        country: r.country,
+        status: r.status,
+        primaryType: r["release-group"]?.["primary-type"],
+        secondaryTypes: r["release-group"]?.["secondary-types"] || [],
+        disambiguation: r.disambiguation,
+        barcode: r.barcode,
+        packaging: r.packaging,
+      }));
+      // Newest first
+      releases.sort((a, b) => (b.date || "").localeCompare(a.date || ""));
+      return {
+        ok: true,
+        result: { releases, count: releases.length, totalCount: data["release-count"], source: "musicbrainz" },
+      };
+    } catch (e) {
+      return { ok: false, error: `musicbrainz unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * mb-lookup-by-isrc — Lookup recordings by International Standard
+   * Recording Code (ISRC). Useful for radio station integrations,
+   * royalty tracking, and disambiguating cover versions.
+   */
+  registerLensAction("music", "mb-lookup-by-isrc", async (_ctx, _artifact, params = {}) => {
+    const isrc = String(params.isrc || "").toUpperCase().replace(/[-\s]/g, "").trim();
+    if (!isrc) return { ok: false, error: "isrc required" };
+    if (!/^[A-Z]{2}[A-Z0-9]{3}\d{7}$/.test(isrc)) {
+      return { ok: false, error: "isrc must be 12 chars: 2 country + 3 registrant + 2 year + 5 designation (e.g. USRC17607839)" };
+    }
+    try {
+      const data = await mbFetch(`/isrc/${encodeURIComponent(isrc)}?inc=artist-credits+releases`);
+      const recordings = (data.recordings || []).map((rec) => ({
+        mbid: rec.id,
+        title: rec.title,
+        lengthMs: rec.length,
+        artistCredit: (rec["artist-credit"] || []).map((ac) => ac.name).join(""),
+        releases: (rec.releases || []).map((rel) => ({ mbid: rel.id, title: rel.title, date: rel.date })),
+        disambiguation: rec.disambiguation,
+      }));
+      return {
+        ok: true,
+        result: { isrc, recordings, count: recordings.length, source: "musicbrainz" },
+      };
+    } catch (e) {
+      return { ok: false, error: `musicbrainz unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
   });
 }

--- a/server/tests/music-domain-parity.test.js
+++ b/server/tests/music-domain-parity.test.js
@@ -1,0 +1,159 @@
+// Contract tests for server/domains/music.js — pure-compute music theory
+// helpers + real MusicBrainz metadata.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerMusicActions from "../domains/music.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, artifactOrParams = {}, maybeParams) {
+  const fn = ACTIONS.get(`music.${name}`);
+  if (!fn) throw new Error(`music.${name} not registered`);
+  const artifact = arguments.length === 4 ? artifactOrParams : { id: null, data: {}, meta: {} };
+  const params = arguments.length === 4 ? (maybeParams || {}) : artifactOrParams;
+  return fn(ctx, artifact, params);
+}
+
+before(() => { registerMusicActions(register); });
+
+beforeEach(() => {
+  globalThis.fetch = async () => { throw new Error("network disabled in tests"); };
+});
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+
+describe("music.bpmAnalyze (pure compute)", () => {
+  it("computes ~120 BPM from half-second beat intervals", () => {
+    const beats = [0, 0.5, 1.0, 1.5, 2.0, 2.5];  // every 0.5s = 120 BPM
+    const r = call("bpmAnalyze", ctxA, { data: { beats } }, {});
+    assert.equal(r.result.bpm, 120);
+    // 120 BPM lands at the Moderato/Allegro boundary; macro uses < 140 → Allegro
+    assert.equal(r.result.tempoClass, "Allegro");
+  });
+});
+
+describe("music.keyDetect (Krumhansl-Schmuckler)", () => {
+  it("detects C major from C-major note bag", () => {
+    const r = call("keyDetect", ctxA, { data: { notes: ["C", "E", "G", "C", "F", "G", "A", "C", "E"] } }, {});
+    assert.equal(r.result.key, "C");
+    assert.equal(r.result.mode, "major");
+  });
+});
+
+describe("music.mb-search-artist (MusicBrainz)", () => {
+  it("rejects empty/short queries", async () => {
+    assert.equal((await call("mb-search-artist", ctxA, {})).ok, false);
+    assert.equal((await call("mb-search-artist", ctxA, { query: "a" })).ok, false);
+  });
+
+  it("hits MusicBrainz + parses real response shape", async () => {
+    let capturedUrl = "", capturedHeaders = {};
+    globalThis.fetch = async (url, opts) => {
+      capturedUrl = url;
+      capturedHeaders = opts?.headers || {};
+      return {
+        ok: true,
+        json: async () => ({
+          count: 1,
+          artists: [{
+            id: "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+            name: "Nirvana", "sort-name": "Nirvana",
+            type: "Group", country: "US",
+            "begin-area": { name: "Aberdeen" },
+            "life-span": { begin: "1987-01", end: "1994-04-05", ended: true },
+            disambiguation: "1980s grunge",
+            score: 100,
+            tags: [{ name: "rock" }, { name: "grunge" }],
+          }],
+        }),
+      };
+    };
+    const r = await call("mb-search-artist", ctxA, { query: "nirvana" });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /musicbrainz\.org\/ws\/2\/artist\?query=nirvana/);
+    assert.match(capturedUrl, /fmt=json/);
+    // ToS-mandated User-Agent
+    assert.match(capturedHeaders["User-Agent"], /Concord-OS/);
+    assert.equal(r.result.artists[0].mbid, "5b11f4ce-a62d-471e-81fc-a69a8278c7da");
+    assert.equal(r.result.artists[0].country, "US");
+    assert.equal(r.result.artists[0].tags[0], "rock");
+    assert.equal(r.result.source, "musicbrainz");
+  });
+
+  it("surfaces 503 rate-limit with explicit message", async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 503, json: async () => ({}) });
+    const r = await call("mb-search-artist", ctxA, { query: "test" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /rate limited/);
+  });
+});
+
+describe("music.mb-artist-releases (MusicBrainz)", () => {
+  it("rejects missing mbid", async () => {
+    assert.equal((await call("mb-artist-releases", ctxA, {})).ok, false);
+  });
+
+  it("rejects malformed mbid", async () => {
+    const r = await call("mb-artist-releases", ctxA, { mbid: "not-a-uuid" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /MusicBrainz UUID/);
+  });
+
+  it("hits MusicBrainz + sorts releases newest first", async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        "release-count": 2,
+        releases: [
+          { id: "rel1", title: "Bleach", date: "1989-06-15", country: "US", status: "Official",
+            "release-group": { "primary-type": "Album", "secondary-types": [] } },
+          { id: "rel2", title: "Nevermind", date: "1991-09-24", country: "US", status: "Official",
+            "release-group": { "primary-type": "Album", "secondary-types": [] } },
+        ],
+      }),
+    });
+    const r = await call("mb-artist-releases", ctxA, { mbid: "5b11f4ce-a62d-471e-81fc-a69a8278c7da" });
+    assert.equal(r.ok, true);
+    // Sorted newest first
+    assert.equal(r.result.releases[0].title, "Nevermind");
+    assert.equal(r.result.releases[1].title, "Bleach");
+  });
+});
+
+describe("music.mb-lookup-by-isrc (MusicBrainz)", () => {
+  it("rejects invalid ISRC format", async () => {
+    assert.equal((await call("mb-lookup-by-isrc", ctxA, { isrc: "INVALID" })).ok, false);
+  });
+
+  it("accepts hyphenated ISRC and normalizes", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => ({ recordings: [] }) };
+    };
+    await call("mb-lookup-by-isrc", ctxA, { isrc: "US-RC1-76-07839" });
+    assert.match(capturedUrl, /\/isrc\/USRC17607839/);
+  });
+
+  it("parses real recording response", async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        recordings: [{
+          id: "rec-uuid",
+          title: "Smells Like Teen Spirit",
+          length: 301000,
+          "artist-credit": [{ name: "Nirvana" }],
+          releases: [{ id: "rel-uuid", title: "Nevermind", date: "1991-09-24" }],
+          disambiguation: "",
+        }],
+      }),
+    });
+    const r = await call("mb-lookup-by-isrc", ctxA, { isrc: "USRC17607839" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.recordings[0].title, "Smells Like Teen Spirit");
+    assert.equal(r.result.recordings[0].artistCredit, "Nirvana");
+    assert.equal(r.result.recordings[0].lengthMs, 301000);
+  });
+});


### PR DESCRIPTION
## Summary

Bucket 1 polish on music lens. Existing pure-compute music-theory helpers (BPM, Krumhansl-Schmuckler key detect, chord progression matcher, setlist planner) are unchanged; adds three real-metadata macros backed by **MusicBrainz** (the authoritative open-source music metadata DB used by Picard, Last.fm, etc.).

### Backend
- **`mb-search-artist`** — fuzzy artist search. MBID, sort name, type, country, life-span, tags, match score.
- **`mb-artist-releases`** — full release catalog by MBID, sorted newest first.
- **`mb-lookup-by-isrc`** — recording lookup by ISRC. Accepts hyphenated or compact form; normalizes to canonical 12-char.

Free + no API key, but MB ToS REQUIRES a contact User-Agent — `MUSICBRAINZ_CONTACT` env, falls back to Concord OS website. Hits 1 req/sec MB rate limit; **503 surfaced as clear "rate limited" message**.

## Test plan

- [x] `node --test server/tests/music-domain-parity.test.js` — **11/11 passing**
- [x] Covers: BPM + key detect pure-compute; mb-search-artist query validation + real Nirvana response + **ToS User-Agent header INVARIANT** + 503 surface; mb-artist-releases UUID validation + sort-newest-first INVARIANT; mb-lookup-by-isrc format validation + hyphen normalization + real recording response

https://claude.ai/code/session_018ucd5N7Hc3K8mNa9p2Lr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_