### PR TITLE
feat(household/commonsense/fork): Open Food Facts + ConceptNet + GitHub API

### DIFF
--- a/server/domains/commonsense.js
+++ b/server/domains/commonsense.js
@@ -1,6 +1,10 @@
 // server/domains/commonsense.js
 // Domain actions for common-sense reasoning: plausibility checking,
-// analogy mapping, and default reasoning with exceptions.
+// analogy mapping, default reasoning with exceptions, plus real
+// ConceptNet knowledge-graph lookups (free, no API key — ~34M
+// edges across 304 languages).
+
+const CONCEPTNET_BASE = "https://api.conceptnet.io";
 
 export default function registerCommonsenseActions(registerLensAction) {
   /**
@@ -536,5 +540,79 @@ export default function registerCommonsenseActions(registerLensAction) {
         ],
       },
     };
+  });
+
+  /**
+   * conceptnet-edges — Real ConceptNet edges for a concept. Returns
+   * related concepts with relation type (IsA / PartOf / UsedFor /
+   * HasProperty / CapableOf / Causes / etc.) + weight.
+   * Free, no API key.
+   *
+   * params: { concept: string, lang?: ISO-2 (default "en"), rel?: relation type filter, limit?: 1-100 }
+   */
+  registerLensAction("commonsense", "conceptnet-edges", async (_ctx, _artifact, params = {}) => {
+    const concept = String(params.concept || "").trim();
+    if (!concept) return { ok: false, error: "concept required" };
+    const lang = String(params.lang || "en").toLowerCase();
+    const limit = Math.max(1, Math.min(100, Number(params.limit) || 25));
+    const normalized = concept.toLowerCase().replace(/\s+/g, "_");
+    const relFilter = params.rel ? `&rel=/r/${encodeURIComponent(String(params.rel))}` : "";
+    try {
+      const r = await fetch(`${CONCEPTNET_BASE}/c/${lang}/${encodeURIComponent(normalized)}?limit=${limit}${relFilter}`);
+      if (!r.ok) throw new Error(`conceptnet ${r.status}`);
+      const data = await r.json();
+      const edges = (data.edges || []).map((e) => ({
+        relation: e.rel?.label,
+        relationId: e.rel?.["@id"],
+        start: e.start?.label,
+        startConcept: e.start?.["@id"],
+        startLang: e.start?.language,
+        end: e.end?.label,
+        endConcept: e.end?.["@id"],
+        endLang: e.end?.language,
+        weight: e.weight,
+        sources: (e.sources || []).map((s) => s.contributor),
+        surfaceText: e.surfaceText,
+      }));
+      return {
+        ok: true,
+        result: {
+          concept, lang, edges, count: edges.length,
+          conceptId: data["@id"],
+          source: "conceptnet-5",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `conceptnet unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * conceptnet-relatedness — Numeric similarity between two concepts
+   * via ConceptNet's embedding-based relatedness score.
+   * params: { concept1, concept2, lang?: default "en" }
+   */
+  registerLensAction("commonsense", "conceptnet-relatedness", async (_ctx, _artifact, params = {}) => {
+    const a = String(params.concept1 || "").trim();
+    const b = String(params.concept2 || "").trim();
+    if (!a || !b) return { ok: false, error: "concept1 + concept2 required" };
+    const lang = String(params.lang || "en").toLowerCase();
+    const norm = (s) => s.toLowerCase().replace(/\s+/g, "_");
+    try {
+      const r = await fetch(`${CONCEPTNET_BASE}/relatedness?node1=/c/${lang}/${encodeURIComponent(norm(a))}&node2=/c/${lang}/${encodeURIComponent(norm(b))}`);
+      if (!r.ok) throw new Error(`conceptnet ${r.status}`);
+      const data = await r.json();
+      return {
+        ok: true,
+        result: {
+          concept1: a, concept2: b, lang,
+          relatedness: data.value,
+          interpretation: data.value > 0.7 ? "very-related" : data.value > 0.4 ? "related" : data.value > 0.2 ? "weakly-related" : "unrelated",
+          source: "conceptnet-5",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `conceptnet unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
   });
 }

--- a/server/domains/fork.js
+++ b/server/domains/fork.js
@@ -1,6 +1,12 @@
 // server/domains/fork.js
-// Domain actions for forking/branching: divergence analysis with Levenshtein
-// edit distance, merge complexity estimation, and fork health scoring.
+// Domain actions for forking/branching: divergence analysis with
+// Levenshtein edit distance, merge complexity estimation, fork health
+// scoring, plus real GitHub API lookups (forks of a repo, repo
+// metadata). GitHub public-API endpoints are free without
+// authentication at 60 req/hr; set GITHUB_TOKEN env to raise to
+// 5000/hr.
+
+const GITHUB_API = "https://api.github.com";
 
 export default function registerForkActions(registerLensAction) {
   /**
@@ -438,5 +444,107 @@ export default function registerForkActions(registerLensAction) {
         recommendations,
       },
     };
+  });
+
+  /**
+   * github-forks — List forks of a GitHub repo (real, live data).
+   * Free, no token (60 req/hr); GITHUB_TOKEN env raises to 5000/hr.
+   *
+   * params: { owner: string, repo: string, sort?: "newest"|"oldest"|"stargazers", limit?: 1-100 }
+   */
+  registerLensAction("fork", "github-forks", async (_ctx, _artifact, params = {}) => {
+    const owner = String(params.owner || "").trim();
+    const repo = String(params.repo || "").trim();
+    if (!owner || !repo) return { ok: false, error: "owner + repo required" };
+    const sort = ["newest", "oldest", "stargazers"].includes(params.sort) ? params.sort : "newest";
+    const perPage = Math.max(1, Math.min(100, Number(params.limit) || 30));
+    const token = process.env.GITHUB_TOKEN;
+    const headers = token ? { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json" } : { Accept: "application/vnd.github+json" };
+    try {
+      const r = await fetch(`${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/forks?sort=${sort}&per_page=${perPage}`, { headers });
+      if (r.status === 404) return { ok: false, error: `repo not found: ${owner}/${repo}` };
+      if (r.status === 403) return { ok: false, error: "github rate limit exceeded — set GITHUB_TOKEN env" };
+      if (!r.ok) throw new Error(`github ${r.status}`);
+      const data = await r.json();
+      const forks = (Array.isArray(data) ? data : []).map((f) => ({
+        id: f.id,
+        fullName: f.full_name,
+        owner: f.owner?.login,
+        ownerType: f.owner?.type,
+        htmlUrl: f.html_url,
+        description: f.description,
+        stargazers: f.stargazers_count,
+        watchers: f.watchers_count,
+        forks: f.forks_count,
+        openIssues: f.open_issues_count,
+        defaultBranch: f.default_branch,
+        language: f.language,
+        license: f.license?.spdx_id,
+        archived: f.archived,
+        disabled: f.disabled,
+        pushedAt: f.pushed_at,
+        createdAt: f.created_at,
+        updatedAt: f.updated_at,
+      }));
+      return {
+        ok: true,
+        result: {
+          owner, repo, sort,
+          forks, count: forks.length,
+          authenticated: !!token,
+          source: "github-api",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `github unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * github-repo — Full metadata for a GitHub repo (stars, forks,
+   * issues, language, default branch, license, push freshness).
+   */
+  registerLensAction("fork", "github-repo", async (_ctx, _artifact, params = {}) => {
+    const owner = String(params.owner || "").trim();
+    const repo = String(params.repo || "").trim();
+    if (!owner || !repo) return { ok: false, error: "owner + repo required" };
+    const token = process.env.GITHUB_TOKEN;
+    const headers = token ? { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json" } : { Accept: "application/vnd.github+json" };
+    try {
+      const r = await fetch(`${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`, { headers });
+      if (r.status === 404) return { ok: false, error: `repo not found: ${owner}/${repo}` };
+      if (r.status === 403) return { ok: false, error: "github rate limit exceeded — set GITHUB_TOKEN env" };
+      if (!r.ok) throw new Error(`github ${r.status}`);
+      const r2 = await r.json();
+      return {
+        ok: true,
+        result: {
+          fullName: r2.full_name,
+          owner: r2.owner?.login,
+          description: r2.description,
+          htmlUrl: r2.html_url,
+          stargazers: r2.stargazers_count,
+          watchers: r2.watchers_count,
+          forks: r2.forks_count,
+          openIssues: r2.open_issues_count,
+          size: r2.size,
+          defaultBranch: r2.default_branch,
+          language: r2.language,
+          topics: r2.topics,
+          license: r2.license?.spdx_id,
+          licenseUrl: r2.license?.url,
+          archived: r2.archived,
+          disabled: r2.disabled,
+          isFork: r2.fork,
+          parent: r2.parent ? r2.parent.full_name : null,
+          pushedAt: r2.pushed_at,
+          createdAt: r2.created_at,
+          updatedAt: r2.updated_at,
+          source: "github-api",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `github unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
   });
 }

--- a/server/domains/household.js
+++ b/server/domains/household.js
@@ -1,5 +1,10 @@
 // server/domains/household.js
-// Domain actions for household management: grocery lists, maintenance, chore rotation.
+// Domain actions for household management: grocery lists, maintenance,
+// chore rotation, plus real Open Food Facts product lookup
+// (2,000,000+ food products, ingredients, allergens, nutrition,
+// Nutri-Score grade). Free, no API key.
+
+const OPEN_FOOD_FACTS = "https://world.openfoodfacts.org/api/v2";
 
 export default function registerHouseholdActions(registerLensAction) {
   /**
@@ -423,5 +428,100 @@ export default function registerHouseholdActions(registerLensAction) {
     artifact.data.lastRotation = result;
 
     return { ok: true, result };
+  });
+
+  /**
+   * off-product-lookup — Real Open Food Facts product lookup by UPC/EAN
+   * barcode. Returns name, brand, ingredients, allergens, Nutri-Score
+   * grade (A-E), Eco-Score, nutrition facts, image URL.
+   * Free, no API key.
+   *
+   * params: { barcode: 8-14 digit UPC/EAN }
+   */
+  registerLensAction("household", "off-product-lookup", async (_ctx, _artifact, params = {}) => {
+    const barcode = String(params.barcode || "").replace(/\D/g, "");
+    if (!barcode) return { ok: false, error: "barcode required (UPC/EAN, 8-14 digits)" };
+    if (barcode.length < 8 || barcode.length > 14) return { ok: false, error: `barcode must be 8-14 digits (got ${barcode.length})` };
+    try {
+      const r = await fetch(`${OPEN_FOOD_FACTS}/product/${barcode}.json`);
+      if (!r.ok) throw new Error(`openfoodfacts ${r.status}`);
+      const data = await r.json();
+      if (data.status !== 1 || !data.product) {
+        return { ok: false, error: `product not found: ${barcode}` };
+      }
+      const p = data.product;
+      return {
+        ok: true,
+        result: {
+          barcode,
+          name: p.product_name,
+          brand: p.brands,
+          quantity: p.quantity,
+          categories: p.categories,
+          ingredients: p.ingredients_text,
+          allergens: p.allergens_tags,
+          additives: p.additives_tags,
+          nutriScore: p.nutriscore_grade,  // a/b/c/d/e
+          ecoScore: p.ecoscore_grade,
+          novaGroup: p.nova_group,  // 1=unprocessed, 4=ultra-processed
+          nutrition: {
+            energyKcal100g: p.nutriments?.["energy-kcal_100g"],
+            fat100g: p.nutriments?.fat_100g,
+            saturatedFat100g: p.nutriments?.["saturated-fat_100g"],
+            sugars100g: p.nutriments?.sugars_100g,
+            salt100g: p.nutriments?.salt_100g,
+            sodium100g: p.nutriments?.sodium_100g,
+            proteins100g: p.nutriments?.proteins_100g,
+            fiber100g: p.nutriments?.fiber_100g,
+            carbohydrates100g: p.nutriments?.carbohydrates_100g,
+          },
+          servingSize: p.serving_size,
+          imageUrl: p.image_url,
+          imageNutritionUrl: p.image_nutrition_url,
+          imageIngredientsUrl: p.image_ingredients_url,
+          countries: p.countries_tags,
+          source: "open-food-facts",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `open food facts unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  });
+
+  /**
+   * off-product-search — Search Open Food Facts by name/brand.
+   * params: { query: string, page?: 1+, pageSize?: 1-100 }
+   */
+  registerLensAction("household", "off-product-search", async (_ctx, _artifact, params = {}) => {
+    const query = String(params.query || "").trim();
+    if (!query) return { ok: false, error: "query required" };
+    if (query.length < 2) return { ok: false, error: "query must be ≥ 2 characters" };
+    const page = Math.max(1, Number(params.page) || 1);
+    const pageSize = Math.max(1, Math.min(100, Number(params.pageSize) || 20));
+    try {
+      const url = `${OPEN_FOOD_FACTS}/search?search_terms=${encodeURIComponent(query)}&page=${page}&page_size=${pageSize}&fields=code,product_name,brands,nutriscore_grade,image_url,quantity`;
+      const r = await fetch(url);
+      if (!r.ok) throw new Error(`openfoodfacts ${r.status}`);
+      const data = await r.json();
+      const products = (data.products || []).map((p) => ({
+        barcode: p.code,
+        name: p.product_name,
+        brand: p.brands,
+        nutriScore: p.nutriscore_grade,
+        imageUrl: p.image_url,
+        quantity: p.quantity,
+      }));
+      return {
+        ok: true,
+        result: {
+          query, products, count: products.length,
+          totalResults: data.count,
+          page,
+          source: "open-food-facts",
+        },
+      };
+    } catch (e) {
+      return { ok: false, error: `open food facts unreachable: ${e instanceof Error ? e.message : String(e)}` };
+    }
   });
 };

--- a/server/tests/household-commonsense-fork-domain-parity.test.js
+++ b/server/tests/household-commonsense-fork-domain-parity.test.js
@@ -1,0 +1,256 @@
+// Contract tests for household (Open Food Facts) + commonsense
+// (ConceptNet) + fork (GitHub) real-API macros.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerHouseholdActions from "../domains/household.js";
+import registerCommonsenseActions from "../domains/commonsense.js";
+import registerForkActions from "../domains/fork.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, params = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`${name} not registered`);
+  return fn(ctx, { id: null, data: {}, meta: {} }, params);
+}
+
+before(() => {
+  registerHouseholdActions(register);
+  registerCommonsenseActions(register);
+  registerForkActions(register);
+});
+
+beforeEach(() => {
+  globalThis.fetch = async () => { throw new Error("network disabled in tests"); };
+  delete process.env.GITHUB_TOKEN;
+});
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+
+describe("household.off-product-lookup (Open Food Facts)", () => {
+  it("rejects bad barcode length", async () => {
+    assert.equal((await call("household.off-product-lookup", ctxA, {})).ok, false);
+    assert.equal((await call("household.off-product-lookup", ctxA, { barcode: "123" })).ok, false);
+  });
+
+  it("strips non-digits", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => ({ status: 1, product: { product_name: "x" } }) };
+    };
+    await call("household.off-product-lookup", ctxA, { barcode: "0-12345-67890-1" });
+    // Strips hyphens; 12 digits → product/012345678901.json
+    assert.match(capturedUrl, /product\/012345678901\.json/);
+  });
+
+  it("parses real OFF response with Nutri-Score + nutrition", async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        status: 1,
+        product: {
+          product_name: "Nutella",
+          brands: "Ferrero",
+          quantity: "400g",
+          categories: "Spreads, Sweet spreads, Cocoa and hazelnuts spreads",
+          ingredients_text: "Sugar, palm oil, hazelnuts (13%)...",
+          allergens_tags: ["en:milk", "en:nuts", "en:soybeans"],
+          nutriscore_grade: "e",
+          ecoscore_grade: "d",
+          nova_group: 4,
+          nutriments: {
+            "energy-kcal_100g": 539,
+            fat_100g: 30.9,
+            "saturated-fat_100g": 10.6,
+            sugars_100g: 56.3,
+            salt_100g: 0.107,
+            proteins_100g: 6.3,
+            carbohydrates_100g: 57.5,
+          },
+          image_url: "https://images.openfoodfacts.org/.../front.jpg",
+        },
+      }),
+    });
+    const r = await call("household.off-product-lookup", ctxA, { barcode: "3017624010701" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.name, "Nutella");
+    assert.equal(r.result.nutriScore, "e");
+    assert.equal(r.result.novaGroup, 4);
+    assert.equal(r.result.nutrition.energyKcal100g, 539);
+    assert.deepEqual(r.result.allergens, ["en:milk", "en:nuts", "en:soybeans"]);
+    assert.equal(r.result.source, "open-food-facts");
+  });
+
+  it("returns clear 'product not found' on status:0", async () => {
+    globalThis.fetch = async () => ({ ok: true, json: async () => ({ status: 0 }) });
+    const r = await call("household.off-product-lookup", ctxA, { barcode: "9999999999999" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /product not found/);
+  });
+});
+
+describe("household.off-product-search", () => {
+  it("rejects short query", async () => {
+    assert.equal((await call("household.off-product-search", ctxA, { query: "x" })).ok, false);
+  });
+
+  it("parses search response", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => ({ count: 42, products: [{ code: "111", product_name: "Bread", brands: "Acme", nutriscore_grade: "b" }] }) };
+    };
+    const r = await call("household.off-product-search", ctxA, { query: "bread" });
+    assert.match(capturedUrl, /search_terms=bread/);
+    assert.equal(r.result.products[0].barcode, "111");
+    assert.equal(r.result.totalResults, 42);
+  });
+});
+
+describe("commonsense.conceptnet-edges", () => {
+  it("rejects empty concept", async () => {
+    assert.equal((await call("commonsense.conceptnet-edges", ctxA, {})).ok, false);
+  });
+
+  it("URL-encodes multi-word concept with underscores", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return { ok: true, json: async () => ({ "@id": "/c/en/ice_cream", edges: [] }) };
+    };
+    await call("commonsense.conceptnet-edges", ctxA, { concept: "ice cream" });
+    assert.match(capturedUrl, /\/c\/en\/ice_cream/);
+  });
+
+  it("parses edges with relation + weight + sources", async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        "@id": "/c/en/cat",
+        edges: [{
+          rel: { label: "IsA", "@id": "/r/IsA" },
+          start: { label: "cat", "@id": "/c/en/cat", language: "en" },
+          end: { label: "animal", "@id": "/c/en/animal", language: "en" },
+          weight: 5.4,
+          sources: [{ contributor: "/s/resource/wordnet/rdf/3.1" }],
+          surfaceText: "A [[cat]] is an [[animal]]",
+        }],
+      }),
+    });
+    const r = await call("commonsense.conceptnet-edges", ctxA, { concept: "cat" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.edges[0].relation, "IsA");
+    assert.equal(r.result.edges[0].weight, 5.4);
+    assert.equal(r.result.source, "conceptnet-5");
+  });
+});
+
+describe("commonsense.conceptnet-relatedness", () => {
+  it("rejects missing concepts", async () => {
+    assert.equal((await call("commonsense.conceptnet-relatedness", ctxA, { concept1: "x" })).ok, false);
+  });
+
+  it("returns numeric relatedness + interpretation buckets", async () => {
+    globalThis.fetch = async () => ({ ok: true, json: async () => ({ value: 0.78 }) });
+    const r = await call("commonsense.conceptnet-relatedness", ctxA, { concept1: "dog", concept2: "puppy" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.relatedness, 0.78);
+    assert.equal(r.result.interpretation, "very-related");
+  });
+});
+
+describe("fork.github-forks", () => {
+  it("rejects missing owner/repo", async () => {
+    assert.equal((await call("fork.github-forks", ctxA, {})).ok, false);
+    assert.equal((await call("fork.github-forks", ctxA, { owner: "x" })).ok, false);
+  });
+
+  it("hits GitHub + parses fork list (anonymous tier)", async () => {
+    let capturedUrl = "", capturedAuth = "";
+    globalThis.fetch = async (url, opts) => {
+      capturedUrl = url;
+      capturedAuth = opts?.headers?.Authorization || "";
+      return {
+        ok: true,
+        json: async () => ([{
+          id: 12345, full_name: "alice/concord-fork",
+          owner: { login: "alice", type: "User" },
+          html_url: "https://github.com/alice/concord-fork",
+          stargazers_count: 5, watchers_count: 5, forks_count: 0,
+          open_issues_count: 2, default_branch: "main",
+          language: "TypeScript",
+          license: { spdx_id: "MIT" },
+          archived: false, disabled: false,
+          pushed_at: "2026-05-10T00:00:00Z",
+          created_at: "2025-08-15T00:00:00Z",
+          updated_at: "2026-05-12T00:00:00Z",
+        }]),
+      };
+    };
+    const r = await call("fork.github-forks", ctxA, { owner: "ryttps94jq-gif", repo: "concord-cognitive-engine" });
+    assert.equal(r.ok, true);
+    assert.match(capturedUrl, /api\.github\.com\/repos\/ryttps94jq-gif\/concord-cognitive-engine\/forks/);
+    assert.equal(capturedAuth, "");
+    assert.equal(r.result.forks[0].fullName, "alice/concord-fork");
+    assert.equal(r.result.forks[0].license, "MIT");
+    assert.equal(r.result.authenticated, false);
+    assert.equal(r.result.source, "github-api");
+  });
+
+  it("uses GITHUB_TOKEN env when set", async () => {
+    process.env.GITHUB_TOKEN = "test-token";
+    let capturedAuth = "";
+    globalThis.fetch = async (_url, opts) => {
+      capturedAuth = opts?.headers?.Authorization || "";
+      return { ok: true, json: async () => ([]) };
+    };
+    const r = await call("fork.github-forks", ctxA, { owner: "x", repo: "y" });
+    assert.equal(capturedAuth, "Bearer test-token");
+    assert.equal(r.result.authenticated, true);
+  });
+
+  it("surfaces 403 rate-limit with helpful pointer", async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 403, json: async () => ({}) });
+    const r = await call("fork.github-forks", ctxA, { owner: "x", repo: "y" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /rate limit.*GITHUB_TOKEN/);
+  });
+});
+
+describe("fork.github-repo", () => {
+  it("rejects missing params", async () => {
+    assert.equal((await call("fork.github-repo", ctxA, {})).ok, false);
+  });
+
+  it("parses repo metadata + parent link", async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        full_name: "alice/concord-fork",
+        owner: { login: "alice" },
+        description: "Fork of concord",
+        html_url: "https://github.com/alice/concord-fork",
+        stargazers_count: 5, watchers_count: 5, forks_count: 0,
+        open_issues_count: 2,
+        size: 5000,
+        default_branch: "main",
+        language: "TypeScript",
+        topics: ["concord", "lens"],
+        license: { spdx_id: "MIT", url: "https://api.github.com/licenses/mit" },
+        archived: false, disabled: false,
+        fork: true,
+        parent: { full_name: "ryttps94jq-gif/concord-cognitive-engine" },
+        pushed_at: "2026-05-10T00:00:00Z",
+        created_at: "2025-08-15T00:00:00Z",
+        updated_at: "2026-05-12T00:00:00Z",
+      }),
+    });
+    const r = await call("fork.github-repo", ctxA, { owner: "alice", repo: "concord-fork" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.isFork, true);
+    assert.equal(r.result.parent, "ryttps94jq-gif/concord-cognitive-engine");
+    assert.deepEqual(r.result.topics, ["concord", "lens"]);
+  });
+});


### PR DESCRIPTION
## Summary

Bucket 1 polish batch — three lenses now have real-data macros.

### household
- **`off-product-lookup`** — Open Food Facts UPC/EAN barcode lookup (2M+ products). Nutri-Score, Eco-Score, NOVA group, full nutrition, allergens, ingredients, image URLs.
- **`off-product-search`** — fuzzy product search by name/brand.

### commonsense
- **`conceptnet-edges`** — ConceptNet 5 edges (IsA / PartOf / UsedFor / etc.) with weights + sources. Multi-language.
- **`conceptnet-relatedness`** — numeric similarity between two concepts with interpretation buckets.

### fork
- **`github-forks`** — real fork list with metadata (license SPDX, archived, push freshness). Anonymous tier; `GITHUB_TOKEN` env raises 60→5000/hr.
- **`github-repo`** — full repo metadata + parent lineage for fork tracing.

## Test plan

- [x] `node --test server/tests/household-commonsense-fork-domain-parity.test.js` — **17/17 passing**
- [x] Covers: OFF bad-barcode rejection + hyphen stripping + real Nutella with Nutri-Score + status:0 not-found; ConceptNet multi-word URL encoding + IsA edge parsing + relatedness buckets; GitHub anonymous + Bearer auth + 403 rate-limit pointer + parent lineage

https://claude.ai/code/session_018ucd5N7Hc3K8mNa9p2Lr8s

---
_Generated by [Claude Code](https://claude.ai/code/session_0191QDc5hW3E1nta3t8Lp5ja)_