### PR TITLE
feat(history): real Wikipedia REST + search + On This Day

### DIFF
--- a/server/domains/history.js
+++ b/server/domains/history.js
@@ -1,4 +1,30 @@
 // server/domains/history.js
+//
+// Pure-compute history helpers (timeline, source evaluation, period
+// comparison, cause-effect chains) plus real Wikipedia REST API +
+// "On This Day" lookups (free, no API key required — but Wikimedia
+// requires a contact User-Agent per their UA policy).
+
+const WIKI_REST = "https://en.wikipedia.org/api/rest_v1";
+const WIKI_API = "https://en.wikipedia.org/w/api.php";
+
+function wikiUserAgent() {
+  const contact = process.env.WIKIPEDIA_CONTACT || "https://concord-os.org";
+  return `Concord-OS/1.0 (${contact})`;
+}
+
+async function wikiFetch(url) {
+  const r = await fetch(url, {
+    headers: {
+      "User-Agent": wikiUserAgent(),
+      Accept: "application/json",
+      "Api-User-Agent": wikiUserAgent(),
+    },
+  });
+  if (!r.ok) throw new Error(`wikipedia ${r.status}`);
+  return r.json();
+}
+
 export default function registerHistoryActions(registerLensAction) {
   registerLensAction("history", "timelineBuild", (ctx, artifact, _params) => {
     const events = artifact.data?.events || [];
@@ -29,5 +55,128 @@ export default function registerHistoryActions(registerLensAction) {
     if (chains.length === 0) return { ok: true, result: { message: "Map cause-effect chains to analyze historical causation." } };
     const analyzed = chains.map(c => ({ cause: c.cause, effect: c.effect, type: c.type || "direct", strength: c.strength || "moderate", timelag: c.timelag || "unknown", evidence: c.evidence || [] }));
     return { ok: true, result: { chains: analyzed, totalLinks: analyzed.length, directCauses: analyzed.filter(c => c.type === "direct").length, indirectCauses: analyzed.filter(c => c.type === "indirect").length, strongLinks: analyzed.filter(c => c.strength === "strong").length, rootCauses: analyzed.filter(c => !chains.some(other => other.effect === c.cause)).map(c => c.cause) } };
+  });
+
+  /**
+   * wiki-lookup — Real article summary from Wikipedia REST API.
+   * Returns title, extract (intro), description, page URL, thumbnail.
+   * Free, no API key. Wikimedia UA policy requires contact header.
+   * params: { title: string }
+   */
+  registerLensAction("history", "wiki-lookup", async (_ctx, _artifact, params = {}) => {
+    const title = String(params.title || "").trim();
+    if (!title) return { ok: false, error: "title required" };
+    try {
+      const data = await wikiFetch(`${WIKI_REST}/page/summary/${encodeURIComponent(title.replace(/ /g, "_"))}`);
+      if (data.type === "disambiguation") {
+        return {
+          ok: true,
+          result: {
+            title: data.title,
+            type: "disambiguation",
+            description: data.description,
+            extract: data.extract,
+            note: "Title resolves to a disambiguation page. Pass a more specific title.",
+            source: "wikipedia-rest",
+          },
+        };
+      }
+      return {
+        ok: true,
+        result: {
+          title: data.title,
+          displayTitle: data.displaytitle,
+          description: data.description,
+          extract: data.extract,
+          extractHtml: data.extract_html,
+          thumbnail: data.thumbnail?.source,
+          pageUrl: data.content_urls?.desktop?.page,
+          mobilePageUrl: data.content_urls?.mobile?.page,
+          lang: data.lang,
+          revisionTimestamp: data.timestamp,
+          type: data.type,
+          source: "wikipedia-rest",
+        },
+      };
+    } catch (e) {
+      if (e instanceof Error && e.message.includes("404")) {
+        return { ok: false, error: `Wikipedia page not found: ${title}` };
+      }
+      return { ok: false, error: `wikipedia unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * wiki-search — Title search via the Wikipedia opensearch endpoint.
+   * Returns up to N matching page titles + extracts + URLs.
+   * params: { query: string, limit?: 1-50 }
+   */
+  registerLensAction("history", "wiki-search", async (_ctx, _artifact, params = {}) => {
+    const query = String(params.query || "").trim();
+    if (!query) return { ok: false, error: "query required" };
+    if (query.length < 2) return { ok: false, error: "query must be ≥ 2 characters" };
+    const limit = Math.max(1, Math.min(50, Number(params.limit) || 10));
+    try {
+      const url = `${WIKI_API}?action=opensearch&format=json&search=${encodeURIComponent(query)}&limit=${limit}&namespace=0`;
+      const data = await wikiFetch(url);
+      // opensearch returns [query, titles[], descriptions[], urls[]]
+      const titles = data[1] || [];
+      const descriptions = data[2] || [];
+      const urls = data[3] || [];
+      const results = titles.map((title, i) => ({
+        title,
+        description: descriptions[i] || null,
+        url: urls[i] || null,
+      }));
+      return {
+        ok: true,
+        result: { query, results, count: results.length, source: "wikipedia-opensearch" },
+      };
+    } catch (e) {
+      return { ok: false, error: `wikipedia unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * on-this-day — Wikipedia "On This Day" feed: events, births, deaths,
+   * holidays, and selected entries that happened on a given month/day.
+   * Free, no API key (UA policy applies).
+   * params: { month: 1-12, day: 1-31, kind?: "events"|"births"|"deaths"|"holidays"|"selected"|"all" }
+   */
+  registerLensAction("history", "on-this-day", async (_ctx, _artifact, params = {}) => {
+    const month = parseInt(params.month, 10);
+    const day = parseInt(params.day, 10);
+    const kind = ["events", "births", "deaths", "holidays", "selected", "all"].includes(params.kind) ? params.kind : "events";
+    if (!Number.isFinite(month) || month < 1 || month > 12) return { ok: false, error: "month must be 1-12" };
+    if (!Number.isFinite(day) || day < 1 || day > 31) return { ok: false, error: "day must be 1-31" };
+    const mm = String(month).padStart(2, "0");
+    const dd = String(day).padStart(2, "0");
+    try {
+      const data = await wikiFetch(`${WIKI_REST}/feed/onthisday/${kind}/${mm}/${dd}`);
+      const shape = (arr) => (arr || []).map((entry) => ({
+        text: entry.text,
+        year: entry.year,
+        pages: (entry.pages || []).slice(0, 3).map((p) => ({
+          title: p.title,
+          extract: p.extract,
+          url: p.content_urls?.desktop?.page,
+          thumbnail: p.thumbnail?.source,
+        })),
+      }));
+      return {
+        ok: true,
+        result: {
+          month, day, kind,
+          events: shape(data.events),
+          births: shape(data.births),
+          deaths: shape(data.deaths),
+          holidays: shape(data.holidays),
+          selected: shape(data.selected),
+          source: "wikipedia-onthisday",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `wikipedia unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
   });
 }

--- a/server/tests/history-domain-parity.test.js
+++ b/server/tests/history-domain-parity.test.js
@@ -1,0 +1,179 @@
+// Contract tests for server/domains/history.js — pure-compute helpers
+// plus real Wikipedia REST + On This Day integration.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerHistoryActions from "../domains/history.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, artifactOrParams = {}, maybeParams) {
+  const fn = ACTIONS.get(`history.${name}`);
+  if (!fn) throw new Error(`history.${name} not registered`);
+  const artifact = arguments.length === 4 ? artifactOrParams : { id: null, data: {}, meta: {} };
+  const params = arguments.length === 4 ? (maybeParams || {}) : artifactOrParams;
+  return fn(ctx, artifact, params);
+}
+
+before(() => { registerHistoryActions(register); });
+
+beforeEach(() => {
+  globalThis.fetch = async () => { throw new Error("network disabled in tests"); };
+});
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+
+describe("history.timelineBuild (pure compute)", () => {
+  it("sorts events chronologically + flags pivotal", () => {
+    const events = [
+      { name: "Industrial Rev", date: "1760", significance: "high", era: "modern" },
+      { name: "WWI", date: "1914", significance: "critical", era: "modern" },
+      { name: "Renaissance", date: "1400", significance: "high", era: "early modern" },
+    ];
+    const r = call("timelineBuild", ctxA, { data: { events } }, {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.timeline[0].event, "Renaissance");
+    assert.equal(r.result.timeline[2].event, "WWI");
+    assert.equal(r.result.pivotalEvents.length, 3);
+  });
+});
+
+describe("history.wiki-lookup (Wikipedia REST)", () => {
+  it("rejects empty title", async () => {
+    const r = await call("wiki-lookup", ctxA, {});
+    assert.equal(r.ok, false);
+  });
+
+  it("fetches summary + sends UA header per Wikimedia policy", async () => {
+    let capturedUrl = "", capturedUA = "";
+    globalThis.fetch = async (url, opts) => {
+      capturedUrl = url;
+      capturedUA = opts?.headers?.["User-Agent"] || "";
+      return {
+        ok: true,
+        json: async () => ({
+          type: "standard",
+          title: "World War II",
+          displaytitle: "World War II",
+          description: "Global war (1939–1945)",
+          extract: "World War II or the Second World War, often abbreviated as WWII or WW2...",
+          extract_html: "<p><b>World War II</b>...</p>",
+          thumbnail: { source: "https://upload.wikimedia.org/.../480px-WWII.jpg" },
+          content_urls: {
+            desktop: { page: "https://en.wikipedia.org/wiki/World_War_II" },
+            mobile: { page: "https://en.m.wikipedia.org/wiki/World_War_II" },
+          },
+          lang: "en",
+          timestamp: "2026-05-01T12:34:56Z",
+        }),
+      };
+    };
+    const r = await call("wiki-lookup", ctxA, { title: "World War II" });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /\/api\/rest_v1\/page\/summary\/World_War_II/);
+    assert.match(capturedUA, /Concord-OS/);
+    assert.equal(r.result.title, "World War II");
+    assert.equal(r.result.description, "Global war (1939–1945)");
+    assert.equal(r.result.source, "wikipedia-rest");
+  });
+
+  it("flags disambiguation pages with a note", async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        type: "disambiguation",
+        title: "Mercury",
+        description: "Various meanings",
+        extract: "Mercury may refer to: Mercury (planet); Mercury (element); ...",
+      }),
+    });
+    const r = await call("wiki-lookup", ctxA, { title: "Mercury" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.type, "disambiguation");
+    assert.match(r.result.note, /more specific/);
+  });
+
+  it("returns clear 404 when page doesn't exist", async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 404, json: async () => ({}) });
+    const r = await call("wiki-lookup", ctxA, { title: "ThisPageDoesNotExistXyz" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /not found/);
+  });
+});
+
+describe("history.wiki-search (Wikipedia opensearch)", () => {
+  it("rejects empty / 1-char queries", async () => {
+    assert.equal((await call("wiki-search", ctxA, {})).ok, false);
+    assert.equal((await call("wiki-search", ctxA, { query: "a" })).ok, false);
+  });
+
+  it("hits opensearch + parses [query, titles, descriptions, urls] tuple", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ([
+          "renaissance",
+          ["Renaissance", "Renaissance art", "Italian Renaissance"],
+          ["Cultural movement", "Visual arts", "European cultural movement"],
+          [
+            "https://en.wikipedia.org/wiki/Renaissance",
+            "https://en.wikipedia.org/wiki/Renaissance_art",
+            "https://en.wikipedia.org/wiki/Italian_Renaissance",
+          ],
+        ]),
+      };
+    };
+    const r = await call("wiki-search", ctxA, { query: "renaissance", limit: 3 });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /w\/api\.php\?action=opensearch/);
+    assert.match(capturedUrl, /search=renaissance/);
+    assert.match(capturedUrl, /limit=3/);
+    assert.equal(r.result.results.length, 3);
+    assert.equal(r.result.results[0].title, "Renaissance");
+    assert.equal(r.result.results[2].url, "https://en.wikipedia.org/wiki/Italian_Renaissance");
+    assert.equal(r.result.source, "wikipedia-opensearch");
+  });
+});
+
+describe("history.on-this-day (Wikipedia)", () => {
+  it("rejects invalid month/day", async () => {
+    assert.equal((await call("on-this-day", ctxA, { month: 13, day: 1 })).ok, false);
+    assert.equal((await call("on-this-day", ctxA, { month: 5, day: 32 })).ok, false);
+    assert.equal((await call("on-this-day", ctxA, {})).ok, false);
+  });
+
+  it("fetches the correct mm/dd endpoint + shapes the response", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ({
+          events: [
+            { text: "End of WWII in Europe", year: 1945, pages: [{ title: "Victory in Europe Day", extract: "VE Day...", content_urls: { desktop: { page: "https://en.wikipedia.org/wiki/Victory_in_Europe_Day" } } }] },
+            { text: "Other event", year: 1900, pages: [] },
+          ],
+        }),
+      };
+    };
+    const r = await call("on-this-day", ctxA, { month: 5, day: 8 });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /\/feed\/onthisday\/events\/05\/08/);
+    assert.equal(r.result.events.length, 2);
+    assert.equal(r.result.events[0].year, 1945);
+    assert.equal(r.result.events[0].pages[0].url, "https://en.wikipedia.org/wiki/Victory_in_Europe_Day");
+    assert.equal(r.result.source, "wikipedia-onthisday");
+  });
+
+  it("supports kind=births / deaths / holidays / selected / all", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => ({}) };
+    };
+    await call("on-this-day", ctxA, { month: 5, day: 16, kind: "births" });
+    assert.match(capturedUrl, /\/feed\/onthisday\/births\/05\/16/);
+  });
+});


### PR DESCRIPTION
## Summary

Bucket 1 polish on history lens. Existing pure-compute helpers (timelineBuild, sourceEvaluate, comparePeriods, causeEffect) unchanged; adds three real-data macros backed by Wikipedia's official REST + opensearch APIs.

### Backend
- **`wiki-lookup`** — page summary by exact title via Wikipedia REST. Description, extract, thumbnail, content URLs, revision timestamp. **Detects disambiguation pages** and flags with a note.
- **`wiki-search`** — title search via opensearch. Parses the `[query, titles[], descriptions[], urls[]]` tuple into clean `{title, description, url}` objects.
- **`on-this-day`** — Wikipedia "On This Day" feed for events/births/deaths/holidays/selected on a given month+day. Text + year + linked pages with extracts.

All three free + no API key. **Wikimedia UA policy enforced** via User-Agent header (`WIKIPEDIA_CONTACT` env for production contact info).

## Test plan

- [x] `node --test server/tests/history-domain-parity.test.js` — **10/10 passing**
- [x] Covers: timeline chronological sort + pivotal flag; wiki-lookup with **UA-header INVARIANT** + disambiguation detection + 404 surface; wiki-search opensearch tuple parsing; on-this-day month/day validation + mm/dd URL format + kind param

https://claude.ai/code/session_018ucd5N7Hc3K8mNa9p2Lr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_