### PR TITLE
lens-primitives: refactor 3 more consumers onto CalcPanel

### DIFF
--- a/concord-frontend/components/environment/ComplianceDiversionPanel.tsx
+++ b/concord-frontend/components/environment/ComplianceDiversionPanel.tsx
@@ -1,41 +1,22 @@
 'use client';
 
 /**
- * ComplianceDiversionPanel — bespoke environmental compliance +
- * waste diversion surface for the environment lens. Wires
- * environment.complianceCheck + environment.diversionRate against
- * editable parameter / waste-stream tables.
+ * ComplianceDiversionPanel — environmental compliance + waste-diversion
+ * surface for the environment lens. Wires environment.complianceCheck +
+ * environment.diversionRate.
  *
- *   • Compliance: parameter rows (name/value/unit/min/max) → pass/fail
- *     per row + overall verdict + violation count
- *   • Diversion: total + diverted volume + per-stream split + target%
- *     → rate %, landfill share, target-met badge
- *   • Save-as-DTU captures inputs + both reports
+ * Refactored to use `CalcPanel` primitive. See
+ * `concord-frontend/components/lens-primitives/CalcPanel.tsx`.
  */
 
 import { useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
-import { Recycle, Loader2, Plus, Trash2, ShieldCheck, ShieldAlert } from 'lucide-react';
-import { apiHelpers } from '@/lib/api/client';
-import { SaveAsDtuButton } from '@/components/dtu/SaveAsDtuButton';
+import { Recycle, Plus, Trash2, ShieldCheck, ShieldAlert } from 'lucide-react';
+import { CalcPanel } from '@/components/lens-primitives/CalcPanel';
 
 interface Param { name: string; value: string; unit: string; min: string; max: string }
 interface Stream { name: string; volume: string }
 interface ComplianceResult { results?: Array<{ parameter: string; value: number; unit: string; threshold?: { min?: number; max?: number }; compliant: boolean }>; overallCompliant?: boolean; violations?: number; checkedAt?: string }
 interface DiversionResult { diversionRate?: number; totalWaste?: number; diverted?: number; landfilled?: number; target?: number; meetsTarget?: boolean; streams?: Stream[] }
-
-async function callEnv<T>(action: string, input: Record<string, unknown>): Promise<T | null> {
-  try {
-    const r = await apiHelpers.lens.runDomain('environment', action, { input });
-    const env = (r as { data?: { ok: boolean; result?: T } }).data;
-    if (!env?.ok) return null;
-    const result = env.result as unknown as { ok?: boolean; result?: T } | T;
-    if (result && typeof result === 'object' && 'ok' in result && 'result' in result) {
-      return (result as { result: T }).result;
-    }
-    return env.result as T;
-  } catch { return null; }
-}
 
 const DEFAULT_PARAMS: Param[] = [
   { name: 'pH', value: '7.2', unit: 'pH', min: '6.5', max: '8.5' },
@@ -56,25 +37,6 @@ export function ComplianceDiversionPanel() {
   const [streams, setStreams] = useState<Stream[]>(DEFAULT_STREAMS);
   const [totalWaste, setTotalWaste] = useState(3500);
   const [target, setTarget] = useState(50);
-  const [compliance, setCompliance] = useState<ComplianceResult | null>(null);
-  const [diversion, setDiversion] = useState<DiversionResult | null>(null);
-
-  const analyze = useMutation({
-    mutationFn: async () => {
-      const parameters = params.filter((p) => p.name.trim() && p.value.trim()).map((p) => ({
-        name: p.name.trim(), value: parseFloat(p.value) || 0, unit: p.unit, threshold: { min: parseFloat(p.min) || 0, max: parseFloat(p.max) || Infinity },
-      }));
-      const cleanStreams = streams.filter((s) => s.name.trim() && s.volume.trim()).map((s) => ({ name: s.name.trim(), volume: parseFloat(s.volume) || 0 }));
-      const divertedVolume = cleanStreams.reduce((sum, s) => sum + s.volume, 0);
-      const [c, d] = await Promise.all([
-        callEnv<ComplianceResult>('complianceCheck', { artifact: { data: { parameters } } }),
-        callEnv<DiversionResult>('diversionRate', { artifact: { data: { totalVolume: totalWaste, divertedVolume, streams: cleanStreams } }, target }),
-      ]);
-      setCompliance(c);
-      setDiversion(d);
-      return { c, d };
-    },
-  });
 
   const addParam = () => setParams((ps) => [...ps, { name: '', value: '', unit: '', min: '', max: '' }]);
   const updateParam = (i: number, key: keyof Param, value: string) =>
@@ -87,113 +49,119 @@ export function ComplianceDiversionPanel() {
   const removeStream = (i: number) => setStreams((ss) => ss.filter((_, idx) => idx !== i));
 
   return (
-    <div className="space-y-4">
-      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-cyan-500/15 pb-3">
-        <div className="flex items-center gap-2">
-          <Recycle className="h-5 w-5 text-emerald-400" />
-          <h2 className="text-sm font-semibold text-white">Compliance + diversion</h2>
-          <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">environment.complianceCheck + diversionRate</span>
-        </div>
-        {(compliance || diversion) && (
-          <SaveAsDtuButton
-            compact
-            apiSource="concord-env-compliance-diversion"
-            title={`Env compliance + diversion — ${compliance?.violations ?? 0} violations · ${diversion?.diversionRate ?? 0}% diverted`}
-            content={`Compliance: ${compliance?.overallCompliant ? 'PASS' : 'FAIL'} (${compliance?.violations ?? 0} violation${compliance?.violations === 1 ? '' : 's'})\n${(compliance?.results || []).map((r) => `  ${r.compliant ? '✓' : '✗'} ${r.parameter} = ${r.value} ${r.unit}${r.threshold ? ` (range ${r.threshold.min ?? '-'}–${r.threshold.max ?? '-'})` : ''}`).join('\n')}\n\nDiversion: ${diversion?.diversionRate}% (target ${diversion?.target}% — ${diversion?.meetsTarget ? 'MET' : 'BELOW'})\n  Total: ${diversion?.totalWaste} | Diverted: ${diversion?.diverted} | Landfilled: ${diversion?.landfilled}\nStreams:\n${(diversion?.streams || []).map((s) => `  ${s.name}: ${s.volume}`).join('\n')}`}
-            extraTags={['environment', 'compliance', 'diversion']}
-            rawData={{ params, streams, totalWaste, target, compliance, diversion }}
-          />
-        )}
-      </header>
-
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <div className="space-y-2">
-          <div className="text-[10px] uppercase tracking-wider text-zinc-500">Parameters (water/air/soil sampling)</div>
-          <div className="grid grid-cols-[1fr_80px_70px_70px_70px_30px] gap-1.5 text-[9px] uppercase tracking-wider text-zinc-500">
-            <span>Name</span><span>Value</span><span>Unit</span><span>Min</span><span>Max</span><span></span>
-          </div>
-          {params.map((p, i) => (
-            <div key={i} className="grid grid-cols-[1fr_80px_70px_70px_70px_30px] gap-1.5">
-              <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white" placeholder="pH" value={p.name} onChange={(e) => updateParam(i, 'name', e.target.value)} />
-              <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" value={p.value} onChange={(e) => updateParam(i, 'value', e.target.value)} />
-              <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" value={p.unit} onChange={(e) => updateParam(i, 'unit', e.target.value)} />
-              <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" value={p.min} onChange={(e) => updateParam(i, 'min', e.target.value)} />
-              <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" value={p.max} onChange={(e) => updateParam(i, 'max', e.target.value)} />
-              <button type="button" onClick={() => removeParam(i)} className="rounded border border-zinc-800 text-xs text-zinc-500 hover:text-rose-300" aria-label="Remove"><Trash2 className="mx-auto h-3 w-3" /></button>
+    <CalcPanel<ComplianceResult, DiversionResult>
+      title="Compliance + diversion"
+      domain="environment"
+      icon={<Recycle className="h-5 w-5 text-emerald-400" />}
+      macroBadge="environment.complianceCheck + diversionRate"
+      accent="emerald"
+      left={{
+        macro: 'complianceCheck',
+        buildArtifact: () => ({
+          data: {
+            parameters: params.filter((p) => p.name.trim() && p.value.trim()).map((p) => ({
+              name: p.name.trim(), value: parseFloat(p.value) || 0, unit: p.unit,
+              threshold: { min: parseFloat(p.min) || 0, max: parseFloat(p.max) || Infinity },
+            })),
+          },
+        }),
+        render: (
+          <div className="space-y-2">
+            <div className="text-[10px] uppercase tracking-wider text-zinc-500">Parameters (water/air/soil sampling)</div>
+            <div className="grid grid-cols-[1fr_80px_70px_70px_70px_30px] gap-1.5 text-[9px] uppercase tracking-wider text-zinc-500">
+              <span>Name</span><span>Value</span><span>Unit</span><span>Min</span><span>Max</span><span></span>
             </div>
-          ))}
-          <button type="button" onClick={addParam} className="inline-flex items-center gap-1 rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-zinc-300 hover:border-emerald-500/40 hover:text-emerald-200"><Plus className="h-3 w-3" />Add parameter</button>
-        </div>
-
-        <div className="space-y-2">
-          <div className="text-[10px] uppercase tracking-wider text-zinc-500">Waste streams (diverted volume)</div>
-          <div className="flex items-center gap-2">
-            <label className="block flex-1">
-              <span className="block text-[9px] uppercase tracking-wider text-zinc-500">Total waste</span>
-              <input type="number" min={0} value={totalWaste} onChange={(e) => setTotalWaste(Math.max(0, Number(e.target.value) || 0))} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white" />
-            </label>
-            <label className="block w-20">
-              <span className="block text-[9px] uppercase tracking-wider text-zinc-500">Target %</span>
-              <input type="number" min={0} max={100} value={target} onChange={(e) => setTarget(Math.max(0, Math.min(100, Number(e.target.value) || 50)))} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white" />
-            </label>
+            {params.map((p, i) => (
+              <div key={i} className="grid grid-cols-[1fr_80px_70px_70px_70px_30px] gap-1.5">
+                <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white" placeholder="pH" value={p.name} onChange={(e) => updateParam(i, 'name', e.target.value)} />
+                <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" value={p.value} onChange={(e) => updateParam(i, 'value', e.target.value)} />
+                <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" value={p.unit} onChange={(e) => updateParam(i, 'unit', e.target.value)} />
+                <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" value={p.min} onChange={(e) => updateParam(i, 'min', e.target.value)} />
+                <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" value={p.max} onChange={(e) => updateParam(i, 'max', e.target.value)} />
+                <button type="button" onClick={() => removeParam(i)} className="rounded border border-zinc-800 text-xs text-zinc-500 hover:text-rose-300" aria-label="Remove"><Trash2 className="mx-auto h-3 w-3" /></button>
+              </div>
+            ))}
+            <button type="button" onClick={addParam} className="inline-flex items-center gap-1 rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-zinc-300 hover:border-emerald-500/40 hover:text-emerald-200"><Plus className="h-3 w-3" />Add parameter</button>
           </div>
-          {streams.map((s, i) => (
-            <div key={i} className="grid grid-cols-[1fr_100px_30px] gap-1.5">
-              <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white" placeholder="Stream name" value={s.name} onChange={(e) => updateStream(i, 'name', e.target.value)} />
-              <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" placeholder="Volume" value={s.volume} onChange={(e) => updateStream(i, 'volume', e.target.value)} />
-              <button type="button" onClick={() => removeStream(i)} className="rounded border border-zinc-800 text-xs text-zinc-500 hover:text-rose-300" aria-label="Remove"><Trash2 className="mx-auto h-3 w-3" /></button>
+        ),
+      }}
+      right={{
+        macro: 'diversionRate',
+        buildArtifact: () => {
+          const cleanStreams = streams.filter((s) => s.name.trim() && s.volume.trim()).map((s) => ({ name: s.name.trim(), volume: parseFloat(s.volume) || 0 }));
+          const divertedVolume = cleanStreams.reduce((sum, s) => sum + s.volume, 0);
+          return { data: { totalVolume: totalWaste, divertedVolume, streams: cleanStreams }, target };
+        },
+        render: (
+          <div className="space-y-2">
+            <div className="text-[10px] uppercase tracking-wider text-zinc-500">Waste streams (diverted volume)</div>
+            <div className="flex items-center gap-2">
+              <label className="block flex-1">
+                <span className="block text-[9px] uppercase tracking-wider text-zinc-500">Total waste</span>
+                <input type="number" min={0} value={totalWaste} onChange={(e) => setTotalWaste(Math.max(0, Number(e.target.value) || 0))} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white" />
+              </label>
+              <label className="block w-20">
+                <span className="block text-[9px] uppercase tracking-wider text-zinc-500">Target %</span>
+                <input type="number" min={0} max={100} value={target} onChange={(e) => setTarget(Math.max(0, Math.min(100, Number(e.target.value) || 50)))} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white" />
+              </label>
             </div>
-          ))}
-          <button type="button" onClick={addStream} className="inline-flex items-center gap-1 rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-zinc-300 hover:border-emerald-500/40 hover:text-emerald-200"><Plus className="h-3 w-3" />Add stream</button>
-        </div>
-      </div>
-
-      <div className="flex items-center">
-        <button type="button" onClick={() => analyze.mutate()} disabled={analyze.isPending} className="inline-flex items-center gap-1 rounded border border-emerald-500/40 bg-emerald-500/15 px-3 py-1.5 text-xs font-mono text-emerald-200 hover:bg-emerald-500/25 disabled:opacity-50">
-          {analyze.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Recycle className="h-3.5 w-3.5" />}
-          Run analysis
-        </button>
-      </div>
-
-      {analyze.isError && <div className="rounded border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-300">Analysis failed.</div>}
-
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        <div className={`rounded-lg border p-3 ${compliance?.overallCompliant ? 'border-emerald-500/30 bg-emerald-500/5' : compliance ? 'border-rose-500/30 bg-rose-500/5' : 'border-zinc-800 bg-zinc-950/40'}`}>
-          <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500">
-            {compliance?.overallCompliant ? <ShieldCheck className="h-3 w-3 text-emerald-300" /> : <ShieldAlert className="h-3 w-3 text-rose-300" />}
-            Compliance
+            {streams.map((s, i) => (
+              <div key={i} className="grid grid-cols-[1fr_100px_30px] gap-1.5">
+                <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white" placeholder="Stream name" value={s.name} onChange={(e) => updateStream(i, 'name', e.target.value)} />
+                <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" placeholder="Volume" value={s.volume} onChange={(e) => updateStream(i, 'volume', e.target.value)} />
+                <button type="button" onClick={() => removeStream(i)} className="rounded border border-zinc-800 text-xs text-zinc-500 hover:text-rose-300" aria-label="Remove"><Trash2 className="mx-auto h-3 w-3" /></button>
+              </div>
+            ))}
+            <button type="button" onClick={addStream} className="inline-flex items-center gap-1 rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-zinc-300 hover:border-emerald-500/40 hover:text-emerald-200"><Plus className="h-3 w-3" />Add stream</button>
           </div>
-          {!compliance && <div className="text-[11px] text-zinc-500">Run to check.</div>}
-          {compliance && (
-            <div className="space-y-1 text-[11px]">
-              <div className={compliance.overallCompliant ? 'text-emerald-200' : 'text-rose-200'}>{compliance.overallCompliant ? 'All parameters within range.' : `${compliance.violations} violation${compliance.violations === 1 ? '' : 's'}`}</div>
-              {compliance.results?.map((r, i) => (
-                <div key={i} className={`flex items-center justify-between rounded border px-2 py-1 ${r.compliant ? 'border-emerald-500/15 bg-emerald-500/5' : 'border-rose-500/30 bg-rose-500/10'}`}>
-                  <span className="text-zinc-100">{r.compliant ? '✓' : '✗'} {r.parameter}</span>
-                  <span className="font-mono text-[10px] text-zinc-300">{r.value} {r.unit}</span>
+        ),
+      }}
+      renderResults={(compliance, diversion) => (
+        <>
+          <div className={`rounded-lg border p-3 ${compliance?.overallCompliant ? 'border-emerald-500/30 bg-emerald-500/5' : compliance ? 'border-rose-500/30 bg-rose-500/5' : 'border-zinc-800 bg-zinc-950/40'}`}>
+            <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500">
+              {compliance?.overallCompliant ? <ShieldCheck className="h-3 w-3 text-emerald-300" /> : <ShieldAlert className="h-3 w-3 text-rose-300" />}
+              Compliance
+            </div>
+            {!compliance && <div className="text-[11px] text-zinc-500">Run to check.</div>}
+            {compliance && (
+              <div className="space-y-1 text-[11px]">
+                <div className={compliance.overallCompliant ? 'text-emerald-200' : 'text-rose-200'}>{compliance.overallCompliant ? 'All parameters within range.' : `${compliance.violations} violation${compliance.violations === 1 ? '' : 's'}`}</div>
+                {compliance.results?.map((r, i) => (
+                  <div key={i} className={`flex items-center justify-between rounded border px-2 py-1 ${r.compliant ? 'border-emerald-500/15 bg-emerald-500/5' : 'border-rose-500/30 bg-rose-500/10'}`}>
+                    <span className="text-zinc-100">{r.compliant ? '✓' : '✗'} {r.parameter}</span>
+                    <span className="font-mono text-[10px] text-zinc-300">{r.value} {r.unit}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+          <div className={`rounded-lg border p-3 ${diversion?.meetsTarget ? 'border-emerald-500/30 bg-emerald-500/5' : diversion ? 'border-amber-500/30 bg-amber-500/5' : 'border-zinc-800 bg-zinc-950/40'}`}>
+            <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Recycle className="h-3 w-3" />Diversion rate</div>
+            {!diversion && <div className="text-[11px] text-zinc-500">Run to compute.</div>}
+            {diversion && (
+              <div className="space-y-1.5 text-[11px]">
+                <div className="flex items-baseline gap-2">
+                  <span className={`font-mono text-2xl ${diversion.meetsTarget ? 'text-emerald-200' : 'text-amber-200'}`}>{diversion.diversionRate}%</span>
+                  <span className="text-zinc-500">target {diversion.target}%</span>
                 </div>
-              ))}
-            </div>
-          )}
-        </div>
-        <div className={`rounded-lg border p-3 ${diversion?.meetsTarget ? 'border-emerald-500/30 bg-emerald-500/5' : diversion ? 'border-amber-500/30 bg-amber-500/5' : 'border-zinc-800 bg-zinc-950/40'}`}>
-          <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Recycle className="h-3 w-3" />Diversion rate</div>
-          {!diversion && <div className="text-[11px] text-zinc-500">Run to compute.</div>}
-          {diversion && (
-            <div className="space-y-1.5 text-[11px]">
-              <div className="flex items-baseline gap-2">
-                <span className={`font-mono text-2xl ${diversion.meetsTarget ? 'text-emerald-200' : 'text-amber-200'}`}>{diversion.diversionRate}%</span>
-                <span className="text-zinc-500">target {diversion.target}%</span>
+                <div className="grid grid-cols-3 gap-1.5">
+                  <div className="rounded border border-zinc-800 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Total</div><div className="font-mono text-zinc-200">{diversion.totalWaste}</div></div>
+                  <div className="rounded border border-emerald-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Diverted</div><div className="font-mono text-emerald-200">{diversion.diverted}</div></div>
+                  <div className="rounded border border-amber-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Landfill</div><div className="font-mono text-amber-200">{diversion.landfilled}</div></div>
+                </div>
               </div>
-              <div className="grid grid-cols-3 gap-1.5">
-                <div className="rounded border border-zinc-800 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Total</div><div className="font-mono text-zinc-200">{diversion.totalWaste}</div></div>
-                <div className="rounded border border-emerald-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Diverted</div><div className="font-mono text-emerald-200">{diversion.diverted}</div></div>
-                <div className="rounded border border-amber-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Landfill</div><div className="font-mono text-amber-200">{diversion.landfilled}</div></div>
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
+            )}
+          </div>
+        </>
+      )}
+      dtu={{
+        apiSource: 'concord-env-compliance-diversion',
+        title: (c, d) => `Env compliance + diversion — ${c.violations ?? 0} violations · ${d.diversionRate ?? 0}% diverted`,
+        content: (c, d) => `Compliance: ${c.overallCompliant ? 'PASS' : 'FAIL'} (${c.violations ?? 0} violation${c.violations === 1 ? '' : 's'})\n${(c.results || []).map((r) => `  ${r.compliant ? '✓' : '✗'} ${r.parameter} = ${r.value} ${r.unit}${r.threshold ? ` (range ${r.threshold.min ?? '-'}–${r.threshold.max ?? '-'})` : ''}`).join('\n')}\n\nDiversion: ${d.diversionRate}% (target ${d.target}% — ${d.meetsTarget ? 'MET' : 'BELOW'})\n  Total: ${d.totalWaste} | Diverted: ${d.diverted} | Landfilled: ${d.landfilled}\nStreams:\n${(d.streams || []).map((s) => `  ${s.name}: ${s.volume}`).join('\n')}`,
+        tags: () => ['environment', 'compliance', 'diversion'],
+        rawData: (c, d) => ({ params, streams, totalWaste, target, compliance: c, diversion: d }),
+      }}
+    />
   );
 }

--- a/concord-frontend/components/history/TimelineSourceTools.tsx
+++ b/concord-frontend/components/history/TimelineSourceTools.tsx
@@ -1,39 +1,21 @@
 'use client';
 
 /**
- * TimelineSourceTools — bespoke historical analysis surface for the
- * history lens. Wires history.timelineBuild + history.sourceEvaluate.
+ * TimelineSourceTools — historical timeline + source-reliability surface
+ * for the history lens. Wires history.timelineBuild + history.sourceEvaluate.
  *
- *   • Timeline: editable event rows (event/date/era/category/significance)
- *     → sorted timeline + span + pivotal-events list + category tags
- *   • Source evaluation: type / bias / author / date inputs → reliability
- *     score (0-100), classification badge, corroboration recommendation
- *   • Save-as-DTU captures inputs + both reports
+ * Refactored to use `CalcPanel` primitive. See
+ * `concord-frontend/components/lens-primitives/CalcPanel.tsx`.
  */
 
 import { useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
-import { History, Loader2, Plus, Trash2, ScrollText, Scale } from 'lucide-react';
-import { apiHelpers } from '@/lib/api/client';
-import { SaveAsDtuButton } from '@/components/dtu/SaveAsDtuButton';
+import { History, Plus, Trash2, ScrollText, Scale } from 'lucide-react';
+import { CalcPanel } from '@/components/lens-primitives/CalcPanel';
 
 interface HistEvent { name: string; date: string; era: string; category: string; significance: 'low' | 'medium' | 'high' | 'critical' }
 interface Source { title: string; type: 'primary' | 'secondary' | 'tertiary'; author: string; date: string; bias: 'none' | 'low' | 'moderate' | 'high' }
 interface TimelineResult { timeline?: Array<{ event: string; date: string; era?: string; significance?: string; category?: string }>; totalEvents?: number; timeSpan?: string; categories?: string[]; eras?: string[]; pivotalEvents?: Array<{ event: string; date: string }> }
 interface SourceResult { title?: string; type?: string; reliabilityScore?: number; classification?: string; corroborationNeeded?: boolean; evaluation?: { sourceType: number; biasAssessment: number; authorAttribution: string; dateProvenance: string } }
-
-async function callHist<T>(action: string, input: Record<string, unknown>): Promise<T | null> {
-  try {
-    const r = await apiHelpers.lens.runDomain('history', action, { input });
-    const env = (r as { data?: { ok: boolean; result?: T } }).data;
-    if (!env?.ok) return null;
-    const result = env.result as unknown as { ok?: boolean; result?: T } | T;
-    if (result && typeof result === 'object' && 'ok' in result && 'result' in result) {
-      return (result as { result: T }).result;
-    }
-    return env.result as T;
-  } catch { return null; }
-}
 
 const CATEGORIES = ['political', 'military', 'cultural', 'economic', 'scientific', 'religious', 'social'] as const;
 const SIGNIFICANCES = ['low', 'medium', 'high', 'critical'] as const;
@@ -47,149 +29,133 @@ const DEFAULT_EVENTS: HistEvent[] = [
   { name: 'Black Death peak', date: '1349', era: 'High Middle Ages', category: 'social', significance: 'high' },
 ];
 
+const reliabilityColour = (score?: number) => {
+  if (!score) return 'text-zinc-400';
+  if (score >= 70) return 'text-emerald-200';
+  if (score >= 40) return 'text-amber-200';
+  return 'text-rose-200';
+};
+
 export function TimelineSourceTools() {
   const [events, setEvents] = useState<HistEvent[]>(DEFAULT_EVENTS);
   const [source, setSource] = useState<Source>({ title: 'Magna Carta facsimile (British Library)', type: 'primary', author: 'Anonymous scribes', date: '1215', bias: 'low' });
-  const [timeline, setTimeline] = useState<TimelineResult | null>(null);
-  const [sourceResult, setSourceResult] = useState<SourceResult | null>(null);
-
-  const analyze = useMutation({
-    mutationFn: async () => {
-      const evs = events.filter((e) => e.name.trim() && e.date.trim());
-      const [t, s] = await Promise.all([
-        callHist<TimelineResult>('timelineBuild', { artifact: { data: { events: evs } } }),
-        callHist<SourceResult>('sourceEvaluate', { artifact: { title: source.title, data: source } }),
-      ]);
-      setTimeline(t);
-      setSourceResult(s);
-      return { t, s };
-    },
-  });
 
   const addEvent = () => setEvents((es) => [...es, { name: '', date: '', era: '', category: 'political', significance: 'medium' }]);
   const updateEvent = <K extends keyof HistEvent>(i: number, key: K, value: HistEvent[K]) =>
     setEvents((es) => es.map((e, idx) => (idx === i ? { ...e, [key]: value } : e)));
   const removeEvent = (i: number) => setEvents((es) => es.filter((_, idx) => idx !== i));
 
-  const reliabilityColour = (score?: number) => {
-    if (!score) return 'text-zinc-400';
-    if (score >= 70) return 'text-emerald-200';
-    if (score >= 40) return 'text-amber-200';
-    return 'text-rose-200';
-  };
-
   return (
-    <div className="space-y-4">
-      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-cyan-500/15 pb-3">
-        <div className="flex items-center gap-2">
-          <History className="h-5 w-5 text-amber-400" />
-          <h2 className="text-sm font-semibold text-white">Timeline + source evaluator</h2>
-          <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">history.timelineBuild + sourceEvaluate</span>
-        </div>
-        {(timeline || sourceResult) && (
-          <SaveAsDtuButton
-            compact
-            apiSource="concord-history-timeline-source"
-            title={`History analysis — ${timeline?.totalEvents ?? 0} events · source ${sourceResult?.reliabilityScore ?? '—'}/100`}
-            content={`Timeline (${timeline?.timeSpan || '—'}):\n${(timeline?.timeline || []).map((e) => `  ${e.date} — ${e.event} [${e.category}, ${e.significance}]`).join('\n')}\n\nPivotal: ${timeline?.pivotalEvents?.map((p) => p.event).join(', ') || 'none'}\n\nSource evaluation:\n  Title: ${sourceResult?.title}\n  Type: ${sourceResult?.type} | Reliability: ${sourceResult?.reliabilityScore}/100 (${sourceResult?.classification})\n  Corroboration needed: ${sourceResult?.corroborationNeeded ? 'yes' : 'no'}`}
-            extraTags={['history', 'timeline', 'sources']}
-            rawData={{ events, source, timeline, sourceResult }}
-          />
-        )}
-      </header>
-
-      <div className="space-y-2">
-        <div className="text-[10px] uppercase tracking-wider text-zinc-500">Historical events</div>
-        <div className="grid grid-cols-[1fr_90px_110px_110px_90px_30px] gap-1.5 text-[9px] uppercase tracking-wider text-zinc-500">
-          <span>Event</span><span>Date</span><span>Era</span><span>Category</span><span>Sig.</span><span></span>
-        </div>
-        {events.map((e, i) => (
-          <div key={i} className="grid grid-cols-[1fr_90px_110px_110px_90px_30px] gap-1.5">
-            <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white" placeholder="Event name" value={e.name} onChange={(ev) => updateEvent(i, 'name', ev.target.value)} />
-            <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" placeholder="1215" value={e.date} onChange={(ev) => updateEvent(i, 'date', ev.target.value)} />
-            <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white" placeholder="Era" value={e.era} onChange={(ev) => updateEvent(i, 'era', ev.target.value)} />
-            <select className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white" value={e.category} onChange={(ev) => updateEvent(i, 'category', ev.target.value)}>
-              {CATEGORIES.map((c) => <option key={c} value={c}>{c}</option>)}
-            </select>
-            <select className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white" value={e.significance} onChange={(ev) => updateEvent(i, 'significance', ev.target.value as HistEvent['significance'])}>
-              {SIGNIFICANCES.map((s) => <option key={s} value={s}>{s}</option>)}
-            </select>
-            <button type="button" onClick={() => removeEvent(i)} className="rounded border border-zinc-800 text-xs text-zinc-500 hover:text-rose-300" aria-label="Remove"><Trash2 className="mx-auto h-3 w-3" /></button>
+    <CalcPanel<TimelineResult, SourceResult>
+      title="Timeline + source evaluator"
+      domain="history"
+      icon={<History className="h-5 w-5 text-amber-400" />}
+      macroBadge="history.timelineBuild + sourceEvaluate"
+      accent="amber"
+      left={{
+        macro: 'timelineBuild',
+        buildArtifact: () => ({ data: { events: events.filter((e) => e.name.trim() && e.date.trim()) } }),
+        render: (
+          <div className="space-y-2">
+            <div className="text-[10px] uppercase tracking-wider text-zinc-500">Historical events</div>
+            <div className="grid grid-cols-[1fr_90px_110px_110px_90px_30px] gap-1.5 text-[9px] uppercase tracking-wider text-zinc-500">
+              <span>Event</span><span>Date</span><span>Era</span><span>Category</span><span>Sig.</span><span></span>
+            </div>
+            {events.map((e, i) => (
+              <div key={i} className="grid grid-cols-[1fr_90px_110px_110px_90px_30px] gap-1.5">
+                <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white" placeholder="Event name" value={e.name} onChange={(ev) => updateEvent(i, 'name', ev.target.value)} />
+                <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white font-mono" placeholder="1215" value={e.date} onChange={(ev) => updateEvent(i, 'date', ev.target.value)} />
+                <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white" placeholder="Era" value={e.era} onChange={(ev) => updateEvent(i, 'era', ev.target.value)} />
+                <select className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white" value={e.category} onChange={(ev) => updateEvent(i, 'category', ev.target.value)}>
+                  {CATEGORIES.map((c) => <option key={c} value={c}>{c}</option>)}
+                </select>
+                <select className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-xs text-white" value={e.significance} onChange={(ev) => updateEvent(i, 'significance', ev.target.value as HistEvent['significance'])}>
+                  {SIGNIFICANCES.map((s) => <option key={s} value={s}>{s}</option>)}
+                </select>
+                <button type="button" onClick={() => removeEvent(i)} className="rounded border border-zinc-800 text-xs text-zinc-500 hover:text-rose-300" aria-label="Remove"><Trash2 className="mx-auto h-3 w-3" /></button>
+              </div>
+            ))}
+            <button type="button" onClick={addEvent} className="inline-flex items-center gap-1 rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-zinc-300 hover:border-amber-500/40 hover:text-amber-200"><Plus className="h-3 w-3" />Add event</button>
           </div>
-        ))}
-        <button type="button" onClick={addEvent} className="inline-flex items-center gap-1 rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-zinc-300 hover:border-amber-500/40 hover:text-amber-200"><Plus className="h-3 w-3" />Add event</button>
-      </div>
-
-      <div className="space-y-2 rounded-lg border border-zinc-800 bg-zinc-950/40 p-3">
-        <div className="text-[10px] uppercase tracking-wider text-zinc-500">Source to evaluate</div>
-        <div className="grid grid-cols-1 gap-2 sm:grid-cols-5">
-          <label className="block sm:col-span-2"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Title</span>
-            <input className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white" value={source.title} onChange={(e) => setSource({ ...source, title: e.target.value })} /></label>
-          <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Type</span>
-            <select className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white" value={source.type} onChange={(e) => setSource({ ...source, type: e.target.value as Source['type'] })}>
-              {TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
-            </select></label>
-          <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Author</span>
-            <input className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white" value={source.author} onChange={(e) => setSource({ ...source, author: e.target.value })} /></label>
-          <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Bias</span>
-            <select className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white" value={source.bias} onChange={(e) => setSource({ ...source, bias: e.target.value as Source['bias'] })}>
-              {BIASES.map((b) => <option key={b} value={b}>{b}</option>)}
-            </select></label>
-        </div>
-      </div>
-
-      <button type="button" onClick={() => analyze.mutate()} disabled={analyze.isPending} className="inline-flex items-center gap-1 rounded border border-amber-500/40 bg-amber-500/15 px-3 py-1.5 text-xs font-mono text-amber-200 hover:bg-amber-500/25 disabled:opacity-50">
-        {analyze.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <History className="h-3.5 w-3.5" />}
-        Analyze
-      </button>
-
-      {analyze.isError && <div className="rounded border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-300">Analysis failed.</div>}
-
-      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-        <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-3">
-          <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><ScrollText className="h-3 w-3" />Timeline</div>
-          {!timeline && <div className="text-[11px] text-zinc-500">Analyze to build.</div>}
-          {timeline?.timeline && (
-            <div className="space-y-1 text-[11px]">
-              <div className="text-zinc-400">{timeline.totalEvents} events · {timeline.timeSpan}</div>
-              {timeline.timeline.map((t, i) => (
-                <div key={i} className="flex items-start gap-2 rounded border border-amber-500/15 bg-zinc-950/40 px-2 py-1">
-                  <span className="font-mono text-[10px] text-amber-200 shrink-0">{t.date}</span>
-                  <div className="flex-1">
-                    <div className="text-zinc-100">{t.event}</div>
-                    <div className="flex gap-1 text-[9px] text-zinc-500">
-                      {t.category && <span className="rounded bg-zinc-800 px-1">{t.category}</span>}
-                      {t.significance && <span className={`rounded px-1 ${t.significance === 'critical' ? 'bg-rose-500/20 text-rose-200' : t.significance === 'high' ? 'bg-amber-500/20 text-amber-200' : 'bg-zinc-800'}`}>{t.significance}</span>}
+        ),
+      }}
+      right={{
+        macro: 'sourceEvaluate',
+        buildArtifact: () => ({ title: source.title, data: source }),
+        render: (
+          <div className="space-y-2 rounded-lg border border-zinc-800 bg-zinc-950/40 p-3">
+            <div className="text-[10px] uppercase tracking-wider text-zinc-500">Source to evaluate</div>
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-5">
+              <label className="block sm:col-span-2"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Title</span>
+                <input className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white" value={source.title} onChange={(e) => setSource({ ...source, title: e.target.value })} /></label>
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Type</span>
+                <select className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white" value={source.type} onChange={(e) => setSource({ ...source, type: e.target.value as Source['type'] })}>
+                  {TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
+                </select></label>
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Author</span>
+                <input className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white" value={source.author} onChange={(e) => setSource({ ...source, author: e.target.value })} /></label>
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Bias</span>
+                <select className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white" value={source.bias} onChange={(e) => setSource({ ...source, bias: e.target.value as Source['bias'] })}>
+                  {BIASES.map((b) => <option key={b} value={b}>{b}</option>)}
+                </select></label>
+            </div>
+          </div>
+        ),
+      }}
+      renderResults={(timeline, sourceResult) => (
+        <>
+          <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-3">
+            <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><ScrollText className="h-3 w-3" />Timeline</div>
+            {!timeline && <div className="text-[11px] text-zinc-500">Analyze to build.</div>}
+            {timeline?.timeline && (
+              <div className="space-y-1 text-[11px]">
+                <div className="text-zinc-400">{timeline.totalEvents} events · {timeline.timeSpan}</div>
+                {timeline.timeline.map((t, i) => (
+                  <div key={i} className="flex items-start gap-2 rounded border border-amber-500/15 bg-zinc-950/40 px-2 py-1">
+                    <span className="font-mono text-[10px] text-amber-200 shrink-0">{t.date}</span>
+                    <div className="flex-1">
+                      <div className="text-zinc-100">{t.event}</div>
+                      <div className="flex gap-1 text-[9px] text-zinc-500">
+                        {t.category && <span className="rounded bg-zinc-800 px-1">{t.category}</span>}
+                        {t.significance && <span className={`rounded px-1 ${t.significance === 'critical' ? 'bg-rose-500/20 text-rose-200' : t.significance === 'high' ? 'bg-amber-500/20 text-amber-200' : 'bg-zinc-800'}`}>{t.significance}</span>}
+                      </div>
                     </div>
                   </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-        <div className="rounded-lg border border-sky-500/20 bg-sky-500/5 p-3">
-          <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Scale className="h-3 w-3" />Source reliability</div>
-          {!sourceResult && <div className="text-[11px] text-zinc-500">Analyze to score.</div>}
-          {sourceResult && (
-            <div className="space-y-2 text-[11px]">
-              <div className="flex items-baseline gap-2">
-                <span className={`font-mono text-3xl ${reliabilityColour(sourceResult.reliabilityScore)}`}>{sourceResult.reliabilityScore}</span>
-                <span className="text-zinc-500">/100</span>
+                ))}
               </div>
-              <div className={`inline-block rounded px-2 py-0.5 text-[10px] ${sourceResult.reliabilityScore && sourceResult.reliabilityScore >= 70 ? 'bg-emerald-500/20 text-emerald-200' : sourceResult.reliabilityScore && sourceResult.reliabilityScore >= 40 ? 'bg-amber-500/20 text-amber-200' : 'bg-rose-500/20 text-rose-200'}`}>{sourceResult.classification}</div>
-              {sourceResult.corroborationNeeded && <div className="text-amber-300">⚠ Corroboration recommended</div>}
-              {sourceResult.evaluation && (
-                <div className="grid grid-cols-2 gap-1 pt-1">
-                  <div className="rounded border border-zinc-800 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Source type</div><div className="font-mono text-zinc-200">{sourceResult.evaluation.sourceType}/90</div></div>
-                  <div className="rounded border border-zinc-800 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Bias</div><div className="font-mono text-zinc-200">{sourceResult.evaluation.biasAssessment}/90</div></div>
-                  <div className="rounded border border-zinc-800 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Author</div><div className="font-mono text-zinc-200">{sourceResult.evaluation.authorAttribution}</div></div>
-                  <div className="rounded border border-zinc-800 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Date prov.</div><div className="font-mono text-zinc-200">{sourceResult.evaluation.dateProvenance}</div></div>
+            )}
+          </div>
+          <div className="rounded-lg border border-sky-500/20 bg-sky-500/5 p-3">
+            <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Scale className="h-3 w-3" />Source reliability</div>
+            {!sourceResult && <div className="text-[11px] text-zinc-500">Analyze to score.</div>}
+            {sourceResult && (
+              <div className="space-y-2 text-[11px]">
+                <div className="flex items-baseline gap-2">
+                  <span className={`font-mono text-3xl ${reliabilityColour(sourceResult.reliabilityScore)}`}>{sourceResult.reliabilityScore}</span>
+                  <span className="text-zinc-500">/100</span>
                 </div>
-              )}
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
+                <div className={`inline-block rounded px-2 py-0.5 text-[10px] ${sourceResult.reliabilityScore && sourceResult.reliabilityScore >= 70 ? 'bg-emerald-500/20 text-emerald-200' : sourceResult.reliabilityScore && sourceResult.reliabilityScore >= 40 ? 'bg-amber-500/20 text-amber-200' : 'bg-rose-500/20 text-rose-200'}`}>{sourceResult.classification}</div>
+                {sourceResult.corroborationNeeded && <div className="text-amber-300">⚠ Corroboration recommended</div>}
+                {sourceResult.evaluation && (
+                  <div className="grid grid-cols-2 gap-1 pt-1">
+                    <div className="rounded border border-zinc-800 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Source type</div><div className="font-mono text-zinc-200">{sourceResult.evaluation.sourceType}/90</div></div>
+                    <div className="rounded border border-zinc-800 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Bias</div><div className="font-mono text-zinc-200">{sourceResult.evaluation.biasAssessment}/90</div></div>
+                    <div className="rounded border border-zinc-800 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Author</div><div className="font-mono text-zinc-200">{sourceResult.evaluation.authorAttribution}</div></div>
+                    <div className="rounded border border-zinc-800 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Date prov.</div><div className="font-mono text-zinc-200">{sourceResult.evaluation.dateProvenance}</div></div>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </>
+      )}
+      dtu={{
+        apiSource: 'concord-history-timeline-source',
+        title: (t, s) => `History analysis — ${t.totalEvents ?? 0} events · source ${s.reliabilityScore ?? '—'}/100`,
+        content: (t, s) => `Timeline (${t.timeSpan || '—'}):\n${(t.timeline || []).map((e) => `  ${e.date} — ${e.event} [${e.category}, ${e.significance}]`).join('\n')}\n\nPivotal: ${t.pivotalEvents?.map((p) => p.event).join(', ') || 'none'}\n\nSource evaluation:\n  Title: ${s.title}\n  Type: ${s.type} | Reliability: ${s.reliabilityScore}/100 (${s.classification})\n  Corroboration needed: ${s.corroborationNeeded ? 'yes' : 'no'}`,
+        tags: () => ['history', 'timeline', 'sources'],
+        rawData: (t, s) => ({ events, source, timeline: t, sourceResult: s }),
+      }}
+    />
   );
 }

--- a/concord-frontend/components/ocean/WaveEcosystemPanel.tsx
+++ b/concord-frontend/components/ocean/WaveEcosystemPanel.tsx
@@ -1,39 +1,21 @@
 'use client';
 
 /**
- * WaveEcosystemPanel — bespoke wave + marine ecosystem analyzer
- * for the ocean lens. Wires ocean.waveAnalysis + ocean.marineEcosystem.
+ * WaveEcosystemPanel — wave + marine ecosystem analyzer for the
+ * ocean lens. Wires ocean.waveAnalysis + ocean.marineEcosystem.
  *
- *   • Wave: height/period/wind → wavelength, speed, energy density,
- *     Beaufort scale, sea state, navigation advisory
- *   • Ecosystem: editable species rows (name/trophic/threatened/invasive)
- *     → Shannon diversity index, trophic distribution, health, counts
- *   • Save-as-DTU captures inputs + both reports
+ * Refactored to use `CalcPanel` primitive. See
+ * `concord-frontend/components/lens-primitives/CalcPanel.tsx`.
  */
 
 import { useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
-import { Waves, Fish, Loader2, Plus, Trash2 } from 'lucide-react';
-import { apiHelpers } from '@/lib/api/client';
-import { SaveAsDtuButton } from '@/components/dtu/SaveAsDtuButton';
+import { Waves, Fish, Plus, Trash2 } from 'lucide-react';
+import { CalcPanel } from '@/components/lens-primitives/CalcPanel';
 
 interface WaveInput { waveHeightMeters: number; wavePeriodSeconds: number; windSpeedKnots: number }
 interface Species { name: string; trophicLevel: 'primary' | 'secondary' | 'tertiary' | 'apex'; threatened: boolean; invasive: boolean }
 interface WaveResult { significantWaveHeight?: string; period?: string; wavelength?: string; speed?: string; energyDensity?: string; beaufortScale?: number; seaState?: string; navigationAdvisory?: string }
 interface EcoResult { speciesCount?: number; trophicLevels?: Record<string, number>; shannonDiversityIndex?: number; ecosystemHealth?: string; threatened?: number; invasive?: number }
-
-async function callOcean<T>(action: string, input: Record<string, unknown>): Promise<T | null> {
-  try {
-    const r = await apiHelpers.lens.runDomain('ocean', action, { input });
-    const env = (r as { data?: { ok: boolean; result?: T } }).data;
-    if (!env?.ok) return null;
-    const result = env.result as unknown as { ok?: boolean; result?: T } | T;
-    if (result && typeof result === 'object' && 'ok' in result && 'result' in result) {
-      return (result as { result: T }).result;
-    }
-    return env.result as T;
-  } catch { return null; }
-}
 
 const TROPHIC_LEVELS = ['primary', 'secondary', 'tertiary', 'apex'] as const;
 
@@ -47,145 +29,127 @@ const DEFAULT_SPECIES: Species[] = [
   { name: 'Lionfish (Atlantic)', trophicLevel: 'tertiary', threatened: false, invasive: true },
 ];
 
+const healthColour = (h?: string) => {
+  if (h === 'thriving') return 'text-emerald-200';
+  if (h === 'moderate') return 'text-sky-200';
+  if (h === 'stressed') return 'text-amber-200';
+  if (h === 'critical') return 'text-rose-200';
+  return 'text-zinc-400';
+};
+
 export function WaveEcosystemPanel() {
   const [wave, setWave] = useState<WaveInput>({ waveHeightMeters: 2.5, wavePeriodSeconds: 9, windSpeedKnots: 22 });
   const [species, setSpecies] = useState<Species[]>(DEFAULT_SPECIES);
-  const [waveResult, setWaveResult] = useState<WaveResult | null>(null);
-  const [ecoResult, setEcoResult] = useState<EcoResult | null>(null);
-
-  const analyze = useMutation({
-    mutationFn: async () => {
-      const sp = species.filter((s) => s.name.trim());
-      const [w, e] = await Promise.all([
-        callOcean<WaveResult>('waveAnalysis', { artifact: { data: wave } }),
-        callOcean<EcoResult>('marineEcosystem', { artifact: { data: { species: sp } } }),
-      ]);
-      setWaveResult(w);
-      setEcoResult(e);
-      return { w, e };
-    },
-  });
 
   const addSpecies = () => setSpecies((ss) => [...ss, { name: '', trophicLevel: 'primary', threatened: false, invasive: false }]);
   const updateSpecies = <K extends keyof Species>(i: number, key: K, value: Species[K]) =>
     setSpecies((ss) => ss.map((s, idx) => (idx === i ? { ...s, [key]: value } : s)));
   const removeSpecies = (i: number) => setSpecies((ss) => ss.filter((_, idx) => idx !== i));
 
-  const healthColour = (h?: string) => {
-    if (h === 'thriving') return 'text-emerald-200';
-    if (h === 'moderate') return 'text-sky-200';
-    if (h === 'stressed') return 'text-amber-200';
-    if (h === 'critical') return 'text-rose-200';
-    return 'text-zinc-400';
-  };
-
   return (
-    <div className="space-y-4">
-      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-cyan-500/15 pb-3">
-        <div className="flex items-center gap-2">
-          <Waves className="h-5 w-5 text-cyan-400" />
-          <h2 className="text-sm font-semibold text-white">Wave + ecosystem analyzer</h2>
-          <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">ocean.waveAnalysis + marineEcosystem</span>
-        </div>
-        {(waveResult || ecoResult) && (
-          <SaveAsDtuButton
-            compact
-            apiSource="concord-ocean-wave-ecosystem"
-            title={`Ocean — ${waveResult?.seaState ?? '—'} seas · ${ecoResult?.speciesCount ?? 0} species`}
-            content={`Wave conditions:\n  Sig. height: ${waveResult?.significantWaveHeight}\n  Period: ${waveResult?.period} | Wavelength: ${waveResult?.wavelength}\n  Speed: ${waveResult?.speed} | Energy: ${waveResult?.energyDensity}\n  Beaufort: ${waveResult?.beaufortScale} | Sea state: ${waveResult?.seaState}\n  Advisory: ${waveResult?.navigationAdvisory}\n\nEcosystem:\n  Species: ${ecoResult?.speciesCount} (Shannon ${ecoResult?.shannonDiversityIndex})\n  Health: ${ecoResult?.ecosystemHealth}\n  Threatened: ${ecoResult?.threatened} | Invasive: ${ecoResult?.invasive}\n  Trophic:\n${Object.entries(ecoResult?.trophicLevels || {}).map(([k, v]) => `    ${k}: ${v}`).join('\n')}`}
-            extraTags={['ocean', 'wave', 'ecosystem']}
-            rawData={{ wave, species, waveResult, ecoResult }}
-          />
-        )}
-      </header>
-
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        <div className="space-y-2 rounded-lg border border-zinc-800 bg-zinc-950/40 p-3">
-          <div className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Waves className="h-3 w-3" />Wave inputs</div>
-          <div className="grid grid-cols-3 gap-2">
-            <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Height (m)</span>
-              <input type="number" step={0.1} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={wave.waveHeightMeters} onChange={(e) => setWave({ ...wave, waveHeightMeters: Number(e.target.value) || 0 })} /></label>
-            <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Period (s)</span>
-              <input type="number" step={0.5} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={wave.wavePeriodSeconds} onChange={(e) => setWave({ ...wave, wavePeriodSeconds: Number(e.target.value) || 0 })} /></label>
-            <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Wind (kt)</span>
-              <input type="number" className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={wave.windSpeedKnots} onChange={(e) => setWave({ ...wave, windSpeedKnots: Number(e.target.value) || 0 })} /></label>
-          </div>
-        </div>
-
-        <div className="space-y-2 rounded-lg border border-zinc-800 bg-zinc-950/40 p-3">
-          <div className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Fish className="h-3 w-3" />Species inventory</div>
-          <div className="max-h-48 space-y-1 overflow-y-auto pr-1">
-            {species.map((s, i) => (
-              <div key={i} className="grid grid-cols-[1fr_90px_55px_55px_30px] gap-1.5">
-                <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-[11px] text-white" placeholder="Species" value={s.name} onChange={(e) => updateSpecies(i, 'name', e.target.value)} />
-                <select className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-[11px] text-white" value={s.trophicLevel} onChange={(e) => updateSpecies(i, 'trophicLevel', e.target.value as Species['trophicLevel'])}>
-                  {TROPHIC_LEVELS.map((t) => <option key={t} value={t}>{t}</option>)}
-                </select>
-                <label className="flex items-center justify-center gap-1 rounded border border-zinc-800 bg-zinc-950 text-[10px] text-zinc-400"><input type="checkbox" checked={s.threatened} onChange={(e) => updateSpecies(i, 'threatened', e.target.checked)} />T</label>
-                <label className="flex items-center justify-center gap-1 rounded border border-zinc-800 bg-zinc-950 text-[10px] text-zinc-400"><input type="checkbox" checked={s.invasive} onChange={(e) => updateSpecies(i, 'invasive', e.target.checked)} />I</label>
-                <button type="button" onClick={() => removeSpecies(i)} className="rounded border border-zinc-800 text-xs text-zinc-500 hover:text-rose-300" aria-label="Remove"><Trash2 className="mx-auto h-3 w-3" /></button>
-              </div>
-            ))}
-          </div>
-          <button type="button" onClick={addSpecies} className="inline-flex items-center gap-1 rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-zinc-300 hover:border-cyan-500/40 hover:text-cyan-200"><Plus className="h-3 w-3" />Add species</button>
-        </div>
-      </div>
-
-      <button type="button" onClick={() => analyze.mutate()} disabled={analyze.isPending} className="inline-flex items-center gap-1 rounded border border-cyan-500/40 bg-cyan-500/15 px-3 py-1.5 text-xs font-mono text-cyan-200 hover:bg-cyan-500/25 disabled:opacity-50">
-        {analyze.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Waves className="h-3.5 w-3.5" />}
-        Analyze
-      </button>
-
-      {analyze.isError && <div className="rounded border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-300">Analysis failed.</div>}
-
-      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-        <div className="rounded-lg border border-cyan-500/20 bg-cyan-500/5 p-3">
-          <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Waves className="h-3 w-3" />Sea conditions</div>
-          {!waveResult && <div className="text-[11px] text-zinc-500">Analyze to compute.</div>}
-          {waveResult && (
-            <div className="space-y-2 text-[11px]">
-              <div className="flex items-center gap-2">
-                <span className={`inline-block rounded px-2 py-0.5 text-[10px] font-mono ${waveResult.seaState === 'rough' || waveResult.seaState === 'very-rough' ? 'bg-rose-500/20 text-rose-200' : waveResult.seaState === 'moderate' ? 'bg-amber-500/20 text-amber-200' : 'bg-emerald-500/20 text-emerald-200'}`}>{waveResult.seaState}</span>
-                <span className="font-mono text-cyan-200">B{waveResult.beaufortScale}</span>
-              </div>
-              <div className="grid grid-cols-2 gap-1.5">
-                <div className="rounded border border-cyan-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Wavelength</div><div className="font-mono text-cyan-200">{waveResult.wavelength}</div></div>
-                <div className="rounded border border-cyan-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Speed</div><div className="font-mono text-cyan-200">{waveResult.speed}</div></div>
-                <div className="rounded border border-cyan-500/15 bg-zinc-950/40 px-2 py-1 col-span-2"><div className="text-[9px] text-zinc-500">Energy density</div><div className="font-mono text-cyan-200">{waveResult.energyDensity}</div></div>
-              </div>
-              <div className={`rounded border px-2 py-1 ${waveResult.navigationAdvisory?.includes('advisory') ? 'border-rose-500/30 bg-rose-500/10 text-rose-200' : 'border-emerald-500/20 bg-emerald-500/5 text-emerald-200'}`}>{waveResult.navigationAdvisory}</div>
+    <CalcPanel<WaveResult, EcoResult>
+      title="Wave + ecosystem analyzer"
+      domain="ocean"
+      icon={<Waves className="h-5 w-5 text-cyan-400" />}
+      macroBadge="ocean.waveAnalysis + marineEcosystem"
+      accent="cyan"
+      left={{
+        macro: 'waveAnalysis',
+        buildArtifact: () => ({ data: wave }),
+        render: (
+          <div className="space-y-2 rounded-lg border border-zinc-800 bg-zinc-950/40 p-3">
+            <div className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Waves className="h-3 w-3" />Wave inputs</div>
+            <div className="grid grid-cols-3 gap-2">
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Height (m)</span>
+                <input type="number" step={0.1} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={wave.waveHeightMeters} onChange={(e) => setWave({ ...wave, waveHeightMeters: Number(e.target.value) || 0 })} /></label>
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Period (s)</span>
+                <input type="number" step={0.5} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={wave.wavePeriodSeconds} onChange={(e) => setWave({ ...wave, wavePeriodSeconds: Number(e.target.value) || 0 })} /></label>
+              <label className="block"><span className="block text-[9px] uppercase tracking-wider text-zinc-500">Wind (kt)</span>
+                <input type="number" className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-white font-mono" value={wave.windSpeedKnots} onChange={(e) => setWave({ ...wave, windSpeedKnots: Number(e.target.value) || 0 })} /></label>
             </div>
-          )}
-        </div>
-        <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3">
-          <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Fish className="h-3 w-3" />Ecosystem health</div>
-          {!ecoResult && <div className="text-[11px] text-zinc-500">Analyze to score.</div>}
-          {ecoResult && (
-            <div className="space-y-2 text-[11px]">
-              <div className="flex items-baseline gap-2">
-                <span className={`font-mono text-2xl ${healthColour(ecoResult.ecosystemHealth)}`}>{ecoResult.ecosystemHealth}</span>
-                <span className="text-zinc-500">· Shannon {ecoResult.shannonDiversityIndex}</span>
-              </div>
-              <div className="grid grid-cols-3 gap-1.5">
-                <div className="rounded border border-emerald-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Species</div><div className="font-mono text-emerald-200">{ecoResult.speciesCount}</div></div>
-                <div className="rounded border border-amber-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Threatened</div><div className="font-mono text-amber-200">{ecoResult.threatened}</div></div>
-                <div className="rounded border border-rose-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Invasive</div><div className="font-mono text-rose-200">{ecoResult.invasive}</div></div>
-              </div>
-              {ecoResult.trophicLevels && (
-                <div className="space-y-0.5">
-                  <div className="text-[9px] uppercase text-zinc-500">Trophic levels</div>
-                  {Object.entries(ecoResult.trophicLevels).map(([k, v]) => (
-                    <div key={k} className="flex items-center justify-between rounded border border-zinc-800 bg-zinc-950/40 px-2 py-0.5">
-                      <span className="text-zinc-300 capitalize">{k}</span>
-                      <span className="font-mono text-emerald-200">{v}</span>
-                    </div>
-                  ))}
+          </div>
+        ),
+      }}
+      right={{
+        macro: 'marineEcosystem',
+        buildArtifact: () => ({ data: { species: species.filter((s) => s.name.trim()) } }),
+        render: (
+          <div className="space-y-2 rounded-lg border border-zinc-800 bg-zinc-950/40 p-3">
+            <div className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Fish className="h-3 w-3" />Species inventory</div>
+            <div className="max-h-48 space-y-1 overflow-y-auto pr-1">
+              {species.map((s, i) => (
+                <div key={i} className="grid grid-cols-[1fr_90px_55px_55px_30px] gap-1.5">
+                  <input className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-[11px] text-white" placeholder="Species" value={s.name} onChange={(e) => updateSpecies(i, 'name', e.target.value)} />
+                  <select className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-1 text-[11px] text-white" value={s.trophicLevel} onChange={(e) => updateSpecies(i, 'trophicLevel', e.target.value as Species['trophicLevel'])}>
+                    {TROPHIC_LEVELS.map((t) => <option key={t} value={t}>{t}</option>)}
+                  </select>
+                  <label className="flex items-center justify-center gap-1 rounded border border-zinc-800 bg-zinc-950 text-[10px] text-zinc-400"><input type="checkbox" checked={s.threatened} onChange={(e) => updateSpecies(i, 'threatened', e.target.checked)} />T</label>
+                  <label className="flex items-center justify-center gap-1 rounded border border-zinc-800 bg-zinc-950 text-[10px] text-zinc-400"><input type="checkbox" checked={s.invasive} onChange={(e) => updateSpecies(i, 'invasive', e.target.checked)} />I</label>
+                  <button type="button" onClick={() => removeSpecies(i)} className="rounded border border-zinc-800 text-xs text-zinc-500 hover:text-rose-300" aria-label="Remove"><Trash2 className="mx-auto h-3 w-3" /></button>
                 </div>
-              )}
+              ))}
             </div>
-          )}
-        </div>
-      </div>
-    </div>
+            <button type="button" onClick={addSpecies} className="inline-flex items-center gap-1 rounded border border-zinc-800 bg-zinc-950 px-2 py-1 text-xs text-zinc-300 hover:border-cyan-500/40 hover:text-cyan-200"><Plus className="h-3 w-3" />Add species</button>
+          </div>
+        ),
+      }}
+      renderResults={(waveResult, ecoResult) => (
+        <>
+          <div className="rounded-lg border border-cyan-500/20 bg-cyan-500/5 p-3">
+            <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Waves className="h-3 w-3" />Sea conditions</div>
+            {!waveResult && <div className="text-[11px] text-zinc-500">Analyze to compute.</div>}
+            {waveResult && (
+              <div className="space-y-2 text-[11px]">
+                <div className="flex items-center gap-2">
+                  <span className={`inline-block rounded px-2 py-0.5 text-[10px] font-mono ${waveResult.seaState === 'rough' || waveResult.seaState === 'very-rough' ? 'bg-rose-500/20 text-rose-200' : waveResult.seaState === 'moderate' ? 'bg-amber-500/20 text-amber-200' : 'bg-emerald-500/20 text-emerald-200'}`}>{waveResult.seaState}</span>
+                  <span className="font-mono text-cyan-200">B{waveResult.beaufortScale}</span>
+                </div>
+                <div className="grid grid-cols-2 gap-1.5">
+                  <div className="rounded border border-cyan-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Wavelength</div><div className="font-mono text-cyan-200">{waveResult.wavelength}</div></div>
+                  <div className="rounded border border-cyan-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Speed</div><div className="font-mono text-cyan-200">{waveResult.speed}</div></div>
+                  <div className="rounded border border-cyan-500/15 bg-zinc-950/40 px-2 py-1 col-span-2"><div className="text-[9px] text-zinc-500">Energy density</div><div className="font-mono text-cyan-200">{waveResult.energyDensity}</div></div>
+                </div>
+                <div className={`rounded border px-2 py-1 ${waveResult.navigationAdvisory?.includes('advisory') ? 'border-rose-500/30 bg-rose-500/10 text-rose-200' : 'border-emerald-500/20 bg-emerald-500/5 text-emerald-200'}`}>{waveResult.navigationAdvisory}</div>
+              </div>
+            )}
+          </div>
+          <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3">
+            <div className="mb-2 flex items-center gap-1 text-[10px] uppercase tracking-wider text-zinc-500"><Fish className="h-3 w-3" />Ecosystem health</div>
+            {!ecoResult && <div className="text-[11px] text-zinc-500">Analyze to score.</div>}
+            {ecoResult && (
+              <div className="space-y-2 text-[11px]">
+                <div className="flex items-baseline gap-2">
+                  <span className={`font-mono text-2xl ${healthColour(ecoResult.ecosystemHealth)}`}>{ecoResult.ecosystemHealth}</span>
+                  <span className="text-zinc-500">· Shannon {ecoResult.shannonDiversityIndex}</span>
+                </div>
+                <div className="grid grid-cols-3 gap-1.5">
+                  <div className="rounded border border-emerald-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Species</div><div className="font-mono text-emerald-200">{ecoResult.speciesCount}</div></div>
+                  <div className="rounded border border-amber-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Threatened</div><div className="font-mono text-amber-200">{ecoResult.threatened}</div></div>
+                  <div className="rounded border border-rose-500/15 bg-zinc-950/40 px-2 py-1"><div className="text-[9px] text-zinc-500">Invasive</div><div className="font-mono text-rose-200">{ecoResult.invasive}</div></div>
+                </div>
+                {ecoResult.trophicLevels && (
+                  <div className="space-y-0.5">
+                    <div className="text-[9px] uppercase text-zinc-500">Trophic levels</div>
+                    {Object.entries(ecoResult.trophicLevels).map(([k, v]) => (
+                      <div key={k} className="flex items-center justify-between rounded border border-zinc-800 bg-zinc-950/40 px-2 py-0.5">
+                        <span className="text-zinc-300 capitalize">{k}</span>
+                        <span className="font-mono text-emerald-200">{v}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </>
+      )}
+      dtu={{
+        apiSource: 'concord-ocean-wave-ecosystem',
+        title: (w, e) => `Ocean — ${w.seaState ?? '—'} seas · ${e.speciesCount ?? 0} species`,
+        content: (w, e) => `Wave conditions:\n  Sig. height: ${w.significantWaveHeight}\n  Period: ${w.period} | Wavelength: ${w.wavelength}\n  Speed: ${w.speed} | Energy: ${w.energyDensity}\n  Beaufort: ${w.beaufortScale} | Sea state: ${w.seaState}\n  Advisory: ${w.navigationAdvisory}\n\nEcosystem:\n  Species: ${e.speciesCount} (Shannon ${e.shannonDiversityIndex})\n  Health: ${e.ecosystemHealth}\n  Threatened: ${e.threatened} | Invasive: ${e.invasive}\n  Trophic:\n${Object.entries(e.trophicLevels || {}).map(([k, v]) => `    ${k}: ${v}`).join('\n')}`,
+        tags: () => ['ocean', 'wave', 'ecosystem'],
+        rawData: (w, e) => ({ wave, species, waveResult: w, ecoResult: e }),
+      }}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- `ocean/WaveEcosystemPanel`, `history/TimelineSourceTools`, `environment/ComplianceDiversionPanel` refactored onto the `CalcPanel` primitive landed in PR #737.
- Combined with the first three (materials/energy/automotive), CalcPanel now has 6 production consumers — well past the "3+ instances" extraction threshold.

## Math
- This PR: -102 LOC (449 → 347 across the 3 refactored components)
- Combined with PR #737: -214 LOC across 6 consumers vs +190 LOC for the primitive = **net -24 LOC overall**, with each future calc-shape panel dropping ~140 LOC of bespoke shell.

## Behavior
Unchanged: same macros, same artifact shapes, same DTU payloads, same default seed data.

## Plan reference
Per `/root/.claude/plans/well-let-s-make-it-stateless-comet.md` Phase 1 validation continuation.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on all 3 files
- [ ] Manual: open ocean/history/environment lens pages; verify panels render and Analyze still produces correct results.

https://claude.ai/code/session_01WfDATSALRXGNnSkLKb4U9j

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfDATSALRXGNnSkLKb4U9j)_