### PR TITLE
pets: real-data retrofit (no seeds, real PetProfile/Activity/Health)

### DIFF
--- a/concord-frontend/components/pets/ActivityWeightDashboard.tsx
+++ b/concord-frontend/components/pets/ActivityWeightDashboard.tsx
@@ -1,24 +1,36 @@
 'use client';
 
 /**
- * ActivityWeightDashboard — PetDesk / Apple-Health-style pet wellness
- * dashboard. Patterned on PetDesk's pet-profile + Apple Activity's
- * concentric rings: hero with pet name + species emoji, a single
- * circular progress ring for weekly activity vs target, a weight
- * trend mini-chart with ideal-range band, and an activity log feed.
+ * ActivityWeightDashboard — PetDesk / Apple-Health-style wellness
+ * dashboard. Pulls the user's REAL data:
  *
- * Backend (no changes): pets.activityScore + pets.weightTracker — both
- * already exist; this is pure UI wiring.
+ *   • `useLensData<PetArtifact>('pets', 'PetProfile')` — list of the
+ *     user's actual pets; the panel picks the active one via a selector
+ *   • `useLensData<PetArtifact>('pets', 'ActivityLog')` — real walks /
+ *     play sessions logged through the lens
+ *   • `useLensData<PetArtifact>('pets', 'HealthRecord')` — real weigh-ins
+ *
+ * No seed defaults. Empty state nudges the user to create their first
+ * pet via the existing lens CRUD editor (kept as the create surface so
+ * this panel stays read-mostly + analyze).
+ *
+ * Backend (no changes): pets.activityScore + pets.weightTracker
+ * macros for the metrics; substrate `useLensData` for the records.
  */
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
-import { Heart, Plus, Trash2, Loader2, TrendingUp, TrendingDown, Minus, Activity } from 'lucide-react';
+import { Heart, Loader2, TrendingUp, TrendingDown, Minus, Activity, PawPrint } from 'lucide-react';
 import { apiHelpers } from '@/lib/api/client';
+import { useLensData, type LensItem } from '@/lib/hooks/use-lens-data';
 import { SaveAsDtuButton } from '@/components/dtu/SaveAsDtuButton';
 
-interface ActivityEntry { date: string; duration: string; type: string }
-interface WeightEntry { date: string; weight: string }
+interface PetArtifact {
+  name?: string; species?: string; age?: number; weight?: number;
+  petName?: string; type?: string;
+  date?: string; duration?: number; activityType?: string;
+  vaccineDate?: string;
+}
 
 interface ActivityResult { dailyTarget?: number; dailyAvg?: number; weeklyTotal?: number; score?: number; rating?: string; activityCount?: number; typeBreakdown?: Record<string, number>; recommendation?: string }
 interface WeightResult { currentWeight?: number; idealRange?: { min: number; max: number; note: string }; status?: string; trend?: string; weeklyChangeLbs?: number; historyPoints?: number; alert?: string }
@@ -36,50 +48,23 @@ async function callPets<T>(action: string, artifact: Record<string, unknown>): P
   } catch { return null; }
 }
 
-const today = new Date();
-const dayOffset = (n: number) => new Date(today.getTime() - n * 86400000).toISOString().slice(0, 10);
+const SPECIES_EMOJI: Record<string, string> = { Dog: '🐕', Cat: '🐈', Rabbit: '🐇', Bird: '🦜', Hamster: '🐹', Fish: '🐟' };
 
-const SPECIES_EMOJI: Record<string, string> = { dog: '🐕', cat: '🐈', rabbit: '🐇', bird: '🦜', hamster: '🐹', fish: '🐟' };
-const ACTIVITY_TYPES = ['walk', 'play', 'training', 'swim', 'fetch'];
-
-const DEFAULT_ACTIVITIES: ActivityEntry[] = [
-  { date: dayOffset(0), duration: '45', type: 'walk' },
-  { date: dayOffset(1), duration: '30', type: 'play' },
-  { date: dayOffset(2), duration: '60', type: 'walk' },
-  { date: dayOffset(3), duration: '20', type: 'training' },
-  { date: dayOffset(4), duration: '50', type: 'walk' },
-  { date: dayOffset(5), duration: '35', type: 'play' },
-  { date: dayOffset(6), duration: '55', type: 'walk' },
-];
-
-const DEFAULT_WEIGHT: WeightEntry[] = [
-  { date: dayOffset(30), weight: '21.5' },
-  { date: dayOffset(20), weight: '21.8' },
-  { date: dayOffset(14), weight: '22.0' },
-  { date: dayOffset(7), weight: '22.2' },
-  { date: dayOffset(0), weight: '22.0' },
-];
-
-function Ring({ percent, size = 140, stroke = 12, colour = '#22d3ee' }: { percent: number; size?: number; stroke?: number; colour?: string }) {
+function Ring({ percent, size = 140, stroke = 12, colour }: { percent: number; size?: number; stroke?: number; colour: string }) {
   const radius = (size - stroke) / 2;
   const circumference = 2 * Math.PI * radius;
   const offset = circumference - (Math.min(100, percent) / 100) * circumference;
   return (
     <svg width={size} height={size} className="-rotate-90">
       <circle cx={size / 2} cy={size / 2} r={radius} stroke="rgba(63, 63, 70, 0.5)" strokeWidth={stroke} fill="none" />
-      <circle
-        cx={size / 2} cy={size / 2} r={radius}
-        stroke={colour} strokeWidth={stroke} fill="none"
-        strokeDasharray={circumference} strokeDashoffset={offset}
-        strokeLinecap="round"
-      />
+      <circle cx={size / 2} cy={size / 2} r={radius} stroke={colour} strokeWidth={stroke} fill="none" strokeDasharray={circumference} strokeDashoffset={offset} strokeLinecap="round" />
     </svg>
   );
 }
 
-function WeightChart({ history, ideal }: { history: WeightEntry[]; ideal?: { min: number; max: number } }) {
-  const values = history.map((h) => parseFloat(h.weight) || 0).filter((v) => v > 0);
-  if (values.length < 2) return <div className="text-[10px] text-zinc-500">Need 2+ weight readings for chart.</div>;
+function WeightChart({ history, ideal }: { history: Array<{ date: string; weight: number }>; ideal?: { min: number; max: number } }) {
+  if (history.length < 2) return <div className="text-[10px] text-zinc-500">Need 2+ weigh-ins (HealthRecord with weight) for chart.</div>;
+  const values = history.map((h) => h.weight);
   const min = Math.min(...values, ideal?.min || values[0]);
   const max = Math.max(...values, ideal?.max || values[0]);
   const range = max - min || 1;
@@ -103,22 +88,50 @@ function WeightChart({ history, ideal }: { history: WeightEntry[]; ideal?: { min
 }
 
 export function ActivityWeightDashboard() {
-  const [petName, setPetName] = useState('Biscuit');
-  const [species, setSpecies] = useState<'dog' | 'cat' | 'rabbit' | 'bird' | 'hamster'>('dog');
-  const [age, setAge] = useState(3);
-  const [activities, setActivities] = useState<ActivityEntry[]>(DEFAULT_ACTIVITIES);
-  const [weightHistory, setWeightHistory] = useState<WeightEntry[]>(DEFAULT_WEIGHT);
+  const { items: pets, isLoading: petsLoading } = useLensData<PetArtifact>('pets', 'PetProfile', { seed: [] });
+  const { items: activityLogs } = useLensData<PetArtifact>('pets', 'ActivityLog', { seed: [] });
+  const { items: healthRecords } = useLensData<PetArtifact>('pets', 'HealthRecord', { seed: [] });
+
+  const [selectedPetId, setSelectedPetId] = useState<string | null>(null);
   const [activity, setActivity] = useState<ActivityResult | null>(null);
   const [weight, setWeight] = useState<WeightResult | null>(null);
 
-  const refresh = useMutation({
+  const activePet: LensItem<PetArtifact> | null = useMemo(() => {
+    if (!pets.length) return null;
+    return pets.find((p) => p.id === selectedPetId) || pets[0];
+  }, [pets, selectedPetId]);
+
+  // Filter activity logs + health records to the active pet (by petName field on the artifact)
+  const petActivities = useMemo(() => {
+    if (!activePet) return [];
+    const name = activePet.data.name || activePet.title;
+    return activityLogs.filter((a) => (a.data.petName || '').toLowerCase() === (name || '').toLowerCase());
+  }, [activePet, activityLogs]);
+
+  const petWeights = useMemo(() => {
+    if (!activePet) return [];
+    const name = activePet.data.name || activePet.title;
+    return healthRecords
+      .filter((h) => (h.data.petName || '').toLowerCase() === (name || '').toLowerCase() && typeof h.data.weight === 'number')
+      .map((h) => ({ date: h.data.vaccineDate || h.createdAt.slice(0, 10), weight: h.data.weight as number }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+  }, [activePet, healthRecords]);
+
+  const analyze = useMutation({
     mutationFn: async () => {
-      const cleanActs = activities.filter((a) => a.duration && a.date).map((a) => ({ date: a.date, duration: parseFloat(a.duration) || 0, type: a.type }));
-      const cleanWeight = weightHistory.filter((w) => w.weight && w.date).map((w) => ({ date: w.date, weight: parseFloat(w.weight) || 0 }));
-      const current = cleanWeight[cleanWeight.length - 1]?.weight || 22;
+      if (!activePet) return null;
+      const d = activePet.data;
+      const acts = petActivities.map((a) => ({
+        date: a.data.date || a.createdAt.slice(0, 10),
+        duration: a.data.duration || 0,
+        type: a.data.activityType || 'walk',
+      }));
+      const weightHistory = petWeights.map((w) => ({ date: w.date, weight: w.weight }));
+      const currentWeight = weightHistory[weightHistory.length - 1]?.weight ?? d.weight ?? 0;
+      const species = (d.species || 'dog').toLowerCase();
       const [a, w] = await Promise.all([
-        callPets<ActivityResult>('activityScore', { data: { species, age, weight: current, activities: cleanActs } }),
-        callPets<WeightResult>('weightTracker', { data: { species, weight: current, weightHistory: cleanWeight } }),
+        callPets<ActivityResult>('activityScore', { data: { species, age: d.age ?? 3, weight: currentWeight, activities: acts } }),
+        callPets<WeightResult>('weightTracker', { data: { species, weight: currentWeight, weightHistory } }),
       ]);
       setActivity(a);
       setWeight(w);
@@ -126,146 +139,129 @@ export function ActivityWeightDashboard() {
     },
   });
 
-  const addActivity = () => setActivities((as) => [...as, { date: dayOffset(0), duration: '', type: 'walk' }]);
-  const updateActivity = <K extends keyof ActivityEntry>(i: number, key: K, value: ActivityEntry[K]) =>
-    setActivities((as) => as.map((a, idx) => (idx === i ? { ...a, [key]: value } : a)));
-  const removeActivity = (i: number) => setActivities((as) => as.filter((_, idx) => idx !== i));
-
-  const addWeight = () => setWeightHistory((ws) => [...ws, { date: dayOffset(0), weight: '' }]);
-  const updateWeight = (i: number, key: keyof WeightEntry, value: string) =>
-    setWeightHistory((ws) => ws.map((w, idx) => (idx === i ? { ...w, [key]: value } : w)));
-  const removeWeight = (i: number) => setWeightHistory((ws) => ws.filter((_, idx) => idx !== i));
-
   const ringColour = activity?.score && activity.score >= 80 ? '#22c55e' : activity?.score && activity.score >= 50 ? '#eab308' : '#ef4444';
   const trendIcon = weight?.trend === 'gaining' ? <TrendingUp className="h-4 w-4 text-amber-400" /> : weight?.trend === 'losing' ? <TrendingDown className="h-4 w-4 text-blue-400" /> : <Minus className="h-4 w-4 text-zinc-400" />;
 
+  // Empty state: no pets yet
+  if (!petsLoading && pets.length === 0) {
+    return (
+      <div className="overflow-hidden rounded-xl border border-zinc-800 bg-zinc-950 p-8 text-center">
+        <PawPrint className="mx-auto h-8 w-8 text-zinc-600" />
+        <div className="mt-3 text-sm text-zinc-300">No pets in your library yet.</div>
+        <div className="mt-1 text-xs text-zinc-500">Add a PetProfile via the lens's "New" button above. Once you have a pet plus some ActivityLog and HealthRecord entries, this dashboard will surface your real wellness data.</div>
+      </div>
+    );
+  }
+
+  if (petsLoading) {
+    return <div className="flex items-center gap-2 rounded-xl border border-zinc-800 bg-zinc-950 p-6 text-xs text-zinc-500"><Loader2 className="h-4 w-4 animate-spin" />Loading your pets…</div>;
+  }
+
+  const d = activePet?.data || {};
+  const speciesKey = (d.species || 'Dog');
+
   return (
     <div className="overflow-hidden rounded-xl border border-zinc-800 bg-gradient-to-br from-zinc-900 via-zinc-950 to-zinc-900">
-      {/* PetDesk-style hero card */}
-      <div className="flex items-center gap-4 border-b border-zinc-800 bg-zinc-900/40 p-4">
+      <div className="flex flex-wrap items-center gap-4 border-b border-zinc-800 bg-zinc-900/40 p-4">
         <div className="grid h-16 w-16 place-items-center rounded-full bg-gradient-to-br from-rose-500/30 to-amber-500/30 text-3xl">
-          {SPECIES_EMOJI[species]}
+          {SPECIES_EMOJI[speciesKey] || '🐾'}
         </div>
         <div className="flex-1 space-y-1">
-          <input
-            className="block w-full rounded border border-transparent bg-transparent text-xl font-semibold text-white hover:border-zinc-700 focus:border-rose-500/40 focus:outline-none"
-            value={petName}
-            onChange={(e) => setPetName(e.target.value)}
-          />
-          <div className="flex items-center gap-2 text-xs text-zinc-400">
-            <select value={species} onChange={(e) => setSpecies(e.target.value as typeof species)} className="rounded border border-zinc-800 bg-zinc-950 px-1.5 py-0.5 text-[11px]">
-              {(Object.keys(SPECIES_EMOJI) as Array<keyof typeof SPECIES_EMOJI>).map((s) => <option key={s} value={s}>{s}</option>)}
+          {pets.length > 1 ? (
+            <select value={activePet?.id || ''} onChange={(e) => setSelectedPetId(e.target.value)} className="rounded border border-zinc-700 bg-zinc-950 px-2 py-1 text-xl font-semibold text-white">
+              {pets.map((p) => <option key={p.id} value={p.id}>{p.data.name || p.title}</option>)}
             </select>
-            <span>·</span>
-            <label className="inline-flex items-center gap-1">
-              <input type="number" min={0} max={30} step={0.5} value={age} onChange={(e) => setAge(Math.max(0, Math.min(30, Number(e.target.value) || 3)))} className="w-12 rounded border border-zinc-800 bg-zinc-950 px-1 py-0.5 text-[11px] font-mono" />
-              <span>yr old</span>
-            </label>
-          </div>
+          ) : (
+            <div className="text-xl font-semibold text-white">{d.name || activePet?.title}</div>
+          )}
+          <div className="text-xs text-zinc-400">{d.species || 'Pet'} {d.age != null && `· ${d.age}y`} {d.weight != null && `· ${d.weight} lb`}</div>
         </div>
-        <button type="button" onClick={() => refresh.mutate()} disabled={refresh.isPending} className="rounded-full bg-rose-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-rose-400 disabled:opacity-50">
-          {refresh.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : 'Refresh'}
+        <button type="button" onClick={() => analyze.mutate()} disabled={analyze.isPending || !activePet} className="rounded-full bg-rose-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-rose-400 disabled:opacity-50">
+          {analyze.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : 'Compute wellness'}
         </button>
-        {(activity || weight) && (
+        {(activity || weight) && activePet && (
           <SaveAsDtuButton
             compact
             apiSource="concord-pets-petdesk-dashboard"
-            title={`${petName} (${species}, ${age}y) — activity ${activity?.score ?? '—'}/100 · weight ${weight?.currentWeight ?? '—'} lb ${weight?.trend ?? ''}`}
-            content={`Pet: ${petName} (${species}, ${age} years)\n\nActivity (last 7d):\n  Score: ${activity?.score}/100 (${activity?.rating})\n  Daily avg: ${activity?.dailyAvg} min / target ${activity?.dailyTarget} min\n  Weekly total: ${activity?.weeklyTotal} min across ${activity?.activityCount} sessions\n  ${activity?.recommendation}\n\nWeight:\n  Current: ${weight?.currentWeight} lb (ideal ${weight?.idealRange?.min}–${weight?.idealRange?.max})\n  Status: ${weight?.status} · Trend: ${weight?.trend} (${weight?.weeklyChangeLbs} lb/week)\n  ${weight?.alert || ''}`}
-            extraTags={['pets', species, 'wellness']}
-            rawData={{ petName, species, age, activities, weightHistory, activity, weight }}
+            title={`${d.name || activePet.title} (${d.species}, ${d.age}y) — activity ${activity?.score ?? '—'}/100 · weight ${weight?.currentWeight ?? '—'} lb ${weight?.trend ?? ''}`}
+            content={`Pet: ${d.name || activePet.title} (${d.species}, ${d.age} years)\n\nActivity (last 7d, from ${petActivities.length} ActivityLog records):\n  Score: ${activity?.score}/100 (${activity?.rating})\n  Daily avg: ${activity?.dailyAvg} min / target ${activity?.dailyTarget} min\n  Weekly total: ${activity?.weeklyTotal} min across ${activity?.activityCount} sessions\n  ${activity?.recommendation || ''}\n\nWeight (from ${petWeights.length} HealthRecord weigh-ins):\n  Current: ${weight?.currentWeight} lb (ideal ${weight?.idealRange?.min}–${weight?.idealRange?.max})\n  Status: ${weight?.status} · Trend: ${weight?.trend} (${weight?.weeklyChangeLbs} lb/week)\n  ${weight?.alert || ''}`}
+            extraTags={['pets', (d.species || '').toLowerCase(), 'wellness']}
+            rawData={{ petId: activePet.id, pet: d, activities: petActivities.map((a) => a.data), weights: petWeights, activity, weight }}
           />
         )}
       </div>
 
       <div className="grid gap-4 p-4 md:grid-cols-2">
-        {/* Activity ring — Apple Activity style */}
         <div className="space-y-3 rounded-lg border border-zinc-800 bg-zinc-900/40 p-4">
-          <div className="flex items-center gap-2 text-[11px] uppercase tracking-wider text-zinc-500"><Activity className="h-3 w-3" />Weekly activity</div>
-          <div className="flex items-center gap-4">
-            <div className="relative grid place-items-center">
-              <Ring percent={activity?.score ?? 0} colour={ringColour} />
-              <div className="absolute text-center">
-                <div className="font-mono text-3xl text-white">{activity?.score ?? '—'}</div>
-                <div className="text-[10px] uppercase tracking-wider text-zinc-500">score</div>
-              </div>
-            </div>
-            <div className="flex-1 space-y-1.5">
-              <div className="rounded border border-zinc-800 bg-zinc-950/40 px-2 py-1">
-                <div className="text-[9px] uppercase tracking-wider text-zinc-500">Daily avg</div>
-                <div className="font-mono text-sm text-rose-200">{activity?.dailyAvg ?? '—'} <span className="text-[10px] text-zinc-500">/ {activity?.dailyTarget ?? '—'} min target</span></div>
-              </div>
-              <div className="rounded border border-zinc-800 bg-zinc-950/40 px-2 py-1">
-                <div className="text-[9px] uppercase tracking-wider text-zinc-500">Week total</div>
-                <div className="font-mono text-sm text-rose-200">{activity?.weeklyTotal ?? '—'} min</div>
-              </div>
-            </div>
+          <div className="flex items-center justify-between text-[11px] uppercase tracking-wider text-zinc-500">
+            <span className="flex items-center gap-2"><Activity className="h-3 w-3" />Weekly activity</span>
+            <span className="text-[10px] text-zinc-500">{petActivities.length} logged</span>
           </div>
-          {activity?.typeBreakdown && Object.keys(activity.typeBreakdown).length > 0 && (
-            <div className="flex flex-wrap gap-1 pt-1">
-              {Object.entries(activity.typeBreakdown).map(([k, v]) => (
-                <span key={k} className="rounded-full bg-rose-500/10 px-2 py-0.5 text-[10px] text-rose-200">{k}: {v}</span>
-              ))}
-            </div>
-          )}
-          {activity?.recommendation && <div className="text-[11px] text-zinc-400">{activity.recommendation}</div>}
-
-          <div className="border-t border-zinc-800 pt-2">
-            <div className="mb-1.5 text-[10px] uppercase tracking-wider text-zinc-500">Log entries</div>
-            <div className="max-h-32 space-y-1 overflow-y-auto pr-1">
-              {activities.map((a, i) => (
-                <div key={i} className="grid grid-cols-[120px_70px_1fr_24px] gap-1">
-                  <input type="date" value={a.date} onChange={(e) => updateActivity(i, 'date', e.target.value)} className="rounded border border-zinc-800 bg-zinc-950 px-1 py-0.5 text-[10px] text-white font-mono" />
-                  <input type="number" min={0} value={a.duration} onChange={(e) => updateActivity(i, 'duration', e.target.value)} className="rounded border border-zinc-800 bg-zinc-950 px-1 py-0.5 text-[10px] text-white font-mono" placeholder="min" />
-                  <select value={a.type} onChange={(e) => updateActivity(i, 'type', e.target.value)} className="rounded border border-zinc-800 bg-zinc-950 px-1 py-0.5 text-[10px] text-white">
-                    {ACTIVITY_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
-                  </select>
-                  <button type="button" onClick={() => removeActivity(i)} className="text-zinc-600 hover:text-rose-300" aria-label="Remove"><Trash2 className="h-3 w-3" /></button>
+          {petActivities.length === 0 ? (
+            <div className="rounded border border-dashed border-zinc-800 p-4 text-center text-[11px] text-zinc-500">No ActivityLog entries for this pet yet. Log walks/play via the lens's "New" button.</div>
+          ) : (
+            <>
+              <div className="flex items-center gap-4">
+                <div className="relative grid place-items-center">
+                  <Ring percent={activity?.score ?? 0} colour={ringColour} />
+                  <div className="absolute text-center">
+                    <div className="font-mono text-3xl text-white">{activity?.score ?? '—'}</div>
+                    <div className="text-[10px] uppercase tracking-wider text-zinc-500">score</div>
+                  </div>
                 </div>
-              ))}
-            </div>
-            <button type="button" onClick={addActivity} className="mt-1 inline-flex items-center gap-1 text-[10px] text-zinc-500 hover:text-rose-300"><Plus className="h-3 w-3" />Log activity</button>
-          </div>
+                <div className="flex-1 space-y-1.5">
+                  <div className="rounded border border-zinc-800 bg-zinc-950/40 px-2 py-1">
+                    <div className="text-[9px] uppercase tracking-wider text-zinc-500">Daily avg</div>
+                    <div className="font-mono text-sm text-rose-200">{activity?.dailyAvg ?? '—'} <span className="text-[10px] text-zinc-500">/ {activity?.dailyTarget ?? '—'} min target</span></div>
+                  </div>
+                  <div className="rounded border border-zinc-800 bg-zinc-950/40 px-2 py-1">
+                    <div className="text-[9px] uppercase tracking-wider text-zinc-500">Week total</div>
+                    <div className="font-mono text-sm text-rose-200">{activity?.weeklyTotal ?? '—'} min</div>
+                  </div>
+                </div>
+              </div>
+              {activity?.typeBreakdown && Object.keys(activity.typeBreakdown).length > 0 && (
+                <div className="flex flex-wrap gap-1 pt-1">
+                  {Object.entries(activity.typeBreakdown).map(([k, v]) => (
+                    <span key={k} className="rounded-full bg-rose-500/10 px-2 py-0.5 text-[10px] text-rose-200">{k}: {v}</span>
+                  ))}
+                </div>
+              )}
+              {activity?.recommendation && <div className="text-[11px] text-zinc-400">{activity.recommendation}</div>}
+            </>
+          )}
         </div>
 
-        {/* Weight trend — Apple Health-style line chart with ideal band */}
         <div className="space-y-3 rounded-lg border border-zinc-800 bg-zinc-900/40 p-4">
-          <div className="flex items-center gap-2 text-[11px] uppercase tracking-wider text-zinc-500"><Heart className="h-3 w-3" />Weight trend</div>
-          <div className="flex items-center gap-3">
-            <div className="font-mono text-3xl text-white">{weight?.currentWeight ?? '—'} <span className="text-sm text-zinc-500">lb</span></div>
-            <div className="flex items-center gap-1 rounded-full border border-zinc-800 bg-zinc-950 px-2 py-0.5 text-[11px] text-zinc-300">{trendIcon}{weight?.trend ?? '—'}</div>
+          <div className="flex items-center justify-between text-[11px] uppercase tracking-wider text-zinc-500">
+            <span className="flex items-center gap-2"><Heart className="h-3 w-3" />Weight trend</span>
+            <span className="text-[10px] text-zinc-500">{petWeights.length} weigh-ins</span>
           </div>
-          {weight?.idealRange && (
-            <div className="text-[10px] text-zinc-500">Ideal range: <span className="text-emerald-300">{weight.idealRange.min}–{weight.idealRange.max} lb</span> · {weight.idealRange.note}</div>
-          )}
-          <div className="overflow-x-auto">
-            <WeightChart history={weightHistory} ideal={weight?.idealRange ? { min: weight.idealRange.min, max: weight.idealRange.max } : undefined} />
-          </div>
-          {weight?.weeklyChangeLbs != null && (
-            <div className="rounded border border-zinc-800 bg-zinc-950/40 px-2 py-1 text-[11px]">
-              <span className="text-zinc-500">Weekly change: </span>
-              <span className={`font-mono ${weight.weeklyChangeLbs > 0.3 ? 'text-amber-300' : weight.weeklyChangeLbs < -0.3 ? 'text-blue-300' : 'text-emerald-300'}`}>
-                {weight.weeklyChangeLbs > 0 ? '+' : ''}{weight.weeklyChangeLbs} lb
-              </span>
-            </div>
-          )}
-          {weight?.alert && (
-            <div className="rounded border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-[11px] text-amber-200">{weight.alert}</div>
-          )}
-
-          <div className="border-t border-zinc-800 pt-2">
-            <div className="mb-1.5 text-[10px] uppercase tracking-wider text-zinc-500">Weigh-ins</div>
-            <div className="max-h-32 space-y-1 overflow-y-auto pr-1">
-              {weightHistory.map((w, i) => (
-                <div key={i} className="grid grid-cols-[120px_90px_24px] gap-1">
-                  <input type="date" value={w.date} onChange={(e) => updateWeight(i, 'date', e.target.value)} className="rounded border border-zinc-800 bg-zinc-950 px-1 py-0.5 text-[10px] text-white font-mono" />
-                  <input type="number" step={0.1} value={w.weight} onChange={(e) => updateWeight(i, 'weight', e.target.value)} className="rounded border border-zinc-800 bg-zinc-950 px-1 py-0.5 text-[10px] text-white font-mono" placeholder="lb" />
-                  <button type="button" onClick={() => removeWeight(i)} className="text-zinc-600 hover:text-rose-300" aria-label="Remove"><Trash2 className="h-3 w-3" /></button>
+          {petWeights.length === 0 ? (
+            <div className="rounded border border-dashed border-zinc-800 p-4 text-center text-[11px] text-zinc-500">No HealthRecord weigh-ins for this pet yet. Add records with a weight field via the lens's "New" button.</div>
+          ) : (
+            <>
+              <div className="flex items-center gap-3">
+                <div className="font-mono text-3xl text-white">{weight?.currentWeight ?? petWeights[petWeights.length - 1]?.weight ?? '—'} <span className="text-sm text-zinc-500">lb</span></div>
+                {weight?.trend && <div className="flex items-center gap-1 rounded-full border border-zinc-800 bg-zinc-950 px-2 py-0.5 text-[11px] text-zinc-300">{trendIcon}{weight.trend}</div>}
+              </div>
+              {weight?.idealRange && (
+                <div className="text-[10px] text-zinc-500">Ideal range: <span className="text-emerald-300">{weight.idealRange.min}–{weight.idealRange.max} lb</span> · {weight.idealRange.note}</div>
+              )}
+              <div className="overflow-x-auto">
+                <WeightChart history={petWeights} ideal={weight?.idealRange ? { min: weight.idealRange.min, max: weight.idealRange.max } : undefined} />
+              </div>
+              {weight?.weeklyChangeLbs != null && (
+                <div className="rounded border border-zinc-800 bg-zinc-950/40 px-2 py-1 text-[11px]">
+                  <span className="text-zinc-500">Weekly change: </span>
+                  <span className={`font-mono ${weight.weeklyChangeLbs > 0.3 ? 'text-amber-300' : weight.weeklyChangeLbs < -0.3 ? 'text-blue-300' : 'text-emerald-300'}`}>
+                    {weight.weeklyChangeLbs > 0 ? '+' : ''}{weight.weeklyChangeLbs} lb
+                  </span>
                 </div>
-              ))}
-            </div>
-            <button type="button" onClick={addWeight} className="mt-1 inline-flex items-center gap-1 text-[10px] text-zinc-500 hover:text-rose-300"><Plus className="h-3 w-3" />Add weigh-in</button>
-          </div>
+              )}
+              {weight?.alert && <div className="rounded border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-[11px] text-amber-200">{weight.alert}</div>}
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/concord-frontend/components/pets/PetCarePlanner.tsx
+++ b/concord-frontend/components/pets/PetCarePlanner.tsx
@@ -1,10 +1,28 @@
 'use client';
 
-import { useState } from 'react';
+/**
+ * PetCarePlanner — feeding plan + vaccination schedule pulled from the
+ * user's actual PetProfile artifacts. No defaults: if the user has no
+ * pets yet, the panel renders an empty-state CTA. Otherwise, picks the
+ * active pet via a selector and feeds the macros real species/weight/
+ * age/activity from that pet's record.
+ *
+ * Backend (no changes): pets.feedingPlan + pets.vaccinationSchedule.
+ * Substrate: useLensData<PetArtifact>('pets', 'PetProfile').
+ */
+
+import { useMemo, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
-import { Heart, Loader2, Wand2, Syringe, Utensils } from 'lucide-react';
+import { Heart, Loader2, Wand2, Syringe, Utensils, PawPrint } from 'lucide-react';
 import { apiHelpers } from '@/lib/api/client';
+import { useLensData, type LensItem } from '@/lib/hooks/use-lens-data';
 import { SaveAsDtuButton } from '@/components/dtu/SaveAsDtuButton';
+
+interface PetArtifact {
+  name?: string; species?: string; age?: number; weight?: number;
+  activityLevel?: 'low' | 'moderate' | 'high';
+  petName?: string; type?: string;
+}
 
 interface FeedingResult { dailyCalories?: number; mealsPerDay?: number; gramsPerMeal?: number; recommendations?: string[]; species?: string; weight?: number }
 interface VaccineEntry { name: string; due?: string; dueAt?: string; ageMonths?: number; status?: string }
@@ -26,16 +44,28 @@ async function callPets<T>(action: string, input: Record<string, unknown>): Prom
 const ACTIVITY = ['low', 'moderate', 'high'] as const;
 
 export function PetCarePlanner() {
-  const [species, setSpecies] = useState<'dog' | 'cat'>('dog');
-  const [weight, setWeight] = useState(15);
-  const [age, setAge] = useState(3);
-  const [activity, setActivity] = useState<typeof ACTIVITY[number]>('moderate');
+  const { items: pets, isLoading } = useLensData<PetArtifact>('pets', 'PetProfile', { seed: [] });
+  const [selectedPetId, setSelectedPetId] = useState<string | null>(null);
+  const [activityOverride, setActivityOverride] = useState<typeof ACTIVITY[number] | null>(null);
   const [feeding, setFeeding] = useState<FeedingResult | null>(null);
   const [vaccines, setVaccines] = useState<VaccineResult | null>(null);
 
+  const activePet: LensItem<PetArtifact> | null = useMemo(() => {
+    if (!pets.length) return null;
+    return pets.find((p) => p.id === selectedPetId) || pets[0];
+  }, [pets, selectedPetId]);
+
+  // Use pet's stored activityLevel, falling back to 'moderate' if missing. User can override per-session via the selector.
+  const effectiveActivity: typeof ACTIVITY[number] = activityOverride ?? activePet?.data.activityLevel ?? 'moderate';
+
   const compute = useMutation({
     mutationFn: async () => {
-      const artifact = { data: { species, weight, age, activityLevel: activity } };
+      if (!activePet) return null;
+      const d = activePet.data;
+      const species = (d.species || '').toLowerCase().includes('cat') ? 'cat' : 'dog';
+      const weight = typeof d.weight === 'number' ? d.weight : 0;
+      const age = typeof d.age === 'number' ? d.age : 0;
+      const artifact = { data: { species, weight, age, activityLevel: effectiveActivity } };
       const [f, v] = await Promise.all([
         callPets<FeedingResult>('feedingPlan', { artifact }),
         callPets<VaccineResult>('vaccinationSchedule', { artifact }),
@@ -48,6 +78,21 @@ export function PetCarePlanner() {
 
   const allVaccines = vaccines ? [...(vaccines.upcoming || []), ...(vaccines.overdue || []), ...(vaccines.schedule || [])] : [];
 
+  if (isLoading) return <div className="flex items-center gap-2 text-xs text-zinc-500"><Loader2 className="h-4 w-4 animate-spin" />Loading pets…</div>;
+
+  if (pets.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-zinc-800 bg-zinc-950 p-8 text-center">
+        <PawPrint className="mx-auto h-8 w-8 text-zinc-600" />
+        <div className="mt-3 text-sm text-zinc-300">Add your first pet to build a care plan.</div>
+        <div className="mt-1 text-xs text-zinc-500">Create a PetProfile via the "New" button above. Once saved, this panel will compute real feeding + vaccination plans from that pet's species, weight, age, and activity level.</div>
+      </div>
+    );
+  }
+
+  const d = activePet?.data || {};
+  const hasMissingFields = typeof d.weight !== 'number' || typeof d.age !== 'number' || !d.species;
+
   return (
     <div className="space-y-4">
       <header className="flex flex-wrap items-center justify-between gap-3 border-b border-cyan-500/15 pb-3">
@@ -56,45 +101,42 @@ export function PetCarePlanner() {
           <h2 className="text-sm font-semibold text-white">Pet care planner</h2>
           <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">pets.feedingPlan + vaccinationSchedule</span>
         </div>
-        {(feeding || vaccines) && (
+        {(feeding || vaccines) && activePet && (
           <SaveAsDtuButton
             compact
             apiSource="concord-pets-care"
-            title={`${species} care plan — ${weight}kg, ${age}y, ${activity}`}
-            content={`Species: ${species}\nWeight: ${weight} kg\nAge: ${age} y\nActivity: ${activity}\n\nFeeding:\n  Daily calories: ${feeding?.dailyCalories ?? '—'}\n  Meals/day: ${feeding?.mealsPerDay ?? '—'}\n  Grams/meal: ${feeding?.gramsPerMeal ?? '—'}\n${feeding?.recommendations?.length ? `\nRecommendations:\n${feeding.recommendations.map((r) => `  - ${r}`).join('\n')}` : ''}\n\nVaccinations:\n${allVaccines.map((v) => `  ${v.name}${v.status ? ` (${v.status})` : ''}${v.due ? ` — due ${v.due}` : ''}`).join('\n')}`}
-            extraTags={['pets', species, 'care-plan']}
-            rawData={{ inputs: { species, weight, age, activity }, feeding, vaccines }}
+            title={`${d.name || activePet.title} care plan — ${d.weight}kg, ${d.age}y, ${effectiveActivity}`}
+            content={`Pet: ${d.name || activePet.title}\nSpecies: ${d.species}\nWeight: ${d.weight} kg\nAge: ${d.age} y\nActivity: ${effectiveActivity}\n\nFeeding:\n  Daily calories: ${feeding?.dailyCalories ?? '—'}\n  Meals/day: ${feeding?.mealsPerDay ?? '—'}\n  Grams/meal: ${feeding?.gramsPerMeal ?? '—'}\n${feeding?.recommendations?.length ? `\nRecommendations:\n${feeding.recommendations.map((r) => `  - ${r}`).join('\n')}` : ''}\n\nVaccinations:\n${allVaccines.map((v) => `  ${v.name}${v.status ? ` (${v.status})` : ''}${v.due ? ` — due ${v.due}` : ''}`).join('\n')}`}
+            extraTags={['pets', (d.species || '').toLowerCase(), 'care-plan']}
+            rawData={{ petId: activePet.id, pet: d, activity: effectiveActivity, feeding, vaccines }}
           />
         )}
       </header>
 
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
-        <label className="block">
-          <span className="block text-[10px] uppercase tracking-wider text-zinc-500">Species</span>
-          <select value={species} onChange={(e) => setSpecies(e.target.value as 'dog' | 'cat')} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-xs text-white">
-            <option value="dog">Dog</option>
-            <option value="cat">Cat</option>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <label className="block sm:col-span-2">
+          <span className="block text-[10px] uppercase tracking-wider text-zinc-500">Pet</span>
+          <select value={activePet?.id || ''} onChange={(e) => { setSelectedPetId(e.target.value); setActivityOverride(null); setFeeding(null); setVaccines(null); }} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-xs text-white">
+            {pets.map((p) => <option key={p.id} value={p.id}>{p.data.name || p.title}{p.data.species ? ` (${p.data.species})` : ''}</option>)}
           </select>
         </label>
         <label className="block">
-          <span className="block text-[10px] uppercase tracking-wider text-zinc-500">Weight (kg)</span>
-          <input type="number" min={0.5} max={100} step={0.5} value={weight} onChange={(e) => setWeight(Math.max(0.5, Math.min(100, Number(e.target.value) || 15)))} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-xs text-white" />
-        </label>
-        <label className="block">
-          <span className="block text-[10px] uppercase tracking-wider text-zinc-500">Age (yrs)</span>
-          <input type="number" min={0} max={30} step={0.5} value={age} onChange={(e) => setAge(Math.max(0, Math.min(30, Number(e.target.value) || 3)))} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-xs text-white" />
-        </label>
-        <label className="block">
-          <span className="block text-[10px] uppercase tracking-wider text-zinc-500">Activity</span>
-          <select value={activity} onChange={(e) => setActivity(e.target.value as typeof ACTIVITY[number])} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-xs text-white">
+          <span className="block text-[10px] uppercase tracking-wider text-zinc-500">Activity (override)</span>
+          <select value={effectiveActivity} onChange={(e) => setActivityOverride(e.target.value as typeof ACTIVITY[number])} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-xs text-white">
             {ACTIVITY.map((a) => <option key={a} value={a}>{a}</option>)}
           </select>
         </label>
-        <button type="button" onClick={() => compute.mutate()} disabled={compute.isPending} className="mt-auto inline-flex items-center justify-center gap-1 rounded border border-rose-500/40 bg-rose-500/15 px-3 py-1.5 text-xs font-mono text-rose-200 hover:bg-rose-500/25 disabled:opacity-50">
+        <button type="button" onClick={() => compute.mutate()} disabled={compute.isPending || !activePet || hasMissingFields} className="mt-auto inline-flex items-center justify-center gap-1 rounded border border-rose-500/40 bg-rose-500/15 px-3 py-1.5 text-xs font-mono text-rose-200 hover:bg-rose-500/25 disabled:opacity-50">
           {compute.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Wand2 className="h-3.5 w-3.5" />}
           Plan
         </button>
       </div>
+
+      {hasMissingFields && (
+        <div className="rounded border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-amber-200">
+          This pet's profile is missing species, weight, or age. Edit the PetProfile above to fill them in, then return to compute.
+        </div>
+      )}
 
       {compute.isError && <div className="rounded border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-300">Plan generation failed.</div>}
 


### PR DESCRIPTION
## Summary
Both pets panels now feed off the user's actual artifacts via `useLensData`. Zero seed defaults.

**PetCarePlanner** — pulls from `useLensData<PetArtifact>('pets', 'PetProfile')`. Pet selector when 2+ pets exist. Disables Plan button if pet is missing species/weight/age (with inline notice).

**ActivityWeightDashboard** — pulls from `useLensData('pets', 'PetProfile')`, `useLensData('pets', 'ActivityLog')` (filtered by petName), and `useLensData('pets', 'HealthRecord')` (filtered by petName + weight present). Per-card empty states when a pet has no logs/weigh-ins yet.

## Backend (no changes)
- `pets.activityScore`, `pets.weightTracker`, `pets.feedingPlan`, `pets.vaccinationSchedule`
- Substrate artifact persistence

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean

https://claude.ai/code/session_01WfDATSALRXGNnSkLKb4U9j

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfDATSALRXGNnSkLKb4U9j)_