### PR TITLE
feat(hr/defense): real BLS time-series + USAspending DoD contracts

### DIFF
--- a/server/domains/defense.js
+++ b/server/domains/defense.js
@@ -1,4 +1,11 @@
 // server/domains/defense.js
+//
+// Pure-compute defense helpers (threat assessment, readiness score,
+// supply chain, mission plan) plus real USAspending.gov DoD contract
+// data. Free, no API key.
+
+const USASPENDING_API = "https://api.usaspending.gov/api/v2";
+
 export default function registerDefenseActions(registerLensAction) {
   registerLensAction("defense", "threatAssessment", (ctx, artifact, _params) => {
     const threats = artifact.data?.threats || [];
@@ -43,5 +50,74 @@ export default function registerDefenseActions(registerLensAction) {
     let available = resources.length;
     for (const m of allocated) { const assign = Math.min(m.resourcesNeeded, available); m.resourcesAssigned = assign; m.status = assign >= m.resourcesNeeded ? "fully-allocated" : assign > 0 ? "partially-allocated" : "unallocated"; available -= assign; }
     return { ok: true, result: { totalResources: resources.length, totalMissions: missions.length, availableAfter: available, allocations: allocated, fullyStaffed: allocated.filter(a => a.status === "fully-allocated").length, understaffed: allocated.filter(a => a.status !== "fully-allocated").length } };
+  });
+
+  /**
+   * usaspending-dod-contracts — Real DoD prime award (contract) data
+   * via USAspending.gov. Free, no API key. Searches the active
+   * federal-procurement registry for DoD awards by keyword + date
+   * range. Returns recipient, award amount, NAICS code, PSC code,
+   * place of performance.
+   *
+   * params: {
+   *   keyword: search term (e.g. "satellite", "aircraft maintenance"),
+   *   awardType?: "contracts"|"grants"|"loans"|"idvs" (default contracts),
+   *   limit?: 1-100, page?: 1+
+   * }
+   */
+  registerLensAction("defense", "usaspending-dod-contracts", async (_ctx, _artifact, params = {}) => {
+    const keyword = String(params.keyword || "").trim();
+    if (!keyword) return { ok: false, error: "keyword required" };
+    const awardType = ["contracts", "grants", "loans", "idvs"].includes(params.awardType) ? params.awardType : "contracts";
+    const limit = Math.max(1, Math.min(100, Number(params.limit) || 25));
+    const page = Math.max(1, Number(params.page) || 1);
+    // DoD agency code is 097 (TLA: Department of Defense).
+    // award_type_codes: A,B,C,D = various contract types
+    const body = {
+      filters: {
+        keywords: [keyword],
+        agencies: [{ type: "awarding", tier: "toptier", name: "Department of Defense" }],
+        time_period: [{ start_date: `${new Date().getFullYear() - 2}-01-01`, end_date: new Date().toISOString().slice(0, 10) }],
+        award_type_codes: awardType === "contracts" ? ["A", "B", "C", "D"] : awardType === "grants" ? ["02", "03", "04", "05"] : awardType === "loans" ? ["07", "08"] : ["IDV_A", "IDV_B", "IDV_C", "IDV_D", "IDV_E"],
+      },
+      fields: ["Award ID", "Recipient Name", "Award Amount", "Awarding Agency", "Awarding Sub Agency", "Description", "Period of Performance Start Date", "Period of Performance Current End Date", "NAICS code", "PSC code", "Place of Performance State Code"],
+      page, limit,
+      sort: "Award Amount",
+      order: "desc",
+    };
+    try {
+      const r = await fetch(`${USASPENDING_API}/search/spending_by_award/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error(`usaspending ${r.status}`);
+      const data = await r.json();
+      const results = (data.results || []).map((row) => ({
+        awardId: row["Award ID"],
+        recipient: row["Recipient Name"],
+        amount: row["Award Amount"],
+        agency: row["Awarding Agency"],
+        subAgency: row["Awarding Sub Agency"],
+        description: row.Description,
+        startDate: row["Period of Performance Start Date"],
+        endDate: row["Period of Performance Current End Date"],
+        naicsCode: row["NAICS code"],
+        pscCode: row["PSC code"],
+        placeOfPerformanceState: row["Place of Performance State Code"],
+      }));
+      return {
+        ok: true,
+        result: {
+          keyword, awardType, page, limit,
+          results, count: results.length,
+          totalPages: data.page_metadata?.total,
+          totalAmount: results.reduce((s, r) => s + (r.amount || 0), 0),
+          source: "usaspending.gov",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `usaspending unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
   });
 }

--- a/server/domains/hr.js
+++ b/server/domains/hr.js
@@ -1,4 +1,12 @@
 // server/domains/hr.js
+//
+// Pure-compute HR helpers (compensation benchmark, turnover analysis,
+// PTO tracking) plus real US Bureau of Labor Statistics (BLS) for
+// real wage/employment data. Free with API key from
+// data.bls.gov/registrationEngine/ (25 req/day anonymous, 500 with key).
+
+const BLS_API = "https://api.bls.gov/publicAPI/v2";
+
 export default function registerHRActions(registerLensAction) {
   registerLensAction("hr", "compensationBenchmark", (ctx, artifact, _params) => {
     const data = artifact.data || {};
@@ -35,5 +43,66 @@ export default function registerHRActions(registerLensAction) {
     const remaining = totalDays - used - pending;
     const monthsLeft = 12 - new Date().getMonth();
     return { ok: true, result: { totalPTO: totalDays, used, pending, remaining, monthsRemaining: monthsLeft, burnRate: used > 0 ? Math.round(used / (12 - monthsLeft) * 10) / 10 : 0, projectedYearEnd: Math.round(remaining - (used / Math.max(12 - monthsLeft, 1)) * monthsLeft), recommendation: remaining > totalDays * 0.6 && monthsLeft < 4 ? "Use PTO — significant balance remaining before year-end" : "PTO usage is on track" } };
+  });
+
+  /**
+   * bls-series-lookup — Real BLS time-series data by series ID.
+   * Free for up to 25 requests/day; BLS_API_KEY env (free at
+   * data.bls.gov/registrationEngine/) raises to 500/day.
+   *
+   * Common series IDs:
+   *   CES0500000003  — All employees, total private, hourly earnings ($)
+   *   LNS14000000    — Unemployment rate (seasonally adjusted)
+   *   OEUN000000000000000074260000004 — National median wage, all occupations
+   *
+   * params: { seriesId: string OR seriesIds: string[], startYear?, endYear? }
+   */
+  registerLensAction("hr", "bls-series-lookup", async (_ctx, _artifact, params = {}) => {
+    const seriesIds = Array.isArray(params.seriesIds) ? params.seriesIds : params.seriesId ? [String(params.seriesId)] : [];
+    if (seriesIds.length === 0) return { ok: false, error: "seriesId or seriesIds[] required (BLS series identifier, e.g. 'LNS14000000' = unemployment rate)" };
+    if (seriesIds.length > 50) return { ok: false, error: "max 50 series per request" };
+    const endYear = String(params.endYear || new Date().getFullYear());
+    const startYear = String(params.startYear || (Number(endYear) - 2));
+    const apiKey = process.env.BLS_API_KEY;
+    const body = {
+      seriesid: seriesIds,
+      startyear: startYear,
+      endyear: endYear,
+      ...(apiKey ? { registrationkey: apiKey } : {}),
+    };
+    try {
+      const r = await fetch(`${BLS_API}/timeseries/data/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error(`bls ${r.status}`);
+      const data = await r.json();
+      if (data.status !== "REQUEST_SUCCEEDED") {
+        return { ok: false, error: `BLS error: ${(data.message || []).join("; ") || data.status}` };
+      }
+      const series = (data.Results?.series || []).map((s) => ({
+        seriesId: s.seriesID,
+        catalog: s.catalog,
+        data: (s.data || []).map((d) => ({
+          year: d.year,
+          period: d.period,
+          periodName: d.periodName,
+          value: parseFloat(d.value),
+          footnotes: (d.footnotes || []).filter((f) => f && f.code).map((f) => f.text),
+        })),
+      }));
+      return {
+        ok: true,
+        result: {
+          series, seriesCount: series.length,
+          startYear, endYear,
+          authenticated: !!apiKey,
+          source: "bls-public-api-v2",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `bls unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
   });
 }

--- a/server/tests/hr-defense-domain-parity.test.js
+++ b/server/tests/hr-defense-domain-parity.test.js
@@ -1,0 +1,147 @@
+// Contract tests for hr (BLS) + defense (USAspending DoD) real-data macros.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerHRActions from "../domains/hr.js";
+import registerDefenseActions from "../domains/defense.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, params = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`${name} not registered`);
+  return fn(ctx, { id: null, data: {}, meta: {} }, params);
+}
+
+before(() => {
+  registerHRActions(register);
+  registerDefenseActions(register);
+});
+
+beforeEach(() => {
+  globalThis.fetch = async () => { throw new Error("network disabled in tests"); };
+  delete process.env.BLS_API_KEY;
+});
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+
+describe("hr.bls-series-lookup (Bureau of Labor Statistics)", () => {
+  it("rejects missing seriesId", async () => {
+    assert.equal((await call("hr.bls-series-lookup", ctxA, {})).ok, false);
+  });
+
+  it("rejects > 50 series", async () => {
+    const seriesIds = Array.from({ length: 51 }, (_, i) => `LNS${String(i).padStart(8, "0")}`);
+    assert.equal((await call("hr.bls-series-lookup", ctxA, { seriesIds })).ok, false);
+  });
+
+  it("POSTs to BLS + parses unemployment-rate series", async () => {
+    let capturedUrl = "", capturedBody = null;
+    globalThis.fetch = async (url, opts) => {
+      capturedUrl = url;
+      capturedBody = JSON.parse(opts.body);
+      return {
+        ok: true,
+        json: async () => ({
+          status: "REQUEST_SUCCEEDED",
+          Results: {
+            series: [{
+              seriesID: "LNS14000000",
+              data: [
+                { year: "2026", period: "M03", periodName: "March", value: "3.8", footnotes: [] },
+                { year: "2026", period: "M02", periodName: "February", value: "3.9", footnotes: [] },
+              ],
+            }],
+          },
+        }),
+      };
+    };
+    const r = await call("hr.bls-series-lookup", ctxA, { seriesId: "LNS14000000", startYear: 2025, endYear: 2026 });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /api\.bls\.gov\/publicAPI\/v2\/timeseries\/data/);
+    assert.deepEqual(capturedBody.seriesid, ["LNS14000000"]);
+    assert.equal(capturedBody.startyear, "2025");
+    assert.equal(capturedBody.endyear, "2026");
+    assert.equal(r.result.series[0].data[0].value, 3.8);
+    assert.equal(r.result.authenticated, false);
+    assert.equal(r.result.source, "bls-public-api-v2");
+  });
+
+  it("includes registrationkey when BLS_API_KEY env set", async () => {
+    process.env.BLS_API_KEY = "real-key";
+    let capturedBody = null;
+    globalThis.fetch = async (_url, opts) => {
+      capturedBody = JSON.parse(opts.body);
+      return { ok: true, json: async () => ({ status: "REQUEST_SUCCEEDED", Results: { series: [] } }) };
+    };
+    const r = await call("hr.bls-series-lookup", ctxA, { seriesId: "LNS14000000" });
+    assert.equal(capturedBody.registrationkey, "real-key");
+    assert.equal(r.result.authenticated, true);
+  });
+
+  it("surfaces BLS in-body error status", async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({ status: "REQUEST_NOT_PROCESSED", message: ["Invalid series ID"] }),
+    });
+    const r = await call("hr.bls-series-lookup", ctxA, { seriesId: "INVALID" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /Invalid series ID/);
+  });
+});
+
+describe("defense.usaspending-dod-contracts", () => {
+  it("rejects empty keyword", async () => {
+    assert.equal((await call("defense.usaspending-dod-contracts", ctxA, {})).ok, false);
+  });
+
+  it("POSTs to USAspending + filters by DoD agency", async () => {
+    let capturedUrl = "", capturedBody = null;
+    globalThis.fetch = async (url, opts) => {
+      capturedUrl = url;
+      capturedBody = JSON.parse(opts.body);
+      return {
+        ok: true,
+        json: async () => ({
+          page_metadata: { total: 4 },
+          results: [{
+            "Award ID": "GS-35F-0119Y",
+            "Recipient Name": "ACME DEFENSE CONTRACTING INC",
+            "Award Amount": 12_500_000,
+            "Awarding Agency": "Department of Defense",
+            "Awarding Sub Agency": "Department of the Navy",
+            Description: "Satellite communications hardware",
+            "Period of Performance Start Date": "2024-09-01",
+            "Period of Performance Current End Date": "2027-08-31",
+            "NAICS code": "517410",
+            "PSC code": "5820",
+            "Place of Performance State Code": "VA",
+          }],
+        }),
+      };
+    };
+    const r = await call("defense.usaspending-dod-contracts", ctxA, { keyword: "satellite", limit: 25 });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /api\.usaspending\.gov\/api\/v2\/search\/spending_by_award/);
+    // DoD agency filter present
+    assert.equal(capturedBody.filters.agencies[0].name, "Department of Defense");
+    // Default = contracts → award_type_codes A,B,C,D
+    assert.deepEqual(capturedBody.filters.award_type_codes, ["A", "B", "C", "D"]);
+    assert.equal(r.result.results[0].recipient, "ACME DEFENSE CONTRACTING INC");
+    assert.equal(r.result.results[0].amount, 12_500_000);
+    assert.equal(r.result.totalAmount, 12_500_000);
+    assert.equal(r.result.source, "usaspending.gov");
+  });
+
+  it("switches award_type_codes for grants/loans/idvs", async () => {
+    let capturedBody = null;
+    globalThis.fetch = async (_url, opts) => {
+      capturedBody = JSON.parse(opts.body);
+      return { ok: true, json: async () => ({ results: [] }) };
+    };
+    await call("defense.usaspending-dod-contracts", ctxA, { keyword: "x", awardType: "grants" });
+    assert.deepEqual(capturedBody.filters.award_type_codes, ["02", "03", "04", "05"]);
+    await call("defense.usaspending-dod-contracts", ctxA, { keyword: "x", awardType: "loans" });
+    assert.deepEqual(capturedBody.filters.award_type_codes, ["07", "08"]);
+  });
+});


### PR DESCRIPTION
## Summary

Bucket 1 polish batch — hr + defense now have real-data macros covering US labor statistics + DoD federal procurement.

### hr
- **`bls-series-lookup`** — real BLS time-series data by series ID (unemployment rate, hourly earnings, wages by occupation, CPI, etc.). POST API; up to 50 series with shared date range. `BLS_API_KEY` env optional (free at data.bls.gov/registrationEngine/, raises 25→500 req/day). Surfaces in-body BLS error status.

### defense
- **`usaspending-dod-contracts`** — real DoD prime awards via USAspending.gov (free, no key). Filter by keyword + date range + DoD agency. Recipient, amount, sub-agency, NAICS/PSC codes, place of performance. Switches `award_type_codes` for contracts/grants/loans/idvs.

## Test plan

- [x] `node --test server/tests/hr-defense-domain-parity.test.js` — **8/8 passing**
- [x] Covers: BLS missing-seriesId + > 50 series rejection + POST body shape + real unemployment-rate response + API_KEY env adds registrationkey + REQUEST_NOT_PROCESSED in-body status; USAspending empty-keyword rejection + **DoD agency filter INVARIANT** + default contracts award codes + grants/loans switching

https://claude.ai/code/session_018ucd5N7Hc3K8mNa9p2Lr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_