### PR TITLE
calc-lenses: real-data retrofit (9 panels, all seeds stripped)

### DIFF
--- a/concord-frontend/components/automotive/FuelRepairPanel.tsx
+++ b/concord-frontend/components/automotive/FuelRepairPanel.tsx
@@ -21,19 +21,6 @@ interface RepairResult { repairs?: Array<{ repair: string; partsCost: number; la
 const today = new Date();
 const dayOffset = (n: number) => new Date(today.getTime() - n * 86400000).toISOString().slice(0, 10);
 
-const DEFAULT_FILLUPS: FillUp[] = [
-  { date: dayOffset(35), mileage: '54200', gallons: '12.4', pricePerGallon: '3.85' },
-  { date: dayOffset(22), mileage: '54580', gallons: '11.8', pricePerGallon: '3.92' },
-  { date: dayOffset(10), mileage: '54920', gallons: '13.1', pricePerGallon: '3.78' },
-  { date: dayOffset(1), mileage: '55290', gallons: '12.0', pricePerGallon: '3.95' },
-];
-
-const DEFAULT_REPAIRS: Repair[] = [
-  { name: 'Front brake pads + rotors', partsCost: '320', laborHours: '2.5', priority: 'high' },
-  { name: 'Oil change (synthetic)', partsCost: '65', laborHours: '0.5', priority: 'medium' },
-  { name: 'Cabin air filter', partsCost: '28', laborHours: '0.3', priority: 'low' },
-];
-
 const prBadge = (p: string) => {
   if (p === 'high') return 'bg-rose-500/20 text-rose-200';
   if (p === 'medium') return 'bg-amber-500/20 text-amber-200';
@@ -41,8 +28,8 @@ const prBadge = (p: string) => {
 };
 
 export function FuelRepairPanel() {
-  const [fillups, setFillups] = useState<FillUp[]>(DEFAULT_FILLUPS);
-  const [repairs, setRepairs] = useState<Repair[]>(DEFAULT_REPAIRS);
+  const [fillups, setFillups] = useState<FillUp[]>([{ date: dayOffset(0), mileage: '', gallons: '', pricePerGallon: '' }, { date: dayOffset(0), mileage: '', gallons: '', pricePerGallon: '' }]);
+  const [repairs, setRepairs] = useState<Repair[]>([{ name: '', partsCost: '', laborHours: '', priority: 'medium' }]);
   const [shopRate, setShopRate] = useState(120);
 
   const addFill = () => setFillups((fs) => [...fs, { date: dayOffset(0), mileage: '', gallons: '', pricePerGallon: '' }]);

--- a/concord-frontend/components/automotive/VehicleHistory.tsx
+++ b/concord-frontend/components/automotive/VehicleHistory.tsx
@@ -52,8 +52,8 @@ type TimelineEvent =
   | { kind: 'maintenance'; mileage: number; item: ScheduleItem };
 
 export function VehicleHistory() {
-  const [vin, setVin] = useState('1HGCM82633A123456');
-  const [odometer, setOdometer] = useState(67500);
+  const [vin, setVin] = useState('');
+  const [odometer, setOdometer] = useState(0);
   const [vinData, setVinData] = useState<VinData | null>(null);
   const [recalls, setRecalls] = useState<Recall[]>([]);
   const [schedule, setSchedule] = useState<ScheduleResult | null>(null);

--- a/concord-frontend/components/energy/SolarCarbonPanel.tsx
+++ b/concord-frontend/components/energy/SolarCarbonPanel.tsx
@@ -26,8 +26,8 @@ const coverageColour = (pct?: number) => {
 };
 
 export function SolarCarbonPanel() {
-  const [solar, setSolar] = useState<SolarInput>({ roofAreaSqFt: 1500, peakSunHours: 5, monthlyUsageKWh: 900 });
-  const [carbon, setCarbon] = useState<CarbonInput>({ electricityKWh: 900, naturalGasTherms: 45, gasolineGallons: 40, flightMiles: 250 });
+  const [solar, setSolar] = useState<SolarInput>({ roofAreaSqFt: 0, peakSunHours: 0, monthlyUsageKWh: 0 });
+  const [carbon, setCarbon] = useState<CarbonInput>({ electricityKWh: 0, naturalGasTherms: 0, gasolineGallons: 0, flightMiles: 0 });
 
   return (
     <CalcPanel<SolarResult, CarbonResult>

--- a/concord-frontend/components/environment/ComplianceDiversionPanel.tsx
+++ b/concord-frontend/components/environment/ComplianceDiversionPanel.tsx
@@ -18,24 +18,10 @@ interface Stream { name: string; volume: string }
 interface ComplianceResult { results?: Array<{ parameter: string; value: number; unit: string; threshold?: { min?: number; max?: number }; compliant: boolean }>; overallCompliant?: boolean; violations?: number; checkedAt?: string }
 interface DiversionResult { diversionRate?: number; totalWaste?: number; diverted?: number; landfilled?: number; target?: number; meetsTarget?: boolean; streams?: Stream[] }
 
-const DEFAULT_PARAMS: Param[] = [
-  { name: 'pH', value: '7.2', unit: 'pH', min: '6.5', max: '8.5' },
-  { name: 'Lead (Pb)', value: '0.008', unit: 'mg/L', min: '0', max: '0.015' },
-  { name: 'Turbidity', value: '0.9', unit: 'NTU', min: '0', max: '1.0' },
-  { name: 'Nitrate', value: '12', unit: 'mg/L', min: '0', max: '10' },
-];
-
-const DEFAULT_STREAMS: Stream[] = [
-  { name: 'Cardboard', volume: '850' },
-  { name: 'Glass', volume: '320' },
-  { name: 'Aluminum', volume: '180' },
-  { name: 'Organics (compost)', volume: '450' },
-];
-
 export function ComplianceDiversionPanel() {
-  const [params, setParams] = useState<Param[]>(DEFAULT_PARAMS);
-  const [streams, setStreams] = useState<Stream[]>(DEFAULT_STREAMS);
-  const [totalWaste, setTotalWaste] = useState(3500);
+  const [params, setParams] = useState<Param[]>([{ name: '', value: '', unit: '', min: '', max: '' }]);
+  const [streams, setStreams] = useState<Stream[]>([{ name: '', volume: '' }]);
+  const [totalWaste, setTotalWaste] = useState(0);
   const [target, setTarget] = useState(50);
 
   const addParam = () => setParams((ps) => [...ps, { name: '', value: '', unit: '', min: '', max: '' }]);

--- a/concord-frontend/components/history/TimelineSourceTools.tsx
+++ b/concord-frontend/components/history/TimelineSourceTools.tsx
@@ -22,13 +22,6 @@ const SIGNIFICANCES = ['low', 'medium', 'high', 'critical'] as const;
 const TYPES = ['primary', 'secondary', 'tertiary'] as const;
 const BIASES = ['none', 'low', 'moderate', 'high'] as const;
 
-const DEFAULT_EVENTS: HistEvent[] = [
-  { name: 'Magna Carta signed', date: '1215', era: 'High Middle Ages', category: 'political', significance: 'critical' },
-  { name: 'Fall of Constantinople', date: '1453', era: 'Late Middle Ages', category: 'military', significance: 'high' },
-  { name: 'Gutenberg press', date: '1440', era: 'Renaissance', category: 'cultural', significance: 'critical' },
-  { name: 'Black Death peak', date: '1349', era: 'High Middle Ages', category: 'social', significance: 'high' },
-];
-
 const reliabilityColour = (score?: number) => {
   if (!score) return 'text-zinc-400';
   if (score >= 70) return 'text-emerald-200';
@@ -37,8 +30,8 @@ const reliabilityColour = (score?: number) => {
 };
 
 export function TimelineSourceTools() {
-  const [events, setEvents] = useState<HistEvent[]>(DEFAULT_EVENTS);
-  const [source, setSource] = useState<Source>({ title: 'Magna Carta facsimile (British Library)', type: 'primary', author: 'Anonymous scribes', date: '1215', bias: 'low' });
+  const [events, setEvents] = useState<HistEvent[]>([{ name: '', date: '', era: '', category: 'political', significance: 'medium' }]);
+  const [source, setSource] = useState<Source>({ title: '', type: 'primary', author: '', date: '', bias: 'none' });
 
   const addEvent = () => setEvents((es) => [...es, { name: '', date: '', era: '', category: 'political', significance: 'medium' }]);
   const updateEvent = <K extends keyof HistEvent>(i: number, key: K, value: HistEvent[K]) =>

--- a/concord-frontend/components/materials/CorrosionThermalPanel.tsx
+++ b/concord-frontend/components/materials/CorrosionThermalPanel.tsx
@@ -36,8 +36,8 @@ const suitColour = (s?: string) => {
 };
 
 export function CorrosionThermalPanel() {
-  const [corrosion, setCorrosion] = useState<CorrosionInput>({ name: '316L stainless', category: 'metal', environment: 'marine', temperature: 22, humidity: 75 });
-  const [thermal, setThermal] = useState<ThermalInput>({ thermalConductivity: 16, meltingPoint: 1400, thermalExpansion: 16, operatingTemp: 200, application: 'high-temp' });
+  const [corrosion, setCorrosion] = useState<CorrosionInput>({ name: '', category: 'metal', environment: 'indoor', temperature: 0, humidity: 0 });
+  const [thermal, setThermal] = useState<ThermalInput>({ thermalConductivity: 0, meltingPoint: 0, thermalExpansion: 0, operatingTemp: 0, application: 'general' });
 
   return (
     <CalcPanel<CorrosionResult, ThermalResult>

--- a/concord-frontend/components/ocean/WaveEcosystemPanel.tsx
+++ b/concord-frontend/components/ocean/WaveEcosystemPanel.tsx
@@ -19,15 +19,6 @@ interface EcoResult { speciesCount?: number; trophicLevels?: Record<string, numb
 
 const TROPHIC_LEVELS = ['primary', 'secondary', 'tertiary', 'apex'] as const;
 
-const DEFAULT_SPECIES: Species[] = [
-  { name: 'Phytoplankton', trophicLevel: 'primary', threatened: false, invasive: false },
-  { name: 'Zooplankton', trophicLevel: 'primary', threatened: false, invasive: false },
-  { name: 'Anchovy', trophicLevel: 'secondary', threatened: false, invasive: false },
-  { name: 'Mackerel', trophicLevel: 'secondary', threatened: false, invasive: false },
-  { name: 'Bluefin tuna', trophicLevel: 'tertiary', threatened: true, invasive: false },
-  { name: 'Great white shark', trophicLevel: 'apex', threatened: true, invasive: false },
-  { name: 'Lionfish (Atlantic)', trophicLevel: 'tertiary', threatened: false, invasive: true },
-];
 
 const healthColour = (h?: string) => {
   if (h === 'thriving') return 'text-emerald-200';
@@ -38,8 +29,8 @@ const healthColour = (h?: string) => {
 };
 
 export function WaveEcosystemPanel() {
-  const [wave, setWave] = useState<WaveInput>({ waveHeightMeters: 2.5, wavePeriodSeconds: 9, windSpeedKnots: 22 });
-  const [species, setSpecies] = useState<Species[]>(DEFAULT_SPECIES);
+  const [wave, setWave] = useState<WaveInput>({ waveHeightMeters: 0, wavePeriodSeconds: 0, windSpeedKnots: 0 });
+  const [species, setSpecies] = useState<Species[]>([{ name: '', trophicLevel: 'primary', threatened: false, invasive: false }]);
 
   const addSpecies = () => setSpecies((ss) => [...ss, { name: '', trophicLevel: 'primary', threatened: false, invasive: false }]);
   const updateSpecies = <K extends keyof Species>(i: number, key: K, value: Species[K]) =>

--- a/concord-frontend/components/security/ThreatVulnPanel.tsx
+++ b/concord-frontend/components/security/ThreatVulnPanel.tsx
@@ -39,21 +39,9 @@ async function callSec<T>(action: string, input: Record<string, unknown>): Promi
   } catch { return null; }
 }
 
-const DEFAULT_THREATS: Threat[] = [
-  { name: 'Ransomware', type: 'malware', probability: 4, impact: 5, vulnerabilities: 3, activeControls: 4, totalControls: 6 },
-  { name: 'Insider data exfil', type: 'insider', probability: 2, impact: 5, vulnerabilities: 2, activeControls: 2, totalControls: 5 },
-  { name: 'Phishing campaign', type: 'social', probability: 5, impact: 3, vulnerabilities: 1, activeControls: 3, totalControls: 4 },
-];
-
-const DEFAULT_SYSTEMS: SysConfig[] = [
-  { hostname: 'web-prod-01', firewall: true, encryption: true, mfa: true, defaultCredentials: false },
-  { hostname: 'db-legacy-03', firewall: true, encryption: false, mfa: false, defaultCredentials: false },
-  { hostname: 'iot-cam-cluster', firewall: false, encryption: false, mfa: false, defaultCredentials: true },
-];
-
 export function ThreatVulnPanel() {
-  const [threats, setThreats] = useState<Threat[]>(DEFAULT_THREATS);
-  const [systems, setSystems] = useState<SysConfig[]>(DEFAULT_SYSTEMS);
+  const [threats, setThreats] = useState<Threat[]>([{ name: '', type: '', probability: 3, impact: 3, vulnerabilities: 0, activeControls: 0, totalControls: 0 }]);
+  const [systems, setSystems] = useState<SysConfig[]>([{ hostname: '', firewall: true, encryption: true, mfa: true, defaultCredentials: false }]);
   const [threatResult, setThreatResult] = useState<ThreatResult | null>(null);
   const [scanResult, setScanResult] = useState<ScanResult | null>(null);
 

--- a/concord-frontend/components/services/RevenueRetentionPanel.tsx
+++ b/concord-frontend/components/services/RevenueRetentionPanel.tsx
@@ -40,24 +40,9 @@ async function callSvc<T>(action: string, input: Record<string, unknown>): Promi
 const today = new Date();
 const dayOffset = (n: number) => new Date(today.getTime() - n * 86400000).toISOString().slice(0, 10);
 
-const DEFAULT_APPTS: Appt[] = [
-  { provider: 'Anya', date: dayOffset(2), price: '120', status: 'completed' },
-  { provider: 'Anya', date: dayOffset(5), price: '85', status: 'paid' },
-  { provider: 'Marcus', date: dayOffset(1), price: '150', status: 'completed' },
-  { provider: 'Marcus', date: dayOffset(8), price: '95', status: 'paid' },
-  { provider: 'Priya', date: dayOffset(3), price: '60', status: 'completed' },
-];
-
-const DEFAULT_CLIENTS: Client[] = [
-  { name: 'Sara Chen', visits: '6', totalRevenue: '720', lastVisit: dayOffset(14) },
-  { name: 'Diego Martinez', visits: '1', totalRevenue: '85', lastVisit: dayOffset(200) },
-  { name: 'Iris Tanaka', visits: '12', totalRevenue: '1800', lastVisit: dayOffset(45) },
-  { name: 'Kofi Asante', visits: '3', totalRevenue: '320', lastVisit: dayOffset(120) },
-];
-
 export function RevenueRetentionPanel() {
-  const [appts, setAppts] = useState<Appt[]>(DEFAULT_APPTS);
-  const [clients, setClients] = useState<Client[]>(DEFAULT_CLIENTS);
+  const [appts, setAppts] = useState<Appt[]>([{ provider: '', date: dayOffset(0), price: '', status: 'completed' }]);
+  const [clients, setClients] = useState<Client[]>([{ name: '', visits: '0', totalRevenue: '0', lastVisit: dayOffset(0) }]);
   const [period, setPeriod] = useState(30);
   const [revenue, setRevenue] = useState<RevenueResult | null>(null);
   const [retention, setRetention] = useState<RetentionResult | null>(null);


### PR DESCRIPTION
## Summary
Strips every `DEFAULT_*` mock-data constant from the 9 calc-shape panels shipped earlier this session. Each panel now boots with one empty row (or zero-valued fields) so user input is the only source of truth.

**Panels retrofitted:**
- environment/ComplianceDiversionPanel — no pH/lead/turbidity/nitrate seeds, no cardboard/glass/aluminum streams
- history/TimelineSourceTools — no Magna Carta / Constantinople / Gutenberg / Black Death events; no British Library facsimile source
- materials/CorrosionThermalPanel — no "316L stainless in marine" defaults
- ocean/WaveEcosystemPanel — no 7-species food web seed
- security/ThreatVulnPanel — no Ransomware/Insider/Phishing threats; no web-prod-01/db-legacy-03/iot-cam-cluster systems
- services/RevenueRetentionPanel — no Anya/Marcus/Priya providers; no Sara Chen / Diego Martinez / Iris Tanaka / Kofi Asante clients
- automotive/FuelRepairPanel — no 4-fillup seed, no brake/oil/filter repair seeds
- automotive/VehicleHistory — no `1HGCM82633A123456` VIN, no 67500 odometer
- energy/SolarCarbonPanel — no 1500 sq ft / 5 sun-h / 900 kWh defaults; carbon inputs all start at 0

## Math
-70 LOC of mock data across 9 files. Same logic, same UI; just zero-valued / empty-string starting state. Backend macros (real free data feeds — NHTSA / Nominatim / EIA / NOAA / EPA) unchanged.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on all 9 files

https://claude.ai/code/session_01WfDATSALRXGNnSkLKb4U9j

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfDATSALRXGNnSkLKb4U9j)_