### PR TITLE
automotive: wire fuelEfficiency + repairEstimate (Bucket A #12)

### DIFF
--- a/concord-frontend/app/lenses/automotive/page.tsx
+++ b/concord-frontend/app/lenses/automotive/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo, useCallback, useRef} from 'react';
 import { LensShell } from '@/components/lens/LensShell';
 import { VinDecoder } from '@/components/automotive/VinDecoder';
+import { FuelRepairPanel } from '@/components/automotive/FuelRepairPanel';
 import { ManifestActionBar } from '@/components/lens/ManifestActionBar';
 import { motion } from 'framer-motion';
 import { useLensData, LensItem } from '@/lib/hooks/use-lens-data';
@@ -708,6 +709,10 @@ export default function AutomotiveLensPage() {
       {/* Bespoke NHTSA VIN decoder + recall lookup with Save-as-DTU */}
       <section className="mt-6 rounded-xl border border-zinc-800 bg-zinc-950/40 p-4">
         <VinDecoder />
+      </section>
+
+      <section className="mt-6 rounded-xl border border-zinc-800 bg-zinc-950/40 p-4">
+        <FuelRepairPanel />
       </section>
     </LensPageShell>
 

--- a/concord-frontend/components/automotive/FuelRepairPanel.tsx
+++ b/concord-frontend/components/automotive/FuelRepairPanel.tsx
@@ -1,0 +1,223 @@
+'use client';
+
+/**
+ * FuelRepairPanel — bespoke fuel economy + repair estimator
+ * for the automotive lens. Wires automotive.fuelEfficiency +
+ * automotive.repairEstimate against editable fill-up and repair
+ * line-item tables.
+ *
+ *   • Fuel: editable fill-up rows (date/mileage/gallons/$/gal) →
+ *     avg MPG, best/worst, total $, cost-per-mile, per-fillup MPG list
+ *   • Repair: editable repair rows (name/parts/hours/priority) +
+ *     shop rate → per-line totals, parts/labor subtotals, tax,
+ *     grand total + recommendation
+ *   • Save-as-DTU captures inputs + both reports
+ */
+
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { Car, Loader2, Plus, Trash2, Fuel, Wrench } from 'lucide-react';
+import { apiHelpers } from '@/lib/api/client';
+import { SaveAsDtuButton } from '@/components/dtu/SaveAsDtuButton';
+
+interface FillUp { date: string; mileage: string; gallons: string; pricePerGallon: string }
+interface Repair { name: string; partsCost: string; laborHours: string; priority: 'low' | 'medium' | 'high' }
+interface FuelResult { avgMPG?: number; bestMPG?: number; worstMPG?: number; totalGallons?: number; totalCost?: number; costPerMile?: number; mpgReadings?: Array<{ date?: string; mpg: number; miles: number; gallons: number }> }
+interface RepairResult { repairs?: Array<{ repair: string; partsCost: number; laborHours: number; laborRate: number; laborCost: number; total: number; priority: string }>; subtotalParts?: number; subtotalLabor?: number; grandTotal?: number; tax?: number; totalWithTax?: number; recommendation?: string }
+
+async function callAuto<T>(action: string, input: Record<string, unknown>): Promise<T | null> {
+  try {
+    const r = await apiHelpers.lens.runDomain('automotive', action, { input });
+    const env = (r as { data?: { ok: boolean; result?: T } }).data;
+    if (!env?.ok) return null;
+    const result = env.result as unknown as { ok?: boolean; result?: T } | T;
+    if (result && typeof result === 'object' && 'ok' in result && 'result' in result) {
+      return (result as { result: T }).result;
+    }
+    return env.result as T;
+  } catch { return null; }
+}
+
+const today = new Date();
+const dayOffset = (n: number) => new Date(today.getTime() - n * 86400000).toISOString().slice(0, 10);
+
+const DEFAULT_FILLUPS: FillUp[] = [
+  { date: dayOffset(35), mileage: '54200', gallons: '12.4', pricePerGallon: '3.85' },
+  { date: dayOffset(22), mileage: '54580', gallons: '11.8', pricePerGallon: '3.92' },
+  { date: dayOffset(10), mileage: '54920', gallons: '13.1', pricePerGallon: '3.78' },
+  { date: dayOffset(1), mileage: '55290', gallons: '12.0', pricePerGallon: '3.95' },
+];
+
+const DEFAULT_REPAIRS: Repair[] = [
+  { name: 'Front brake pads + rotors', partsCost: '320', laborHours: '2.5', priority: 'high' },
+  { name: 'Oil change (synthetic)', partsCost: '65', laborHours: '0.5', priority: 'medium' },
+  { name: 'Cabin air filter', partsCost: '28', laborHours: '0.3', priority: 'low' },
+];
+
+export function FuelRepairPanel() {
+  const [fillups, setFillups] = useState<FillUp[]>(DEFAULT_FILLUPS);
+  const [repairs, setRepairs] = useState<Repair[]>(DEFAULT_REPAIRS);
+  const [shopRate, setShopRate] = useState(120);
+  const [fuelResult, setFuelResult] = useState<FuelResult | null>(null);
+  const [repairResult, setRepairResult] = useState<RepairResult | null>(null);
+
+  const analyze = useMutation({
+    mutationFn: async () => {
+      const cleanFills = fillups.filter((f) => f.mileage && f.gallons);
+      const cleanRepairs = repairs.filter((r) => r.name.trim());
+      const [f, r] = await Promise.all([
+        callAuto<FuelResult>('fuelEfficiency', { artifact: { data: { fillups: cleanFills } } }),
+        callAuto<RepairResult>('repairEstimate', { artifact: { data: { repairs: cleanRepairs, shopRate } } }),
+      ]);
+      setFuelResult(f);
+      setRepairResult(r);
+      return { f, r };
+    },
+  });
+
+  const addFill = () => setFillups((fs) => [...fs, { date: dayOffset(0), mileage: '', gallons: '', pricePerGallon: '' }]);
+  const updateFill = <K extends keyof FillUp>(i: number, key: K, value: FillUp[K]) =>
+    setFillups((fs) => fs.map((f, idx) => (idx === i ? { ...f, [key]: value } : f)));
+  const removeFill = (i: number) => setFillups((fs) => fs.filter((_, idx) => idx !== i));
+
+  const addRep = () => setRepairs((rs) => [...rs, { name: '', partsCost: '', laborHours: '', priority: 'medium' }]);
+  const updateRep = <K extends keyof Repair>(i: number, key: K, value: Repair[K]) =>
+    setRepairs((rs) => rs.map((r, idx) => (idx === i ? { ...r, [key]: value } : r)));
+  const removeRep = (i: number) => setRepairs((rs) => rs.filter((_, idx) => idx !== i));
+
+  const prBadge = (p: string) => {
+    if (p === 'high') return 'bg-rose-500/20 text-rose-200';
+    if (p === 'medium') return 'bg-amber-500/20 text-amber-200';
+    return 'bg-zinc-700 text-zinc-300';
+  };
+
+  return (
+    <div className="space-y-4">
+      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-cyan-500/15 pb-3">
+        <div className="flex items-center gap-2">
+          <Car className="h-5 w-5 text-blue-400" />
+          <h2 className="text-sm font-semibold text-white">Fuel economy + repair estimate</h2>
+          <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">automotive.fuelEfficiency + repairEstimate</span>
+        </div>
+        {(fuelResult || repairResult) && (
+          <SaveAsDtuButton
+            compact
+            apiSource="concord-auto-fuel-repair"
+            title={`Auto — ${fuelResult?.avgMPG ?? '—'} MPG · $${repairResult?.totalWithTax ?? '—'} repair est`}
+            content={`Fuel:\n  Avg MPG: ${fuelResult?.avgMPG} (best ${fuelResult?.bestMPG}, worst ${fuelResult?.worstMPG})\n  Total gallons: ${fuelResult?.totalGallons} | Cost: $${fuelResult?.totalCost?.toFixed?.(2) ?? '—'} | Cost/mile: $${fuelResult?.costPerMile}\n\nRepair estimate (shop rate $${shopRate}/hr):\n${(repairResult?.repairs || []).map((r) => `  ${r.repair} — parts $${r.partsCost} + labor ${r.laborHours}h ($${r.laborCost}) = $${r.total} [${r.priority}]`).join('\n')}\n  Parts subtotal: $${repairResult?.subtotalParts}\n  Labor subtotal: $${repairResult?.subtotalLabor}\n  Tax: $${repairResult?.tax}\n  Total with tax: $${repairResult?.totalWithTax}\n  Note: ${repairResult?.recommendation}`}
+            extraTags={['automotive', 'fuel-economy', 'repair']}
+            rawData={{ fillups, repairs, shopRate, fuelResult, repairResult }}
+          />
+        )}
+      </header>
+
+      <div className="space-y-2">
+        <div className="text-[10px] uppercase tracking-wider text-zinc-500">Fill-ups (chronological)</div>
+        <div className="grid grid-cols-[130px_100px_90px_90px_30px] gap-1.5 text-[9px] uppercase tracking-wider text-zinc-500">
+          <span>Date</span><span>Mileage</span><span>Gallons</span><span>$ / gal</span><span></span>
+        </div>
+        {fillups.map((f, i) => (
+          <div key={i} className="grid grid-cols-[130px_100px_90px_90px_30px] gap-1.5">
+            <input type="date" className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" value={f.date} onChange={(e) => updateFill(i, 'date', e.target.value)} />
+            <input type="number" className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" placeholder="54200" value={f.mileage} onChange={(e) => updateFill(i, 'mileage', e.target.value)} />
+            <input type="number" step={0.1} className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" placeholder="12.4" value={f.gallons} onChange={(e) => updateFill(i, 'gallons', e.target.value)} />
+            <input type="number" step={0.01} className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" placeholder="3.85" value={f.pricePerGallon} onChange={(e) => updateFill(i, 'pricePerGallon', e.target.value)} />
+            <button type="button" onClick={() => removeFill(i)} className="rounded border border-zinc-800 text-xs text-zinc-500 hover:text-rose-300" aria-label="Remove"><Trash2 className="mx-auto h-3 w-3" /></button>
+          </div>
+        ))}
+        <button type="button" onClick={addFill} className="inline-flex items-center gap-1 rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-zinc-300 hover:border-blue-500/40 hover:text-blue-200"><Plus className="h-3 w-3" />Add fill-up</button>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <div className="text-[10px] uppercase tracking-wider text-zinc-500">Repair line items</div>
+          <label className="text-[10px] text-zinc-500">Shop labor rate ($/hr)
+            <input type="number" min={50} max={300} value={shopRate} onChange={(e) => setShopRate(Math.max(50, Math.min(300, Number(e.target.value) || 120)))} className="ml-2 w-16 rounded border border-zinc-800 bg-zinc-950 px-1.5 py-0.5 text-xs text-white font-mono" />
+          </label>
+        </div>
+        <div className="grid grid-cols-[1fr_90px_80px_100px_30px] gap-1.5 text-[9px] uppercase tracking-wider text-zinc-500">
+          <span>Repair</span><span>Parts $</span><span>Labor (h)</span><span>Priority</span><span></span>
+        </div>
+        {repairs.map((r, i) => (
+          <div key={i} className="grid grid-cols-[1fr_90px_80px_100px_30px] gap-1.5">
+            <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white" placeholder="Repair name" value={r.name} onChange={(e) => updateRep(i, 'name', e.target.value)} />
+            <input type="number" className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" value={r.partsCost} onChange={(e) => updateRep(i, 'partsCost', e.target.value)} />
+            <input type="number" step={0.1} className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" value={r.laborHours} onChange={(e) => updateRep(i, 'laborHours', e.target.value)} />
+            <select className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white" value={r.priority} onChange={(e) => updateRep(i, 'priority', e.target.value as Repair['priority'])}>
+              <option value="low">low</option>
+              <option value="medium">medium</option>
+              <option value="high">high</option>
+            </select>
+            <button type="button" onClick={() => removeRep(i)} className="rounded border border-zinc-800 text-xs text-zinc-500 hover:text-rose-300" aria-label="Remove"><Trash2 className="mx-auto h-3 w-3" /></button>
+          </div>
+        ))}
+        <button type="button" onClick={addRep} className="inline-flex items-center gap-1 rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-zinc-300 hover:border-blue-500/40 hover:text-blue-200"><Plus className="h-3 w-3" />Add repair</button>
+      </div>
+
+      <button type="button" onClick={() => analyze.mutate()} disabled={analyze.isPending} className="inline-flex items-center gap-1 rounded border border-blue-500/40 bg-blue-500/15 px-3 py-1.5 text-xs font-mono text-blue-200 hover:bg-blue-500/25 disabled:opacity-50">
+        {analyze.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Car className="h-3.5 w-3.5" />}
+        Analyze
+      </button>
+
+      {analyze.isError && <div className="rounded border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-300">Analysis failed.</div>}
+
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+        <div className="rounded-lg border border-blue-500/20 bg-blue-500/5 p-3">
+          <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Fuel className="h-3 w-3" />Fuel economy</div>
+          {!fuelResult && <div className="text-[11px] text-zinc-500">Analyze to compute.</div>}
+          {fuelResult && (
+            <div className="space-y-2 text-[11px]">
+              <div className="rounded border border-blue-500/20 bg-zinc-950/40 px-2 py-1">
+                <div className="text-[9px] text-zinc-500">Average MPG</div>
+                <div className="font-mono text-2xl text-blue-200">{fuelResult.avgMPG}</div>
+              </div>
+              <div className="grid grid-cols-3 gap-1.5">
+                <div className="rounded border border-emerald-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Best</div><div className="font-mono text-emerald-200">{fuelResult.bestMPG}</div></div>
+                <div className="rounded border border-rose-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Worst</div><div className="font-mono text-rose-200">{fuelResult.worstMPG}</div></div>
+                <div className="rounded border border-blue-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">$/mile</div><div className="font-mono text-blue-200">${fuelResult.costPerMile}</div></div>
+              </div>
+              {fuelResult.mpgReadings && fuelResult.mpgReadings.length > 0 && (
+                <details className="text-[10px]">
+                  <summary className="cursor-pointer text-zinc-500 hover:text-zinc-300">Per-fillup readings ({fuelResult.mpgReadings.length})</summary>
+                  <div className="mt-1 space-y-0.5">
+                    {fuelResult.mpgReadings.map((r, i) => (
+                      <div key={i} className="flex items-center justify-between rounded border border-blue-500/10 bg-zinc-950/40 px-2 py-0.5"><span className="text-zinc-300">{r.date || `Fillup ${i + 2}`}</span><span className="font-mono text-blue-200">{r.mpg} MPG</span></div>
+                    ))}
+                  </div>
+                </details>
+              )}
+            </div>
+          )}
+        </div>
+        <div className="rounded-lg border border-orange-500/20 bg-orange-500/5 p-3">
+          <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Wrench className="h-3 w-3" />Repair estimate</div>
+          {!repairResult && <div className="text-[11px] text-zinc-500">Analyze to compute.</div>}
+          {repairResult && (
+            <div className="space-y-1.5 text-[11px]">
+              <div className="rounded border border-orange-500/20 bg-zinc-950/40 px-2 py-1">
+                <div className="text-[9px] text-zinc-500">Total with tax</div>
+                <div className="font-mono text-2xl text-orange-200">${repairResult.totalWithTax?.toLocaleString()}</div>
+                <div className="text-[10px] text-zinc-500">parts ${repairResult.subtotalParts} + labor ${repairResult.subtotalLabor} + tax ${repairResult.tax}</div>
+              </div>
+              <div className="space-y-1">
+                {repairResult.repairs?.map((r, i) => (
+                  <div key={i} className="rounded border border-orange-500/15 bg-zinc-950/40 px-2 py-1">
+                    <div className="flex items-center justify-between">
+                      <span className="text-zinc-100">{r.repair}</span>
+                      <span className="font-mono text-orange-200">${r.total}</span>
+                    </div>
+                    <div className="flex items-center justify-between text-[9px] text-zinc-500">
+                      <span>parts ${r.partsCost} + labor {r.laborHours}h × ${r.laborRate} = ${r.laborCost}</span>
+                      <span className={`rounded px-1 ${prBadge(r.priority)}`}>{r.priority}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+              {repairResult.recommendation && <div className="rounded border border-amber-500/20 bg-amber-500/5 px-2 py-1 text-[10px] text-amber-200">{repairResult.recommendation}</div>}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `FuelRepairPanel` wires `automotive.fuelEfficiency` + `automotive.repairEstimate`: editable fill-up rows → avg/best/worst MPG, total cost, cost/mile; editable repair line items + shop rate → per-line totals, subtotals, tax, grand total + recommendation.
- Defaults preload 4 chronological fill-ups (~30 MPG) + 3 realistic repairs (brakes/oil/cabin filter).
- Save-as-DTU captures inputs + both reports.

`automotive` had 6 backend macros, 3 wired in `VinDecoder` (`vin-decode`, `recall-lookup`, `diagnosticLookup`); this lands 2 more (1 remaining: `maintenanceSchedule`).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on changed files

https://claude.ai/code/session_01WfDATSALRXGNnSkLKb4U9j

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfDATSALRXGNnSkLKb4U9j)_