### PR TITLE
feat(geology): real USGS earthquake catalog + ASCE 7-22 seismic-hazard

### DIFF
--- a/server/domains/geology.js
+++ b/server/domains/geology.js
@@ -1,4 +1,16 @@
 // server/domains/geology.js
+//
+// Pure-compute geology helpers (rock classify, mineral ID,
+// stratigraphic column) plus real USGS APIs for earthquake data
+// and seismic-hazard design parameters.
+//
+// Free, no API key:
+//   • USGS Earthquake Catalog: earthquake.usgs.gov/fdsnws/event/1/
+//   • USGS DESIGNMAPS (ASCE 7 / IBC seismic): earthquake.usgs.gov/ws/designmaps/asce7-22
+
+const USGS_EQ_API = "https://earthquake.usgs.gov/fdsnws/event/1/query";
+const USGS_DESIGNMAPS = "https://earthquake.usgs.gov/ws/designmaps/asce7-22.json";
+
 export default function registerGeologyActions(registerLensAction) {
   registerLensAction("geology", "rockClassify", (ctx, artifact, _params) => {
     const data = artifact.data || {};
@@ -33,5 +45,133 @@ export default function registerGeologyActions(registerLensAction) {
     let cumulativeDepth = 0;
     const column = layers.map(l => { const thick = parseFloat(l.thickness) || 1; cumulativeDepth += thick; return { formation: l.name || l.formation, lithology: l.lithology || l.rockType || "unknown", thickness: thick, depthTop: cumulativeDepth - thick, depthBottom: cumulativeDepth, age: l.age || "unknown", fossils: l.fossils || [] }; });
     return { ok: true, result: { layers: column, totalThickness: cumulativeDepth, layerCount: layers.length, oldestFormation: column[column.length - 1]?.formation, youngestFormation: column[0]?.formation, fossiliferous: column.filter(l => l.fossils.length > 0).length } };
+  });
+
+  /**
+   * recent-earthquakes — Real seismic events from USGS Earthquake
+   * Catalog (FDSN web service). Free, no API key. Default window
+   * is the last 24 hours globally with magnitude ≥ 2.5.
+   *
+   * params: {
+   *   minMagnitude?: number (default 2.5),
+   *   limit?: number (1-200, default 20),
+   *   latitude?, longitude?, radiusKm? — circle filter,
+   *   minlatitude?, maxlatitude?, minlongitude?, maxlongitude? — bbox filter,
+   *   sinceHours?: number (default 24)
+   * }
+   */
+  registerLensAction("geology", "recent-earthquakes", async (_ctx, _artifact, params = {}) => {
+    const minMagnitude = Number(params.minMagnitude);
+    const limit = Math.max(1, Math.min(200, Number(params.limit) || 20));
+    const sinceHours = Math.max(0.5, Math.min(24 * 30, Number(params.sinceHours) || 24));
+    const starttime = new Date(Date.now() - sinceHours * 3600 * 1000).toISOString();
+    const qs = new URLSearchParams({
+      format: "geojson",
+      starttime,
+      orderby: "time",
+      limit: String(limit),
+    });
+    if (Number.isFinite(minMagnitude) && minMagnitude > 0) qs.set("minmagnitude", String(minMagnitude));
+    if (params.latitude != null && params.longitude != null && params.radiusKm != null) {
+      qs.set("latitude", String(Number(params.latitude)));
+      qs.set("longitude", String(Number(params.longitude)));
+      qs.set("maxradiuskm", String(Number(params.radiusKm)));
+    } else if (
+      params.minlatitude != null && params.maxlatitude != null &&
+      params.minlongitude != null && params.maxlongitude != null
+    ) {
+      qs.set("minlatitude", String(Number(params.minlatitude)));
+      qs.set("maxlatitude", String(Number(params.maxlatitude)));
+      qs.set("minlongitude", String(Number(params.minlongitude)));
+      qs.set("maxlongitude", String(Number(params.maxlongitude)));
+    }
+    try {
+      const r = await fetch(`${USGS_EQ_API}?${qs.toString()}`);
+      if (!r.ok) throw new Error(`usgs ${r.status}`);
+      const data = await r.json();
+      const events = (data.features || []).map((f) => ({
+        id: f.id,
+        magnitude: f.properties?.mag,
+        magnitudeType: f.properties?.magType,
+        place: f.properties?.place,
+        time: f.properties?.time ? new Date(f.properties.time).toISOString() : null,
+        updated: f.properties?.updated ? new Date(f.properties.updated).toISOString() : null,
+        url: f.properties?.url,
+        status: f.properties?.status,
+        tsunami: f.properties?.tsunami === 1,
+        felt: f.properties?.felt,
+        cdi: f.properties?.cdi,            // community-decimal intensity (felt)
+        mmi: f.properties?.mmi,            // ShakeMap-decimal intensity
+        alert: f.properties?.alert,        // pager alert (green/yellow/orange/red)
+        sig: f.properties?.sig,            // significance
+        longitude: f.geometry?.coordinates?.[0],
+        latitude: f.geometry?.coordinates?.[1],
+        depthKm: f.geometry?.coordinates?.[2],
+      }));
+      return {
+        ok: true,
+        result: {
+          events,
+          count: events.length,
+          sinceHours,
+          generated: data.metadata?.generated ? new Date(data.metadata.generated).toISOString() : null,
+          source: "usgs-earthquake-catalog",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `usgs earthquake unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * usgs-seismic-hazard — Real ASCE 7-22 / IBC seismic design
+   * parameters for a US location via USGS DESIGNMAPS web service.
+   * Returns Ss, S1, MCEr ground motion + site-modified Sds, Sd1
+   * for the requested site class. Free, no API key.
+   *
+   * params: { latitude, longitude, riskCategory?: 1|2|3|4, siteClass?: "A"|"B"|"BC"|"C"|"CD"|"D"|"DE"|"E"|"F" }
+   */
+  registerLensAction("geology", "usgs-seismic-hazard", async (_ctx, _artifact, params = {}) => {
+    const lat = Number(params.latitude);
+    const lng = Number(params.longitude);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+      return { ok: false, error: "latitude + longitude required" };
+    }
+    if (lat < 18 || lat > 72 || lng < -180 || lng > -65) {
+      return { ok: false, error: "USGS DESIGNMAPS only covers US territory (lat 18-72, lng -180 to -65)" };
+    }
+    const riskCategory = [1, 2, 3, 4].includes(Number(params.riskCategory)) ? Number(params.riskCategory) : 2;
+    const siteClass = ["A", "B", "BC", "C", "CD", "D", "DE", "E", "F"].includes(params.siteClass) ? params.siteClass : "D";
+    const url = `${USGS_DESIGNMAPS}?latitude=${lat}&longitude=${lng}&riskCategory=${riskCategory}&siteClass=${siteClass}&title=Concord+OS+Lookup`;
+    try {
+      const r = await fetch(url);
+      if (!r.ok) {
+        if (r.status === 400) return { ok: false, error: "USGS rejected the lookup (location may be outside ASCE 7 coverage)" };
+        throw new Error(`usgs designmaps ${r.status}`);
+      }
+      const data = await r.json();
+      const resp = data?.response?.data;
+      if (!resp) return { ok: false, error: "USGS returned no design parameters" };
+      return {
+        ok: true,
+        result: {
+          location: { lat, lng },
+          riskCategory, siteClass,
+          ss: resp.ss,                    // 0.2s spectral acceleration (g)
+          s1: resp.s1,                    // 1.0s spectral acceleration (g)
+          fa: resp.fa,                    // short-period site coefficient
+          fv: resp.fv,                    // long-period site coefficient
+          sms: resp.sms, sm1: resp.sm1,   // MCE site-modified
+          sds: resp.sds, sd1: resp.sd1,   // ASCE 7 design spectrum
+          sdc: resp.sdc,                  // seismic design category
+          pga: resp.pga,                  // peak ground acceleration
+          pgam: resp.pgam,                // site-modified PGA
+          tl: resp.tl,                    // long-period transition (s)
+          source: "usgs-designmaps-asce7-22",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `usgs designmaps unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
   });
 }

--- a/server/tests/geology-domain-parity.test.js
+++ b/server/tests/geology-domain-parity.test.js
@@ -1,0 +1,153 @@
+// Contract tests for server/domains/geology.js — pure-compute helpers
+// plus real USGS Earthquake + DESIGNMAPS integrations.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerGeologyActions from "../domains/geology.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, artifactOrParams = {}, maybeParams) {
+  const fn = ACTIONS.get(`geology.${name}`);
+  if (!fn) throw new Error(`geology.${name} not registered`);
+  const artifact = arguments.length === 4 ? artifactOrParams : { id: null, data: {}, meta: {} };
+  const params = arguments.length === 4 ? (maybeParams || {}) : artifactOrParams;
+  return fn(ctx, artifact, params);
+}
+
+before(() => { registerGeologyActions(register); });
+beforeEach(() => { globalThis.fetch = async () => { throw new Error("network disabled in tests"); }; });
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+
+describe("geology.rockClassify (pure compute)", () => {
+  it("classifies foliated specimen as metamorphic", () => {
+    const r = call("rockClassify", ctxA, { data: { texture: "foliated", mohsHardness: 6, color: "gray" } }, {});
+    assert.equal(r.result.rockType, "metamorphic");
+    assert.equal(r.result.durability, "moderate");
+  });
+});
+
+describe("geology.recent-earthquakes (USGS catalog)", () => {
+  it("hits USGS + parses GeoJSON FeatureCollection", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ({
+          metadata: { generated: 1715882400000 },
+          features: [
+            {
+              id: "us6000mzqw",
+              properties: {
+                mag: 5.2, magType: "mb",
+                place: "30 km W of Petrolia, CA",
+                time: 1715882000000, updated: 1715882400000,
+                url: "https://earthquake.usgs.gov/earthquakes/eventpage/us6000mzqw",
+                status: "reviewed", tsunami: 0, felt: 42, cdi: 4.5, mmi: 5.1,
+                alert: "green", sig: 416,
+              },
+              geometry: { coordinates: [-124.5, 40.3, 18.5] },
+            },
+          ],
+        }),
+      };
+    };
+    const r = await call("recent-earthquakes", ctxA, { minMagnitude: 5, sinceHours: 24 });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /earthquake\.usgs\.gov\/fdsnws\/event\/1\/query/);
+    assert.match(capturedUrl, /format=geojson/);
+    assert.match(capturedUrl, /minmagnitude=5/);
+    assert.equal(r.result.events.length, 1);
+    assert.equal(r.result.events[0].magnitude, 5.2);
+    assert.equal(r.result.events[0].latitude, 40.3);
+    assert.equal(r.result.events[0].longitude, -124.5);
+    assert.equal(r.result.events[0].depthKm, 18.5);
+    assert.equal(r.result.events[0].alert, "green");
+    assert.equal(r.result.events[0].tsunami, false);
+    assert.equal(r.result.source, "usgs-earthquake-catalog");
+  });
+
+  it("supports circle filter (lat/lng/radiusKm)", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => ({ features: [] }) };
+    };
+    await call("recent-earthquakes", ctxA, { latitude: 37.7, longitude: -122.4, radiusKm: 100 });
+    assert.match(capturedUrl, /latitude=37\.7/);
+    assert.match(capturedUrl, /longitude=-122\.4/);
+    assert.match(capturedUrl, /maxradiuskm=100/);
+  });
+
+  it("supports bbox filter (min/max lat/lng)", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => ({ features: [] }) };
+    };
+    await call("recent-earthquakes", ctxA, {
+      minlatitude: 30, maxlatitude: 45,
+      minlongitude: -130, maxlongitude: -100,
+    });
+    assert.match(capturedUrl, /minlatitude=30/);
+    assert.match(capturedUrl, /maxlatitude=45/);
+    assert.match(capturedUrl, /minlongitude=-130/);
+    assert.match(capturedUrl, /maxlongitude=-100/);
+  });
+
+  it("surfaces USGS network errors", async () => {
+    const r = await call("recent-earthquakes", ctxA, {});
+    assert.equal(r.ok, false);
+    assert.match(r.error, /usgs earthquake unreachable/);
+  });
+});
+
+describe("geology.usgs-seismic-hazard (DESIGNMAPS ASCE 7-22)", () => {
+  it("rejects missing or invalid coords", async () => {
+    assert.equal((await call("usgs-seismic-hazard", ctxA, {})).ok, false);
+    const r = await call("usgs-seismic-hazard", ctxA, { latitude: 5, longitude: 50 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /only covers US/);
+  });
+
+  it("hits DESIGNMAPS and parses ASCE 7 spectrum", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ({
+          response: {
+            data: {
+              ss: 2.106, s1: 0.815, fa: 1.0, fv: 1.5,
+              sms: 2.106, sm1: 1.223,
+              sds: 1.404, sd1: 0.815,
+              sdc: "D", pga: 0.847, pgam: 0.847,
+              tl: 12,
+            },
+          },
+        }),
+      };
+    };
+    const r = await call("usgs-seismic-hazard", ctxA, {
+      latitude: 37.78, longitude: -122.42,
+      riskCategory: 2, siteClass: "D",
+    });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /asce7-22\.json/);
+    assert.match(capturedUrl, /latitude=37\.78/);
+    assert.match(capturedUrl, /siteClass=D/);
+    assert.equal(r.result.ss, 2.106);
+    assert.equal(r.result.sdc, "D");
+    assert.equal(r.result.source, "usgs-designmaps-asce7-22");
+  });
+
+  it("returns clear error on USGS 400 (outside coverage)", async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 400, json: async () => ({}) });
+    const r = await call("usgs-seismic-hazard", ctxA, { latitude: 37.78, longitude: -122.42 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /outside ASCE 7 coverage/);
+  });
+});


### PR DESCRIPTION
## Summary

Bucket 1 polish on geology lens. Existing pure-compute helpers unchanged; adds two real-data macros backed by USGS.

### Backend
- **`recent-earthquakes`** — USGS Earthquake Catalog (FDSN web service). Real seismic events with magnitude/depth/lat/lng/CDI/MMI/PAGER alert/tsunami flag. Circle (lat,lng,radiusKm) + bbox (min/max lat,lng) filters; configurable sinceHours + minMagnitude. Free, no API key.
- **`usgs-seismic-hazard`** — USGS DESIGNMAPS **ASCE 7-22** service. Real spectral accelerations (Ss, S1), site coefficients (Fa, Fv), MCE site-modified (Sms, Sm1), design spectrum (Sds, Sd1), seismic design category, PGA, long-period transition. US-only (lat 18-72, lng -180 to -65). All 9 ASCE site classes supported.

## Test plan

- [x] `node --test server/tests/geology-domain-parity.test.js` — **8/8 passing**
- [x] Covers: rockClassify foliated→metamorphic; recent-earthquakes real GeoJSON parsing (Petrolia M5.2) + circle filter URL + bbox filter URL + network error; usgs-seismic-hazard missing-coords + out-of-coverage rejection + real ASCE 7-22 spectrum parsing + 400 outside-coverage surface

https://claude.ai/code/session_018ucd5N7Hc3K8mNa9p2Lr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_