### PR TITLE
feat(pharmacy): real OpenFDA drug labels + adverse-events + interaction signals

### DIFF
--- a/server/domains/pharmacy.js
+++ b/server/domains/pharmacy.js
@@ -1,7 +1,183 @@
 // server/domains/pharmacy.js
+//
+// Pure-compute pharmacy helpers (dosage calc, inventory alerts,
+// formulary search) plus real OpenFDA Drug API for label info,
+// adverse events, and drug interactions sourced from FDA's
+// Structured Product Labeling (SPL) database.
+//
+// OpenFDA is free, no API key required (rate-limited 240 req/min
+// per IP). For higher quotas, register at open.fda.gov/apis/authentication
+// and set OPENFDA_API_KEY env.
+//
+// Per the "everything must be real" directive: drugInteractionCheck
+// previously hardcoded 5 interactions; now hits the real FDA label
+// database (50,000+ drug labels with full DRUG_INTERACTIONS sections).
+
+const OPENFDA_BASE = "https://api.fda.gov/drug";
+
+async function openfdaLabelLookup(name) {
+  const apiKey = process.env.OPENFDA_API_KEY;
+  const keyParam = apiKey ? `&api_key=${encodeURIComponent(apiKey)}` : "";
+  const url = `${OPENFDA_BASE}/label.json?search=openfda.brand_name:"${encodeURIComponent(name)}"+OR+openfda.generic_name:"${encodeURIComponent(name)}"&limit=1${keyParam}`;
+  const r = await fetch(url);
+  if (r.status === 404) return null;
+  if (!r.ok) {
+    if (r.status === 429) throw new Error("openfda rate limit exceeded — set OPENFDA_API_KEY env");
+    throw new Error(`openfda ${r.status}`);
+  }
+  const data = await r.json();
+  return data?.results?.[0] || null;
+}
+
 export default function registerPharmacyActions(registerLensAction) {
-  registerLensAction("pharmacy", "drugInteractionCheck", (ctx, artifact, _params) => { const medications = artifact.data?.medications || []; if (medications.length < 2) return { ok: true, result: { message: "Add at least 2 medications to check interactions." } }; const knownInteractions = { "warfarin-aspirin": { severity: "high", effect: "Increased bleeding risk" }, "ssri-maoi": { severity: "critical", effect: "Serotonin syndrome risk" }, "statin-grapefruit": { severity: "moderate", effect: "Increased statin levels" }, "metformin-alcohol": { severity: "moderate", effect: "Lactic acidosis risk" }, "ace-potassium": { severity: "moderate", effect: "Hyperkalemia risk" } }; const found = []; const medNames = medications.map(m => (m.name || m).toLowerCase()); for (let i = 0; i < medNames.length; i++) { for (let j = i+1; j < medNames.length; j++) { const key1 = `${medNames[i]}-${medNames[j]}`; const key2 = `${medNames[j]}-${medNames[i]}`; const interaction = knownInteractions[key1] || knownInteractions[key2]; if (interaction) found.push({ drug1: medNames[i], drug2: medNames[j], ...interaction }); } } return { ok: true, result: { medicationsChecked: medications.length, interactionsFound: found.length, interactions: found, severity: found.some(f => f.severity === "critical") ? "critical" : found.some(f => f.severity === "high") ? "high" : found.length > 0 ? "moderate" : "none", disclaimer: "This is informational only — consult a pharmacist or physician" } }; });
+  /**
+   * drugInteractionCheck — Real drug-interaction lookup via OpenFDA SPL.
+   * Pulls the DRUG_INTERACTIONS section from each drug's FDA label and
+   * reports cross-mentions. This is NOT a true interaction matrix
+   * (requires First Databank or Wolters Kluwer paid feeds); it's the
+   * authoritative published warnings text. For clinical decision
+   * support, use Lexicomp / FDB / Wolters Kluwer.
+   */
+  registerLensAction("pharmacy", "drugInteractionCheck", async (_ctx, artifact, params = {}) => {
+    const medications = artifact?.data?.medications || params.medications || [];
+    if (!Array.isArray(medications) || medications.length < 2) {
+      return { ok: false, error: "at least 2 medications required" };
+    }
+    const names = medications.map((m) => String(typeof m === "string" ? m : (m.name || "")).trim()).filter(Boolean);
+    if (names.length < 2) return { ok: false, error: "medications must have non-empty names" };
+
+    const labels = [];
+    for (const name of names) {
+      try {
+        const label = await openfdaLabelLookup(name);
+        if (!label) { labels.push({ name, found: false }); continue; }
+        labels.push({
+          name,
+          found: true,
+          genericName: label.openfda?.generic_name?.[0] || null,
+          brandName: label.openfda?.brand_name?.[0] || null,
+          manufacturer: label.openfda?.manufacturer_name?.[0] || null,
+          drugInteractionsText: Array.isArray(label.drug_interactions) ? label.drug_interactions[0]?.slice(0, 2000) : null,
+          warningsText: Array.isArray(label.warnings) ? label.warnings[0]?.slice(0, 1000) : null,
+          spIDsetId: label.set_id,
+        });
+      } catch (e) {
+        return { ok: false, error: `openfda unreachable for "${name}": ${e instanceof Error ? e.message : String(e)}` };
+      }
+    }
+
+    // Co-mention signal: does each drug's DRUG_INTERACTIONS section
+    // mention the other by generic or brand name?
+    const pairs = [];
+    for (let i = 0; i < labels.length; i++) {
+      for (let j = i + 1; j < labels.length; j++) {
+        const a = labels[i], b = labels[j];
+        if (!a.found || !b.found) continue;
+        const aText = `${a.drugInteractionsText || ""} ${a.warningsText || ""}`.toLowerCase();
+        const bText = `${b.drugInteractionsText || ""} ${b.warningsText || ""}`.toLowerCase();
+        const aMentionsB = [b.genericName, b.brandName].filter(Boolean).some((n) => aText.includes(n.toLowerCase()));
+        const bMentionsA = [a.genericName, a.brandName].filter(Boolean).some((n) => bText.includes(n.toLowerCase()));
+        if (aMentionsB || bMentionsA) {
+          pairs.push({
+            drug1: a.name, drug2: b.name,
+            aMentionsB, bMentionsA,
+            source: "fda-spl-cross-mention",
+            severity: "review-label",
+          });
+        }
+      }
+    }
+    return {
+      ok: true,
+      result: {
+        medications: names,
+        labels: labels.map(({ drugInteractionsText: _d, warningsText: _w, ...meta }) => meta),
+        interactionsFound: pairs.length,
+        coMentions: pairs,
+        source: "openfda-drug-label",
+        disclaimer: "FDA SPL cross-mention is a SIGNAL, not a clinical decision. For pharmacy-grade interaction screening, use Lexicomp / First Databank / Wolters Kluwer. ALWAYS verify with a pharmacist.",
+      },
+    };
+  });
+
   registerLensAction("pharmacy", "dosageCalculator", (ctx, artifact, _params) => { const data = artifact.data || {}; const weight = parseFloat(data.weightKg) || 70; const dosePerKg = parseFloat(data.dosePerKg) || 0; const frequency = parseInt(data.frequencyPerDay) || 1; const maxDaily = parseFloat(data.maxDailyDose) || Infinity; if (!dosePerKg) return { ok: true, result: { message: "Provide dose per kg to calculate." } }; const singleDose = Math.round(weight * dosePerKg * 100) / 100; const dailyDose = singleDose * frequency; const capped = Math.min(dailyDose, maxDaily); return { ok: true, result: { weightKg: weight, dosePerKg, singleDose: `${singleDose} mg`, frequency: `${frequency}x daily`, dailyDose: `${Math.round(capped)} mg`, maxDailyDose: isFinite(maxDaily) ? `${maxDaily} mg` : "not specified", capped: dailyDose > maxDaily, disclaimer: "Verify all dosages with prescriber" } }; });
   registerLensAction("pharmacy", "inventoryAlert", (ctx, artifact, _params) => { const items = artifact.data?.inventory || []; if (items.length === 0) return { ok: true, result: { message: "Add inventory items to monitor." } }; const alerts = items.map(i => { const qty = parseInt(i.quantity) || 0; const reorder = parseInt(i.reorderPoint) || 10; const expiry = i.expiryDate ? new Date(i.expiryDate) : null; const daysToExpiry = expiry ? Math.ceil((expiry.getTime() - Date.now()) / 86400000) : null; return { name: i.name, quantity: qty, reorderPoint: reorder, lowStock: qty <= reorder, expired: daysToExpiry !== null && daysToExpiry <= 0, nearExpiry: daysToExpiry !== null && daysToExpiry > 0 && daysToExpiry <= 30, daysToExpiry }; }); return { ok: true, result: { totalItems: items.length, lowStock: alerts.filter(a => a.lowStock).length, expired: alerts.filter(a => a.expired).length, nearExpiry: alerts.filter(a => a.nearExpiry).length, alerts: alerts.filter(a => a.lowStock || a.expired || a.nearExpiry), allClear: alerts.every(a => !a.lowStock && !a.expired && !a.nearExpiry) } }; });
   registerLensAction("pharmacy", "formularySearch", (ctx, artifact, _params) => { const query = (artifact.data?.query || artifact.data?.drugName || "").toLowerCase(); const formulary = artifact.data?.formulary || []; if (!query) return { ok: true, result: { message: "Provide a drug name to search." } }; const matches = formulary.filter(f => (f.name || f.genericName || "").toLowerCase().includes(query) || (f.brandName || "").toLowerCase().includes(query)); return { ok: true, result: { query, matches: matches.map(m => ({ generic: m.genericName || m.name, brand: m.brandName || "", tier: m.tier || "unknown", covered: m.covered !== false, priorAuth: m.priorAuth || false })), found: matches.length, formularySize: formulary.length } }; });
+
+  /**
+   * drug-label — Full FDA-approved label by drug name.
+   * params: { drug: string }
+   */
+  registerLensAction("pharmacy", "drug-label", async (_ctx, _artifact, params = {}) => {
+    const drug = String(params.drug || "").trim();
+    if (!drug) return { ok: false, error: "drug required" };
+    try {
+      const label = await openfdaLabelLookup(drug);
+      if (!label) return { ok: false, error: `no FDA label found for: ${drug}` };
+      const pick = (k) => Array.isArray(label[k]) ? label[k][0] : null;
+      return {
+        ok: true,
+        result: {
+          query: drug,
+          genericName: label.openfda?.generic_name?.[0] || null,
+          brandName: label.openfda?.brand_name?.[0] || null,
+          manufacturer: label.openfda?.manufacturer_name?.[0] || null,
+          productType: label.openfda?.product_type?.[0] || null,
+          route: label.openfda?.route?.[0] || null,
+          rxOtc: label.openfda?.rxotc?.[0] || null,
+          indications: pick("indications_and_usage"),
+          dosageAndAdministration: pick("dosage_and_administration"),
+          warnings: pick("warnings"),
+          contraindications: pick("contraindications"),
+          adverseReactions: pick("adverse_reactions"),
+          drugInteractions: pick("drug_interactions"),
+          mechanismOfAction: pick("mechanism_of_action"),
+          pregnancyCategory: pick("pregnancy"),
+          spIDsetId: label.set_id,
+          source: "openfda-drug-label",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `openfda unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * adverse-events — Real adverse event reports via OpenFDA FAERS.
+   * params: { drug: string, since?: "YYYYMMDD", until?: "YYYYMMDD" }
+   */
+  registerLensAction("pharmacy", "adverse-events", async (_ctx, _artifact, params = {}) => {
+    const drug = String(params.drug || "").trim();
+    if (!drug) return { ok: false, error: "drug required" };
+    const apiKey = process.env.OPENFDA_API_KEY;
+    const keyParam = apiKey ? `&api_key=${encodeURIComponent(apiKey)}` : "";
+    const since = params.since && /^\d{8}$/.test(String(params.since))
+      ? `+AND+receivedate:[${params.since}+TO+${params.until && /^\d{8}$/.test(String(params.until)) ? params.until : new Date().toISOString().slice(0, 10).replace(/-/g, "")}]`
+      : "";
+    try {
+      const url = `${OPENFDA_BASE}/event.json?search=patient.drug.medicinalproduct:"${encodeURIComponent(drug)}"${since}&count=patient.reaction.reactionmeddrapt.exact&limit=20${keyParam}`;
+      const r = await fetch(url);
+      if (r.status === 404) {
+        return { ok: true, result: { drug, reportCount: 0, topReactions: [], source: "openfda-faers", note: "no reports found" } };
+      }
+      if (!r.ok) {
+        if (r.status === 429) return { ok: false, error: "openfda rate limit exceeded — set OPENFDA_API_KEY env" };
+        throw new Error(`openfda ${r.status}`);
+      }
+      const data = await r.json();
+      const topReactions = (data.results || []).map((rec) => ({ term: rec.term, count: rec.count }));
+      const reportCount = topReactions.reduce((s, rec) => s + rec.count, 0);
+      return {
+        ok: true,
+        result: {
+          drug, reportCount, topReactions,
+          since: params.since || null,
+          source: "openfda-faers",
+          disclaimer: "FAERS reports are voluntary submissions and DO NOT establish causality. Underreporting is significant.",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `openfda unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
 }

--- a/server/tests/pharmacy-domain-parity.test.js
+++ b/server/tests/pharmacy-domain-parity.test.js
@@ -1,0 +1,198 @@
+// Contract tests for server/domains/pharmacy.js — pure-compute helpers
+// (dosage, inventory, formulary) plus real OpenFDA Drug API integration.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerPharmacyActions from "../domains/pharmacy.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, artifactOrParams = {}, maybeParams) {
+  const fn = ACTIONS.get(`pharmacy.${name}`);
+  if (!fn) throw new Error(`pharmacy.${name} not registered`);
+  const artifact = arguments.length === 4 ? artifactOrParams : { id: null, data: {}, meta: {} };
+  const params = arguments.length === 4 ? (maybeParams || {}) : artifactOrParams;
+  return fn(ctx, artifact, params);
+}
+
+before(() => { registerPharmacyActions(register); });
+
+beforeEach(() => {
+  globalThis.fetch = async () => { throw new Error("network disabled in tests"); };
+  delete process.env.OPENFDA_API_KEY;
+});
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+
+describe("pharmacy.dosageCalculator (pure compute)", () => {
+  it("computes single + daily dose from weight × dosePerKg × freq", () => {
+    const r = call("dosageCalculator", ctxA, { data: { weightKg: 70, dosePerKg: 10, frequencyPerDay: 3, maxDailyDose: 4000 } }, {});
+    assert.equal(r.result.singleDose, "700 mg");
+    assert.equal(r.result.dailyDose, "2100 mg");
+    assert.equal(r.result.capped, false);
+  });
+});
+
+describe("pharmacy.drugInteractionCheck (real OpenFDA SPL)", () => {
+  it("rejects fewer than 2 medications", async () => {
+    const r = await call("drugInteractionCheck", ctxA, { data: { medications: ["aspirin"] } }, {});
+    assert.equal(r.ok, false);
+    assert.match(r.error, /at least 2/);
+  });
+
+  it("fetches each drug's SPL label + detects cross-mentions (warfarin ↔ aspirin)", async () => {
+    let urlCount = 0;
+    globalThis.fetch = async (url) => {
+      urlCount++;
+      const isAspirin = url.includes("aspirin");
+      return {
+        ok: true,
+        json: async () => ({
+          results: [{
+            set_id: isAspirin ? "asp-set-id" : "warf-set-id",
+            openfda: {
+              generic_name: [isAspirin ? "aspirin" : "warfarin sodium"],
+              brand_name: [isAspirin ? "Bayer Aspirin" : "Coumadin"],
+              manufacturer_name: [isAspirin ? "Bayer" : "Bristol-Myers Squibb"],
+            },
+            drug_interactions: [isAspirin
+              ? "Anticoagulants such as warfarin sodium (Coumadin) increase bleeding risk when co-administered with aspirin."
+              : "NSAIDs including aspirin (Bayer Aspirin) may increase the anticoagulant effect of warfarin sodium."],
+            warnings: ["Standard hemorrhage warnings apply."],
+          }],
+        }),
+      };
+    };
+    const r = await call("drugInteractionCheck", ctxA, {
+      data: { medications: ["warfarin", "aspirin"] },
+    }, {});
+    assert.equal(r.ok, true);
+    assert.equal(urlCount, 2);  // one fetch per drug
+    assert.equal(r.result.interactionsFound, 1);
+    assert.equal(r.result.coMentions[0].drug1, "warfarin");
+    assert.equal(r.result.coMentions[0].drug2, "aspirin");
+    assert.equal(r.result.coMentions[0].aMentionsB, true);
+    assert.equal(r.result.coMentions[0].bMentionsA, true);
+    assert.match(r.result.disclaimer, /Lexicomp/);
+    assert.equal(r.result.source, "openfda-drug-label");
+  });
+
+  it("handles drugs not found in OpenFDA (404 per drug)", async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 404, json: async () => ({}) });
+    const r = await call("drugInteractionCheck", ctxA, {
+      data: { medications: ["xyzbogus1", "xyzbogus2"] },
+    }, {});
+    assert.equal(r.ok, true);
+    // No labels found → no interactions surfaced (correct behavior)
+    assert.equal(r.result.interactionsFound, 0);
+    assert.equal(r.result.labels[0].found, false);
+  });
+
+  it("surfaces 429 rate-limit with helpful key-setup pointer", async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 429, json: async () => ({}) });
+    const r = await call("drugInteractionCheck", ctxA, {
+      data: { medications: ["aspirin", "warfarin"] },
+    }, {});
+    assert.equal(r.ok, false);
+    assert.match(r.error, /rate limit exceeded.*OPENFDA_API_KEY/);
+  });
+
+  it("uses OPENFDA_API_KEY env when set", async () => {
+    process.env.OPENFDA_API_KEY = "test-key";
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => ({ results: [] }) };
+    };
+    await call("drugInteractionCheck", ctxA, { data: { medications: ["a", "b"] } }, {});
+    assert.match(capturedUrl, /api_key=test-key/);
+  });
+});
+
+describe("pharmacy.drug-label (real OpenFDA)", () => {
+  it("rejects missing drug", async () => {
+    const r = await call("drug-label", ctxA, {});
+    assert.equal(r.ok, false);
+  });
+
+  it("hits OpenFDA + shapes the label response", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ({
+          results: [{
+            set_id: "abc-set-id",
+            openfda: {
+              generic_name: ["atorvastatin calcium"],
+              brand_name: ["Lipitor"],
+              manufacturer_name: ["Pfizer"],
+              product_type: ["HUMAN PRESCRIPTION DRUG"],
+              route: ["ORAL"],
+              rxotc: ["RX"],
+            },
+            indications_and_usage: ["INDICATIONS AND USAGE\nLipitor is indicated to reduce the risk of MI, stroke..."],
+            warnings: ["WARNINGS AND PRECAUTIONS\nMyopathy/Rhabdomyolysis..."],
+            mechanism_of_action: ["MECHANISM OF ACTION\nLipitor is a selective, competitive inhibitor of HMG-CoA reductase..."],
+            pregnancy: ["Pregnancy Category X"],
+          }],
+        }),
+      };
+    };
+    const r = await call("drug-label", ctxA, { drug: "Lipitor" });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /api\.fda\.gov\/drug\/label\.json/);
+    assert.equal(r.result.brandName, "Lipitor");
+    assert.equal(r.result.genericName, "atorvastatin calcium");
+    assert.equal(r.result.rxOtc, "RX");
+    assert.match(r.result.indications, /reduce the risk/);
+    assert.match(r.result.mechanismOfAction, /HMG-CoA reductase/);
+    assert.equal(r.result.source, "openfda-drug-label");
+  });
+
+  it("returns clear 404 when drug doesn't exist in OpenFDA", async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 404, json: async () => ({}) });
+    const r = await call("drug-label", ctxA, { drug: "xyzbogus" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /no FDA label found/);
+  });
+});
+
+describe("pharmacy.adverse-events (real OpenFDA FAERS)", () => {
+  it("rejects missing drug", async () => {
+    assert.equal((await call("adverse-events", ctxA, {})).ok, false);
+  });
+
+  it("hits FAERS + aggregates top reactions", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ({
+          results: [
+            { term: "HEADACHE", count: 1450 },
+            { term: "NAUSEA", count: 980 },
+            { term: "DIZZINESS", count: 620 },
+          ],
+        }),
+      };
+    };
+    const r = await call("adverse-events", ctxA, { drug: "Lipitor" });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /api\.fda\.gov\/drug\/event\.json/);
+    assert.match(capturedUrl, /patient\.drug\.medicinalproduct/);
+    assert.equal(r.result.reportCount, 3050);
+    assert.equal(r.result.topReactions[0].term, "HEADACHE");
+    assert.match(r.result.disclaimer, /voluntary submissions.*causality/);
+  });
+
+  it("handles 404 (no reports) gracefully as ok:true with 0 reports", async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 404, json: async () => ({}) });
+    const r = await call("adverse-events", ctxA, { drug: "xyzbogus" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.reportCount, 0);
+    assert.deepEqual(r.result.topReactions, []);
+  });
+});


### PR DESCRIPTION
## Summary

Bucket 1 polish on pharmacy lens. Previously had a 5-interaction hardcoded table (warfarin-aspirin etc.); now hits real **OpenFDA Drug API** for 50,000+ FDA-approved drug labels.

### Backend
- **`drugInteractionCheck`** (rewritten) — fetches each drug's SPL from OpenFDA, extracts DRUG_INTERACTIONS section, detects cross-mentions (does drug A's label mention drug B?). Clear disclaimer: this is a SIGNAL not a clinical CDS — Lexicomp/FDB/Wolters Kluwer for pharmacy-grade screening.
- **`drug-label` (NEW)** — full FDA label: indications, dosage, warnings, contraindications, adverse reactions, drug interactions, mechanism of action, pregnancy category.
- **`adverse-events` (NEW)** — FAERS aggregated reaction counts for a drug, optional date range. Clear disclaimer about voluntary submissions / no causality.
- dosageCalculator + inventoryAlert + formularySearch unchanged.

Free, no API key required (240 req/min/IP). `OPENFDA_API_KEY` env raises quota.

## Test plan

- [x] `node --test server/tests/pharmacy-domain-parity.test.js` — **12/12 passing**
- [x] Covers: dosage compute; interaction <2-meds rejection + real SPL warfarin↔aspirin cross-mention + 404 graceful + 429 rate-limit pointer + API key env override; drug-label real Lipitor parsing + unknown 404; FAERS aggregation + 404 → 0 reports

https://claude.ai/code/session_018ucd5N7Hc3K8mNa9p2Lr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_