### PR TITLE
feat(linguistics): real Free Dictionary + Datamuse word associations

### DIFF
--- a/server/domains/linguistics.js
+++ b/server/domains/linguistics.js
@@ -1,4 +1,12 @@
 // server/domains/linguistics.js
+//
+// Pure-compute text-analysis helpers (readability, morphology,
+// frequency) plus real Free Dictionary API + Datamuse word
+// associations (both free, no API key).
+
+const FREE_DICTIONARY = "https://api.dictionaryapi.dev/api/v2/entries";
+const DATAMUSE = "https://api.datamuse.com/words";
+
 export default function registerLinguisticsActions(registerLensAction) {
   registerLensAction("linguistics", "textAnalysis", (ctx, artifact, _params) => {
     const text = artifact.data?.text || artifact.data?.content || "";
@@ -41,5 +49,92 @@ export default function registerLinguisticsActions(registerLensAction) {
     for (const w of words) { if (positive.some(p => w.includes(p))) posCount++; if (negative.some(n => w.includes(n))) negCount++; }
     const score = words.length > 0 ? Math.round(((posCount - negCount) / Math.max(posCount + negCount, 1)) * 100) : 0;
     return { ok: true, result: { sentiment: score > 20 ? "positive" : score < -20 ? "negative" : "neutral", score, positiveWords: posCount, negativeWords: negCount, totalWords: words.length, confidence: (posCount + negCount) > 3 ? "high" : (posCount + negCount) > 0 ? "moderate" : "low" } };
+  });
+
+  /**
+   * dictionary-lookup — Real word definition via Free Dictionary API.
+   * Returns definitions, etymology, examples, pronunciations (IPA +
+   * audio URLs when available), synonyms/antonyms. Free, no API key.
+   * params: { word: string, lang?: ISO-2 (default "en") }
+   */
+  registerLensAction("linguistics", "dictionary-lookup", async (_ctx, _artifact, params = {}) => {
+    const word = String(params.word || "").trim();
+    if (!word) return { ok: false, error: "word required" };
+    const lang = String(params.lang || "en").toLowerCase();
+    try {
+      const r = await fetch(`${FREE_DICTIONARY}/${lang}/${encodeURIComponent(word)}`);
+      if (r.status === 404) return { ok: false, error: `word not found: ${word}` };
+      if (!r.ok) throw new Error(`dictionary ${r.status}`);
+      const data = await r.json();
+      const entries = (Array.isArray(data) ? data : []).map((entry) => ({
+        word: entry.word,
+        phonetic: entry.phonetic,
+        phonetics: (entry.phonetics || []).map((p) => ({ text: p.text, audio: p.audio })),
+        origin: entry.origin,
+        meanings: (entry.meanings || []).map((m) => ({
+          partOfSpeech: m.partOfSpeech,
+          definitions: (m.definitions || []).map((d) => ({
+            definition: d.definition,
+            example: d.example,
+            synonyms: d.synonyms || [],
+            antonyms: d.antonyms || [],
+          })),
+          synonyms: m.synonyms || [],
+          antonyms: m.antonyms || [],
+        })),
+      }));
+      return {
+        ok: true,
+        result: { word, lang, entries, count: entries.length, source: "free-dictionary-api" },
+      };
+    } catch (e) {
+      return { ok: false, error: `dictionary unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * datamuse-words — Word association lookup via Datamuse API.
+   * Free, no key. Supports rhymes, synonyms, "means like", "sounds
+   * like", "related to topic", and many more constraint queries.
+   *
+   * params: One or more of:
+   *   rel_rhy: "perfectly rhyming with"
+   *   rel_nry: "near-rhyming with"
+   *   ml: "means like"
+   *   sl: "sounds like"
+   *   sp: "spelled like" (supports wildcards * and ?)
+   *   rel_syn: "synonym of"
+   *   rel_ant: "antonym of"
+   *   topics: "related to topic"
+   *   max?: 1-1000 (default 25)
+   */
+  registerLensAction("linguistics", "datamuse-words", async (_ctx, _artifact, params = {}) => {
+    const allowed = ["rel_rhy", "rel_nry", "ml", "sl", "sp", "rel_syn", "rel_ant", "topics"];
+    const supplied = Object.keys(params).filter((k) => allowed.includes(k));
+    if (supplied.length === 0) {
+      return { ok: false, error: `at least one of: ${allowed.join(", ")} required` };
+    }
+    const max = Math.max(1, Math.min(1000, Number(params.max) || 25));
+    const qs = new URLSearchParams({ max: String(max) });
+    for (const k of supplied) {
+      qs.set(k, String(params[k]));
+    }
+    try {
+      const r = await fetch(`${DATAMUSE}?${qs.toString()}`);
+      if (!r.ok) throw new Error(`datamuse ${r.status}`);
+      const data = await r.json();
+      const words = (data || []).map((w) => ({
+        word: w.word,
+        score: w.score,
+        numSyllables: w.numSyllables,
+        tags: w.tags,
+      }));
+      return {
+        ok: true,
+        result: { query: Object.fromEntries(supplied.map((k) => [k, params[k]])), words, count: words.length, source: "datamuse" },
+      };
+    } catch (e) {
+      return { ok: false, error: `datamuse unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
   });
 }

--- a/server/tests/linguistics-domain-parity.test.js
+++ b/server/tests/linguistics-domain-parity.test.js
@@ -1,0 +1,125 @@
+// Contract tests for server/domains/linguistics.js — pure-compute
+// text-analysis helpers plus real Free Dictionary API + Datamuse.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerLinguisticsActions from "../domains/linguistics.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, params = {}) {
+  const fn = ACTIONS.get(`linguistics.${name}`);
+  if (!fn) throw new Error(`linguistics.${name} not registered`);
+  return fn(ctx, { id: null, data: {}, meta: {} }, params);
+}
+
+before(() => { registerLinguisticsActions(register); });
+beforeEach(() => { globalThis.fetch = async () => { throw new Error("network disabled in tests"); }; });
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+
+describe("linguistics.dictionary-lookup (Free Dictionary)", () => {
+  it("rejects empty word", async () => {
+    assert.equal((await call("dictionary-lookup", ctxA, {})).ok, false);
+  });
+
+  it("hits Free Dictionary + shapes entry response", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ([{
+          word: "serendipity",
+          phonetic: "/ˌsɛɹənˈdɪpɪti/",
+          phonetics: [
+            { text: "/ˌsɛɹənˈdɪpɪti/", audio: "https://api.dictionaryapi.dev/media/pronunciations/en/serendipity-us.mp3" },
+          ],
+          origin: "1754: coined by Horace Walpole, suggested by The Three Princes of Serendip.",
+          meanings: [{
+            partOfSpeech: "noun",
+            definitions: [{
+              definition: "The faculty or phenomenon of finding valuable or agreeable things not sought for.",
+              example: "Stumbling onto that book was pure serendipity.",
+              synonyms: ["luck", "chance"],
+              antonyms: ["misfortune"],
+            }],
+            synonyms: [], antonyms: [],
+          }],
+        }]),
+      };
+    };
+    const r = await call("dictionary-lookup", ctxA, { word: "serendipity" });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /api\.dictionaryapi\.dev\/api\/v2\/entries\/en\/serendipity/);
+    assert.equal(r.result.entries[0].word, "serendipity");
+    assert.equal(r.result.entries[0].meanings[0].partOfSpeech, "noun");
+    assert.equal(r.result.entries[0].meanings[0].definitions[0].synonyms[0], "luck");
+    assert.equal(r.result.source, "free-dictionary-api");
+  });
+
+  it("returns clear 404 for unknown words", async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 404, json: async () => ({}) });
+    const r = await call("dictionary-lookup", ctxA, { word: "xyzbogus" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /word not found/);
+  });
+});
+
+describe("linguistics.datamuse-words (word associations)", () => {
+  it("rejects when no query constraint supplied", async () => {
+    const r = await call("datamuse-words", ctxA, { max: 10 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /at least one of/);
+  });
+
+  it("supports rhymes (rel_rhy)", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        json: async () => ([
+          { word: "cat", score: 1000, numSyllables: 1 },
+          { word: "bat", score: 900, numSyllables: 1 },
+          { word: "rat", score: 850, numSyllables: 1 },
+        ]),
+      };
+    };
+    const r = await call("datamuse-words", ctxA, { rel_rhy: "hat", max: 5 });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /api\.datamuse\.com\/words/);
+    assert.match(capturedUrl, /rel_rhy=hat/);
+    assert.match(capturedUrl, /max=5/);
+    assert.equal(r.result.words.length, 3);
+    assert.equal(r.result.words[0].word, "cat");
+    assert.equal(r.result.source, "datamuse");
+  });
+
+  it("supports means-like (ml) + synonyms (rel_syn) combined", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => [] };
+    };
+    await call("datamuse-words", ctxA, { ml: "happy", rel_syn: "happy" });
+    assert.match(capturedUrl, /ml=happy/);
+    assert.match(capturedUrl, /rel_syn=happy/);
+  });
+
+  it("supports spelled-like wildcards (sp)", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => [] };
+    };
+    await call("datamuse-words", ctxA, { sp: "c?t" });
+    assert.match(capturedUrl, /sp=c%3Ft/);
+  });
+
+  it("surfaces datamuse network errors", async () => {
+    const r = await call("datamuse-words", ctxA, { rel_rhy: "x" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /datamuse unreachable/);
+  });
+});


### PR DESCRIPTION
## Summary

Bucket 1 polish on linguistics lens. Pure-compute helpers (text readability, morphology, frequency, sentiment) unchanged; adds two real-data macros backed by free no-key APIs.

### Backend
- **`dictionary-lookup`** — Free Dictionary API. Real word definitions per part-of-speech, etymology, **IPA phonetic + audio pronunciation URLs**, examples, synonyms, antonyms. Multi-language (`lang` param).
- **`datamuse-words`** — Datamuse word-association lookup. Eight constraint types: rhymes, near-rhymes, means-like, sounds-like, spelled-like (wildcards), synonyms, antonyms, topic-related. All combinable in one call.

## Test plan

- [x] `node --test server/tests/linguistics-domain-parity.test.js` — **8/8 passing**
- [x] Covers: empty-word rejection + real serendipity entry parsing (phonetics/audio/meanings/syn/ant) + 404 surface; datamuse no-constraint rejection + rhymes URL + combined ml+rel_syn + sp wildcard URL-encoding + network error

https://claude.ai/code/session_018ucd5N7Hc3K8mNa9p2Lr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_