### PR TITLE
feat(ocean): real NOAA Tides & Currents — predictions + water level + stations

### DIFF
--- a/server/domains/ocean.js
+++ b/server/domains/ocean.js
@@ -1,7 +1,157 @@
 // server/domains/ocean.js
+//
+// Pure-compute ocean helpers (wave analysis, salinity profile,
+// marine ecosystem, approximate tidal sin curve) plus real NOAA
+// Tides & Currents API for water-level / tide prediction / met
+// observations at thousands of NOAA stations. Free, no API key.
+
+const NOAA_TIDES_BASE = "https://api.tidesandcurrents.noaa.gov/api/prod/datagetter";
+const NOAA_MDAPI_BASE = "https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi";
+
 export default function registerOceanActions(registerLensAction) {
   registerLensAction("ocean", "waveAnalysis", (ctx, artifact, _params) => { const data = artifact.data || {}; const height = parseFloat(data.waveHeightMeters) || 1; const period = parseFloat(data.wavePeriodSeconds) || 8; const windSpeed = parseFloat(data.windSpeedKnots) || 15; const wavelength = 1.56 * period * period; const deepWaterSpeed = 1.56 * period; const energy = 0.5 * 1025 * 9.81 * height * height; const beaufort = windSpeed < 1 ? 0 : windSpeed < 4 ? 1 : windSpeed < 7 ? 2 : windSpeed < 11 ? 3 : windSpeed < 17 ? 4 : windSpeed < 22 ? 5 : windSpeed < 28 ? 6 : windSpeed < 34 ? 7 : 8; return { ok: true, result: { significantWaveHeight: `${height}m`, period: `${period}s`, wavelength: `${Math.round(wavelength)}m`, speed: `${Math.round(deepWaterSpeed*10)/10} m/s`, energyDensity: `${Math.round(energy)} J/m²`, beaufortScale: beaufort, seaState: height < 0.5 ? "calm" : height < 1.25 ? "slight" : height < 2.5 ? "moderate" : height < 4 ? "rough" : "very-rough", navigationAdvisory: height > 3 ? "Small craft advisory" : "Safe for navigation" } }; });
   registerLensAction("ocean", "tidalPrediction", (ctx, artifact, _params) => { const data = artifact.data || {}; const location = data.location || "unknown"; const lunarDay = ((Date.now() / 86400000) % 29.53); const phase = lunarDay / 29.53; const tidalRange = parseFloat(data.tidalRangeMeters) || 2; const currentHeight = Math.round(Math.sin(phase * 2 * Math.PI) * tidalRange / 2 * 100) / 100; return { ok: true, result: { location, lunarPhase: phase < 0.25 ? "new-moon" : phase < 0.5 ? "first-quarter" : phase < 0.75 ? "full-moon" : "last-quarter", springOrNeap: phase < 0.1 || Math.abs(phase - 0.5) < 0.1 ? "spring-tide" : "neap-tide", estimatedCurrentHeight: `${currentHeight}m`, tidalRange: `${tidalRange}m`, nextHigh: "~6 hours", nextLow: "~12 hours", note: "Approximate — use official tide tables for navigation" } }; });
   registerLensAction("ocean", "salinityProfile", (ctx, artifact, _params) => { const readings = artifact.data?.readings || []; if (readings.length === 0) return { ok: true, result: { message: "Add depth/salinity readings to build profile." } }; const sorted = readings.map(r => ({ depth: parseFloat(r.depth) || 0, salinity: parseFloat(r.salinity) || 35, temperature: parseFloat(r.temperature) || 15 })).sort((a,b) => a.depth - b.depth); const avgSalinity = sorted.reduce((s,r) => s + r.salinity, 0) / sorted.length; const halocline = sorted.find((r,i) => i > 0 && Math.abs(r.salinity - sorted[i-1].salinity) > 1); return { ok: true, result: { readings: sorted, avgSalinity: Math.round(avgSalinity*10)/10, maxDepth: sorted[sorted.length-1]?.depth || 0, haloclineDepth: halocline?.depth || "none detected", waterMass: avgSalinity > 36 ? "subtropical" : avgSalinity > 34 ? "temperate" : "sub-polar" } }; });
   registerLensAction("ocean", "marineEcosystem", (ctx, artifact, _params) => { const species = artifact.data?.species || []; const byTrophic = {}; for (const s of species) { const lvl = s.trophicLevel || "primary"; byTrophic[lvl] = (byTrophic[lvl] || 0) + 1; } const diversity = species.length; const shannonIndex = species.length > 1 ? Math.round(Math.log(species.length) * 100) / 100 : 0; return { ok: true, result: { speciesCount: diversity, trophicLevels: byTrophic, shannonDiversityIndex: shannonIndex, ecosystemHealth: diversity > 20 ? "thriving" : diversity > 10 ? "moderate" : diversity > 3 ? "stressed" : "critical", threatened: species.filter(s => s.threatened || s.endangered).length, invasive: species.filter(s => s.invasive).length } }; });
+
+  /**
+   * noaa-tide-prediction — Real predicted tide for a NOAA station
+   * over a date range. Free, no API key. Returns high/low predicted
+   * water levels with time.
+   *
+   * params: {
+   *   stationId: string (CO-OPS station ID, e.g. "9414290" for SF),
+   *   beginDate?: "YYYYMMDD" (default today),
+   *   endDate?: "YYYYMMDD" (default beginDate + 1 day),
+   *   units?: "english"|"metric"      // default metric
+   * }
+   */
+  registerLensAction("ocean", "noaa-tide-prediction", async (_ctx, _artifact, params = {}) => {
+    const stationId = String(params.stationId || "").trim();
+    if (!stationId) return { ok: false, error: "stationId required (NOAA CO-OPS station ID, e.g. 9414290 = San Francisco)" };
+    const today = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+    const beginDate = String(params.beginDate || today);
+    const endDate = String(params.endDate || (() => {
+      const d = new Date();
+      d.setUTCDate(d.getUTCDate() + 1);
+      return d.toISOString().slice(0, 10).replace(/-/g, "");
+    })());
+    if (!/^\d{8}$/.test(beginDate) || !/^\d{8}$/.test(endDate)) {
+      return { ok: false, error: "beginDate / endDate must be YYYYMMDD" };
+    }
+    const units = ["metric", "english"].includes(params.units) ? params.units : "metric";
+    const qs = new URLSearchParams({
+      product: "predictions",
+      application: "Concord-OS",
+      begin_date: beginDate, end_date: endDate,
+      datum: "MLLW",
+      station: stationId,
+      time_zone: "gmt",
+      units, format: "json",
+      interval: "hilo",  // high/low only — efficient + most useful
+    });
+    try {
+      const r = await fetch(`${NOAA_TIDES_BASE}?${qs.toString()}`);
+      if (!r.ok) throw new Error(`noaa tides ${r.status}`);
+      const data = await r.json();
+      if (data.error) return { ok: false, error: `NOAA error: ${data.error.message || JSON.stringify(data.error)}` };
+      const predictions = (data.predictions || []).map((p) => ({
+        time: p.t,
+        height: parseFloat(p.v),
+        type: p.type === "H" ? "high" : p.type === "L" ? "low" : p.type,
+      }));
+      return {
+        ok: true,
+        result: {
+          stationId, beginDate, endDate, units, datum: "MLLW",
+          predictions, count: predictions.length,
+          source: "noaa-tides-and-currents",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `noaa tides unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * noaa-water-level — Real observed water level at a station for a
+   * date range (6-min readings; defaults to last 24h).
+   * params: { stationId, beginDate?, endDate?, units? }
+   */
+  registerLensAction("ocean", "noaa-water-level", async (_ctx, _artifact, params = {}) => {
+    const stationId = String(params.stationId || "").trim();
+    if (!stationId) return { ok: false, error: "stationId required" };
+    const today = new Date();
+    const yesterday = new Date(today.getTime() - 86400000);
+    const beginDate = String(params.beginDate || yesterday.toISOString().slice(0, 10).replace(/-/g, ""));
+    const endDate = String(params.endDate || today.toISOString().slice(0, 10).replace(/-/g, ""));
+    const units = ["metric", "english"].includes(params.units) ? params.units : "metric";
+    const qs = new URLSearchParams({
+      product: "water_level",
+      application: "Concord-OS",
+      begin_date: beginDate, end_date: endDate,
+      datum: "MLLW",
+      station: stationId,
+      time_zone: "gmt",
+      units, format: "json",
+    });
+    try {
+      const r = await fetch(`${NOAA_TIDES_BASE}?${qs.toString()}`);
+      if (!r.ok) throw new Error(`noaa tides ${r.status}`);
+      const data = await r.json();
+      if (data.error) return { ok: false, error: `NOAA error: ${data.error.message || JSON.stringify(data.error)}` };
+      const readings = (data.data || []).map((d) => ({
+        time: d.t,
+        waterLevel: parseFloat(d.v),
+        sigma: parseFloat(d.s),
+        flags: d.f,
+      }));
+      const latest = readings[readings.length - 1] || null;
+      return {
+        ok: true,
+        result: {
+          stationId, beginDate, endDate, units, datum: "MLLW",
+          latest, readings, count: readings.length,
+          source: "noaa-tides-and-currents",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `noaa tides unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * noaa-stations — Real list of all NOAA tide/water-level stations
+   * (or by state). Useful for picking a stationId for the above macros.
+   * params: { state?: 2-letter US code (e.g. "CA"), type?: "tidepredictions"|"waterlevels" }
+   */
+  registerLensAction("ocean", "noaa-stations", async (_ctx, _artifact, params = {}) => {
+    const type = ["tidepredictions", "waterlevels"].includes(params.type) ? params.type : "tidepredictions";
+    const url = `${NOAA_MDAPI_BASE}/stations.json?type=${type}`;
+    try {
+      const r = await fetch(url);
+      if (!r.ok) throw new Error(`noaa mdapi ${r.status}`);
+      const data = await r.json();
+      let stations = (data.stations || []).map((s) => ({
+        id: s.id,
+        name: s.name,
+        state: s.state,
+        latitude: s.lat,
+        longitude: s.lng,
+        timezone: s.timezone,
+        timezoneOffset: s.timezonecorr,
+        type,
+      }));
+      if (params.state) {
+        const st = String(params.state).toUpperCase();
+        stations = stations.filter((s) => s.state === st);
+      }
+      return {
+        ok: true,
+        result: { stations, count: stations.length, type, source: "noaa-mdapi" },
+      };
+    } catch (e) {
+      return { ok: false, error: `noaa mdapi unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
 }

--- a/server/tests/ocean-domain-parity.test.js
+++ b/server/tests/ocean-domain-parity.test.js
@@ -1,0 +1,130 @@
+// Contract tests for server/domains/ocean.js — pure-compute helpers
+// plus real NOAA Tides & Currents API.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerOceanActions from "../domains/ocean.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, artifactOrParams = {}, maybeParams) {
+  const fn = ACTIONS.get(`ocean.${name}`);
+  if (!fn) throw new Error(`ocean.${name} not registered`);
+  const artifact = arguments.length === 4 ? artifactOrParams : { id: null, data: {}, meta: {} };
+  const params = arguments.length === 4 ? (maybeParams || {}) : artifactOrParams;
+  return fn(ctx, artifact, params);
+}
+
+before(() => { registerOceanActions(register); });
+beforeEach(() => { globalThis.fetch = async () => { throw new Error("network disabled in tests"); }; });
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+
+describe("ocean.waveAnalysis (pure compute)", () => {
+  it("classifies 2m waves as moderate state", () => {
+    const r = call("waveAnalysis", ctxA, { data: { waveHeightMeters: 2, wavePeriodSeconds: 8 } }, {});
+    assert.equal(r.result.seaState, "moderate");
+  });
+});
+
+describe("ocean.noaa-tide-prediction", () => {
+  it("rejects missing stationId", async () => {
+    assert.equal((await call("noaa-tide-prediction", ctxA, {})).ok, false);
+  });
+
+  it("rejects invalid date format", async () => {
+    const r = await call("noaa-tide-prediction", ctxA, { stationId: "9414290", beginDate: "tomorrow" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /YYYYMMDD/);
+  });
+
+  it("hits NOAA API + parses high/low predictions", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ({
+          predictions: [
+            { t: "2026-05-16 04:18", v: "-0.213", type: "L" },
+            { t: "2026-05-16 11:06", v: "1.685", type: "H" },
+            { t: "2026-05-16 16:42", v: "0.092", type: "L" },
+            { t: "2026-05-16 23:18", v: "1.972", type: "H" },
+          ],
+        }),
+      };
+    };
+    const r = await call("noaa-tide-prediction", ctxA, { stationId: "9414290", beginDate: "20260516", endDate: "20260517" });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /api\.tidesandcurrents\.noaa\.gov.*product=predictions/);
+    assert.match(capturedUrl, /station=9414290/);
+    assert.match(capturedUrl, /interval=hilo/);
+    assert.match(capturedUrl, /units=metric/);
+    assert.equal(r.result.predictions.length, 4);
+    assert.equal(r.result.predictions[0].type, "low");
+    assert.equal(r.result.predictions[1].type, "high");
+    assert.equal(r.result.predictions[1].height, 1.685);
+    assert.equal(r.result.source, "noaa-tides-and-currents");
+  });
+
+  it("surfaces NOAA API errors in response body", async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({ error: { message: "No station found" } }),
+    });
+    const r = await call("noaa-tide-prediction", ctxA, { stationId: "9999999" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /No station found/);
+  });
+});
+
+describe("ocean.noaa-water-level", () => {
+  it("hits NOAA API + parses observed readings", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ({
+          data: [
+            { t: "2026-05-16 00:00", v: "1.234", s: "0.012", f: "0,0,0,0" },
+            { t: "2026-05-16 00:06", v: "1.250", s: "0.011", f: "0,0,0,0" },
+            { t: "2026-05-16 00:12", v: "1.265", s: "0.013", f: "0,0,0,0" },
+          ],
+        }),
+      };
+    };
+    const r = await call("noaa-water-level", ctxA, { stationId: "9414290" });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /product=water_level/);
+    assert.equal(r.result.readings.length, 3);
+    assert.equal(r.result.latest.waterLevel, 1.265);
+  });
+});
+
+describe("ocean.noaa-stations", () => {
+  it("lists stations + filters by state", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ({
+          stations: [
+            { id: "9414290", name: "San Francisco", state: "CA", lat: 37.806, lng: -122.465, timezone: "PST", timezonecorr: -8 },
+            { id: "9414750", name: "Alameda", state: "CA", lat: 37.772, lng: -122.300, timezone: "PST", timezonecorr: -8 },
+            { id: "9410660", name: "Los Angeles", state: "CA", lat: 33.720, lng: -118.272, timezone: "PST", timezonecorr: -8 },
+            { id: "8410140", name: "Eastport", state: "ME", lat: 44.904, lng: -66.985, timezone: "EST", timezonecorr: -5 },
+          ],
+        }),
+      };
+    };
+    const all = await call("noaa-stations", ctxA, {});
+    assert.equal(all.result.count, 4);
+    assert.match(capturedUrl, /type=tidepredictions/);
+
+    const ca = await call("noaa-stations", ctxA, { state: "CA" });
+    assert.equal(ca.result.count, 3);
+    assert.ok(ca.result.stations.every((s) => s.state === "CA"));
+  });
+});


### PR DESCRIPTION
## Summary

Bucket 1 polish on ocean lens. Pure-compute helpers unchanged; adds three real-data macros backed by NOAA Tides & Currents API (free, no API key, authoritative US tidal data).

### Backend
- **`noaa-tide-prediction`** — real predicted tide for a NOAA station over a date range. High/low water levels with time (`interval=hilo` for efficiency). Configurable units (metric/english).
- **`noaa-water-level`** — real observed water level (6-min readings) with sigma + flags. Returns latest + full series.
- **`noaa-stations`** — full station list (tide-predictions or water-level), filterable by US state.

Uses NOAA CO-OPS + Metadata API.

## Test plan

- [x] `node --test server/tests/ocean-domain-parity.test.js` — **7/7 passing**
- [x] Covers: waveAnalysis pure-compute; tide-prediction missing-stationId + invalid-date rejection + real hi/lo parsing + in-body NOAA error surface; water-level real 6-min observation parsing; stations state filter (CA→3 of 4)

https://claude.ai/code/session_018ucd5N7Hc3K8mNa9p2Lr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_