### PR TITLE
lens-primitives: extract CalcPanel + refactor 3 consumers (Phase 1)

### DIFF
--- a/concord-frontend/components/automotive/FuelRepairPanel.tsx
+++ b/concord-frontend/components/automotive/FuelRepairPanel.tsx
@@ -1,42 +1,22 @@
 'use client';
 
 /**
- * FuelRepairPanel — bespoke fuel economy + repair estimator
- * for the automotive lens. Wires automotive.fuelEfficiency +
- * automotive.repairEstimate against editable fill-up and repair
- * line-item tables.
+ * FuelRepairPanel — fuel economy + repair estimator for the
+ * automotive lens. Wires automotive.fuelEfficiency +
+ * automotive.repairEstimate.
  *
- *   • Fuel: editable fill-up rows (date/mileage/gallons/$/gal) →
- *     avg MPG, best/worst, total $, cost-per-mile, per-fillup MPG list
- *   • Repair: editable repair rows (name/parts/hours/priority) +
- *     shop rate → per-line totals, parts/labor subtotals, tax,
- *     grand total + recommendation
- *   • Save-as-DTU captures inputs + both reports
+ * Refactored to use `CalcPanel` primitive. See
+ * `concord-frontend/components/lens-primitives/CalcPanel.tsx`.
  */
 
 import { useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
-import { Car, Loader2, Plus, Trash2, Fuel, Wrench } from 'lucide-react';
-import { apiHelpers } from '@/lib/api/client';
-import { SaveAsDtuButton } from '@/components/dtu/SaveAsDtuButton';
+import { Plus, Trash2, Fuel, Wrench, Car } from 'lucide-react';
+import { CalcPanel } from '@/components/lens-primitives/CalcPanel';
 
 interface FillUp { date: string; mileage: string; gallons: string; pricePerGallon: string }
 interface Repair { name: string; partsCost: string; laborHours: string; priority: 'low' | 'medium' | 'high' }
 interface FuelResult { avgMPG?: number; bestMPG?: number; worstMPG?: number; totalGallons?: number; totalCost?: number; costPerMile?: number; mpgReadings?: Array<{ date?: string; mpg: number; miles: number; gallons: number }> }
 interface RepairResult { repairs?: Array<{ repair: string; partsCost: number; laborHours: number; laborRate: number; laborCost: number; total: number; priority: string }>; subtotalParts?: number; subtotalLabor?: number; grandTotal?: number; tax?: number; totalWithTax?: number; recommendation?: string }
-
-async function callAuto<T>(action: string, input: Record<string, unknown>): Promise<T | null> {
-  try {
-    const r = await apiHelpers.lens.runDomain('automotive', action, { input });
-    const env = (r as { data?: { ok: boolean; result?: T } }).data;
-    if (!env?.ok) return null;
-    const result = env.result as unknown as { ok?: boolean; result?: T } | T;
-    if (result && typeof result === 'object' && 'ok' in result && 'result' in result) {
-      return (result as { result: T }).result;
-    }
-    return env.result as T;
-  } catch { return null; }
-}
 
 const today = new Date();
 const dayOffset = (n: number) => new Date(today.getTime() - n * 86400000).toISOString().slice(0, 10);
@@ -54,26 +34,16 @@ const DEFAULT_REPAIRS: Repair[] = [
   { name: 'Cabin air filter', partsCost: '28', laborHours: '0.3', priority: 'low' },
 ];
 
+const prBadge = (p: string) => {
+  if (p === 'high') return 'bg-rose-500/20 text-rose-200';
+  if (p === 'medium') return 'bg-amber-500/20 text-amber-200';
+  return 'bg-zinc-700 text-zinc-300';
+};
+
 export function FuelRepairPanel() {
   const [fillups, setFillups] = useState<FillUp[]>(DEFAULT_FILLUPS);
   const [repairs, setRepairs] = useState<Repair[]>(DEFAULT_REPAIRS);
   const [shopRate, setShopRate] = useState(120);
-  const [fuelResult, setFuelResult] = useState<FuelResult | null>(null);
-  const [repairResult, setRepairResult] = useState<RepairResult | null>(null);
-
-  const analyze = useMutation({
-    mutationFn: async () => {
-      const cleanFills = fillups.filter((f) => f.mileage && f.gallons);
-      const cleanRepairs = repairs.filter((r) => r.name.trim());
-      const [f, r] = await Promise.all([
-        callAuto<FuelResult>('fuelEfficiency', { artifact: { data: { fillups: cleanFills } } }),
-        callAuto<RepairResult>('repairEstimate', { artifact: { data: { repairs: cleanRepairs, shopRate } } }),
-      ]);
-      setFuelResult(f);
-      setRepairResult(r);
-      return { f, r };
-    },
-  });
 
   const addFill = () => setFillups((fs) => [...fs, { date: dayOffset(0), mileage: '', gallons: '', pricePerGallon: '' }]);
   const updateFill = <K extends keyof FillUp>(i: number, key: K, value: FillUp[K]) =>
@@ -85,139 +55,132 @@ export function FuelRepairPanel() {
     setRepairs((rs) => rs.map((r, idx) => (idx === i ? { ...r, [key]: value } : r)));
   const removeRep = (i: number) => setRepairs((rs) => rs.filter((_, idx) => idx !== i));
 
-  const prBadge = (p: string) => {
-    if (p === 'high') return 'bg-rose-500/20 text-rose-200';
-    if (p === 'medium') return 'bg-amber-500/20 text-amber-200';
-    return 'bg-zinc-700 text-zinc-300';
-  };
-
   return (
-    <div className="space-y-4">
-      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-cyan-500/15 pb-3">
-        <div className="flex items-center gap-2">
-          <Car className="h-5 w-5 text-blue-400" />
-          <h2 className="text-sm font-semibold text-white">Fuel economy + repair estimate</h2>
-          <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">automotive.fuelEfficiency + repairEstimate</span>
-        </div>
-        {(fuelResult || repairResult) && (
-          <SaveAsDtuButton
-            compact
-            apiSource="concord-auto-fuel-repair"
-            title={`Auto — ${fuelResult?.avgMPG ?? '—'} MPG · $${repairResult?.totalWithTax ?? '—'} repair est`}
-            content={`Fuel:\n  Avg MPG: ${fuelResult?.avgMPG} (best ${fuelResult?.bestMPG}, worst ${fuelResult?.worstMPG})\n  Total gallons: ${fuelResult?.totalGallons} | Cost: $${fuelResult?.totalCost?.toFixed?.(2) ?? '—'} | Cost/mile: $${fuelResult?.costPerMile}\n\nRepair estimate (shop rate $${shopRate}/hr):\n${(repairResult?.repairs || []).map((r) => `  ${r.repair} — parts $${r.partsCost} + labor ${r.laborHours}h ($${r.laborCost}) = $${r.total} [${r.priority}]`).join('\n')}\n  Parts subtotal: $${repairResult?.subtotalParts}\n  Labor subtotal: $${repairResult?.subtotalLabor}\n  Tax: $${repairResult?.tax}\n  Total with tax: $${repairResult?.totalWithTax}\n  Note: ${repairResult?.recommendation}`}
-            extraTags={['automotive', 'fuel-economy', 'repair']}
-            rawData={{ fillups, repairs, shopRate, fuelResult, repairResult }}
-          />
-        )}
-      </header>
-
-      <div className="space-y-2">
-        <div className="text-[10px] uppercase tracking-wider text-zinc-500">Fill-ups (chronological)</div>
-        <div className="grid grid-cols-[130px_100px_90px_90px_30px] gap-1.5 text-[9px] uppercase tracking-wider text-zinc-500">
-          <span>Date</span><span>Mileage</span><span>Gallons</span><span>$ / gal</span><span></span>
-        </div>
-        {fillups.map((f, i) => (
-          <div key={i} className="grid grid-cols-[130px_100px_90px_90px_30px] gap-1.5">
-            <input type="date" className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" value={f.date} onChange={(e) => updateFill(i, 'date', e.target.value)} />
-            <input type="number" className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" placeholder="54200" value={f.mileage} onChange={(e) => updateFill(i, 'mileage', e.target.value)} />
-            <input type="number" step={0.1} className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" placeholder="12.4" value={f.gallons} onChange={(e) => updateFill(i, 'gallons', e.target.value)} />
-            <input type="number" step={0.01} className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" placeholder="3.85" value={f.pricePerGallon} onChange={(e) => updateFill(i, 'pricePerGallon', e.target.value)} />
-            <button type="button" onClick={() => removeFill(i)} className="rounded border border-zinc-800 text-xs text-zinc-500 hover:text-rose-300" aria-label="Remove"><Trash2 className="mx-auto h-3 w-3" /></button>
-          </div>
-        ))}
-        <button type="button" onClick={addFill} className="inline-flex items-center gap-1 rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-zinc-300 hover:border-blue-500/40 hover:text-blue-200"><Plus className="h-3 w-3" />Add fill-up</button>
-      </div>
-
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <div className="text-[10px] uppercase tracking-wider text-zinc-500">Repair line items</div>
-          <label className="text-[10px] text-zinc-500">Shop labor rate ($/hr)
-            <input type="number" min={50} max={300} value={shopRate} onChange={(e) => setShopRate(Math.max(50, Math.min(300, Number(e.target.value) || 120)))} className="ml-2 w-16 rounded border border-zinc-800 bg-zinc-950 px-1.5 py-0.5 text-xs text-white font-mono" />
-          </label>
-        </div>
-        <div className="grid grid-cols-[1fr_90px_80px_100px_30px] gap-1.5 text-[9px] uppercase tracking-wider text-zinc-500">
-          <span>Repair</span><span>Parts $</span><span>Labor (h)</span><span>Priority</span><span></span>
-        </div>
-        {repairs.map((r, i) => (
-          <div key={i} className="grid grid-cols-[1fr_90px_80px_100px_30px] gap-1.5">
-            <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white" placeholder="Repair name" value={r.name} onChange={(e) => updateRep(i, 'name', e.target.value)} />
-            <input type="number" className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" value={r.partsCost} onChange={(e) => updateRep(i, 'partsCost', e.target.value)} />
-            <input type="number" step={0.1} className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" value={r.laborHours} onChange={(e) => updateRep(i, 'laborHours', e.target.value)} />
-            <select className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white" value={r.priority} onChange={(e) => updateRep(i, 'priority', e.target.value as Repair['priority'])}>
-              <option value="low">low</option>
-              <option value="medium">medium</option>
-              <option value="high">high</option>
-            </select>
-            <button type="button" onClick={() => removeRep(i)} className="rounded border border-zinc-800 text-xs text-zinc-500 hover:text-rose-300" aria-label="Remove"><Trash2 className="mx-auto h-3 w-3" /></button>
-          </div>
-        ))}
-        <button type="button" onClick={addRep} className="inline-flex items-center gap-1 rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-zinc-300 hover:border-blue-500/40 hover:text-blue-200"><Plus className="h-3 w-3" />Add repair</button>
-      </div>
-
-      <button type="button" onClick={() => analyze.mutate()} disabled={analyze.isPending} className="inline-flex items-center gap-1 rounded border border-blue-500/40 bg-blue-500/15 px-3 py-1.5 text-xs font-mono text-blue-200 hover:bg-blue-500/25 disabled:opacity-50">
-        {analyze.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Car className="h-3.5 w-3.5" />}
-        Analyze
-      </button>
-
-      {analyze.isError && <div className="rounded border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-300">Analysis failed.</div>}
-
-      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-        <div className="rounded-lg border border-blue-500/20 bg-blue-500/5 p-3">
-          <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Fuel className="h-3 w-3" />Fuel economy</div>
-          {!fuelResult && <div className="text-[11px] text-zinc-500">Analyze to compute.</div>}
-          {fuelResult && (
-            <div className="space-y-2 text-[11px]">
-              <div className="rounded border border-blue-500/20 bg-zinc-950/40 px-2 py-1">
-                <div className="text-[9px] text-zinc-500">Average MPG</div>
-                <div className="font-mono text-2xl text-blue-200">{fuelResult.avgMPG}</div>
-              </div>
-              <div className="grid grid-cols-3 gap-1.5">
-                <div className="rounded border border-emerald-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Best</div><div className="font-mono text-emerald-200">{fuelResult.bestMPG}</div></div>
-                <div className="rounded border border-rose-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Worst</div><div className="font-mono text-rose-200">{fuelResult.worstMPG}</div></div>
-                <div className="rounded border border-blue-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">$/mile</div><div className="font-mono text-blue-200">${fuelResult.costPerMile}</div></div>
-              </div>
-              {fuelResult.mpgReadings && fuelResult.mpgReadings.length > 0 && (
-                <details className="text-[10px]">
-                  <summary className="cursor-pointer text-zinc-500 hover:text-zinc-300">Per-fillup readings ({fuelResult.mpgReadings.length})</summary>
-                  <div className="mt-1 space-y-0.5">
-                    {fuelResult.mpgReadings.map((r, i) => (
-                      <div key={i} className="flex items-center justify-between rounded border border-blue-500/10 bg-zinc-950/40 px-2 py-0.5"><span className="text-zinc-300">{r.date || `Fillup ${i + 2}`}</span><span className="font-mono text-blue-200">{r.mpg} MPG</span></div>
-                    ))}
-                  </div>
-                </details>
-              )}
+    <CalcPanel<FuelResult, RepairResult>
+      title="Fuel economy + repair estimate"
+      domain="automotive"
+      icon={<Car className="h-5 w-5 text-blue-400" />}
+      macroBadge="automotive.fuelEfficiency + repairEstimate"
+      accent="blue"
+      left={{
+        macro: 'fuelEfficiency',
+        buildArtifact: () => ({ data: { fillups: fillups.filter((f) => f.mileage && f.gallons) } }),
+        render: (
+          <div className="space-y-2">
+            <div className="text-[10px] uppercase tracking-wider text-zinc-500">Fill-ups (chronological)</div>
+            <div className="grid grid-cols-[130px_100px_90px_90px_30px] gap-1.5 text-[9px] uppercase tracking-wider text-zinc-500">
+              <span>Date</span><span>Mileage</span><span>Gallons</span><span>$ / gal</span><span></span>
             </div>
-          )}
-        </div>
-        <div className="rounded-lg border border-orange-500/20 bg-orange-500/5 p-3">
-          <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Wrench className="h-3 w-3" />Repair estimate</div>
-          {!repairResult && <div className="text-[11px] text-zinc-500">Analyze to compute.</div>}
-          {repairResult && (
-            <div className="space-y-1.5 text-[11px]">
-              <div className="rounded border border-orange-500/20 bg-zinc-950/40 px-2 py-1">
-                <div className="text-[9px] text-zinc-500">Total with tax</div>
-                <div className="font-mono text-2xl text-orange-200">${repairResult.totalWithTax?.toLocaleString()}</div>
-                <div className="text-[10px] text-zinc-500">parts ${repairResult.subtotalParts} + labor ${repairResult.subtotalLabor} + tax ${repairResult.tax}</div>
+            {fillups.map((f, i) => (
+              <div key={i} className="grid grid-cols-[130px_100px_90px_90px_30px] gap-1.5">
+                <input type="date" className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" value={f.date} onChange={(e) => updateFill(i, 'date', e.target.value)} />
+                <input type="number" className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" value={f.mileage} onChange={(e) => updateFill(i, 'mileage', e.target.value)} />
+                <input type="number" step={0.1} className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" value={f.gallons} onChange={(e) => updateFill(i, 'gallons', e.target.value)} />
+                <input type="number" step={0.01} className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" value={f.pricePerGallon} onChange={(e) => updateFill(i, 'pricePerGallon', e.target.value)} />
+                <button type="button" onClick={() => removeFill(i)} className="rounded border border-zinc-800 text-xs text-zinc-500 hover:text-rose-300" aria-label="Remove"><Trash2 className="mx-auto h-3 w-3" /></button>
               </div>
-              <div className="space-y-1">
-                {repairResult.repairs?.map((r, i) => (
-                  <div key={i} className="rounded border border-orange-500/15 bg-zinc-950/40 px-2 py-1">
-                    <div className="flex items-center justify-between">
-                      <span className="text-zinc-100">{r.repair}</span>
-                      <span className="font-mono text-orange-200">${r.total}</span>
-                    </div>
-                    <div className="flex items-center justify-between text-[9px] text-zinc-500">
-                      <span>parts ${r.partsCost} + labor {r.laborHours}h × ${r.laborRate} = ${r.laborCost}</span>
-                      <span className={`rounded px-1 ${prBadge(r.priority)}`}>{r.priority}</span>
-                    </div>
-                  </div>
-                ))}
-              </div>
-              {repairResult.recommendation && <div className="rounded border border-amber-500/20 bg-amber-500/5 px-2 py-1 text-[10px] text-amber-200">{repairResult.recommendation}</div>}
+            ))}
+            <button type="button" onClick={addFill} className="inline-flex items-center gap-1 rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-zinc-300 hover:border-blue-500/40 hover:text-blue-200"><Plus className="h-3 w-3" />Add fill-up</button>
+          </div>
+        ),
+      }}
+      right={{
+        macro: 'repairEstimate',
+        buildArtifact: () => ({ data: { repairs: repairs.filter((r) => r.name.trim()), shopRate } }),
+        render: (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <div className="text-[10px] uppercase tracking-wider text-zinc-500">Repair line items</div>
+              <label className="text-[10px] text-zinc-500">Shop labor rate ($/hr)
+                <input type="number" min={50} max={300} value={shopRate} onChange={(e) => setShopRate(Math.max(50, Math.min(300, Number(e.target.value) || 120)))} className="ml-2 w-16 rounded border border-zinc-800 bg-zinc-950 px-1.5 py-0.5 text-xs text-white font-mono" />
+              </label>
             </div>
-          )}
-        </div>
-      </div>
-    </div>
+            <div className="grid grid-cols-[1fr_90px_80px_100px_30px] gap-1.5 text-[9px] uppercase tracking-wider text-zinc-500">
+              <span>Repair</span><span>Parts $</span><span>Labor (h)</span><span>Priority</span><span></span>
+            </div>
+            {repairs.map((r, i) => (
+              <div key={i} className="grid grid-cols-[1fr_90px_80px_100px_30px] gap-1.5">
+                <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white" placeholder="Repair name" value={r.name} onChange={(e) => updateRep(i, 'name', e.target.value)} />
+                <input type="number" className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" value={r.partsCost} onChange={(e) => updateRep(i, 'partsCost', e.target.value)} />
+                <input type="number" step={0.1} className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" value={r.laborHours} onChange={(e) => updateRep(i, 'laborHours', e.target.value)} />
+                <select className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white" value={r.priority} onChange={(e) => updateRep(i, 'priority', e.target.value as Repair['priority'])}>
+                  <option value="low">low</option>
+                  <option value="medium">medium</option>
+                  <option value="high">high</option>
+                </select>
+                <button type="button" onClick={() => removeRep(i)} className="rounded border border-zinc-800 text-xs text-zinc-500 hover:text-rose-300" aria-label="Remove"><Trash2 className="mx-auto h-3 w-3" /></button>
+              </div>
+            ))}
+            <button type="button" onClick={addRep} className="inline-flex items-center gap-1 rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-zinc-300 hover:border-blue-500/40 hover:text-blue-200"><Plus className="h-3 w-3" />Add repair</button>
+          </div>
+        ),
+      }}
+      renderResults={(fuelResult, repairResult) => (
+        <>
+          <div className="rounded-lg border border-blue-500/20 bg-blue-500/5 p-3">
+            <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Fuel className="h-3 w-3" />Fuel economy</div>
+            {!fuelResult && <div className="text-[11px] text-zinc-500">Analyze to compute.</div>}
+            {fuelResult && (
+              <div className="space-y-2 text-[11px]">
+                <div className="rounded border border-blue-500/20 bg-zinc-950/40 px-2 py-1">
+                  <div className="text-[9px] text-zinc-500">Average MPG</div>
+                  <div className="font-mono text-2xl text-blue-200">{fuelResult.avgMPG}</div>
+                </div>
+                <div className="grid grid-cols-3 gap-1.5">
+                  <div className="rounded border border-emerald-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Best</div><div className="font-mono text-emerald-200">{fuelResult.bestMPG}</div></div>
+                  <div className="rounded border border-rose-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Worst</div><div className="font-mono text-rose-200">{fuelResult.worstMPG}</div></div>
+                  <div className="rounded border border-blue-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">$/mile</div><div className="font-mono text-blue-200">${fuelResult.costPerMile}</div></div>
+                </div>
+                {fuelResult.mpgReadings && fuelResult.mpgReadings.length > 0 && (
+                  <details className="text-[10px]">
+                    <summary className="cursor-pointer text-zinc-500 hover:text-zinc-300">Per-fillup readings ({fuelResult.mpgReadings.length})</summary>
+                    <div className="mt-1 space-y-0.5">
+                      {fuelResult.mpgReadings.map((r, i) => (
+                        <div key={i} className="flex items-center justify-between rounded border border-blue-500/10 bg-zinc-950/40 px-2 py-0.5"><span className="text-zinc-300">{r.date || `Fillup ${i + 2}`}</span><span className="font-mono text-blue-200">{r.mpg} MPG</span></div>
+                      ))}
+                    </div>
+                  </details>
+                )}
+              </div>
+            )}
+          </div>
+          <div className="rounded-lg border border-orange-500/20 bg-orange-500/5 p-3">
+            <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Wrench className="h-3 w-3" />Repair estimate</div>
+            {!repairResult && <div className="text-[11px] text-zinc-500">Analyze to compute.</div>}
+            {repairResult && (
+              <div className="space-y-1.5 text-[11px]">
+                <div className="rounded border border-orange-500/20 bg-zinc-950/40 px-2 py-1">
+                  <div className="text-[9px] text-zinc-500">Total with tax</div>
+                  <div className="font-mono text-2xl text-orange-200">${repairResult.totalWithTax?.toLocaleString()}</div>
+                  <div className="text-[10px] text-zinc-500">parts ${repairResult.subtotalParts} + labor ${repairResult.subtotalLabor} + tax ${repairResult.tax}</div>
+                </div>
+                <div className="space-y-1">
+                  {repairResult.repairs?.map((r, i) => (
+                    <div key={i} className="rounded border border-orange-500/15 bg-zinc-950/40 px-2 py-1">
+                      <div className="flex items-center justify-between">
+                        <span className="text-zinc-100">{r.repair}</span>
+                        <span className="font-mono text-orange-200">${r.total}</span>
+                      </div>
+                      <div className="flex items-center justify-between text-[9px] text-zinc-500">
+                        <span>parts ${r.partsCost} + labor {r.laborHours}h × ${r.laborRate} = ${r.laborCost}</span>
+                        <span className={`rounded px-1 ${prBadge(r.priority)}`}>{r.priority}</span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                {repairResult.recommendation && <div className="rounded border border-amber-500/20 bg-amber-500/5 px-2 py-1 text-[10px] text-amber-200">{repairResult.recommendation}</div>}
+              </div>
+            )}
+          </div>
+        </>
+      )}
+      dtu={{
+        apiSource: 'concord-auto-fuel-repair',
+        title: (f, r) => `Auto — ${f.avgMPG ?? '—'} MPG · $${r.totalWithTax ?? '—'} repair est`,
+        content: (f, r) => `Fuel:\n  Avg MPG: ${f.avgMPG} (best ${f.bestMPG}, worst ${f.worstMPG})\n  Total gallons: ${f.totalGallons} | Cost: $${f.totalCost?.toFixed?.(2) ?? '—'} | Cost/mile: $${f.costPerMile}\n\nRepair estimate (shop rate $${shopRate}/hr):\n${(r.repairs || []).map((rr) => `  ${rr.repair} — parts $${rr.partsCost} + labor ${rr.laborHours}h ($${rr.laborCost}) = $${rr.total} [${rr.priority}]`).join('\n')}\n  Parts subtotal: $${r.subtotalParts}\n  Labor subtotal: $${r.subtotalLabor}\n  Tax: $${r.tax}\n  Total with tax: $${r.totalWithTax}\n  Note: ${r.recommendation}`,
+        tags: () => ['automotive', 'fuel-economy', 'repair'],
+        rawData: (f, r) => ({ fillups, repairs, shopRate, fuelResult: f, repairResult: r }),
+      }}
+    />
   );
 }

--- a/concord-frontend/components/energy/SolarCarbonPanel.tsx
+++ b/concord-frontend/components/energy/SolarCarbonPanel.tsx
@@ -1,185 +1,148 @@
 'use client';
 
 /**
- * SolarCarbonPanel — bespoke residential solar sizing + carbon
- * footprint surface for the energy lens. Wires energy.solarEstimate
- * + energy.carbonFootprint against form inputs.
+ * SolarCarbonPanel — residential solar sizing + carbon footprint
+ * surface for the energy lens. Wires energy.solarEstimate +
+ * energy.carbonFootprint.
  *
- *   • Solar: roof sq ft + peak sun hours + monthly kWh → max panels,
- *     system kW, monthly production, coverage %, cost, after-tax
- *     credit, annual savings, payback years
- *   • Carbon: kWh + therms + gasoline gal + flight mi → CO2 breakdown
- *     metric tons, annual estimate, vs-US-average %, top source,
- *     reduction tips
- *   • Save-as-DTU captures inputs + reports
+ * Refactored to use `CalcPanel` primitive. See
+ * `concord-frontend/components/lens-primitives/CalcPanel.tsx`.
  */
 
 import { useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
-import { Sun, Leaf, Loader2, Zap } from 'lucide-react';
-import { apiHelpers } from '@/lib/api/client';
-import { SaveAsDtuButton } from '@/components/dtu/SaveAsDtuButton';
+import { Sun, Leaf, Zap } from 'lucide-react';
+import { CalcPanel } from '@/components/lens-primitives/CalcPanel';
 
 interface SolarInput { roofAreaSqFt: number; peakSunHours: number; monthlyUsageKWh: number }
 interface CarbonInput { electricityKWh: number; naturalGasTherms: number; gasolineGallons: number; flightMiles: number }
 interface SolarResult { roofArea?: number; maxPanels?: number; systemSizeKW?: number; monthlyProductionKWh?: number; coveragePercent?: number; estimatedCost?: number; afterTaxCredit?: number; annualSavings?: number; paybackYears?: number; recommendation?: string }
 interface CarbonResult { breakdown?: Record<string, number>; totalMetricTons?: number; annualEstimate?: number; vsUSAverage?: string; topSource?: string; reductionTips?: string[] }
 
-async function callEng<T>(action: string, input: Record<string, unknown>): Promise<T | null> {
-  try {
-    const r = await apiHelpers.lens.runDomain('energy', action, { input });
-    const env = (r as { data?: { ok: boolean; result?: T } }).data;
-    if (!env?.ok) return null;
-    const result = env.result as unknown as { ok?: boolean; result?: T } | T;
-    if (result && typeof result === 'object' && 'ok' in result && 'result' in result) {
-      return (result as { result: T }).result;
-    }
-    return env.result as T;
-  } catch { return null; }
-}
+const coverageColour = (pct?: number) => {
+  if (!pct) return 'text-zinc-400';
+  if (pct >= 100) return 'text-emerald-200';
+  if (pct >= 60) return 'text-amber-200';
+  return 'text-rose-200';
+};
 
 export function SolarCarbonPanel() {
   const [solar, setSolar] = useState<SolarInput>({ roofAreaSqFt: 1500, peakSunHours: 5, monthlyUsageKWh: 900 });
   const [carbon, setCarbon] = useState<CarbonInput>({ electricityKWh: 900, naturalGasTherms: 45, gasolineGallons: 40, flightMiles: 250 });
-  const [solarResult, setSolarResult] = useState<SolarResult | null>(null);
-  const [carbonResult, setCarbonResult] = useState<CarbonResult | null>(null);
-
-  const analyze = useMutation({
-    mutationFn: async () => {
-      const [s, c] = await Promise.all([
-        callEng<SolarResult>('solarEstimate', { artifact: { data: solar } }),
-        callEng<CarbonResult>('carbonFootprint', { artifact: { data: carbon } }),
-      ]);
-      setSolarResult(s);
-      setCarbonResult(c);
-      return { s, c };
-    },
-  });
-
-  const coverageColour = (pct?: number) => {
-    if (!pct) return 'text-zinc-400';
-    if (pct >= 100) return 'text-emerald-200';
-    if (pct >= 60) return 'text-amber-200';
-    return 'text-rose-200';
-  };
 
   return (
-    <div className="space-y-4">
-      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-cyan-500/15 pb-3">
-        <div className="flex items-center gap-2">
-          <Zap className="h-5 w-5 text-yellow-400" />
-          <h2 className="text-sm font-semibold text-white">Solar + carbon footprint</h2>
-          <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">energy.solarEstimate + carbonFootprint</span>
-        </div>
-        {(solarResult || carbonResult) && (
-          <SaveAsDtuButton
-            compact
-            apiSource="concord-energy-solar-carbon"
-            title={`Solar ${solarResult?.systemSizeKW ?? '—'} kW · Carbon ${carbonResult?.annualEstimate ?? '—'} t/yr`}
-            content={`Solar:\n  ${solarResult?.recommendation}\n  System: ${solarResult?.systemSizeKW} kW (${solarResult?.maxPanels} panels)\n  Monthly production: ${solarResult?.monthlyProductionKWh} kWh\n  Cost: $${solarResult?.estimatedCost?.toLocaleString()} (after 30% credit: $${solarResult?.afterTaxCredit?.toLocaleString()})\n  Savings: $${solarResult?.annualSavings}/yr · Payback: ${solarResult?.paybackYears} years\n\nCarbon:\n  Monthly: ${carbonResult?.totalMetricTons} tons CO2 | Annual: ${carbonResult?.annualEstimate} tons\n  vs US avg: ${carbonResult?.vsUSAverage}\n  Top source: ${carbonResult?.topSource}\n  Breakdown:\n${Object.entries(carbonResult?.breakdown || {}).map(([k, v]) => `    ${k}: ${v} t`).join('\n')}\n  Tips:\n${(carbonResult?.reductionTips || []).map((t) => `    • ${t}`).join('\n')}`}
-            extraTags={['energy', 'solar', 'carbon']}
-            rawData={{ solar, carbon, solarResult, carbonResult }}
-          />
-        )}
-      </header>
-
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <div className="space-y-2 rounded-lg border border-zinc-800 bg-zinc-950/40 p-3">
-          <div className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Sun className="h-3 w-3" />Solar inputs</div>
-          <div className="grid grid-cols-1 gap-2">
-            <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Roof area (sq ft)</span>
-              <input type="number" min={100} max={10000} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={solar.roofAreaSqFt} onChange={(e) => setSolar({ ...solar, roofAreaSqFt: Math.max(100, Math.min(10000, Number(e.target.value) || 1000)) })} /></label>
-            <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Peak sun hours (avg/day)</span>
-              <input type="number" min={1} max={10} step={0.1} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={solar.peakSunHours} onChange={(e) => setSolar({ ...solar, peakSunHours: Math.max(1, Math.min(10, Number(e.target.value) || 5)) })} /></label>
-            <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Monthly usage (kWh)</span>
-              <input type="number" min={100} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={solar.monthlyUsageKWh} onChange={(e) => setSolar({ ...solar, monthlyUsageKWh: Math.max(100, Number(e.target.value) || 900) })} /></label>
-          </div>
-        </div>
-
-        <div className="space-y-2 rounded-lg border border-zinc-800 bg-zinc-950/40 p-3">
-          <div className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Leaf className="h-3 w-3" />Carbon inputs (monthly)</div>
-          <div className="grid grid-cols-2 gap-2">
-            <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Electricity (kWh)</span>
-              <input type="number" min={0} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={carbon.electricityKWh} onChange={(e) => setCarbon({ ...carbon, electricityKWh: Math.max(0, Number(e.target.value) || 0) })} /></label>
-            <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Nat. gas (therms)</span>
-              <input type="number" min={0} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={carbon.naturalGasTherms} onChange={(e) => setCarbon({ ...carbon, naturalGasTherms: Math.max(0, Number(e.target.value) || 0) })} /></label>
-            <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Gasoline (gal)</span>
-              <input type="number" min={0} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={carbon.gasolineGallons} onChange={(e) => setCarbon({ ...carbon, gasolineGallons: Math.max(0, Number(e.target.value) || 0) })} /></label>
-            <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Flights (mi)</span>
-              <input type="number" min={0} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={carbon.flightMiles} onChange={(e) => setCarbon({ ...carbon, flightMiles: Math.max(0, Number(e.target.value) || 0) })} /></label>
-          </div>
-        </div>
-      </div>
-
-      <button type="button" onClick={() => analyze.mutate()} disabled={analyze.isPending} className="inline-flex items-center gap-1 rounded border border-yellow-500/40 bg-yellow-500/15 px-3 py-1.5 text-xs font-mono text-yellow-200 hover:bg-yellow-500/25 disabled:opacity-50">
-        {analyze.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Zap className="h-3.5 w-3.5" />}
-        Analyze
-      </button>
-
-      {analyze.isError && <div className="rounded border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-300">Analysis failed.</div>}
-
-      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-        <div className="rounded-lg border border-yellow-500/20 bg-yellow-500/5 p-3">
-          <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Sun className="h-3 w-3" />Solar estimate</div>
-          {!solarResult && <div className="text-[11px] text-zinc-500">Analyze to estimate.</div>}
-          {solarResult && (
-            <div className="space-y-2 text-[11px]">
-              <div className="flex items-baseline gap-2">
-                <span className={`font-mono text-2xl ${coverageColour(solarResult.coveragePercent)}`}>{solarResult.coveragePercent}%</span>
-                <span className="text-zinc-500">of usage covered</span>
-              </div>
-              <div className="grid grid-cols-2 gap-1.5">
-                <div className="rounded border border-yellow-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">System</div><div className="font-mono text-yellow-200">{solarResult.systemSizeKW} kW</div></div>
-                <div className="rounded border border-yellow-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Panels</div><div className="font-mono text-yellow-200">{solarResult.maxPanels}</div></div>
-                <div className="rounded border border-yellow-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Production</div><div className="font-mono text-yellow-200">{solarResult.monthlyProductionKWh} kWh/mo</div></div>
-                <div className="rounded border border-emerald-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Savings</div><div className="font-mono text-emerald-200">${solarResult.annualSavings}/yr</div></div>
-              </div>
-              <div className="rounded border border-yellow-500/20 bg-zinc-950/40 px-2 py-1">
-                <div className="text-[9px] text-zinc-500">Cost</div>
-                <div className="font-mono text-yellow-200">${solarResult.estimatedCost?.toLocaleString()} <span className="text-[9px] text-zinc-500">(after 30% credit: ${solarResult.afterTaxCredit?.toLocaleString()})</span></div>
-                <div className="text-[10px] text-zinc-400">Payback: ~{solarResult.paybackYears} years</div>
-              </div>
+    <CalcPanel<SolarResult, CarbonResult>
+      title="Solar + carbon footprint"
+      domain="energy"
+      icon={<Zap className="h-5 w-5 text-yellow-400" />}
+      macroBadge="energy.solarEstimate + carbonFootprint"
+      accent="yellow"
+      left={{
+        macro: 'solarEstimate',
+        buildArtifact: () => ({ data: solar }),
+        render: (
+          <div className="space-y-2 rounded-lg border border-zinc-800 bg-zinc-950/40 p-3">
+            <div className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Sun className="h-3 w-3" />Solar inputs</div>
+            <div className="grid grid-cols-1 gap-2">
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Roof area (sq ft)</span>
+                <input type="number" min={100} max={10000} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={solar.roofAreaSqFt} onChange={(e) => setSolar({ ...solar, roofAreaSqFt: Math.max(100, Math.min(10000, Number(e.target.value) || 1000)) })} /></label>
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Peak sun hours (avg/day)</span>
+                <input type="number" min={1} max={10} step={0.1} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={solar.peakSunHours} onChange={(e) => setSolar({ ...solar, peakSunHours: Math.max(1, Math.min(10, Number(e.target.value) || 5)) })} /></label>
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Monthly usage (kWh)</span>
+                <input type="number" min={100} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={solar.monthlyUsageKWh} onChange={(e) => setSolar({ ...solar, monthlyUsageKWh: Math.max(100, Number(e.target.value) || 900) })} /></label>
             </div>
-          )}
-        </div>
-        <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3">
-          <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Leaf className="h-3 w-3" />Carbon footprint</div>
-          {!carbonResult && <div className="text-[11px] text-zinc-500">Analyze to compute.</div>}
-          {carbonResult && (
-            <div className="space-y-2 text-[11px]">
-              <div className="flex items-baseline gap-2">
-                <span className="font-mono text-2xl text-emerald-200">{carbonResult.annualEstimate}</span>
-                <span className="text-zinc-500">tons CO₂/yr</span>
-              </div>
-              <div className="text-[10px] text-zinc-400">{carbonResult.vsUSAverage} · top source: <span className="text-rose-300">{carbonResult.topSource}</span></div>
-              {carbonResult.breakdown && (
-                <div className="space-y-0.5">
-                  {Object.entries(carbonResult.breakdown).map(([k, v]) => {
-                    const max = Math.max(...Object.values(carbonResult.breakdown || {}));
-                    const pct = max > 0 ? (v / max) * 100 : 0;
-                    return (
-                      <div key={k} className="rounded border border-emerald-500/15 bg-zinc-950/40 px-2 py-1">
-                        <div className="flex items-center justify-between">
-                          <span className="text-zinc-300 capitalize">{k}</span>
-                          <span className="font-mono text-emerald-200">{v} t</span>
-                        </div>
-                        <div className="mt-0.5 h-1 overflow-hidden rounded-full bg-zinc-800">
-                          <div className="h-full bg-emerald-500/60" style={{ width: `${pct}%` }} />
-                        </div>
-                      </div>
-                    );
-                  })}
+          </div>
+        ),
+      }}
+      right={{
+        macro: 'carbonFootprint',
+        buildArtifact: () => ({ data: carbon }),
+        render: (
+          <div className="space-y-2 rounded-lg border border-zinc-800 bg-zinc-950/40 p-3">
+            <div className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Leaf className="h-3 w-3" />Carbon inputs (monthly)</div>
+            <div className="grid grid-cols-2 gap-2">
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Electricity (kWh)</span>
+                <input type="number" min={0} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={carbon.electricityKWh} onChange={(e) => setCarbon({ ...carbon, electricityKWh: Math.max(0, Number(e.target.value) || 0) })} /></label>
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Nat. gas (therms)</span>
+                <input type="number" min={0} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={carbon.naturalGasTherms} onChange={(e) => setCarbon({ ...carbon, naturalGasTherms: Math.max(0, Number(e.target.value) || 0) })} /></label>
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Gasoline (gal)</span>
+                <input type="number" min={0} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={carbon.gasolineGallons} onChange={(e) => setCarbon({ ...carbon, gasolineGallons: Math.max(0, Number(e.target.value) || 0) })} /></label>
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Flights (mi)</span>
+                <input type="number" min={0} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={carbon.flightMiles} onChange={(e) => setCarbon({ ...carbon, flightMiles: Math.max(0, Number(e.target.value) || 0) })} /></label>
+            </div>
+          </div>
+        ),
+      }}
+      renderResults={(solarResult, carbonResult) => (
+        <>
+          <div className="rounded-lg border border-yellow-500/20 bg-yellow-500/5 p-3">
+            <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Sun className="h-3 w-3" />Solar estimate</div>
+            {!solarResult && <div className="text-[11px] text-zinc-500">Analyze to estimate.</div>}
+            {solarResult && (
+              <div className="space-y-2 text-[11px]">
+                <div className="flex items-baseline gap-2">
+                  <span className={`font-mono text-2xl ${coverageColour(solarResult.coveragePercent)}`}>{solarResult.coveragePercent}%</span>
+                  <span className="text-zinc-500">of usage covered</span>
                 </div>
-              )}
-              {carbonResult.reductionTips && (
-                <ul className="list-disc space-y-0.5 pl-4 text-[10px] text-zinc-400">
-                  {carbonResult.reductionTips.map((t, i) => <li key={i}>{t}</li>)}
-                </ul>
-              )}
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
+                <div className="grid grid-cols-2 gap-1.5">
+                  <div className="rounded border border-yellow-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">System</div><div className="font-mono text-yellow-200">{solarResult.systemSizeKW} kW</div></div>
+                  <div className="rounded border border-yellow-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Panels</div><div className="font-mono text-yellow-200">{solarResult.maxPanels}</div></div>
+                  <div className="rounded border border-yellow-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Production</div><div className="font-mono text-yellow-200">{solarResult.monthlyProductionKWh} kWh/mo</div></div>
+                  <div className="rounded border border-emerald-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Savings</div><div className="font-mono text-emerald-200">${solarResult.annualSavings}/yr</div></div>
+                </div>
+                <div className="rounded border border-yellow-500/20 bg-zinc-950/40 px-2 py-1">
+                  <div className="text-[9px] text-zinc-500">Cost</div>
+                  <div className="font-mono text-yellow-200">${solarResult.estimatedCost?.toLocaleString()} <span className="text-[9px] text-zinc-500">(after 30% credit: ${solarResult.afterTaxCredit?.toLocaleString()})</span></div>
+                  <div className="text-[10px] text-zinc-400">Payback: ~{solarResult.paybackYears} years</div>
+                </div>
+              </div>
+            )}
+          </div>
+          <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3">
+            <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Leaf className="h-3 w-3" />Carbon footprint</div>
+            {!carbonResult && <div className="text-[11px] text-zinc-500">Analyze to compute.</div>}
+            {carbonResult && (
+              <div className="space-y-2 text-[11px]">
+                <div className="flex items-baseline gap-2">
+                  <span className="font-mono text-2xl text-emerald-200">{carbonResult.annualEstimate}</span>
+                  <span className="text-zinc-500">tons CO₂/yr</span>
+                </div>
+                <div className="text-[10px] text-zinc-400">{carbonResult.vsUSAverage} · top source: <span className="text-rose-300">{carbonResult.topSource}</span></div>
+                {carbonResult.breakdown && (
+                  <div className="space-y-0.5">
+                    {Object.entries(carbonResult.breakdown).map(([k, v]) => {
+                      const max = Math.max(...Object.values(carbonResult.breakdown || {}));
+                      const pct = max > 0 ? (v / max) * 100 : 0;
+                      return (
+                        <div key={k} className="rounded border border-emerald-500/15 bg-zinc-950/40 px-2 py-1">
+                          <div className="flex items-center justify-between">
+                            <span className="text-zinc-300 capitalize">{k}</span>
+                            <span className="font-mono text-emerald-200">{v} t</span>
+                          </div>
+                          <div className="mt-0.5 h-1 overflow-hidden rounded-full bg-zinc-800">
+                            <div className="h-full bg-emerald-500/60" style={{ width: `${pct}%` }} />
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+                {carbonResult.reductionTips && (
+                  <ul className="list-disc space-y-0.5 pl-4 text-[10px] text-zinc-400">
+                    {carbonResult.reductionTips.map((t, i) => <li key={i}>{t}</li>)}
+                  </ul>
+                )}
+              </div>
+            )}
+          </div>
+        </>
+      )}
+      dtu={{
+        apiSource: 'concord-energy-solar-carbon',
+        title: (s, c) => `Solar ${s.systemSizeKW ?? '—'} kW · Carbon ${c.annualEstimate ?? '—'} t/yr`,
+        content: (s, c) => `Solar:\n  ${s.recommendation}\n  System: ${s.systemSizeKW} kW (${s.maxPanels} panels)\n  Monthly production: ${s.monthlyProductionKWh} kWh\n  Cost: $${s.estimatedCost?.toLocaleString()} (after 30% credit: $${s.afterTaxCredit?.toLocaleString()})\n  Savings: $${s.annualSavings}/yr · Payback: ${s.paybackYears} years\n\nCarbon:\n  Monthly: ${c.totalMetricTons} tons CO2 | Annual: ${c.annualEstimate} tons\n  vs US avg: ${c.vsUSAverage}\n  Top source: ${c.topSource}\n  Breakdown:\n${Object.entries(c.breakdown || {}).map(([k, v]) => `    ${k}: ${v} t`).join('\n')}\n  Tips:\n${(c.reductionTips || []).map((t) => `    • ${t}`).join('\n')}`,
+        tags: () => ['energy', 'solar', 'carbon'],
+        rawData: (s, c) => ({ solar, carbon, solarResult: s, carbonResult: c }),
+      }}
+    />
   );
 }

--- a/concord-frontend/components/lens-primitives/CalcPanel.tsx
+++ b/concord-frontend/components/lens-primitives/CalcPanel.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+/**
+ * CalcPanel — generic two-macro analyze + render + Save-as-DTU shell.
+ *
+ * Empirically derived from 8 lens panels that landed in PRs #729–#736
+ * (calendar, environment, history, materials, ocean, security,
+ * services, automotive, energy). All share the same shape:
+ *
+ *   • Two input regions (form fields or editable table rows)
+ *   • Single Analyze button calling two domain macros in parallel
+ *   • Two-column result cards
+ *   • Save-as-DTU button packing inputs + outputs
+ *
+ * CalcPanel owns: the mutation, the Promise.all, the Analyze button,
+ * the header, the error display, the Save-as-DTU integration. The
+ * consumer supplies: two `MacroSlot` configs (input renderer +
+ * artifact builder) + a `renderResults` render-prop + DTU composition.
+ *
+ * Pattern matches `apiHelpers.lens.runDomain(domain, action, { input })`
+ * which is the universal macro caller per `concord-frontend/lib/api/client.ts`.
+ */
+
+import { useState, type ReactNode } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { Loader2, Wand2 } from 'lucide-react';
+import { apiHelpers } from '@/lib/api/client';
+import { SaveAsDtuButton } from '@/components/dtu/SaveAsDtuButton';
+
+export interface MacroSlot {
+  /** Macro action name on the lens domain (e.g. "feedingPlan", "vaccinationSchedule") */
+  macro: string;
+  /**
+   * Build the artifact body sent to the macro. Receives nothing — caller closes over its own input state.
+   * Return shape: `{ data: <whatever your macro expects under artifact.data> }`.
+   * CalcPanel wraps this in `{ input: { artifact } }` before sending.
+   */
+  buildArtifact: () => Record<string, unknown>;
+}
+
+export interface CalcPanelDtu<L, R> {
+  apiSource: string;
+  title: (left: L, right: R) => string;
+  content: (left: L, right: R) => string;
+  tags: (left: L, right: R) => string[];
+  rawData?: (left: L, right: R) => Record<string, unknown>;
+}
+
+export interface CalcPanelProps<LR, RR> {
+  /** Panel title, e.g. "Pet care planner" */
+  title: string;
+  /** Domain name, e.g. "pets" */
+  domain: string;
+  /** Header icon (already coloured by caller) */
+  icon: ReactNode;
+  /** Inline macro reference, e.g. "pets.feedingPlan + vaccinationSchedule" */
+  macroBadge: string;
+  /** Tailwind ring/border accent for the Analyze button, e.g. "rose" */
+  accent?: 'rose' | 'emerald' | 'cyan' | 'amber' | 'sky' | 'blue' | 'violet' | 'indigo' | 'orange' | 'yellow' | 'red';
+
+  /** Left input region: render + macro configuration */
+  left: MacroSlot & { render: ReactNode };
+  /** Right input region: render + macro configuration */
+  right: MacroSlot & { render: ReactNode };
+
+  /** Render the two result cards (called after each successful Analyze). */
+  renderResults: (left: LR | null, right: RR | null) => ReactNode;
+
+  /** Save-as-DTU composition. Only invoked when both results are non-null. */
+  dtu: CalcPanelDtu<LR, RR>;
+
+  /** Analyze button label. Default: "Analyze" */
+  buttonLabel?: string;
+  /** Error message. Default: "Analysis failed." */
+  errorLabel?: string;
+  /** Allow disabling Analyze button (e.g. minimum row count not yet reached). */
+  disabled?: boolean;
+  /** Disabled reason tooltip. */
+  disabledHint?: string;
+}
+
+async function callMacro<T>(
+  domain: string,
+  action: string,
+  artifact: Record<string, unknown>,
+): Promise<T | null> {
+  try {
+    const r = await apiHelpers.lens.runDomain(domain, action, { input: { artifact } });
+    const env = (r as { data?: { ok: boolean; result?: T } }).data;
+    if (!env?.ok) return null;
+    const result = env.result as unknown as { ok?: boolean; result?: T } | T;
+    if (result && typeof result === 'object' && 'ok' in result && 'result' in result) {
+      return (result as { result: T }).result;
+    }
+    return env.result as T;
+  } catch {
+    return null;
+  }
+}
+
+const ACCENT_RING: Record<NonNullable<CalcPanelProps<unknown, unknown>['accent']>, string> = {
+  rose:    'border-rose-500/40 bg-rose-500/15 text-rose-200 hover:bg-rose-500/25',
+  emerald: 'border-emerald-500/40 bg-emerald-500/15 text-emerald-200 hover:bg-emerald-500/25',
+  cyan:    'border-cyan-500/40 bg-cyan-500/15 text-cyan-200 hover:bg-cyan-500/25',
+  amber:   'border-amber-500/40 bg-amber-500/15 text-amber-200 hover:bg-amber-500/25',
+  sky:     'border-sky-500/40 bg-sky-500/15 text-sky-200 hover:bg-sky-500/25',
+  blue:    'border-blue-500/40 bg-blue-500/15 text-blue-200 hover:bg-blue-500/25',
+  violet:  'border-violet-500/40 bg-violet-500/15 text-violet-200 hover:bg-violet-500/25',
+  indigo:  'border-indigo-500/40 bg-indigo-500/15 text-indigo-200 hover:bg-indigo-500/25',
+  orange:  'border-orange-500/40 bg-orange-500/15 text-orange-200 hover:bg-orange-500/25',
+  yellow:  'border-yellow-500/40 bg-yellow-500/15 text-yellow-200 hover:bg-yellow-500/25',
+  red:     'border-red-500/40 bg-red-500/15 text-red-200 hover:bg-red-500/25',
+};
+
+export function CalcPanel<LR, RR>({
+  title,
+  domain,
+  icon,
+  macroBadge,
+  accent = 'cyan',
+  left,
+  right,
+  renderResults,
+  dtu,
+  buttonLabel = 'Analyze',
+  errorLabel = 'Analysis failed.',
+  disabled = false,
+  disabledHint,
+}: CalcPanelProps<LR, RR>) {
+  const [leftResult, setLeftResult] = useState<LR | null>(null);
+  const [rightResult, setRightResult] = useState<RR | null>(null);
+
+  const analyze = useMutation({
+    mutationFn: async () => {
+      const [l, r] = await Promise.all([
+        callMacro<LR>(domain, left.macro, left.buildArtifact()),
+        callMacro<RR>(domain, right.macro, right.buildArtifact()),
+      ]);
+      setLeftResult(l);
+      setRightResult(r);
+      return { l, r };
+    },
+  });
+
+  const canSave = leftResult !== null && rightResult !== null;
+
+  return (
+    <div className="space-y-4">
+      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-cyan-500/15 pb-3">
+        <div className="flex items-center gap-2">
+          {icon}
+          <h2 className="text-sm font-semibold text-white">{title}</h2>
+          <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">{macroBadge}</span>
+        </div>
+        {canSave && (
+          <SaveAsDtuButton
+            compact
+            apiSource={dtu.apiSource}
+            title={dtu.title(leftResult as LR, rightResult as RR)}
+            content={dtu.content(leftResult as LR, rightResult as RR)}
+            extraTags={dtu.tags(leftResult as LR, rightResult as RR)}
+            rawData={dtu.rawData ? dtu.rawData(leftResult as LR, rightResult as RR) : { left: leftResult, right: rightResult }}
+          />
+        )}
+      </header>
+
+      <div className="space-y-4">{left.render}</div>
+      <div className="space-y-4">{right.render}</div>
+
+      <button
+        type="button"
+        onClick={() => analyze.mutate()}
+        disabled={analyze.isPending || disabled}
+        title={disabled ? disabledHint : undefined}
+        className={`inline-flex items-center gap-1 rounded border px-3 py-1.5 text-xs font-mono disabled:opacity-50 ${ACCENT_RING[accent]}`}
+      >
+        {analyze.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Wand2 className="h-3.5 w-3.5" />}
+        {buttonLabel}
+      </button>
+
+      {analyze.isError && <div className="rounded border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-300">{errorLabel}</div>}
+
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">{renderResults(leftResult, rightResult)}</div>
+    </div>
+  );
+}

--- a/concord-frontend/components/materials/CorrosionThermalPanel.tsx
+++ b/concord-frontend/components/materials/CorrosionThermalPanel.tsx
@@ -1,197 +1,159 @@
 'use client';
 
 /**
- * CorrosionThermalPanel — bespoke material-selection surface for
- * the materials lens. Wires materials.corrosionRisk +
- * materials.thermalAnalysis against form inputs.
+ * CorrosionThermalPanel — corrosion + thermal analyzer for the
+ * materials lens. Wires materials.corrosionRisk + materials.thermalAnalysis.
  *
- *   • Corrosion: material name + category + environment + temp/humidity
- *     → resistance score 0-100, risk class, recommendations
- *   • Thermal: thermal conductivity + melting point + expansion +
- *     operating temp + application → safety margin %, class,
- *     per-application suitability, warnings
- *   • Save-as-DTU captures inputs + both reports
+ * Refactored to use `CalcPanel` primitive. See
+ * `concord-frontend/components/lens-primitives/CalcPanel.tsx`.
  */
 
 import { useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
-import { Cog, Loader2, Droplet, Thermometer } from 'lucide-react';
-import { apiHelpers } from '@/lib/api/client';
-import { SaveAsDtuButton } from '@/components/dtu/SaveAsDtuButton';
+import { Cog, Droplet, Thermometer } from 'lucide-react';
+import { CalcPanel } from '@/components/lens-primitives/CalcPanel';
 
 interface CorrosionInput { name: string; category: 'metal' | 'polymer' | 'ceramic' | 'composite' | 'semiconductor' | 'biomaterial'; environment: 'indoor' | 'outdoor' | 'marine' | 'chemical' | 'industrial' | 'underground'; temperature: number; humidity: number }
 interface ThermalInput { thermalConductivity: number; meltingPoint: number; thermalExpansion: number; operatingTemp: number; application: string }
 interface CorrosionResult { material?: string; resistanceScore?: number; riskClass?: string; recommendations?: string[]; estimatedLifeYears?: number; environmentFactor?: number }
 interface ThermalResult { thermalClass?: string; safetyMarginPercent?: number; isSafe?: boolean; suitability?: Record<string, string>; warnings?: string[]; recommendations?: string[] }
 
-async function callMat<T>(action: string, input: Record<string, unknown>): Promise<T | null> {
-  try {
-    const r = await apiHelpers.lens.runDomain('materials', action, { input });
-    const env = (r as { data?: { ok: boolean; result?: T } }).data;
-    if (!env?.ok) return null;
-    const result = env.result as unknown as { ok?: boolean; result?: T } | T;
-    if (result && typeof result === 'object' && 'ok' in result && 'result' in result) {
-      return (result as { result: T }).result;
-    }
-    return env.result as T;
-  } catch { return null; }
-}
-
 const CATEGORIES = ['metal', 'polymer', 'ceramic', 'composite', 'semiconductor', 'biomaterial'] as const;
 const ENVS = ['indoor', 'outdoor', 'marine', 'chemical', 'industrial', 'underground'] as const;
 const APPS = ['general', 'heat-sink', 'insulation', 'high-temp', 'cryogenic'];
 
+const riskColour = (score?: number) => {
+  if (!score) return 'text-zinc-400';
+  if (score >= 75) return 'text-emerald-200';
+  if (score >= 50) return 'text-amber-200';
+  return 'text-rose-200';
+};
+const suitColour = (s?: string) => {
+  if (!s) return 'text-zinc-400';
+  if (s === 'excellent' || s === 'suitable') return 'text-emerald-300';
+  if (s === 'good') return 'text-sky-300';
+  if (s === 'poor' || s === 'not-recommended') return 'text-rose-300';
+  return 'text-amber-300';
+};
+
 export function CorrosionThermalPanel() {
   const [corrosion, setCorrosion] = useState<CorrosionInput>({ name: '316L stainless', category: 'metal', environment: 'marine', temperature: 22, humidity: 75 });
   const [thermal, setThermal] = useState<ThermalInput>({ thermalConductivity: 16, meltingPoint: 1400, thermalExpansion: 16, operatingTemp: 200, application: 'high-temp' });
-  const [corResult, setCorResult] = useState<CorrosionResult | null>(null);
-  const [thermResult, setThermResult] = useState<ThermalResult | null>(null);
-
-  const analyze = useMutation({
-    mutationFn: async () => {
-      const [c, t] = await Promise.all([
-        callMat<CorrosionResult>('corrosionRisk', { artifact: { data: corrosion } }),
-        callMat<ThermalResult>('thermalAnalysis', { artifact: { data: thermal } }),
-      ]);
-      setCorResult(c);
-      setThermResult(t);
-      return { c, t };
-    },
-  });
-
-  const riskColour = (score?: number) => {
-    if (!score) return 'text-zinc-400';
-    if (score >= 75) return 'text-emerald-200';
-    if (score >= 50) return 'text-amber-200';
-    return 'text-rose-200';
-  };
-
-  const suitColour = (s?: string) => {
-    if (!s) return 'text-zinc-400';
-    if (s === 'excellent' || s === 'suitable') return 'text-emerald-300';
-    if (s === 'good') return 'text-sky-300';
-    if (s === 'poor' || s === 'not-recommended') return 'text-rose-300';
-    return 'text-amber-300';
-  };
 
   return (
-    <div className="space-y-4">
-      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-cyan-500/15 pb-3">
-        <div className="flex items-center gap-2">
-          <Cog className="h-5 w-5 text-orange-400" />
-          <h2 className="text-sm font-semibold text-white">Corrosion + thermal analyzer</h2>
-          <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">materials.corrosionRisk + thermalAnalysis</span>
-        </div>
-        {(corResult || thermResult) && (
-          <SaveAsDtuButton
-            compact
-            apiSource="concord-materials-corrosion-thermal"
-            title={`${corrosion.name} — corrosion ${corResult?.resistanceScore ?? '—'} · thermal ${thermResult?.thermalClass ?? '—'}`}
-            content={`Corrosion (${corrosion.name} in ${corrosion.environment}):\n  Resistance: ${corResult?.resistanceScore}/100 (${corResult?.riskClass})\n  Estimated life: ${corResult?.estimatedLifeYears ?? '—'} years\n${(corResult?.recommendations || []).map((r) => `  • ${r}`).join('\n')}\n\nThermal (operating ${thermal.operatingTemp}°C, app=${thermal.application}):\n  Class: ${thermResult?.thermalClass}\n  Safety margin: ${thermResult?.safetyMarginPercent}% (${thermResult?.isSafe ? 'SAFE' : 'AT-RISK'})\n  Suitability:\n${Object.entries(thermResult?.suitability || {}).map(([k, v]) => `    ${k}: ${v}`).join('\n')}\n${(thermResult?.warnings || []).map((w) => `  ⚠ ${w}`).join('\n')}`}
-            extraTags={['materials', corrosion.category, corrosion.environment]}
-            rawData={{ corrosion, thermal, corResult, thermResult }}
-          />
-        )}
-      </header>
-
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <div className="space-y-2 rounded-lg border border-zinc-800 bg-zinc-950/40 p-3">
-          <div className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Droplet className="h-3 w-3" />Corrosion inputs</div>
-          <div className="grid grid-cols-2 gap-2">
-            <label className="block col-span-2"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Material name</span>
-              <input className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white" value={corrosion.name} onChange={(e) => setCorrosion({ ...corrosion, name: e.target.value })} /></label>
-            <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Category</span>
-              <select className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white" value={corrosion.category} onChange={(e) => setCorrosion({ ...corrosion, category: e.target.value as CorrosionInput['category'] })}>
-                {CATEGORIES.map((c) => <option key={c} value={c}>{c}</option>)}
-              </select></label>
-            <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Environment</span>
-              <select className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white" value={corrosion.environment} onChange={(e) => setCorrosion({ ...corrosion, environment: e.target.value as CorrosionInput['environment'] })}>
-                {ENVS.map((c) => <option key={c} value={c}>{c}</option>)}
-              </select></label>
-            <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Temperature (°C)</span>
-              <input type="number" className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={corrosion.temperature} onChange={(e) => setCorrosion({ ...corrosion, temperature: Number(e.target.value) || 25 })} /></label>
-            <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Humidity (%)</span>
-              <input type="number" min={0} max={100} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={corrosion.humidity} onChange={(e) => setCorrosion({ ...corrosion, humidity: Math.max(0, Math.min(100, Number(e.target.value) || 50)) })} /></label>
+    <CalcPanel<CorrosionResult, ThermalResult>
+      title="Corrosion + thermal analyzer"
+      domain="materials"
+      icon={<Cog className="h-5 w-5 text-orange-400" />}
+      macroBadge="materials.corrosionRisk + thermalAnalysis"
+      accent="orange"
+      left={{
+        macro: 'corrosionRisk',
+        buildArtifact: () => ({ data: corrosion }),
+        render: (
+          <div className="space-y-2 rounded-lg border border-zinc-800 bg-zinc-950/40 p-3">
+            <div className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Droplet className="h-3 w-3" />Corrosion inputs</div>
+            <div className="grid grid-cols-2 gap-2">
+              <label className="block col-span-2"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Material name</span>
+                <input className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white" value={corrosion.name} onChange={(e) => setCorrosion({ ...corrosion, name: e.target.value })} /></label>
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Category</span>
+                <select className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white" value={corrosion.category} onChange={(e) => setCorrosion({ ...corrosion, category: e.target.value as CorrosionInput['category'] })}>
+                  {CATEGORIES.map((c) => <option key={c} value={c}>{c}</option>)}
+                </select></label>
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Environment</span>
+                <select className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white" value={corrosion.environment} onChange={(e) => setCorrosion({ ...corrosion, environment: e.target.value as CorrosionInput['environment'] })}>
+                  {ENVS.map((c) => <option key={c} value={c}>{c}</option>)}
+                </select></label>
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Temperature (°C)</span>
+                <input type="number" className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={corrosion.temperature} onChange={(e) => setCorrosion({ ...corrosion, temperature: Number(e.target.value) || 25 })} /></label>
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Humidity (%)</span>
+                <input type="number" min={0} max={100} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={corrosion.humidity} onChange={(e) => setCorrosion({ ...corrosion, humidity: Math.max(0, Math.min(100, Number(e.target.value) || 50)) })} /></label>
+            </div>
           </div>
-        </div>
-
-        <div className="space-y-2 rounded-lg border border-zinc-800 bg-zinc-950/40 p-3">
-          <div className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Thermometer className="h-3 w-3" />Thermal inputs</div>
-          <div className="grid grid-cols-2 gap-2">
-            <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Thermal cond. (W/mK)</span>
-              <input type="number" className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={thermal.thermalConductivity} onChange={(e) => setThermal({ ...thermal, thermalConductivity: Number(e.target.value) || 0 })} /></label>
-            <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Melting point (°C)</span>
-              <input type="number" className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={thermal.meltingPoint} onChange={(e) => setThermal({ ...thermal, meltingPoint: Number(e.target.value) || 0 })} /></label>
-            <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Thermal exp. (µm/m·K)</span>
-              <input type="number" className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={thermal.thermalExpansion} onChange={(e) => setThermal({ ...thermal, thermalExpansion: Number(e.target.value) || 0 })} /></label>
-            <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Operating temp (°C)</span>
-              <input type="number" className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={thermal.operatingTemp} onChange={(e) => setThermal({ ...thermal, operatingTemp: Number(e.target.value) || 25 })} /></label>
-            <label className="block col-span-2"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Application</span>
-              <select className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white" value={thermal.application} onChange={(e) => setThermal({ ...thermal, application: e.target.value })}>
-                {APPS.map((a) => <option key={a} value={a}>{a}</option>)}
-              </select></label>
+        ),
+      }}
+      right={{
+        macro: 'thermalAnalysis',
+        buildArtifact: () => ({ data: thermal }),
+        render: (
+          <div className="space-y-2 rounded-lg border border-zinc-800 bg-zinc-950/40 p-3">
+            <div className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Thermometer className="h-3 w-3" />Thermal inputs</div>
+            <div className="grid grid-cols-2 gap-2">
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Thermal cond. (W/mK)</span>
+                <input type="number" className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={thermal.thermalConductivity} onChange={(e) => setThermal({ ...thermal, thermalConductivity: Number(e.target.value) || 0 })} /></label>
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Melting point (°C)</span>
+                <input type="number" className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={thermal.meltingPoint} onChange={(e) => setThermal({ ...thermal, meltingPoint: Number(e.target.value) || 0 })} /></label>
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Thermal exp. (µm/m·K)</span>
+                <input type="number" className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={thermal.thermalExpansion} onChange={(e) => setThermal({ ...thermal, thermalExpansion: Number(e.target.value) || 0 })} /></label>
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Operating temp (°C)</span>
+                <input type="number" className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={thermal.operatingTemp} onChange={(e) => setThermal({ ...thermal, operatingTemp: Number(e.target.value) || 25 })} /></label>
+              <label className="block col-span-2"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Application</span>
+                <select className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white" value={thermal.application} onChange={(e) => setThermal({ ...thermal, application: e.target.value })}>
+                  {APPS.map((a) => <option key={a} value={a}>{a}</option>)}
+                </select></label>
+            </div>
           </div>
-        </div>
-      </div>
-
-      <button type="button" onClick={() => analyze.mutate()} disabled={analyze.isPending} className="inline-flex items-center gap-1 rounded border border-orange-500/40 bg-orange-500/15 px-3 py-1.5 text-xs font-mono text-orange-200 hover:bg-orange-500/25 disabled:opacity-50">
-        {analyze.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Cog className="h-3.5 w-3.5" />}
-        Analyze
-      </button>
-
-      {analyze.isError && <div className="rounded border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-300">Analysis failed.</div>}
-
-      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-        <div className="rounded-lg border border-blue-500/20 bg-blue-500/5 p-3">
-          <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Droplet className="h-3 w-3" />Corrosion resistance</div>
-          {!corResult && <div className="text-[11px] text-zinc-500">Analyze to score.</div>}
-          {corResult && (
-            <div className="space-y-2 text-[11px]">
-              <div className="flex items-baseline gap-2">
-                <span className={`font-mono text-3xl ${riskColour(corResult.resistanceScore)}`}>{corResult.resistanceScore}</span>
-                <span className="text-zinc-500">/100</span>
+        ),
+      }}
+      renderResults={(corResult, thermResult) => (
+        <>
+          <div className="rounded-lg border border-blue-500/20 bg-blue-500/5 p-3">
+            <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Droplet className="h-3 w-3" />Corrosion resistance</div>
+            {!corResult && <div className="text-[11px] text-zinc-500">Analyze to score.</div>}
+            {corResult && (
+              <div className="space-y-2 text-[11px]">
+                <div className="flex items-baseline gap-2">
+                  <span className={`font-mono text-3xl ${riskColour(corResult.resistanceScore)}`}>{corResult.resistanceScore}</span>
+                  <span className="text-zinc-500">/100</span>
+                </div>
+                <div className={`inline-block rounded px-2 py-0.5 text-[10px] ${corResult.resistanceScore && corResult.resistanceScore >= 75 ? 'bg-emerald-500/20 text-emerald-200' : corResult.resistanceScore && corResult.resistanceScore >= 50 ? 'bg-amber-500/20 text-amber-200' : 'bg-rose-500/20 text-rose-200'}`}>{corResult.riskClass}</div>
+                {corResult.estimatedLifeYears != null && (
+                  <div className="rounded border border-zinc-800 bg-zinc-950/40 px-2 py-1">
+                    <div className="text-[9px] text-zinc-500">Estimated service life</div>
+                    <div className="font-mono text-blue-200">{corResult.estimatedLifeYears} years</div>
+                  </div>
+                )}
+                {corResult.recommendations && corResult.recommendations.length > 0 && (
+                  <ul className="list-disc space-y-0.5 pl-4 text-zinc-300">
+                    {corResult.recommendations.map((r, i) => <li key={i}>{r}</li>)}
+                  </ul>
+                )}
               </div>
-              <div className={`inline-block rounded px-2 py-0.5 text-[10px] ${corResult.resistanceScore && corResult.resistanceScore >= 75 ? 'bg-emerald-500/20 text-emerald-200' : corResult.resistanceScore && corResult.resistanceScore >= 50 ? 'bg-amber-500/20 text-amber-200' : 'bg-rose-500/20 text-rose-200'}`}>{corResult.riskClass}</div>
-              {corResult.estimatedLifeYears != null && (
-                <div className="rounded border border-zinc-800 bg-zinc-950/40 px-2 py-1">
-                  <div className="text-[9px] text-zinc-500">Estimated service life</div>
-                  <div className="font-mono text-blue-200">{corResult.estimatedLifeYears} years</div>
-                </div>
-              )}
-              {corResult.recommendations && corResult.recommendations.length > 0 && (
-                <ul className="list-disc space-y-0.5 pl-4 text-zinc-300">
-                  {corResult.recommendations.map((r, i) => <li key={i}>{r}</li>)}
-                </ul>
-              )}
-            </div>
-          )}
-        </div>
-        <div className="rounded-lg border border-orange-500/20 bg-orange-500/5 p-3">
-          <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Thermometer className="h-3 w-3" />Thermal profile</div>
-          {!thermResult && <div className="text-[11px] text-zinc-500">Analyze to evaluate.</div>}
-          {thermResult && (
-            <div className="space-y-2 text-[11px]">
-              <div className={`inline-block rounded px-2 py-0.5 text-[10px] font-mono ${thermResult.thermalClass === 'excellent-conductor' ? 'bg-orange-500/20 text-orange-200' : 'bg-zinc-800 text-zinc-300'}`}>{thermResult.thermalClass}</div>
-              <div className={`text-[10px] ${thermResult.isSafe ? 'text-emerald-300' : 'text-rose-300'}`}>Safety margin: {thermResult.safetyMarginPercent}% — {thermResult.isSafe ? 'SAFE' : 'AT-RISK'}</div>
-              {thermResult.suitability && (
-                <div className="grid grid-cols-2 gap-1">
-                  {Object.entries(thermResult.suitability).map(([k, v]) => (
-                    <div key={k} className="rounded border border-zinc-800 bg-zinc-950/40 px-2 py-1">
-                      <div className="text-[9px] text-zinc-500">{k}</div>
-                      <div className={`font-mono ${suitColour(v)}`}>{v}</div>
-                    </div>
-                  ))}
-                </div>
-              )}
-              {thermResult.warnings && thermResult.warnings.length > 0 && (
-                <div className="rounded border border-amber-500/30 bg-amber-500/10 px-2 py-1">
-                  {thermResult.warnings.map((w, i) => <div key={i} className="text-amber-200">⚠ {w}</div>)}
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
+            )}
+          </div>
+          <div className="rounded-lg border border-orange-500/20 bg-orange-500/5 p-3">
+            <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Thermometer className="h-3 w-3" />Thermal profile</div>
+            {!thermResult && <div className="text-[11px] text-zinc-500">Analyze to evaluate.</div>}
+            {thermResult && (
+              <div className="space-y-2 text-[11px]">
+                <div className={`inline-block rounded px-2 py-0.5 text-[10px] font-mono ${thermResult.thermalClass === 'excellent-conductor' ? 'bg-orange-500/20 text-orange-200' : 'bg-zinc-800 text-zinc-300'}`}>{thermResult.thermalClass}</div>
+                <div className={`text-[10px] ${thermResult.isSafe ? 'text-emerald-300' : 'text-rose-300'}`}>Safety margin: {thermResult.safetyMarginPercent}% — {thermResult.isSafe ? 'SAFE' : 'AT-RISK'}</div>
+                {thermResult.suitability && (
+                  <div className="grid grid-cols-2 gap-1">
+                    {Object.entries(thermResult.suitability).map(([k, v]) => (
+                      <div key={k} className="rounded border border-zinc-800 bg-zinc-950/40 px-2 py-1">
+                        <div className="text-[9px] text-zinc-500">{k}</div>
+                        <div className={`font-mono ${suitColour(v)}`}>{v}</div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {thermResult.warnings && thermResult.warnings.length > 0 && (
+                  <div className="rounded border border-amber-500/30 bg-amber-500/10 px-2 py-1">
+                    {thermResult.warnings.map((w, i) => <div key={i} className="text-amber-200">⚠ {w}</div>)}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </>
+      )}
+      dtu={{
+        apiSource: 'concord-materials-corrosion-thermal',
+        title: (cor, therm) => `${corrosion.name} — corrosion ${cor.resistanceScore ?? '—'} · thermal ${therm.thermalClass ?? '—'}`,
+        content: (cor, therm) => `Corrosion (${corrosion.name} in ${corrosion.environment}):\n  Resistance: ${cor.resistanceScore}/100 (${cor.riskClass})\n  Estimated life: ${cor.estimatedLifeYears ?? '—'} years\n${(cor.recommendations || []).map((r) => `  • ${r}`).join('\n')}\n\nThermal (operating ${thermal.operatingTemp}°C, app=${thermal.application}):\n  Class: ${therm.thermalClass}\n  Safety margin: ${therm.safetyMarginPercent}% (${therm.isSafe ? 'SAFE' : 'AT-RISK'})\n  Suitability:\n${Object.entries(therm.suitability || {}).map(([k, v]) => `    ${k}: ${v}`).join('\n')}\n${(therm.warnings || []).map((w) => `  ⚠ ${w}`).join('\n')}`,
+        tags: () => ['materials', corrosion.category, corrosion.environment],
+        rawData: (cor, therm) => ({ corrosion, thermal, corResult: cor, thermResult: therm }),
+      }}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- New primitive `concord-frontend/components/lens-primitives/CalcPanel.tsx` — generic two-macro analyze + render + Save-as-DTU shell. Empirically derived from 8 lens panels landed PRs #729–#736 (calendar, environment, history, materials, ocean, security, services, automotive, energy) all sharing the same shape.
- Refactored 3 consumers as API validation: `materials/CorrosionThermalPanel`, `energy/SolarCarbonPanel`, `automotive/FuelRepairPanel`.
- Generic over `<LR, RR>` (result types). 11 named accent colours. `buildArtifact()` returns `{ data: ... }`; CalcPanel wraps in `{ input: { artifact } }` before calling `apiHelpers.lens.runDomain`.

## Math
- Refactored 3 consumers: -112 LOC net
- New primitive: +190 LOC
- Break-even at consumer #2
- Each future calc-shape panel drops from ~280 LOC bespoke → ~140 LOC using CalcPanel

## Plan reference
Per `/root/.claude/plans/well-let-s-make-it-stateless-comet.md` Phase 1, Track B, primitive #1. Next: refactor remaining 5 calc-shape components from this session (calendar/environment/history/ocean/security/services), then start Wave 1 of the sweep (trade calcs).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on all 4 files
- [ ] Manual: verify materials/energy/automotive panels render and Analyze still works end-to-end after refactor (no behavior change expected — same macros, same result shapes, same DTU payload).

https://claude.ai/code/session_01WfDATSALRXGNnSkLKb4U9j

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfDATSALRXGNnSkLKb4U9j)_