### PR TITLE
feat(poetry/podcast/photography): real PoetryDB + iTunes + Pexels APIs

### DIFF
--- a/server/domains/photography.js
+++ b/server/domains/photography.js
@@ -1,5 +1,12 @@
 // server/domains/photography.js
+//
+// Pure-compute photography helpers (exposure calc, composition score,
+// gear recommendation, print size, vision via LLaVA) plus real Pexels
+// stock photo search (free with API key from pexels.com/api).
+
 import { callVision, callVisionUrl, visionPromptForDomain } from "../lib/vision-inference.js";
+
+const PEXELS_BASE = "https://api.pexels.com/v1";
 
 export default function registerPhotographyActions(registerLensAction) {
   registerLensAction("photography", "vision", async (ctx, artifact, _params) => {
@@ -12,4 +19,54 @@ export default function registerPhotographyActions(registerLensAction) {
   registerLensAction("photography", "compositionAnalysis", (ctx, artifact, _params) => { const data = artifact.data || {}; const rules = ["rule-of-thirds","leading-lines","symmetry","framing","depth","negative-space","golden-ratio","patterns"]; const applied = (data.compositionRules || []).filter(r => rules.includes(r.toLowerCase())); return { ok: true, result: { rulesApplied: applied, score: Math.round((applied.length / rules.length) * 100), allRules: rules, suggestions: rules.filter(r => !applied.includes(r)).slice(0,3), strength: applied.length >= 3 ? "strong-composition" : applied.length >= 1 ? "basic-composition" : "no-rules-applied" } }; });
   registerLensAction("photography", "gearRecommend", (ctx, artifact, _params) => { const data = artifact.data || {}; const genre = (data.genre || data.style || "general").toLowerCase(); const budget = (data.budget || "medium").toLowerCase(); const recs = { portrait: { lens: "85mm f/1.8", lighting: "Softbox or natural window light", accessory: "Reflector" }, landscape: { lens: "16-35mm f/4", lighting: "Golden hour", accessory: "Tripod + filters" }, street: { lens: "35mm f/2", lighting: "Available light", accessory: "Small bag" }, macro: { lens: "100mm f/2.8 Macro", lighting: "Ring light", accessory: "Focus rail" }, sports: { lens: "70-200mm f/2.8", lighting: "High ISO capability", accessory: "Monopod" }, general: { lens: "24-70mm f/2.8", lighting: "Speedlight", accessory: "Camera bag" } }; const rec = recs[genre] || recs.general; return { ok: true, result: { genre, budget, recommendation: rec, tip: genre === "portrait" ? "Shoot wide open for creamy bokeh" : genre === "landscape" ? "Use f/8-f/11 for maximum sharpness" : "Practice with what you have" } }; });
   registerLensAction("photography", "printSize", (ctx, artifact, _params) => { const data = artifact.data || {}; const widthPx = parseInt(data.widthPixels) || 4000; const heightPx = parseInt(data.heightPixels) || 3000; const dpi = parseInt(data.dpi) || 300; const widthIn = Math.round(widthPx / dpi * 10) / 10; const heightIn = Math.round(heightPx / dpi * 10) / 10; const megapixels = Math.round(widthPx * heightPx / 1000000 * 10) / 10; const maxPrint = { at300dpi: `${widthIn}" x ${heightIn}"`, at150dpi: `${Math.round(widthPx/150*10)/10}" x ${Math.round(heightPx/150*10)/10}"` }; return { ok: true, result: { resolution: `${widthPx} x ${heightPx}`, megapixels, maxPrintAt300DPI: maxPrint.at300dpi, maxPrintAt150DPI: maxPrint.at150dpi, quality: widthPx >= 4000 ? "professional" : widthPx >= 2000 ? "good" : "web-only" } }; });
+
+  /**
+   * pexels-search — Real Pexels stock photo search. Requires
+   * PEXELS_API_KEY env (free at pexels.com/api).
+   * params: { query, perPage?: 1-80, orientation?: "landscape"|"portrait"|"square" }
+   */
+  registerLensAction("photography", "pexels-search", async (_ctx, _artifact, params = {}) => {
+    const apiKey = process.env.PEXELS_API_KEY;
+    if (!apiKey) return { ok: false, error: "PEXELS_API_KEY env required (free at pexels.com/api)" };
+    const query = String(params.query || "").trim();
+    if (!query) return { ok: false, error: "query required" };
+    const perPage = Math.max(1, Math.min(80, Number(params.perPage) || 15));
+    const orientation = ["landscape", "portrait", "square"].includes(params.orientation) ? `&orientation=${params.orientation}` : "";
+    try {
+      const r = await fetch(`${PEXELS_BASE}/search?query=${encodeURIComponent(query)}&per_page=${perPage}${orientation}`, {
+        headers: { Authorization: apiKey },
+      });
+      if (r.status === 401) return { ok: false, error: "PEXELS_API_KEY invalid" };
+      if (!r.ok) throw new Error(`pexels ${r.status}`);
+      const data = await r.json();
+      const photos = (data.photos || []).map((p) => ({
+        id: p.id,
+        photographer: p.photographer,
+        photographerUrl: p.photographer_url,
+        width: p.width,
+        height: p.height,
+        avgColor: p.avg_color,
+        originalUrl: p.src?.original,
+        largeUrl: p.src?.large,
+        mediumUrl: p.src?.medium,
+        smallUrl: p.src?.small,
+        portraitUrl: p.src?.portrait,
+        landscapeUrl: p.src?.landscape,
+        tinyUrl: p.src?.tiny,
+        pexelsUrl: p.url,
+        alt: p.alt,
+      }));
+      return {
+        ok: true,
+        result: {
+          query, photos, count: photos.length,
+          totalResults: data.total_results,
+          nextPage: data.next_page,
+          source: "pexels",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `pexels unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
 }

--- a/server/domains/podcast.js
+++ b/server/domains/podcast.js
@@ -1,7 +1,93 @@
 // server/domains/podcast.js
+//
+// Pure-compute podcast helpers (episode analytics, guest research,
+// production checklist, monetization calc) plus real iTunes Search
+// API for the Apple Podcasts directory. Free, no API key.
+
+const ITUNES_SEARCH = "https://itunes.apple.com/search";
+const ITUNES_LOOKUP = "https://itunes.apple.com/lookup";
+
 export default function registerPodcastActions(registerLensAction) {
   registerLensAction("podcast", "episodeAnalytics", (ctx, artifact, _params) => { const episodes = artifact.data?.episodes || []; if (episodes.length === 0) return { ok: true, result: { message: "Add episodes with listen counts to analyze." } }; const totalListens = episodes.reduce((s,e) => s + (parseInt(e.listens || e.plays) || 0), 0); const avgListens = Math.round(totalListens / episodes.length); const totalDuration = episodes.reduce((s,e) => s + (parseInt(e.durationMinutes || e.duration) || 30), 0); const completionRate = episodes.reduce((s,e) => s + (parseFloat(e.completionRate) || 0.65), 0) / episodes.length; return { ok: true, result: { episodes: episodes.length, totalListens, avgListensPerEpisode: avgListens, totalDurationMinutes: totalDuration, avgDurationMinutes: Math.round(totalDuration / episodes.length), completionRate: Math.round(completionRate * 100), topEpisode: episodes.sort((a,b) => (parseInt(b.listens || b.plays) || 0) - (parseInt(a.listens || a.plays) || 0))[0]?.title || "N/A", growth: episodes.length > 5 ? "established" : "growing" } }; });
   registerLensAction("podcast", "guestResearch", (ctx, artifact, _params) => { const guest = artifact.data || {}; const topics = guest.topics || guest.expertise || []; const platforms = guest.platforms || []; return { ok: true, result: { name: guest.name || artifact.title, bio: guest.bio || "", topics, platforms, audienceOverlap: platforms.length > 0 ? "likely" : "unknown", questionSuggestions: topics.map(t => `Tell us about your experience with ${t}`), prepChecklist: ["Research guest background", "Prepare 5-7 questions", "Test audio setup", "Send guest prep sheet", "Confirm recording time"] } }; });
   registerLensAction("podcast", "productionChecklist", (ctx, artifact, _params) => { const data = artifact.data || {}; const preProduction = ["Topic research", "Outline/script", "Guest coordination", "Equipment check"]; const production = ["Audio recording", "Backup recording", "Room tone capture", "Marker/chapter points"]; const postProduction = ["Edit audio", "Add intro/outro", "Level audio", "Export final", "Write show notes", "Create artwork", "Publish to host", "Promote on social"]; const completed = data.completedSteps || []; const allSteps = [...preProduction, ...production, ...postProduction]; const done = allSteps.filter(s => completed.includes(s)).length; return { ok: true, result: { preProduction, production, postProduction, totalSteps: allSteps.length, completed: done, progress: Math.round((done / allSteps.length) * 100), nextStep: allSteps.find(s => !completed.includes(s)) || "All done!" } }; });
   registerLensAction("podcast", "monetizationCalc", (ctx, artifact, _params) => { const data = artifact.data || {}; const downloads = parseInt(data.monthlyDownloads) || 0; const cpm = parseFloat(data.cpmRate) || 25; const sponsors = parseInt(data.sponsorSlots) || 2; const premium = parseInt(data.premiumSubscribers) || 0; const premiumPrice = parseFloat(data.premiumPrice) || 5; const adRevenue = Math.round(downloads / 1000 * cpm * sponsors); const premiumRevenue = premium * premiumPrice; return { ok: true, result: { monthlyDownloads: downloads, adRevenue, premiumRevenue, totalMonthlyRevenue: adRevenue + premiumRevenue, annualProjection: (adRevenue + premiumRevenue) * 12, cpmRate: cpm, tier: downloads > 50000 ? "top-10%" : downloads > 10000 ? "established" : downloads > 1000 ? "growing" : "emerging", nextMilestone: downloads < 1000 ? "1,000 downloads — attracts first sponsors" : downloads < 10000 ? "10,000 downloads — mid-tier sponsorships" : "50,000+ — premium sponsorship rates" } }; });
+
+  /**
+   * itunes-search — Apple Podcasts directory search via iTunes Search API.
+   * Free, no API key. Returns top podcasts matching the query with
+   * artwork, RSS feed URL, genre, episode count.
+   * params: { query: string, limit?: 1-50, country?: ISO-2 (default US) }
+   */
+  registerLensAction("podcast", "itunes-search", async (_ctx, _artifact, params = {}) => {
+    const query = String(params.query || "").trim();
+    if (!query) return { ok: false, error: "query required" };
+    const limit = Math.max(1, Math.min(50, Number(params.limit) || 10));
+    const country = String(params.country || "US").toUpperCase();
+    if (!/^[A-Z]{2}$/.test(country)) return { ok: false, error: "country must be 2-letter code" };
+    try {
+      const url = `${ITUNES_SEARCH}?term=${encodeURIComponent(query)}&media=podcast&entity=podcast&limit=${limit}&country=${country}`;
+      const r = await fetch(url);
+      if (!r.ok) throw new Error(`itunes ${r.status}`);
+      const data = await r.json();
+      const podcasts = (data.results || []).map((p) => ({
+        collectionId: p.collectionId,
+        trackId: p.trackId,
+        title: p.collectionName || p.trackName,
+        artist: p.artistName,
+        genre: p.primaryGenreName,
+        genres: p.genres,
+        artwork: p.artworkUrl600 || p.artworkUrl100 || p.artworkUrl60,
+        feedUrl: p.feedUrl,
+        episodeCount: p.trackCount,
+        country: p.country,
+        contentAdvisory: p.contentAdvisoryRating,
+        releaseDate: p.releaseDate,
+        collectionUrl: p.collectionViewUrl,
+      }));
+      return {
+        ok: true,
+        result: { query, podcasts, count: podcasts.length, totalResults: data.resultCount, source: "itunes-search" },
+      };
+    } catch (e) {
+      return { ok: false, error: `itunes unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * itunes-podcast — Lookup a specific podcast by its iTunes
+   * collectionId (returned by itunes-search). Returns full metadata.
+   */
+  registerLensAction("podcast", "itunes-podcast", async (_ctx, _artifact, params = {}) => {
+    const collectionId = Number(params.collectionId);
+    if (!Number.isFinite(collectionId) || collectionId <= 0) return { ok: false, error: "collectionId required" };
+    try {
+      const r = await fetch(`${ITUNES_LOOKUP}?id=${collectionId}&entity=podcast`);
+      if (!r.ok) throw new Error(`itunes ${r.status}`);
+      const data = await r.json();
+      if (!data.results || data.results.length === 0) {
+        return { ok: false, error: `podcast not found: ${collectionId}` };
+      }
+      const p = data.results[0];
+      return {
+        ok: true,
+        result: {
+          collectionId: p.collectionId,
+          title: p.collectionName,
+          artist: p.artistName,
+          genre: p.primaryGenreName,
+          genres: p.genres,
+          artwork: p.artworkUrl600,
+          feedUrl: p.feedUrl,
+          episodeCount: p.trackCount,
+          country: p.country,
+          releaseDate: p.releaseDate,
+          collectionUrl: p.collectionViewUrl,
+          source: "itunes-lookup",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `itunes unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
 }

--- a/server/domains/poetry.js
+++ b/server/domains/poetry.js
@@ -1,7 +1,71 @@
 // server/domains/poetry.js
+//
+// Pure-compute poetry helpers (meter, rhyme scheme, form guide,
+// word frequency) plus real PoetryDB integration (~3000 classical
+// poems by 100+ authors). Free, no API key.
+
+const POETRYDB_BASE = "https://poetrydb.org";
+
 export default function registerPoetryActions(registerLensAction) {
   registerLensAction("poetry", "meterAnalysis", (ctx, artifact, _params) => { const text = artifact.data?.text || artifact.data?.poem || ""; if (!text) return { ok: true, result: { message: "Add poem text to analyze meter." } }; const lines = text.split("\n").filter(l => l.trim()); const syllableCounts = lines.map(l => { const words = l.trim().split(/\s+/); return words.reduce((s, w) => s + Math.max(1, (w.match(/[aeiouy]+/gi) || []).length), 0); }); const avgSyllables = syllableCounts.length > 0 ? Math.round(syllableCounts.reduce((s,v)=>s+v,0)/syllableCounts.length * 10) / 10 : 0; const consistent = syllableCounts.length > 1 && Math.max(...syllableCounts) - Math.min(...syllableCounts) <= 2; return { ok: true, result: { lines: lines.length, syllablesPerLine: syllableCounts, avgSyllables, meterConsistency: consistent ? "regular" : "irregular", possibleForm: syllableCounts.length === 14 ? "sonnet" : syllableCounts.join(",").includes("5,7,5") ? "haiku" : lines.length === 3 && syllableCounts[0] === syllableCounts[2] ? "tercet" : "free-verse" } }; });
   registerLensAction("poetry", "rhymeScheme", (ctx, artifact, _params) => { const text = artifact.data?.text || artifact.data?.poem || ""; if (!text) return { ok: true, result: { message: "Add poem text to detect rhyme scheme." } }; const lines = text.split("\n").filter(l => l.trim()); const endWords = lines.map(l => { const words = l.trim().split(/\s+/); return (words[words.length - 1] || "").toLowerCase().replace(/[^a-z]/g, ""); }); const getEnding = w => w.length > 2 ? w.slice(-2) : w; const scheme = []; const rhymeMap = {}; let letter = 65; for (const word of endWords) { const ending = getEnding(word); if (rhymeMap[ending]) { scheme.push(rhymeMap[ending]); } else { rhymeMap[ending] = String.fromCharCode(letter); scheme.push(rhymeMap[ending]); letter++; } } return { ok: true, result: { lines: lines.length, scheme: scheme.join(""), endWords, form: scheme.join("") === "ABAB" ? "alternate-rhyme" : scheme.join("") === "AABB" ? "couplets" : scheme.join("") === "ABBA" ? "enclosed-rhyme" : "other", rhyming: new Set(scheme).size < scheme.length } }; });
   registerLensAction("poetry", "formGuide", (ctx, artifact, _params) => { const form = (artifact.data?.form || "sonnet").toLowerCase(); const forms = { sonnet: { lines: 14, meter: "iambic pentameter", rhyme: "ABAB CDCD EFEF GG (Shakespearean) or ABBAABBA CDECDE (Petrarchan)", structure: "3 quatrains + couplet or octave + sestet" }, haiku: { lines: 3, meter: "5-7-5 syllables", rhyme: "none", structure: "Nature image → deeper meaning" }, limerick: { lines: 5, meter: "AABBA", rhyme: "AABBA", structure: "Setup (AA) → twist (BB) → punchline (A)" }, villanelle: { lines: 19, meter: "iambic pentameter", rhyme: "ABA pattern with refrains", structure: "5 tercets + quatrain, 2 refrains" }, "free-verse": { lines: "any", meter: "none required", rhyme: "none required", structure: "Let meaning dictate form" } }; const guide = forms[form] || forms["free-verse"]; return { ok: true, result: { form, ...guide, tip: "Start with the feeling, then fit it to the form" } }; });
   registerLensAction("poetry", "wordFrequency", (ctx, artifact, _params) => { const text = artifact.data?.text || ""; if (!text) return { ok: true, result: { message: "Add poem text to analyze word frequency." } }; const words = text.toLowerCase().replace(/[^a-z\s]/g,"").split(/\s+/).filter(Boolean); const freq = {}; const stopWords = new Set(["the","a","an","and","or","but","in","on","at","to","for","of","with","by","from","is","are","was","were","be","been","have","has","had","it","its","i","my","me","we","our","you","your","he","she","they","them","this","that","not","no"]); for (const w of words) { if (!stopWords.has(w)) freq[w] = (freq[w] || 0) + 1; } const ranked = Object.entries(freq).sort((a,b) => b[1] - a[1]); return { ok: true, result: { totalWords: words.length, uniqueWords: Object.keys(freq).length, topWords: ranked.slice(0,10).map(([w,c]) => ({ word: w, count: c })), keyImages: ranked.slice(0,5).map(([w]) => w), lexicalDensity: Math.round((Object.keys(freq).length / words.length) * 100) } }; });
+
+  /**
+   * poetrydb-search — Real classical poetry lookup via PoetryDB.
+   * Free, no API key. ~3000 poems by 100+ public-domain authors
+   * (Shakespeare, Dickinson, Frost, Whitman, etc.).
+   *
+   * params: { author?: string, title?: string, lines?: string (linecount: "14" or substring) }
+   */
+  registerLensAction("poetry", "poetrydb-search", async (_ctx, _artifact, params = {}) => {
+    const author = params.author ? String(params.author).trim() : null;
+    const title = params.title ? String(params.title).trim() : null;
+    if (!author && !title) return { ok: false, error: "author or title required" };
+    let path;
+    if (author && title) {
+      path = `/author,title/${encodeURIComponent(author)};${encodeURIComponent(title)}`;
+    } else if (author) {
+      path = `/author/${encodeURIComponent(author)}`;
+    } else {
+      path = `/title/${encodeURIComponent(title)}`;
+    }
+    try {
+      const r = await fetch(`${POETRYDB_BASE}${path}`);
+      if (!r.ok) throw new Error(`poetrydb ${r.status}`);
+      const data = await r.json();
+      // PoetryDB returns { status: 404, reason: "Not found" } on no match (still 200 HTTP)
+      if (data && !Array.isArray(data) && data.status === 404) {
+        return { ok: true, result: { poems: [], count: 0, source: "poetrydb", note: "no poems found" } };
+      }
+      const poems = (Array.isArray(data) ? data : []).map((p) => ({
+        title: p.title,
+        author: p.author,
+        lines: p.lines || [],
+        lineCount: parseInt(p.linecount, 10) || (p.lines || []).length,
+      }));
+      return {
+        ok: true,
+        result: { poems, count: poems.length, source: "poetrydb" },
+      };
+    } catch (e) {
+      return { ok: false, error: `poetrydb unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * poetrydb-authors — Full list of authors available in PoetryDB.
+   */
+  registerLensAction("poetry", "poetrydb-authors", async (_ctx, _artifact, _params = {}) => {
+    try {
+      const r = await fetch(`${POETRYDB_BASE}/author`);
+      if (!r.ok) throw new Error(`poetrydb ${r.status}`);
+      const data = await r.json();
+      const authors = data?.authors || [];
+      return { ok: true, result: { authors, count: authors.length, source: "poetrydb" } };
+    } catch (e) {
+      return { ok: false, error: `poetrydb unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
 }

--- a/server/tests/poetry-podcast-photography-domain-parity.test.js
+++ b/server/tests/poetry-podcast-photography-domain-parity.test.js
@@ -1,0 +1,217 @@
+// Contract tests for the new real-API macros across poetry, podcast,
+// and photography domains.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerPoetryActions from "../domains/poetry.js";
+import registerPodcastActions from "../domains/podcast.js";
+import registerPhotographyActions from "../domains/photography.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, params = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`${name} not registered`);
+  return fn(ctx, { id: null, data: {}, meta: {} }, params);
+}
+
+before(() => {
+  registerPoetryActions(register);
+  registerPodcastActions(register);
+  registerPhotographyActions(register);
+});
+
+beforeEach(() => {
+  globalThis.fetch = async () => { throw new Error("network disabled in tests"); };
+  delete process.env.PEXELS_API_KEY;
+});
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+
+describe("poetry.poetrydb-search (PoetryDB)", () => {
+  it("rejects no author + no title", async () => {
+    assert.equal((await call("poetry.poetrydb-search", ctxA, {})).ok, false);
+  });
+
+  it("hits author endpoint when only author supplied", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ([
+          { title: "Sonnet 18", author: "William Shakespeare", lines: ["Shall I compare thee to a summer's day?", "..."], linecount: "14" },
+        ]),
+      };
+    };
+    const r = await call("poetry.poetrydb-search", ctxA, { author: "Shakespeare" });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /poetrydb\.org\/author\/Shakespeare/);
+    assert.equal(r.result.poems[0].author, "William Shakespeare");
+    assert.equal(r.result.poems[0].lineCount, 14);
+  });
+
+  it("hits author,title compound endpoint when both supplied", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => ([{ title: "Sonnet 18", author: "Shakespeare", lines: [] }]) };
+    };
+    await call("poetry.poetrydb-search", ctxA, { author: "Shakespeare", title: "Sonnet 18" });
+    assert.match(capturedUrl, /poetrydb\.org\/author,title\/Shakespeare;Sonnet%2018/);
+  });
+
+  it("handles PoetryDB 404 status as empty list (not error)", async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({ status: 404, reason: "Not found" }),
+    });
+    const r = await call("poetry.poetrydb-search", ctxA, { author: "NonexistentPoet" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.count, 0);
+  });
+});
+
+describe("poetry.poetrydb-authors (PoetryDB)", () => {
+  it("returns full author list", async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({ authors: ["Adam Lindsay Gordon", "Alan Seeger", "William Shakespeare"] }),
+    });
+    const r = await call("poetry.poetrydb-authors", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.count, 3);
+    assert.equal(r.result.authors[2], "William Shakespeare");
+  });
+});
+
+describe("podcast.itunes-search (Apple Podcasts)", () => {
+  it("rejects empty query", async () => {
+    assert.equal((await call("podcast.itunes-search", ctxA, {})).ok, false);
+  });
+
+  it("rejects bad country code", async () => {
+    const r = await call("podcast.itunes-search", ctxA, { query: "x", country: "USA" });
+    assert.equal(r.ok, false);
+  });
+
+  it("hits iTunes Search + shapes podcast response", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ({
+          resultCount: 42,
+          results: [{
+            collectionId: 1200361736, trackId: 1200361736,
+            collectionName: "The Daily", trackName: "The Daily",
+            artistName: "The New York Times",
+            primaryGenreName: "News",
+            genres: ["News", "Daily News", "Podcasts"],
+            artworkUrl600: "https://example.org/600.jpg",
+            artworkUrl100: "https://example.org/100.jpg",
+            feedUrl: "https://feeds.simplecast.com/54nAGcIl",
+            trackCount: 2500,
+            country: "USA",
+            releaseDate: "2026-05-16T09:00:00Z",
+            collectionViewUrl: "https://podcasts.apple.com/us/podcast/the-daily/id1200361736",
+          }],
+        }),
+      };
+    };
+    const r = await call("podcast.itunes-search", ctxA, { query: "the daily" });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /itunes\.apple\.com\/search\?term=the%20daily/);
+    assert.match(capturedUrl, /media=podcast/);
+    assert.match(capturedUrl, /country=US/);
+    assert.equal(r.result.podcasts[0].title, "The Daily");
+    assert.equal(r.result.podcasts[0].artist, "The New York Times");
+    assert.equal(r.result.podcasts[0].episodeCount, 2500);
+    assert.equal(r.result.podcasts[0].feedUrl, "https://feeds.simplecast.com/54nAGcIl");
+    assert.equal(r.result.source, "itunes-search");
+  });
+});
+
+describe("podcast.itunes-podcast (Lookup)", () => {
+  it("rejects missing collectionId", async () => {
+    assert.equal((await call("podcast.itunes-podcast", ctxA, {})).ok, false);
+  });
+
+  it("returns clear error when iTunes returns no results", async () => {
+    globalThis.fetch = async () => ({ ok: true, json: async () => ({ results: [] }) });
+    const r = await call("podcast.itunes-podcast", ctxA, { collectionId: 999999 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /not found/);
+  });
+
+  it("parses lookup response", async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        results: [{ collectionId: 1200361736, collectionName: "The Daily", artistName: "NYT", feedUrl: "https://feed", trackCount: 2500 }],
+      }),
+    });
+    const r = await call("podcast.itunes-podcast", ctxA, { collectionId: 1200361736 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.title, "The Daily");
+  });
+});
+
+describe("photography.pexels-search", () => {
+  it("rejects when key not set", async () => {
+    const r = await call("photography.pexels-search", ctxA, { query: "sunset" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /PEXELS_API_KEY/);
+  });
+
+  it("rejects empty query", async () => {
+    process.env.PEXELS_API_KEY = "test-key";
+    assert.equal((await call("photography.pexels-search", ctxA, {})).ok, false);
+  });
+
+  it("hits Pexels with Authorization header + shapes photos", async () => {
+    process.env.PEXELS_API_KEY = "test-key";
+    let capturedUrl = "", capturedAuth = "";
+    globalThis.fetch = async (url, opts) => {
+      capturedUrl = url;
+      capturedAuth = opts?.headers?.Authorization || "";
+      return {
+        ok: true,
+        json: async () => ({
+          total_results: 100, next_page: "https://api.pexels.com/v1/search?query=sunset&page=2",
+          photos: [{
+            id: 12345, photographer: "Jane Doe", photographer_url: "https://example.org/jane",
+            width: 5184, height: 3456, avg_color: "#a37b50",
+            src: {
+              original: "https://images.pexels.com/photos/12345/.jpg",
+              large: "https://images.pexels.com/photos/12345/?h=650",
+              medium: "https://images.pexels.com/photos/12345/?h=350",
+              small: "https://images.pexels.com/photos/12345/?h=130",
+              tiny: "https://images.pexels.com/photos/12345/?w=280&h=200&dpr=1",
+              portrait: "https://images.pexels.com/photos/12345/?h=1200&w=800",
+              landscape: "https://images.pexels.com/photos/12345/?h=600&w=1200",
+            },
+            url: "https://www.pexels.com/photo/12345/",
+            alt: "Sunset over the ocean",
+          }],
+        }),
+      };
+    };
+    const r = await call("photography.pexels-search", ctxA, { query: "sunset", orientation: "landscape" });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /api\.pexels\.com\/v1\/search/);
+    assert.match(capturedUrl, /orientation=landscape/);
+    assert.equal(capturedAuth, "test-key");
+    assert.equal(r.result.photos[0].photographer, "Jane Doe");
+    assert.equal(r.result.totalResults, 100);
+  });
+
+  it("surfaces 401 invalid-key", async () => {
+    process.env.PEXELS_API_KEY = "bad";
+    globalThis.fetch = async () => ({ ok: false, status: 401, json: async () => ({}) });
+    const r = await call("photography.pexels-search", ctxA, { query: "x" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /invalid/);
+  });
+});


### PR DESCRIPTION
## Summary

Bucket 1 polish batch — three thin one-liner domain files (7-15 LOC) now have real-API integrations.

### poetry
- **`poetrydb-search`** — PoetryDB (free, no key). ~3000 classical poems by 100+ public-domain authors (Shakespeare, Dickinson, Frost, Whitman). Handles PoetryDB's quirky in-body 404 as empty list.
- **`poetrydb-authors`** — full author list.

### podcast
- **`itunes-search`** — Apple Podcasts directory via iTunes Search API (free, no key). Artwork, RSS feed URL, episode count, genre.
- **`itunes-podcast`** — single-podcast lookup by collectionId.

### photography
- **`pexels-search`** — real stock photo search via Pexels. Requires `PEXELS_API_KEY` env (free at pexels.com/api). Returns photographer + all 6 size URLs + orientation filter.

## Test plan

- [x] `node --test server/tests/poetry-podcast-photography-domain-parity.test.js` — **15/15 passing**
- [x] Covers: poetrydb missing-params + author-only/compound URLs + in-body 404 INVARIANT; iTunes empty/bad-country rejection + real Daily response; iTunes lookup empty-results error; Pexels missing-key/query + Authorization header INVARIANT + 401 surface

https://claude.ai/code/session_018ucd5N7Hc3K8mNa9p2Lr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_