### PR TITLE
feat(energy): real EIA electricity rates + generation mix

### DIFF
--- a/server/domains/energy.js
+++ b/server/domains/energy.js
@@ -1,4 +1,12 @@
 // server/domains/energy.js
+//
+// Pure-compute energy helpers (consumption, solar estimate, carbon
+// footprint, grid status) plus real US Energy Information
+// Administration (EIA) data. EIA API requires free API key (register
+// at https://www.eia.gov/opendata/register.php); set EIA_API_KEY env.
+
+const EIA_BASE = "https://api.eia.gov/v2";
+
 export default function registerEnergyActions(registerLensAction) {
   registerLensAction("energy", "consumptionAnalysis", (ctx, artifact, _params) => {
     const readings = artifact.data?.readings || [];
@@ -41,6 +49,119 @@ export default function registerEnergyActions(registerLensAction) {
     const usAvg = 16; // tons per capita
     return { ok: true, result: { breakdown: { electricity: Math.round(co2Electricity * 1000) / 1000, naturalGas: Math.round(co2Gas * 1000) / 1000, transportation: Math.round(co2Gasoline * 1000) / 1000, flights: Math.round(co2Flights * 1000) / 1000 }, totalMetricTons: Math.round(total * 1000) / 1000, annualEstimate: Math.round(total * 12 * 100) / 100, vsUSAverage: `${Math.round((total * 12 / usAvg) * 100)}% of US average`, topSource: [["electricity", co2Electricity], ["naturalGas", co2Gas], ["transportation", co2Gasoline], ["flights", co2Flights]].sort((a, b) => b[1] - a[1])[0][0], reductionTips: co2Electricity > co2Gas ? ["Switch to renewable energy provider", "Improve insulation", "LED lighting"] : ["Improve heating efficiency", "Seal air leaks", "Smart thermostat"] } };
   });
+  /**
+   * eia-electricity-rates — Real average retail electricity price by
+   * state (cents/kWh). Pulled from EIA's seriesId
+   * ELEC.PRICE.{STATE}-RES.M (residential, monthly).
+   * Requires EIA_API_KEY env (free at eia.gov/opendata/register.php).
+   * params: { state: "CA"|"TX"|..., sector?: "RES"|"COM"|"IND" }
+   */
+  registerLensAction("energy", "eia-electricity-rates", async (_ctx, _artifact, params = {}) => {
+    const state = String(params.state || "").toUpperCase().trim();
+    const sector = String(params.sector || "RES").toUpperCase();
+    if (!state) return { ok: false, error: "state required (2-letter code)" };
+    if (!/^[A-Z]{2}$/.test(state)) return { ok: false, error: "state must be 2-letter code (e.g. CA, TX)" };
+    if (!["RES", "COM", "IND", "TRA", "ALL"].includes(sector)) {
+      return { ok: false, error: "sector must be one of: RES (residential), COM (commercial), IND (industrial), TRA (transport), ALL" };
+    }
+    const apiKey = process.env.EIA_API_KEY;
+    if (!apiKey) {
+      return { ok: false, error: "EIA_API_KEY env required (free at https://www.eia.gov/opendata/register.php)" };
+    }
+    try {
+      const url = `${EIA_BASE}/electricity/retail-sales/data/?api_key=${encodeURIComponent(apiKey)}&frequency=monthly&data[0]=price&facets[stateid][]=${state}&facets[sectorid][]=${sector}&sort[0][column]=period&sort[0][direction]=desc&offset=0&length=12`;
+      const r = await fetch(url);
+      if (!r.ok) {
+        if (r.status === 403) return { ok: false, error: "EIA API key invalid or quota exceeded" };
+        throw new Error(`eia ${r.status}`);
+      }
+      const data = await r.json();
+      const rows = data?.response?.data || [];
+      const series = rows.map((row) => ({
+        period: row.period,
+        state: row.stateDescription,
+        sector: row.sectorName,
+        priceCentsPerKwh: parseFloat(row.price),
+      }));
+      const latest = series[0];
+      const yearAgo = series[11];
+      return {
+        ok: true,
+        result: {
+          state, sector,
+          latest: latest ? { period: latest.period, priceCentsPerKwh: latest.priceCentsPerKwh } : null,
+          yearOverYearChangePct: latest && yearAgo && yearAgo.priceCentsPerKwh > 0
+            ? Math.round(((latest.priceCentsPerKwh - yearAgo.priceCentsPerKwh) / yearAgo.priceCentsPerKwh) * 1000) / 10
+            : null,
+          monthlySeries: series,
+          source: "eia-electricity-retail-sales",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `eia unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * eia-generation-mix — Real generation source mix by region (coal,
+   * natural gas, nuclear, hydro, solar, wind, etc.). Latest monthly
+   * data from EIA seriesId ELEC.GEN.*.M.
+   * params: { region?: "US"|"CAL"|"TEX"|"NY"|... (regionId from EIA) }
+   */
+  registerLensAction("energy", "eia-generation-mix", async (_ctx, _artifact, params = {}) => {
+    const region = String(params.region || "US").toUpperCase().trim();
+    const apiKey = process.env.EIA_API_KEY;
+    if (!apiKey) {
+      return { ok: false, error: "EIA_API_KEY env required (free at https://www.eia.gov/opendata/register.php)" };
+    }
+    try {
+      const url = `${EIA_BASE}/electricity/electric-power-operational-data/data/?api_key=${encodeURIComponent(apiKey)}&frequency=monthly&data[0]=generation&facets[location][]=${region}&facets[sectorid][]=99&sort[0][column]=period&sort[0][direction]=desc&offset=0&length=50`;
+      const r = await fetch(url);
+      if (!r.ok) {
+        if (r.status === 403) return { ok: false, error: "EIA API key invalid or quota exceeded" };
+        throw new Error(`eia ${r.status}`);
+      }
+      const data = await r.json();
+      const rows = data?.response?.data || [];
+      if (rows.length === 0) {
+        return { ok: true, result: { region, mix: [], totalMWh: 0, source: "eia-electric-power-operational" } };
+      }
+      // Group by fuel type from the latest period.
+      const latestPeriod = rows[0]?.period;
+      const latestRows = rows.filter((r) => r.period === latestPeriod);
+      const byFuel = {};
+      let totalMWh = 0;
+      for (const row of latestRows) {
+        const fuel = row.fueltypeDescription || row.fueltype || "Other";
+        const gen = parseFloat(row.generation) || 0;
+        byFuel[fuel] = (byFuel[fuel] || 0) + gen;
+        totalMWh += gen;
+      }
+      const mix = Object.entries(byFuel)
+        .map(([fuel, mwh]) => ({
+          fuel,
+          mwh: Math.round(mwh),
+          sharePct: totalMWh > 0 ? Math.round((mwh / totalMWh) * 1000) / 10 : 0,
+        }))
+        .sort((a, b) => b.mwh - a.mwh);
+      const renewables = ["Solar", "Wind", "Hydro", "Geothermal", "Other Biomass", "Wood and Wood-Derived Fuels"];
+      const renewableShare = mix
+        .filter((m) => renewables.some((r) => m.fuel.toLowerCase().includes(r.toLowerCase())))
+        .reduce((s, m) => s + m.sharePct, 0);
+      return {
+        ok: true,
+        result: {
+          region, latestPeriod,
+          mix, totalMWh,
+          renewableSharePct: Math.round(renewableShare * 10) / 10,
+          source: "eia-electric-power-operational",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `eia unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
   registerLensAction("energy", "gridStatus", (ctx, artifact, _params) => {
     const data = artifact.data || {};
     const demandMW = parseFloat(data.currentDemandMW) || 0;

--- a/server/tests/energy-domain-parity.test.js
+++ b/server/tests/energy-domain-parity.test.js
@@ -1,0 +1,148 @@
+// Contract tests for server/domains/energy.js — pure-compute helpers
+// plus real EIA (US Energy Information Administration) integration.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerEnergyActions from "../domains/energy.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, artifactOrParams = {}, maybeParams) {
+  const fn = ACTIONS.get(`energy.${name}`);
+  if (!fn) throw new Error(`energy.${name} not registered`);
+  const artifact = arguments.length === 4 ? artifactOrParams : { id: null, data: {}, meta: {} };
+  const params = arguments.length === 4 ? (maybeParams || {}) : artifactOrParams;
+  return fn(ctx, artifact, params);
+}
+
+before(() => { registerEnergyActions(register); });
+
+beforeEach(() => {
+  globalThis.fetch = async () => { throw new Error("network disabled in tests"); };
+  delete process.env.EIA_API_KEY;
+});
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+
+describe("energy.consumptionAnalysis (pure compute)", () => {
+  it("computes total + avg + peak-to-avg ratio", () => {
+    const r = call("consumptionAnalysis", ctxA, {
+      data: { readings: [{ kWh: 10 }, { kWh: 15 }, { kWh: 50 }, { kWh: 20 }] },
+    }, {});
+    assert.equal(r.result.totalKWh, 95);
+    assert.equal(r.result.peakKWh, 50);
+    // peak/avg = 50/23.75 ≈ 2.1
+    assert.ok(r.result.peakToAvgRatio > 2);
+  });
+});
+
+describe("energy.carbonFootprint (EPA emission factors)", () => {
+  it("computes carbon from electricity + gas + gasoline + flights", () => {
+    const r = call("carbonFootprint", ctxA, {
+      data: {
+        electricityKWh: 1000, naturalGasTherms: 50,
+        gasolineGallons: 30, flightMiles: 500,
+      },
+    }, {});
+    assert.equal(r.ok, true);
+    // 0.417 + 0.265 + 0.2661 + 0.1275 ≈ 1.076 metric tons
+    assert.ok(r.result.totalMetricTons > 1 && r.result.totalMetricTons < 1.2);
+  });
+});
+
+describe("energy.eia-electricity-rates (EIA API)", () => {
+  it("rejects missing/bad state", async () => {
+    assert.equal((await call("eia-electricity-rates", ctxA, {})).ok, false);
+    assert.equal((await call("eia-electricity-rates", ctxA, { state: "C" })).ok, false);
+  });
+
+  it("rejects when EIA_API_KEY env not set", async () => {
+    const r = await call("eia-electricity-rates", ctxA, { state: "CA" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /EIA_API_KEY env required/);
+  });
+
+  it("hits EIA + parses real response", async () => {
+    process.env.EIA_API_KEY = "test-key";
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ({
+          response: {
+            data: [
+              { period: "2026-04", stateDescription: "California", sectorName: "residential", price: 29.5 },
+              { period: "2026-03", stateDescription: "California", sectorName: "residential", price: 29.1 },
+              { period: "2026-02", stateDescription: "California", sectorName: "residential", price: 28.9 },
+              { period: "2026-01", stateDescription: "California", sectorName: "residential", price: 28.7 },
+              { period: "2025-12", stateDescription: "California", sectorName: "residential", price: 28.5 },
+              { period: "2025-11", stateDescription: "California", sectorName: "residential", price: 28.3 },
+              { period: "2025-10", stateDescription: "California", sectorName: "residential", price: 28.0 },
+              { period: "2025-09", stateDescription: "California", sectorName: "residential", price: 27.8 },
+              { period: "2025-08", stateDescription: "California", sectorName: "residential", price: 27.6 },
+              { period: "2025-07", stateDescription: "California", sectorName: "residential", price: 27.4 },
+              { period: "2025-06", stateDescription: "California", sectorName: "residential", price: 27.2 },
+              { period: "2025-05", stateDescription: "California", sectorName: "residential", price: 27.0 },
+            ],
+          },
+        }),
+      };
+    };
+    const r = await call("eia-electricity-rates", ctxA, { state: "CA" });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /api\.eia\.gov\/v2\/electricity\/retail-sales/);
+    assert.match(capturedUrl, /facets\[stateid\]\[\]=CA/);
+    assert.match(capturedUrl, /facets\[sectorid\]\[\]=RES/);
+    assert.equal(r.result.latest.priceCentsPerKwh, 29.5);
+    // 12-month delta: (29.5 - 27.0) / 27.0 * 100 ≈ 9.3%
+    assert.ok(r.result.yearOverYearChangePct > 9 && r.result.yearOverYearChangePct < 10);
+    assert.equal(r.result.source, "eia-electricity-retail-sales");
+  });
+
+  it("surfaces 403 invalid-key cleanly", async () => {
+    process.env.EIA_API_KEY = "bad";
+    globalThis.fetch = async () => ({ ok: false, status: 403, json: async () => ({}) });
+    const r = await call("eia-electricity-rates", ctxA, { state: "CA" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /invalid or quota/);
+  });
+});
+
+describe("energy.eia-generation-mix (EIA API)", () => {
+  it("rejects when EIA_API_KEY env not set", async () => {
+    const r = await call("eia-generation-mix", ctxA, {});
+    assert.equal(r.ok, false);
+    assert.match(r.error, /EIA_API_KEY/);
+  });
+
+  it("groups latest period by fuel + computes renewable share", async () => {
+    process.env.EIA_API_KEY = "test-key";
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        response: {
+          data: [
+            { period: "2026-04", fueltypeDescription: "Natural Gas", generation: 150000 },
+            { period: "2026-04", fueltypeDescription: "Nuclear", generation: 70000 },
+            { period: "2026-04", fueltypeDescription: "Solar", generation: 40000 },
+            { period: "2026-04", fueltypeDescription: "Wind", generation: 60000 },
+            { period: "2026-04", fueltypeDescription: "Hydroelectric", generation: 20000 },
+            { period: "2026-04", fueltypeDescription: "Coal", generation: 60000 },
+            // Older period — should be filtered out
+            { period: "2026-03", fueltypeDescription: "Natural Gas", generation: 140000 },
+          ],
+        },
+      }),
+    });
+    const r = await call("eia-generation-mix", ctxA, { region: "US" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.latestPeriod, "2026-04");
+    // Latest only: total = 400,000 MWh; mix sorted by mwh desc
+    assert.equal(r.result.mix[0].fuel, "Natural Gas");
+    assert.equal(r.result.totalMWh, 400000);
+    // Renewable share: solar 10% + wind 15% + hydroelectric 5% = 30%
+    assert.ok(r.result.renewableSharePct > 28 && r.result.renewableSharePct < 32);
+    assert.equal(r.result.source, "eia-electric-power-operational");
+  });
+});


### PR DESCRIPTION
## Summary

Bucket 1 polish on energy lens. Existing pure-compute helpers (consumption, solar estimate, carbon footprint, grid status) unchanged; adds two real-data macros backed by the **US Energy Information Administration (EIA) API**.

### Backend
- **`eia-electricity-rates`** — real average retail electricity price by state + sector (RES/COM/IND/TRA/ALL). Returns latest price + 12-month trailing series + year-over-year delta. Requires `EIA_API_KEY` env (free at eia.gov/opendata/register.php). Validates 2-letter state code; surfaces 403 invalid-key cleanly.
- **`eia-generation-mix`** — real generation source mix by region (Coal/Natural Gas/Nuclear/Hydro/Solar/Wind/Geothermal/Biomass). Groups latest monthly period by fuel + computes total MWh + renewable share %. Filters older periods so the snapshot is clean.

## Test plan

- [x] `node --test server/tests/energy-domain-parity.test.js` — **8/8 passing**
- [x] Covers: consumption + carbon footprint compute; state validation + missing-key error pointing to registration URL + real CA response with YoY delta + 403 surface; generation-mix latest-period-only INVARIANT + renewable share calc

https://claude.ai/code/session_018ucd5N7Hc3K8mNa9p2Lr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_