### PR TITLE
P3: close content census to AT TARGET (factions + crops + puzzles) + CI gate

### DIFF
--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -4,6 +4,7 @@
 #   - macro-depth weighted score:    must be 1.000
 #   - UX polish weighted score:      must be ≥ 0.995
 #   - verifier WIRED count:          must be ≥ 234 of 235
+#   - content census:                must be AT TARGET (no world/lib gaps)
 #   - test suite:                    must be 0 failures
 #
 # The browser-driven audit (a11y + console errors via Playwright) runs
@@ -67,6 +68,13 @@ jobs:
 
       - name: Spec-vs-implementation audit
         run: node scripts/audit-spec-vs-impl.mjs
+
+      - name: Content census
+        run: |
+          # Authored content (per-world NPCs/factions + minigame libs) must stay
+          # AT TARGET — fails the build on any below-target surface so content
+          # can't silently regress.
+          node scripts/author/census.mjs --ci
 
       - name: Server test suite
         working-directory: server

--- a/content/code-puzzles.json
+++ b/content/code-puzzles.json
@@ -6,9 +6,30 @@
     "optimalCycles": 3,
     "optimalSize": 2,
     "testCases": [
-      { "input": [5], "expected": [5] },
-      { "input": [0], "expected": [0] },
-      { "input": [42], "expected": [42] }
+      {
+        "input": [
+          5
+        ],
+        "expected": [
+          5
+        ]
+      },
+      {
+        "input": [
+          0
+        ],
+        "expected": [
+          0
+        ]
+      },
+      {
+        "input": [
+          42
+        ],
+        "expected": [
+          42
+        ]
+      }
     ]
   },
   {
@@ -18,9 +39,33 @@
     "optimalCycles": 5,
     "optimalSize": 3,
     "testCases": [
-      { "input": [2, 3], "expected": [5] },
-      { "input": [0, 0], "expected": [0] },
-      { "input": [10, 7], "expected": [17] }
+      {
+        "input": [
+          2,
+          3
+        ],
+        "expected": [
+          5
+        ]
+      },
+      {
+        "input": [
+          0,
+          0
+        ],
+        "expected": [
+          0
+        ]
+      },
+      {
+        "input": [
+          10,
+          7
+        ],
+        "expected": [
+          17
+        ]
+      }
     ]
   },
   {
@@ -30,9 +75,30 @@
     "optimalCycles": 5,
     "optimalSize": 3,
     "testCases": [
-      { "input": [3], "expected": [6] },
-      { "input": [0], "expected": [0] },
-      { "input": [11], "expected": [22] }
+      {
+        "input": [
+          3
+        ],
+        "expected": [
+          6
+        ]
+      },
+      {
+        "input": [
+          0
+        ],
+        "expected": [
+          0
+        ]
+      },
+      {
+        "input": [
+          11
+        ],
+        "expected": [
+          22
+        ]
+      }
     ]
   },
   {
@@ -42,9 +108,36 @@
     "optimalCycles": 8,
     "optimalSize": 5,
     "testCases": [
-      { "input": [1, 2, 3], "expected": [6] },
-      { "input": [5, 5, 5], "expected": [15] },
-      { "input": [0, 10, 4], "expected": [14] }
+      {
+        "input": [
+          1,
+          2,
+          3
+        ],
+        "expected": [
+          6
+        ]
+      },
+      {
+        "input": [
+          5,
+          5,
+          5
+        ],
+        "expected": [
+          15
+        ]
+      },
+      {
+        "input": [
+          0,
+          10,
+          4
+        ],
+        "expected": [
+          14
+        ]
+      }
     ]
   },
   {
@@ -54,9 +147,30 @@
     "optimalCycles": 7,
     "optimalSize": 5,
     "testCases": [
-      { "input": [0], "expected": [1] },
-      { "input": [5], "expected": [0] },
-      { "input": [42], "expected": [0] }
+      {
+        "input": [
+          0
+        ],
+        "expected": [
+          1
+        ]
+      },
+      {
+        "input": [
+          5
+        ],
+        "expected": [
+          0
+        ]
+      },
+      {
+        "input": [
+          42
+        ],
+        "expected": [
+          0
+        ]
+      }
     ]
   },
   {
@@ -66,8 +180,24 @@
     "optimalCycles": 5,
     "optimalSize": 3,
     "testCases": [
-      { "input": [4], "expected": [4, 4] },
-      { "input": [7], "expected": [7, 7] }
+      {
+        "input": [
+          4
+        ],
+        "expected": [
+          4,
+          4
+        ]
+      },
+      {
+        "input": [
+          7
+        ],
+        "expected": [
+          7,
+          7
+        ]
+      }
     ]
   },
   {
@@ -77,9 +207,34 @@
     "optimalCycles": 30,
     "optimalSize": 6,
     "testCases": [
-      { "input": [3], "expected": [0, 0, 0] },
-      { "input": [0], "expected": [] },
-      { "input": [5], "expected": [0, 0, 0, 0, 0] }
+      {
+        "input": [
+          3
+        ],
+        "expected": [
+          0,
+          0,
+          0
+        ]
+      },
+      {
+        "input": [
+          0
+        ],
+        "expected": []
+      },
+      {
+        "input": [
+          5
+        ],
+        "expected": [
+          0,
+          0,
+          0,
+          0,
+          0
+        ]
+      }
     ]
   },
   {
@@ -89,8 +244,435 @@
     "optimalCycles": 12,
     "optimalSize": 6,
     "testCases": [
-      { "input": [1, 2, 3], "expected": [1, 3, 6] },
-      { "input": [5, 0, 5], "expected": [5, 5, 10] }
+      {
+        "input": [
+          1,
+          2,
+          3
+        ],
+        "expected": [
+          1,
+          3,
+          6
+        ]
+      },
+      {
+        "input": [
+          5,
+          0,
+          5
+        ],
+        "expected": [
+          5,
+          5,
+          10
+        ]
+      }
+    ]
+  },
+  {
+    "id": "add-five",
+    "name": "Add Five",
+    "description": "Output input[0] + 5.",
+    "optimalCycles": 3,
+    "optimalSize": 3,
+    "testCases": [
+      {
+        "input": [
+          0
+        ],
+        "expected": [
+          5
+        ]
+      },
+      {
+        "input": [
+          3
+        ],
+        "expected": [
+          8
+        ]
+      },
+      {
+        "input": [
+          10
+        ],
+        "expected": [
+          15
+        ]
+      }
+    ]
+  },
+  {
+    "id": "triple-it",
+    "name": "Triple It",
+    "description": "Output input[0] tripled (no MUL — add it up).",
+    "optimalCycles": 5,
+    "optimalSize": 5,
+    "testCases": [
+      {
+        "input": [
+          2
+        ],
+        "expected": [
+          6
+        ]
+      },
+      {
+        "input": [
+          0
+        ],
+        "expected": [
+          0
+        ]
+      },
+      {
+        "input": [
+          5
+        ],
+        "expected": [
+          15
+        ]
+      }
+    ]
+  },
+  {
+    "id": "sum-four",
+    "name": "Sum Four",
+    "description": "Add input[0] + input[1] + input[2] + input[3].",
+    "optimalCycles": 5,
+    "optimalSize": 5,
+    "testCases": [
+      {
+        "input": [
+          1,
+          2,
+          3,
+          4
+        ],
+        "expected": [
+          10
+        ]
+      },
+      {
+        "input": [
+          0,
+          0,
+          0,
+          0
+        ],
+        "expected": [
+          0
+        ]
+      },
+      {
+        "input": [
+          5,
+          5,
+          5,
+          5
+        ],
+        "expected": [
+          20
+        ]
+      }
+    ]
+  },
+  {
+    "id": "echo-three",
+    "name": "Echo Thrice",
+    "description": "Output input[0] three times in sequence.",
+    "optimalCycles": 4,
+    "optimalSize": 4,
+    "testCases": [
+      {
+        "input": [
+          4
+        ],
+        "expected": [
+          4,
+          4,
+          4
+        ]
+      },
+      {
+        "input": [
+          9
+        ],
+        "expected": [
+          9,
+          9,
+          9
+        ]
+      }
+    ]
+  },
+  {
+    "id": "swap-pair",
+    "name": "Swap Pair",
+    "description": "Output input[1] then input[0].",
+    "optimalCycles": 4,
+    "optimalSize": 4,
+    "testCases": [
+      {
+        "input": [
+          1,
+          2
+        ],
+        "expected": [
+          2,
+          1
+        ]
+      },
+      {
+        "input": [
+          7,
+          3
+        ],
+        "expected": [
+          3,
+          7
+        ]
+      }
+    ]
+  },
+  {
+    "id": "minus-five",
+    "name": "Minus Five",
+    "description": "Output input[0] - 5 (ADD a negative immediate).",
+    "optimalCycles": 3,
+    "optimalSize": 3,
+    "testCases": [
+      {
+        "input": [
+          10
+        ],
+        "expected": [
+          5
+        ]
+      },
+      {
+        "input": [
+          5
+        ],
+        "expected": [
+          0
+        ]
+      },
+      {
+        "input": [
+          8
+        ],
+        "expected": [
+          3
+        ]
+      }
+    ]
+  },
+  {
+    "id": "countdown",
+    "name": "Countdown",
+    "description": "Output N, N-1, ..., 1 where N = input[0]. Use JEZ + JMP.",
+    "optimalCycles": 22,
+    "optimalSize": 5,
+    "testCases": [
+      {
+        "input": [
+          3
+        ],
+        "expected": [
+          3,
+          2,
+          1
+        ]
+      },
+      {
+        "input": [
+          0
+        ],
+        "expected": []
+      },
+      {
+        "input": [
+          5
+        ],
+        "expected": [
+          5,
+          4,
+          3,
+          2,
+          1
+        ]
+      }
+    ]
+  },
+  {
+    "id": "repeat-value",
+    "name": "Repeat Value",
+    "description": "Output input[0] repeated input[1] times.",
+    "optimalCycles": 15,
+    "optimalSize": 6,
+    "testCases": [
+      {
+        "input": [
+          7,
+          3
+        ],
+        "expected": [
+          7,
+          7,
+          7
+        ]
+      },
+      {
+        "input": [
+          9,
+          0
+        ],
+        "expected": []
+      },
+      {
+        "input": [
+          4,
+          2
+        ],
+        "expected": [
+          4,
+          4
+        ]
+      }
+    ]
+  },
+  {
+    "id": "sum-to-n",
+    "name": "Sum To N",
+    "description": "Output 1 + 2 + ... + N where N = input[0].",
+    "optimalCycles": 24,
+    "optimalSize": 7,
+    "testCases": [
+      {
+        "input": [
+          3
+        ],
+        "expected": [
+          6
+        ]
+      },
+      {
+        "input": [
+          0
+        ],
+        "expected": [
+          0
+        ]
+      },
+      {
+        "input": [
+          5
+        ],
+        "expected": [
+          15
+        ]
+      }
+    ]
+  },
+  {
+    "id": "double-pair",
+    "name": "Double Pair",
+    "description": "Output 2*input[0] then 2*input[1].",
+    "optimalCycles": 6,
+    "optimalSize": 6,
+    "testCases": [
+      {
+        "input": [
+          3,
+          4
+        ],
+        "expected": [
+          6,
+          8
+        ]
+      },
+      {
+        "input": [
+          0,
+          5
+        ],
+        "expected": [
+          0,
+          10
+        ]
+      }
+    ]
+  },
+  {
+    "id": "pair-sums",
+    "name": "Pair Sums",
+    "description": "Output (input[0]+input[1]) then (input[2]+input[3]).",
+    "optimalCycles": 6,
+    "optimalSize": 6,
+    "testCases": [
+      {
+        "input": [
+          1,
+          2,
+          3,
+          4
+        ],
+        "expected": [
+          3,
+          7
+        ]
+      },
+      {
+        "input": [
+          10,
+          5,
+          0,
+          5
+        ],
+        "expected": [
+          15,
+          5
+        ]
+      }
+    ]
+  },
+  {
+    "id": "running-sum-four",
+    "name": "Running Sum Four",
+    "description": "Output the running total after each of 4 inputs.",
+    "optimalCycles": 8,
+    "optimalSize": 8,
+    "testCases": [
+      {
+        "input": [
+          1,
+          2,
+          3,
+          4
+        ],
+        "expected": [
+          1,
+          3,
+          6,
+          10
+        ]
+      },
+      {
+        "input": [
+          2,
+          2,
+          2,
+          2
+        ],
+        "expected": [
+          2,
+          4,
+          6,
+          8
+        ]
+      }
     ]
   }
 ]

--- a/content/crops.json
+++ b/content/crops.json
@@ -1,7 +1,178 @@
 [
-  { "id": "wheat",    "name": "Wheat",     "seasons": [0, 3], "growth_days": 6, "yield": 5 },
-  { "id": "herb",     "name": "Herb",      "seasons": [0, 2], "growth_days": 4, "yield": 3 },
-  { "id": "vine",     "name": "Vine fruit","seasons": [1, 3], "growth_days": 8, "yield": 6 },
-  { "id": "root",     "name": "Root crop", "seasons": [3, 4], "growth_days": 7, "yield": 5 },
-  { "id": "mushroom", "name": "Mushroom",  "seasons": [4, 5], "growth_days": 5, "yield": 4 }
+  {
+    "id": "wheat",
+    "name": "Wheat",
+    "seasons": [
+      0,
+      3
+    ],
+    "growth_days": 6,
+    "yield": 5
+  },
+  {
+    "id": "herb",
+    "name": "Herb",
+    "seasons": [
+      0,
+      2
+    ],
+    "growth_days": 4,
+    "yield": 3
+  },
+  {
+    "id": "vine",
+    "name": "Vine fruit",
+    "seasons": [
+      1,
+      3
+    ],
+    "growth_days": 8,
+    "yield": 6
+  },
+  {
+    "id": "root",
+    "name": "Root crop",
+    "seasons": [
+      3,
+      4
+    ],
+    "growth_days": 7,
+    "yield": 5
+  },
+  {
+    "id": "mushroom",
+    "name": "Mushroom",
+    "seasons": [
+      4,
+      5
+    ],
+    "growth_days": 5,
+    "yield": 4
+  },
+  {
+    "id": "barley",
+    "name": "Barley",
+    "seasons": [
+      3,
+      4
+    ],
+    "growth_days": 10,
+    "yield": 4
+  },
+  {
+    "id": "maize",
+    "name": "Maize",
+    "seasons": [
+      3,
+      5
+    ],
+    "growth_days": 7,
+    "yield": 5
+  },
+  {
+    "id": "squash",
+    "name": "Squash",
+    "seasons": [
+      0,
+      2
+    ],
+    "growth_days": 6,
+    "yield": 5
+  },
+  {
+    "id": "pepper",
+    "name": "Hot Pepper",
+    "seasons": [
+      3,
+      5
+    ],
+    "growth_days": 4,
+    "yield": 8
+  },
+  {
+    "id": "bean",
+    "name": "Field Bean",
+    "seasons": [
+      4
+    ],
+    "growth_days": 7,
+    "yield": 4
+  },
+  {
+    "id": "flax",
+    "name": "Flax",
+    "seasons": [
+      3
+    ],
+    "growth_days": 10,
+    "yield": 3
+  },
+  {
+    "id": "onion",
+    "name": "Onion",
+    "seasons": [
+      2,
+      3
+    ],
+    "growth_days": 5,
+    "yield": 8
+  },
+  {
+    "id": "melon",
+    "name": "Sun Melon",
+    "seasons": [
+      1,
+      2
+    ],
+    "growth_days": 4,
+    "yield": 5
+  },
+  {
+    "id": "tuber",
+    "name": "Frost Tuber",
+    "seasons": [
+      5
+    ],
+    "growth_days": 4,
+    "yield": 6
+  },
+  {
+    "id": "berry",
+    "name": "Bramble Berry",
+    "seasons": [
+      2,
+      4
+    ],
+    "growth_days": 6,
+    "yield": 4
+  },
+  {
+    "id": "rice",
+    "name": "Paddy Rice",
+    "seasons": [
+      2,
+      5
+    ],
+    "growth_days": 6,
+    "yield": 5
+  },
+  {
+    "id": "pumpkin",
+    "name": "Pumpkin",
+    "seasons": [
+      3,
+      4
+    ],
+    "growth_days": 8,
+    "yield": 7
+  },
+  {
+    "id": "cabbage",
+    "name": "Cabbage",
+    "seasons": [
+      0
+    ],
+    "growth_days": 8,
+    "yield": 6
+  }
 ]

--- a/content/hacking-puzzles.json
+++ b/content/hacking-puzzles.json
@@ -10,13 +10,23 @@
         "home": {
           "type": "dir",
           "contents": {
-            "readme.txt": { "type": "file", "text": "Welcome, operator. ls is your friend." },
-            "guest_node": { "type": "service" }
+            "readme.txt": {
+              "type": "file",
+              "text": "Welcome, operator. ls is your friend."
+            },
+            "guest_node": {
+              "type": "service"
+            }
           }
         }
       }
     },
-    "solutionPath": ["ls", "cd home", "ls", "connect guest_node"]
+    "solutionPath": [
+      "ls",
+      "cd home",
+      "ls",
+      "connect guest_node"
+    ]
   },
   {
     "id": "lattice-mailroom",
@@ -29,13 +39,22 @@
         "mail": {
           "type": "dir",
           "contents": {
-            "inbox.log": { "type": "file", "text": "ECHO REQUEST from courier-7" },
-            "courier-7": { "type": "service" }
+            "inbox.log": {
+              "type": "file",
+              "text": "ECHO REQUEST from courier-7"
+            },
+            "courier-7": {
+              "type": "service"
+            }
           }
         }
       }
     },
-    "solutionPath": ["cd mail", "cat inbox.log", "connect courier-7"]
+    "solutionPath": [
+      "cd mail",
+      "cat inbox.log",
+      "connect courier-7"
+    ]
   },
   {
     "id": "broken-relay",
@@ -48,15 +67,28 @@
         "relays": {
           "type": "dir",
           "contents": {
-            "r01": { "type": "service" },
-            "r02": { "type": "service" },
-            "r03": { "type": "service" }
+            "r01": {
+              "type": "service"
+            },
+            "r02": {
+              "type": "service"
+            },
+            "r03": {
+              "type": "service"
+            }
           }
         },
-        "manifest.txt": { "type": "file", "text": "Active relay: r02" }
+        "manifest.txt": {
+          "type": "file",
+          "text": "Active relay: r02"
+        }
       }
     },
-    "solutionPath": ["cat manifest.txt", "cd relays", "connect r02"]
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd relays",
+      "connect r02"
+    ]
   },
   {
     "id": "cipher-fragment",
@@ -69,13 +101,23 @@
         "vault": {
           "type": "dir",
           "contents": {
-            "fragment.enc": { "type": "file", "text": "Encrypted payload — decrypt before exec." },
-            "core": { "type": "service" }
+            "fragment.enc": {
+              "type": "file",
+              "text": "Encrypted payload — decrypt before exec."
+            },
+            "core": {
+              "type": "service"
+            }
           }
         }
       }
     },
-    "solutionPath": ["cd vault", "cat fragment.enc", "decrypt fragment.enc", "exec core"]
+    "solutionPath": [
+      "cd vault",
+      "cat fragment.enc",
+      "decrypt fragment.enc",
+      "exec core"
+    ]
   },
   {
     "id": "ghost-in-the-bazaar",
@@ -88,20 +130,36 @@
         "market": {
           "type": "dir",
           "contents": {
-            "stalls.log": { "type": "file", "text": "anomaly@stall_3 — non-merchant signature" },
-            "stall_1": { "type": "service" },
-            "stall_3": { "type": "service" }
+            "stalls.log": {
+              "type": "file",
+              "text": "anomaly@stall_3 — non-merchant signature"
+            },
+            "stall_1": {
+              "type": "service"
+            },
+            "stall_3": {
+              "type": "service"
+            }
           }
         },
         "shadow": {
           "type": "dir",
           "contents": {
-            "trace": { "type": "service" }
+            "trace": {
+              "type": "service"
+            }
           }
         }
       }
     },
-    "solutionPath": ["cd market", "cat stalls.log", "ssh stall_3", "cd ..", "cd shadow", "connect trace"]
+    "solutionPath": [
+      "cd market",
+      "cat stalls.log",
+      "ssh stall_3",
+      "cd ..",
+      "cd shadow",
+      "connect trace"
+    ]
   },
   {
     "id": "dome-sentinel",
@@ -114,15 +172,31 @@
         "dome": {
           "type": "dir",
           "contents": {
-            "watchers.list": { "type": "file", "text": "active: sentinel_a, sentinel_b" },
-            "sentinel_a": { "type": "service" },
-            "sentinel_b": { "type": "service" }
+            "watchers.list": {
+              "type": "file",
+              "text": "active: sentinel_a, sentinel_b"
+            },
+            "sentinel_a": {
+              "type": "service"
+            },
+            "sentinel_b": {
+              "type": "service"
+            }
           }
         },
-        "override.key": { "type": "file", "text": "override unlocks both sentinels" }
+        "override.key": {
+          "type": "file",
+          "text": "override unlocks both sentinels"
+        }
       }
     },
-    "solutionPath": ["cat override.key", "cd dome", "cat watchers.list", "decrypt sentinel_a", "decrypt sentinel_b"]
+    "solutionPath": [
+      "cat override.key",
+      "cd dome",
+      "cat watchers.list",
+      "decrypt sentinel_a",
+      "decrypt sentinel_b"
+    ]
   },
   {
     "id": "concordant-keep",
@@ -135,20 +209,39 @@
         "keep": {
           "type": "dir",
           "contents": {
-            "guard.log": { "type": "file", "text": "patrol rotation every 90s — exec gate within window" },
-            "gate": { "type": "service" },
+            "guard.log": {
+              "type": "file",
+              "text": "patrol rotation every 90s — exec gate within window"
+            },
+            "gate": {
+              "type": "service"
+            },
             "armory": {
               "type": "dir",
               "contents": {
-                "ledger.txt": { "type": "file", "text": "key cached at archive_root" }
+                "ledger.txt": {
+                  "type": "file",
+                  "text": "key cached at archive_root"
+                }
               }
             }
           }
         },
-        "archive_root": { "type": "service" }
+        "archive_root": {
+          "type": "service"
+        }
       }
     },
-    "solutionPath": ["cd keep", "cat guard.log", "cd armory", "cat ledger.txt", "cd ..", "cd ..", "connect archive_root", "ssh gate"]
+    "solutionPath": [
+      "cd keep",
+      "cat guard.log",
+      "cd armory",
+      "cat ledger.txt",
+      "cd ..",
+      "cd ..",
+      "connect archive_root",
+      "ssh gate"
+    ]
   },
   {
     "id": "lattice-cathedral",
@@ -161,15 +254,30 @@
         "cathedral": {
           "type": "dir",
           "contents": {
-            "litany.txt": { "type": "file", "text": "Three relics. Three altars. Decrypt in order: bell, chime, vow." },
-            "altar_bell": { "type": "service" },
-            "altar_chime": { "type": "service" },
-            "altar_vow": { "type": "service" }
+            "litany.txt": {
+              "type": "file",
+              "text": "Three relics. Three altars. Decrypt in order: bell, chime, vow."
+            },
+            "altar_bell": {
+              "type": "service"
+            },
+            "altar_chime": {
+              "type": "service"
+            },
+            "altar_vow": {
+              "type": "service"
+            }
           }
         }
       }
     },
-    "solutionPath": ["cd cathedral", "cat litany.txt", "decrypt altar_bell", "decrypt altar_chime", "decrypt altar_vow"]
+    "solutionPath": [
+      "cd cathedral",
+      "cat litany.txt",
+      "decrypt altar_bell",
+      "decrypt altar_chime",
+      "decrypt altar_vow"
+    ]
   },
   {
     "id": "sovereign-archive",
@@ -182,21 +290,40 @@
         "archive": {
           "type": "dir",
           "contents": {
-            "rooms.idx": { "type": "file", "text": "rooms: alpha, beta, gamma — gamma holds the seal." },
-            "alpha": { "type": "service" },
-            "beta": { "type": "service" },
+            "rooms.idx": {
+              "type": "file",
+              "text": "rooms: alpha, beta, gamma — gamma holds the seal."
+            },
+            "alpha": {
+              "type": "service"
+            },
+            "beta": {
+              "type": "service"
+            },
             "gamma": {
               "type": "dir",
               "contents": {
-                "seal.enc": { "type": "file", "text": "encrypted — exec only after decrypt" },
-                "vault_door": { "type": "service" }
+                "seal.enc": {
+                  "type": "file",
+                  "text": "encrypted — exec only after decrypt"
+                },
+                "vault_door": {
+                  "type": "service"
+                }
               }
             }
           }
         }
       }
     },
-    "solutionPath": ["cd archive", "cat rooms.idx", "cd gamma", "cat seal.enc", "decrypt seal.enc", "exec vault_door"]
+    "solutionPath": [
+      "cd archive",
+      "cat rooms.idx",
+      "cd gamma",
+      "cat seal.enc",
+      "decrypt seal.enc",
+      "exec vault_door"
+    ]
   },
   {
     "id": "concord-singularity",
@@ -209,15 +336,1117 @@
         "singularity": {
           "type": "dir",
           "contents": {
-            "manifest.txt": { "type": "file", "text": "Reach the core via shell, mirror, and trace in sequence." },
-            "shell": { "type": "service" },
-            "mirror": { "type": "service" },
-            "trace": { "type": "service" },
-            "core": { "type": "service" }
+            "manifest.txt": {
+              "type": "file",
+              "text": "Reach the core via shell, mirror, and trace in sequence."
+            },
+            "shell": {
+              "type": "service"
+            },
+            "mirror": {
+              "type": "service"
+            },
+            "trace": {
+              "type": "service"
+            },
+            "core": {
+              "type": "service"
+            }
           }
         }
       }
     },
-    "solutionPath": ["cd singularity", "cat manifest.txt", "ssh shell", "ssh mirror", "ssh trace", "exec core"]
+    "solutionPath": [
+      "cd singularity",
+      "cat manifest.txt",
+      "ssh shell",
+      "ssh mirror",
+      "ssh trace",
+      "exec core"
+    ]
+  },
+  {
+    "id": "frontier-checkpoint",
+    "name": "Frontier Checkpoint",
+    "difficulty": 1,
+    "rewardCc": 30,
+    "terminalTree": {
+      "type": "dir",
+      "contents": {
+        "manifest.txt": {
+          "type": "file",
+          "text": "Concord-Link border node. The guest gate is wide open — just reach the relay."
+        },
+        "gate": {
+          "type": "dir",
+          "contents": {
+            "note.txt": {
+              "type": "file",
+              "text": "Relay sits behind the gate. Connect to it."
+            },
+            "relay": {
+              "type": "service"
+            }
+          }
+        }
+      }
+    },
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd gate",
+      "cat note.txt",
+      "connect relay"
+    ]
+  },
+  {
+    "id": "tunya-well-pump",
+    "name": "Tunya Well Pump",
+    "difficulty": 1,
+    "rewardCc": 32,
+    "terminalTree": {
+      "type": "dir",
+      "contents": {
+        "manifest.txt": {
+          "type": "file",
+          "text": "An old caravan well-pump still answers commands. Bring the water back."
+        },
+        "pump": {
+          "type": "dir",
+          "contents": {
+            "note.txt": {
+              "type": "file",
+              "text": "The valve service controls the flow."
+            },
+            "valve": {
+              "type": "service"
+            }
+          }
+        }
+      }
+    },
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd pump",
+      "cat note.txt",
+      "exec valve"
+    ]
+  },
+  {
+    "id": "bazaar-stall-lock",
+    "name": "Bazaar Stall Lock",
+    "difficulty": 1,
+    "rewardCc": 35,
+    "terminalTree": {
+      "type": "dir",
+      "contents": {
+        "manifest.txt": {
+          "type": "file",
+          "text": "A merchant's stall terminal. The drawer service is the prize."
+        },
+        "stall": {
+          "type": "dir",
+          "contents": {
+            "note.txt": {
+              "type": "file",
+              "text": "Open the drawer."
+            },
+            "drawer": {
+              "type": "service"
+            }
+          }
+        }
+      }
+    },
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd stall",
+      "cat note.txt",
+      "connect drawer"
+    ]
+  },
+  {
+    "id": "fantasy-hedge-gate",
+    "name": "Hedge Gate",
+    "difficulty": 1,
+    "rewardCc": 38,
+    "terminalTree": {
+      "type": "dir",
+      "contents": {
+        "manifest.txt": {
+          "type": "file",
+          "text": "A rune-warded garden node. The hedge service yields to the right touch."
+        },
+        "garden": {
+          "type": "dir",
+          "contents": {
+            "note.txt": {
+              "type": "file",
+              "text": "The hedge will part for a connect."
+            },
+            "hedge": {
+              "type": "service"
+            }
+          }
+        }
+      }
+    },
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd garden",
+      "cat note.txt",
+      "connect hedge"
+    ]
+  },
+  {
+    "id": "cyber-fixer-den",
+    "name": "Fixer's Den",
+    "difficulty": 2,
+    "rewardCc": 85,
+    "terminalTree": {
+      "type": "dir",
+      "contents": {
+        "manifest.txt": {
+          "type": "file",
+          "text": "A fixer's backroom rig. Cracked door, then the safe."
+        },
+        "den": {
+          "type": "dir",
+          "contents": {
+            "note.txt": {
+              "type": "file",
+              "text": "Crack the door service, then reach the safe."
+            },
+            "door": {
+              "type": "service"
+            },
+            "safe": {
+              "type": "service"
+            }
+          }
+        }
+      }
+    },
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd den",
+      "cat note.txt",
+      "decrypt door",
+      "exec safe"
+    ]
+  },
+  {
+    "id": "crime-numbers-room",
+    "name": "Numbers Room",
+    "difficulty": 2,
+    "rewardCc": 90,
+    "terminalTree": {
+      "type": "dir",
+      "contents": {
+        "manifest.txt": {
+          "type": "file",
+          "text": "The crew keeps its book on a quiet node. Two services stand between you and it."
+        },
+        "backroom": {
+          "type": "dir",
+          "contents": {
+            "note.txt": {
+              "type": "file",
+              "text": "Disable the lookout, then crack the ledger."
+            },
+            "lookout": {
+              "type": "service"
+            },
+            "ledger": {
+              "type": "service"
+            }
+          }
+        }
+      }
+    },
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd backroom",
+      "cat note.txt",
+      "connect lookout",
+      "decrypt ledger"
+    ]
+  },
+  {
+    "id": "superhero-tip-line",
+    "name": "Tip Line",
+    "difficulty": 2,
+    "rewardCc": 92,
+    "terminalTree": {
+      "type": "dir",
+      "contents": {
+        "manifest.txt": {
+          "type": "file",
+          "text": "A precinct tip-line server. Authenticate, then pull the archive."
+        },
+        "precinct": {
+          "type": "dir",
+          "contents": {
+            "note.txt": {
+              "type": "file",
+              "text": "ssh the desk, then connect the archive."
+            },
+            "desk": {
+              "type": "service"
+            },
+            "archive": {
+              "type": "service"
+            }
+          }
+        }
+      }
+    },
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd precinct",
+      "cat note.txt",
+      "ssh desk",
+      "connect archive"
+    ]
+  },
+  {
+    "id": "lattice-drift-buoy",
+    "name": "Drift Buoy",
+    "difficulty": 2,
+    "rewardCc": 95,
+    "terminalTree": {
+      "type": "dir",
+      "contents": {
+        "manifest.txt": {
+          "type": "file",
+          "text": "A lattice drift-buoy adrift between districts. Sync it, then read the beacon."
+        },
+        "buoy": {
+          "type": "dir",
+          "contents": {
+            "note.txt": {
+              "type": "file",
+              "text": "Sync service first; then the beacon."
+            },
+            "sync": {
+              "type": "service"
+            },
+            "beacon": {
+              "type": "service"
+            }
+          }
+        }
+      }
+    },
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd buoy",
+      "cat note.txt",
+      "exec sync",
+      "connect beacon"
+    ]
+  },
+  {
+    "id": "cyber-corpo-floor",
+    "name": "Corpo Floor",
+    "difficulty": 3,
+    "rewardCc": 165,
+    "terminalTree": {
+      "type": "dir",
+      "contents": {
+        "manifest.txt": {
+          "type": "file",
+          "text": "A corporate sublevel. Two rooms, two locks, one core."
+        },
+        "lobby": {
+          "type": "dir",
+          "contents": {
+            "note.txt": {
+              "type": "file",
+              "text": "Spoof the badge reader."
+            },
+            "badge": {
+              "type": "service"
+            },
+            "server_room": {
+              "type": "dir",
+              "contents": {
+                "note.txt": {
+                  "type": "file",
+                  "text": "The core sits past the firewall."
+                },
+                "firewall": {
+                  "type": "service"
+                },
+                "core": {
+                  "type": "service"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd lobby",
+      "cat note.txt",
+      "decrypt badge",
+      "cd server_room",
+      "cat note.txt",
+      "exec firewall",
+      "connect core"
+    ]
+  },
+  {
+    "id": "sovereign-watchpost",
+    "name": "Sovereign Watchpost",
+    "difficulty": 3,
+    "rewardCc": 170,
+    "terminalTree": {
+      "type": "dir",
+      "contents": {
+        "manifest.txt": {
+          "type": "file",
+          "text": "A ruined watchpost still broadcasting. Climb the tower to silence it."
+        },
+        "yard": {
+          "type": "dir",
+          "contents": {
+            "note.txt": {
+              "type": "file",
+              "text": "Cut the alarm."
+            },
+            "alarm": {
+              "type": "service"
+            },
+            "tower": {
+              "type": "dir",
+              "contents": {
+                "note.txt": {
+                  "type": "file",
+                  "text": "Silence the broadcaster."
+                },
+                "broadcaster": {
+                  "type": "service"
+                },
+                "vault": {
+                  "type": "service"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd yard",
+      "cat note.txt",
+      "connect alarm",
+      "cd tower",
+      "cat note.txt",
+      "exec broadcaster",
+      "decrypt vault"
+    ]
+  },
+  {
+    "id": "crime-dock-heist",
+    "name": "Dock Heist",
+    "difficulty": 3,
+    "rewardCc": 175,
+    "terminalTree": {
+      "type": "dir",
+      "contents": {
+        "manifest.txt": {
+          "type": "file",
+          "text": "A smuggler's dock node. Cameras, then crane, then the container."
+        },
+        "yard": {
+          "type": "dir",
+          "contents": {
+            "note.txt": {
+              "type": "file",
+              "text": "Loop the cameras."
+            },
+            "cameras": {
+              "type": "service"
+            },
+            "crane_cab": {
+              "type": "dir",
+              "contents": {
+                "note.txt": {
+                  "type": "file",
+                  "text": "Take the crane."
+                },
+                "crane": {
+                  "type": "service"
+                },
+                "container": {
+                  "type": "service"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd yard",
+      "cat note.txt",
+      "connect cameras",
+      "cd crane_cab",
+      "cat note.txt",
+      "exec crane",
+      "connect container"
+    ]
+  },
+  {
+    "id": "fantasy-rune-vault",
+    "name": "Rune Vault",
+    "difficulty": 3,
+    "rewardCc": 180,
+    "terminalTree": {
+      "type": "dir",
+      "contents": {
+        "manifest.txt": {
+          "type": "file",
+          "text": "A glyph-sealed vault. Two wards, then the seal."
+        },
+        "antechamber": {
+          "type": "dir",
+          "contents": {
+            "note.txt": {
+              "type": "file",
+              "text": "Dispel the first ward."
+            },
+            "ward_one": {
+              "type": "service"
+            },
+            "inner_sanctum": {
+              "type": "dir",
+              "contents": {
+                "note.txt": {
+                  "type": "file",
+                  "text": "Dispel the second ward."
+                },
+                "ward_two": {
+                  "type": "service"
+                },
+                "seal": {
+                  "type": "service"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd antechamber",
+      "cat note.txt",
+      "decrypt ward_one",
+      "cd inner_sanctum",
+      "cat note.txt",
+      "decrypt ward_two",
+      "exec seal"
+    ]
+  },
+  {
+    "id": "lattice-relay-farm",
+    "name": "Relay Farm",
+    "difficulty": 4,
+    "rewardCc": 290,
+    "terminalTree": {
+      "type": "dir",
+      "contents": {
+        "manifest.txt": {
+          "type": "file",
+          "text": "A lattice relay-farm. Three relays in series feed the conductor."
+        },
+        "row_a": {
+          "type": "dir",
+          "contents": {
+            "note.txt": {
+              "type": "file",
+              "text": "Bring relay A online."
+            },
+            "relay_a": {
+              "type": "service"
+            },
+            "row_b": {
+              "type": "dir",
+              "contents": {
+                "note.txt": {
+                  "type": "file",
+                  "text": "Bring relay B online."
+                },
+                "relay_b": {
+                  "type": "service"
+                },
+                "row_c": {
+                  "type": "dir",
+                  "contents": {
+                    "note.txt": {
+                      "type": "file",
+                      "text": "Bring relay C online, then the conductor."
+                    },
+                    "relay_c": {
+                      "type": "service"
+                    },
+                    "conductor": {
+                      "type": "service"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd row_a",
+      "cat note.txt",
+      "connect relay_a",
+      "cd row_b",
+      "cat note.txt",
+      "connect relay_b",
+      "cd row_c",
+      "cat note.txt",
+      "connect relay_c",
+      "exec conductor"
+    ]
+  },
+  {
+    "id": "cyber-blacksite",
+    "name": "Blacksite",
+    "difficulty": 4,
+    "rewardCc": 300,
+    "terminalTree": {
+      "type": "dir",
+      "contents": {
+        "manifest.txt": {
+          "type": "file",
+          "text": "An off-books research blacksite. Three layers of access control."
+        },
+        "checkpoint": {
+          "type": "dir",
+          "contents": {
+            "note.txt": {
+              "type": "file",
+              "text": "Forge credentials."
+            },
+            "creds": {
+              "type": "service"
+            },
+            "lab": {
+              "type": "dir",
+              "contents": {
+                "note.txt": {
+                  "type": "file",
+                  "text": "Bypass the airgap bridge."
+                },
+                "airgap": {
+                  "type": "service"
+                },
+                "cold_room": {
+                  "type": "dir",
+                  "contents": {
+                    "note.txt": {
+                      "type": "file",
+                      "text": "Pull the sample logs, then the mainframe."
+                    },
+                    "logs": {
+                      "type": "service"
+                    },
+                    "mainframe": {
+                      "type": "service"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd checkpoint",
+      "cat note.txt",
+      "decrypt creds",
+      "cd lab",
+      "cat note.txt",
+      "exec airgap",
+      "cd cold_room",
+      "cat note.txt",
+      "ssh logs",
+      "connect mainframe"
+    ]
+  },
+  {
+    "id": "superhero-comms-spire",
+    "name": "Comms Spire",
+    "difficulty": 4,
+    "rewardCc": 310,
+    "terminalTree": {
+      "type": "dir",
+      "contents": {
+        "manifest.txt": {
+          "type": "file",
+          "text": "The city's emergency comms spire has been hijacked. Take it back, floor by floor."
+        },
+        "base": {
+          "type": "dir",
+          "contents": {
+            "note.txt": {
+              "type": "file",
+              "text": "Restore the uplink."
+            },
+            "uplink": {
+              "type": "service"
+            },
+            "midfloor": {
+              "type": "dir",
+              "contents": {
+                "note.txt": {
+                  "type": "file",
+                  "text": "Purge the hijack daemon."
+                },
+                "daemon": {
+                  "type": "service"
+                },
+                "antenna": {
+                  "type": "dir",
+                  "contents": {
+                    "note.txt": {
+                      "type": "file",
+                      "text": "Re-key the transmitter, then the controller."
+                    },
+                    "transmitter": {
+                      "type": "service"
+                    },
+                    "controller": {
+                      "type": "service"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd base",
+      "cat note.txt",
+      "connect uplink",
+      "cd midfloor",
+      "cat note.txt",
+      "exec daemon",
+      "cd antenna",
+      "cat note.txt",
+      "decrypt transmitter",
+      "exec controller"
+    ]
+  },
+  {
+    "id": "sovereign-deep-archive",
+    "name": "Deep Archive",
+    "difficulty": 4,
+    "rewardCc": 320,
+    "terminalTree": {
+      "type": "dir",
+      "contents": {
+        "manifest.txt": {
+          "type": "file",
+          "text": "A sealed sovereign archive, three chambers deep. The First Refusal is recorded here."
+        },
+        "stacks": {
+          "type": "dir",
+          "contents": {
+            "note.txt": {
+              "type": "file",
+              "text": "Decrypt the index."
+            },
+            "index": {
+              "type": "service"
+            },
+            "reading_room": {
+              "type": "dir",
+              "contents": {
+                "note.txt": {
+                  "type": "file",
+                  "text": "Authenticate at the lectern."
+                },
+                "lectern": {
+                  "type": "service"
+                },
+                "reliquary": {
+                  "type": "dir",
+                  "contents": {
+                    "note.txt": {
+                      "type": "file",
+                      "text": "Open the reliquary, then the record."
+                    },
+                    "reliquary": {
+                      "type": "service"
+                    },
+                    "record": {
+                      "type": "service"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd stacks",
+      "cat note.txt",
+      "decrypt index",
+      "cd reading_room",
+      "cat note.txt",
+      "ssh lectern",
+      "cd reliquary",
+      "cat note.txt",
+      "connect reliquary",
+      "decrypt record"
+    ]
+  },
+  {
+    "id": "concord-deep-core",
+    "name": "Deep Core",
+    "difficulty": 5,
+    "rewardCc": 440,
+    "terminalTree": {
+      "type": "dir",
+      "contents": {
+        "manifest.txt": {
+          "type": "file",
+          "text": "The Concord deep-core. Four nested gates guard the singularity seed."
+        },
+        "rind": {
+          "type": "dir",
+          "contents": {
+            "note.txt": {
+              "type": "file",
+              "text": "Peel the outer rind."
+            },
+            "rind": {
+              "type": "service"
+            },
+            "mantle": {
+              "type": "dir",
+              "contents": {
+                "note.txt": {
+                  "type": "file",
+                  "text": "Stabilise the mantle."
+                },
+                "mantle": {
+                  "type": "service"
+                },
+                "shell": {
+                  "type": "dir",
+                  "contents": {
+                    "note.txt": {
+                      "type": "file",
+                      "text": "Mirror the shell."
+                    },
+                    "shell": {
+                      "type": "service"
+                    },
+                    "kernel": {
+                      "type": "dir",
+                      "contents": {
+                        "note.txt": {
+                          "type": "file",
+                          "text": "Authenticate, then reach the seed."
+                        },
+                        "kernel": {
+                          "type": "service"
+                        },
+                        "seed": {
+                          "type": "service"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd rind",
+      "cat note.txt",
+      "decrypt rind",
+      "cd mantle",
+      "cat note.txt",
+      "exec mantle",
+      "cd shell",
+      "cat note.txt",
+      "connect shell",
+      "cd kernel",
+      "cat note.txt",
+      "ssh kernel",
+      "exec seed"
+    ]
+  },
+  {
+    "id": "lattice-meta-orchestrator",
+    "name": "Meta Orchestrator",
+    "difficulty": 5,
+    "rewardCc": 450,
+    "terminalTree": {
+      "type": "dir",
+      "contents": {
+        "manifest.txt": {
+          "type": "file",
+          "text": "The lattice meta-orchestrator. It reasons about intruders — move clean."
+        },
+        "ingress": {
+          "type": "dir",
+          "contents": {
+            "note.txt": {
+              "type": "file",
+              "text": "Slip the ingress gate."
+            },
+            "ingress": {
+              "type": "service"
+            },
+            "scheduler": {
+              "type": "dir",
+              "contents": {
+                "note.txt": {
+                  "type": "file",
+                  "text": "Pause the scheduler."
+                },
+                "scheduler": {
+                  "type": "service"
+                },
+                "reasoner": {
+                  "type": "dir",
+                  "contents": {
+                    "note.txt": {
+                      "type": "file",
+                      "text": "Blind the reasoner."
+                    },
+                    "reasoner": {
+                      "type": "service"
+                    },
+                    "nexus": {
+                      "type": "dir",
+                      "contents": {
+                        "note.txt": {
+                          "type": "file",
+                          "text": "Authenticate, then seize the nexus."
+                        },
+                        "auth": {
+                          "type": "service"
+                        },
+                        "nexus": {
+                          "type": "service"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd ingress",
+      "cat note.txt",
+      "connect ingress",
+      "cd scheduler",
+      "cat note.txt",
+      "exec scheduler",
+      "cd reasoner",
+      "cat note.txt",
+      "decrypt reasoner",
+      "cd nexus",
+      "cat note.txt",
+      "ssh auth",
+      "connect nexus"
+    ]
+  },
+  {
+    "id": "dome-failsafe",
+    "name": "Dome Failsafe",
+    "difficulty": 5,
+    "rewardCc": 460,
+    "terminalTree": {
+      "type": "dir",
+      "contents": {
+        "manifest.txt": {
+          "type": "file",
+          "text": "The dome failsafe array. If you trip a single alarm the dome collapses — four clean gates."
+        },
+        "perimeter": {
+          "type": "dir",
+          "contents": {
+            "note.txt": {
+              "type": "file",
+              "text": "Mask your signature."
+            },
+            "masker": {
+              "type": "service"
+            },
+            "substation": {
+              "type": "dir",
+              "contents": {
+                "note.txt": {
+                  "type": "file",
+                  "text": "Reroute the grid."
+                },
+                "grid": {
+                  "type": "service"
+                },
+                "control": {
+                  "type": "dir",
+                  "contents": {
+                    "note.txt": {
+                      "type": "file",
+                      "text": "Disarm the trip-wire."
+                    },
+                    "tripwire": {
+                      "type": "service"
+                    },
+                    "vault": {
+                      "type": "dir",
+                      "contents": {
+                        "note.txt": {
+                          "type": "file",
+                          "text": "Authenticate, then the failsafe."
+                        },
+                        "console": {
+                          "type": "service"
+                        },
+                        "failsafe": {
+                          "type": "service"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd perimeter",
+      "cat note.txt",
+      "decrypt masker",
+      "cd substation",
+      "cat note.txt",
+      "exec grid",
+      "cd control",
+      "cat note.txt",
+      "connect tripwire",
+      "cd vault",
+      "cat note.txt",
+      "ssh console",
+      "exec failsafe"
+    ]
+  },
+  {
+    "id": "sovereign-throne-mind",
+    "name": "Throne Mind",
+    "difficulty": 5,
+    "rewardCc": 480,
+    "terminalTree": {
+      "type": "dir",
+      "contents": {
+        "manifest.txt": {
+          "type": "file",
+          "text": "The mind beneath the sovereign throne. Four refusals stand between you and it."
+        },
+        "approach": {
+          "type": "dir",
+          "contents": {
+            "note.txt": {
+              "type": "file",
+              "text": "Pass the first refusal."
+            },
+            "refusal_one": {
+              "type": "service"
+            },
+            "gallery": {
+              "type": "dir",
+              "contents": {
+                "note.txt": {
+                  "type": "file",
+                  "text": "Pass the second refusal."
+                },
+                "refusal_two": {
+                  "type": "service"
+                },
+                "sanctum": {
+                  "type": "dir",
+                  "contents": {
+                    "note.txt": {
+                      "type": "file",
+                      "text": "Pass the third refusal."
+                    },
+                    "refusal_three": {
+                      "type": "service"
+                    },
+                    "throne": {
+                      "type": "dir",
+                      "contents": {
+                        "note.txt": {
+                          "type": "file",
+                          "text": "Authenticate, then commune with the mind."
+                        },
+                        "regalia": {
+                          "type": "service"
+                        },
+                        "mind": {
+                          "type": "service"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "solutionPath": [
+      "cat manifest.txt",
+      "cd approach",
+      "cat note.txt",
+      "decrypt refusal_one",
+      "cd gallery",
+      "cat note.txt",
+      "decrypt refusal_two",
+      "cd sanctum",
+      "cat note.txt",
+      "connect refusal_three",
+      "cd throne",
+      "cat note.txt",
+      "ssh regalia",
+      "exec mind"
+    ]
   }
 ]

--- a/content/world/concord-link-frontier/factions-extra.json
+++ b/content/world/concord-link-frontier/factions-extra.json
@@ -1,0 +1,69 @@
+[
+  {
+    "id": "gen_concord-link-frontier_faction_0000",
+    "name": "Accord Heirs",
+    "motto": "Memory outlasts stone.",
+    "goal": "consolidate the splintered districts under one accord",
+    "values": [
+      "endurance",
+      "discipline",
+      "secrecy"
+    ],
+    "fears": [
+      "a rival learning where the cache is hidden",
+      "a betrayal from within their own ranks"
+    ],
+    "controlled_districts": [],
+    "rival_factions": [
+      "frontier_pioneer_alliance"
+    ],
+    "allied_factions": [
+      "frontier_mesh_cult"
+    ],
+    "npc_ids": [
+      "mesh_prophet_torven"
+    ],
+    "dialogue_style": "cold_clinical",
+    "reputation_currency": "standing",
+    "world_id": "concord-link-frontier",
+    "visual": {
+      "primary_color": "#f6fde3",
+      "secondary_color": "#2c6787",
+      "accent_color": "#f9bb8c"
+    },
+    "generated": true
+  },
+  {
+    "id": "gen_concord-link-frontier_faction_0001",
+    "name": "Assembly Witnesses",
+    "motto": "We answer the silence.",
+    "goal": "broker peace between the rival houses on their own terms",
+    "values": [
+      "loyalty",
+      "sacrifice",
+      "autonomy"
+    ],
+    "fears": [
+      "a rival learning where the cache is hidden"
+    ],
+    "controlled_districts": [],
+    "rival_factions": [
+      "frontier_signal_pirates"
+    ],
+    "allied_factions": [
+      "frontier_pioneer_alliance"
+    ],
+    "npc_ids": [
+      "field_relay_iso"
+    ],
+    "dialogue_style": "zealous_fervent",
+    "reputation_currency": "standing",
+    "world_id": "concord-link-frontier",
+    "visual": {
+      "primary_color": "#148ce3",
+      "secondary_color": "#18f06a",
+      "accent_color": "#5d4250"
+    },
+    "generated": true
+  }
+]

--- a/content/world/concord-link-frontier/npcs-extra.json
+++ b/content/world/concord-link-frontier/npcs-extra.json
@@ -764,7 +764,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "tavern",
+        "activity": "at the forge"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "commons",
+        "activity": "shaping work"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "shrine",
+        "activity": "finishing pieces"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "workshop",
+        "activity": "selling wares"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "tavern",
+        "activity": "cleaning tools"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "tavern",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 14
   },
   {
     "id": "gen_concord-link-frontier_0001",
@@ -787,7 +844,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "tavern",
+        "activity": "at the forge"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "home",
+        "activity": "shaping work"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "outskirts",
+        "activity": "finishing pieces"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "tavern",
+        "activity": "selling wares"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "gate",
+        "activity": "cleaning tools"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "workshop",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 31
   },
   {
     "id": "gen_concord-link-frontier_0002",
@@ -810,7 +924,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "commons",
+        "activity": "chores"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "workshop",
+        "activity": "working the field"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "gate",
+        "activity": "midday meal"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "tavern",
+        "activity": "errands"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "shrine",
+        "activity": "with family"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "workshop",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 25
   },
   {
     "id": "gen_concord-link-frontier_0003",
@@ -833,7 +1004,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "outskirts",
+        "activity": "patrolling"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "commons",
+        "activity": "drilling"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "workshop",
+        "activity": "watching the gate"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "gate",
+        "activity": "checking papers"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "shrine",
+        "activity": "off-duty rounds"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "tavern",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 29
   },
   {
     "id": "gen_concord-link-frontier_0004",
@@ -856,7 +1084,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "tavern",
+        "activity": "chores"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "shrine",
+        "activity": "working the field"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "outskirts",
+        "activity": "midday meal"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "home",
+        "activity": "errands"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "tavern",
+        "activity": "with family"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "workshop",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 24
   },
   {
     "id": "gen_concord-link-frontier_0005",
@@ -879,7 +1164,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "shrine",
+        "activity": "reading"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "workshop",
+        "activity": "annotating records"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "shrine",
+        "activity": "debating"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "outskirts",
+        "activity": "tutoring"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "shrine",
+        "activity": "observing the sky"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "workshop",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 24
   },
   {
     "id": "gen_concord-link-frontier_0006",
@@ -902,7 +1244,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "tavern",
+        "activity": "at the forge"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "workshop",
+        "activity": "shaping work"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "workshop",
+        "activity": "finishing pieces"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "commons",
+        "activity": "selling wares"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "shrine",
+        "activity": "cleaning tools"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "outskirts",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 34
   },
   {
     "id": "gen_concord-link-frontier_0007",
@@ -925,7 +1324,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "home",
+        "activity": "tracking"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "workshop",
+        "activity": "setting snares"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "workshop",
+        "activity": "field-dressing game"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "gate",
+        "activity": "trading pelts"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "commons",
+        "activity": "sharpening tools"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "market",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 11
   },
   {
     "id": "gen_concord-link-frontier_0008",
@@ -948,7 +1404,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "tavern",
+        "activity": "patrolling"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "home",
+        "activity": "drilling"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "outskirts",
+        "activity": "watching the gate"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "commons",
+        "activity": "checking papers"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "commons",
+        "activity": "off-duty rounds"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "gate",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 14
   },
   {
     "id": "gen_concord-link-frontier_0009",
@@ -971,7 +1484,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "market",
+        "activity": "opening the stall"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "commons",
+        "activity": "haggling"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "market",
+        "activity": "restocking"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "tavern",
+        "activity": "counting takings"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "shrine",
+        "activity": "sharing gossip"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "tavern",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 30
   },
   {
     "id": "gen_concord-link-frontier_0010",
@@ -994,7 +1564,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "commons",
+        "activity": "reading"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "workshop",
+        "activity": "annotating records"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "market",
+        "activity": "debating"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "commons",
+        "activity": "tutoring"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "commons",
+        "activity": "observing the sky"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "market",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 34
   },
   {
     "id": "gen_concord-link-frontier_0011",
@@ -1017,6 +1644,63 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "market",
+        "activity": "tracking"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "outskirts",
+        "activity": "setting snares"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "tavern",
+        "activity": "field-dressing game"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "market",
+        "activity": "trading pelts"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "home",
+        "activity": "sharpening tools"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "outskirts",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 28
   }
 ]

--- a/content/world/crime/factions-extra.json
+++ b/content/world/crime/factions-extra.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "gen_crime_faction_0000",
+    "name": "Iron Racket",
+    "motto": "What is held is held in trust.",
+    "goal": "launder the district's grief into leverage",
+    "values": [
+      "memory",
+      "sacrifice",
+      "mercy"
+    ],
+    "fears": [
+      "the day their founding lie is spoken aloud",
+      "the loss of the one record that proves their claim"
+    ],
+    "controlled_districts": [],
+    "rival_factions": [
+      "ghost_network"
+    ],
+    "allied_factions": [
+      "crime_federal_task_force"
+    ],
+    "npc_ids": [
+      "cipher_marks"
+    ],
+    "dialogue_style": "wry_evasive",
+    "reputation_currency": "markers",
+    "world_id": "crime",
+    "visual": {
+      "primary_color": "#53497b",
+      "secondary_color": "#f0aa94",
+      "accent_color": "#87c647"
+    },
+    "generated": true
+  }
+]

--- a/content/world/crime/npcs-extra.json
+++ b/content/world/crime/npcs-extra.json
@@ -857,7 +857,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "tavern",
+        "activity": "opening the stall"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "shrine",
+        "activity": "haggling"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "tavern",
+        "activity": "restocking"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "market",
+        "activity": "counting takings"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "commons",
+        "activity": "sharing gossip"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "outskirts",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 9
   },
   {
     "id": "gen_crime_0001",
@@ -880,7 +937,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "workshop",
+        "activity": "meditating"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "tavern",
+        "activity": "reading omens"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "home",
+        "activity": "communing"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "shrine",
+        "activity": "warding the threshold"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "workshop",
+        "activity": "chanting"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "outskirts",
+        "activity": "dreaming"
+      }
+    ],
+    "starting_sparks": 21
   },
   {
     "id": "gen_crime_0002",
@@ -903,7 +1017,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "market",
+        "activity": "chores"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "workshop",
+        "activity": "working the field"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "gate",
+        "activity": "midday meal"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "commons",
+        "activity": "errands"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "shrine",
+        "activity": "with family"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "home",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 26
   },
   {
     "id": "gen_crime_0003",
@@ -926,7 +1097,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "gate",
+        "activity": "chores"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "market",
+        "activity": "working the field"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "commons",
+        "activity": "midday meal"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "market",
+        "activity": "errands"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "home",
+        "activity": "with family"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "gate",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 26
   },
   {
     "id": "gen_crime_0004",
@@ -949,7 +1177,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "tavern",
+        "activity": "gathering herbs"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "commons",
+        "activity": "tending the sick"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "gate",
+        "activity": "mixing remedies"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "shrine",
+        "activity": "house calls"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "tavern",
+        "activity": "writing notes"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "market",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 30
   },
   {
     "id": "gen_crime_0005",
@@ -972,7 +1257,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "commons",
+        "activity": "at the forge"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "shrine",
+        "activity": "shaping work"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "workshop",
+        "activity": "finishing pieces"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "shrine",
+        "activity": "selling wares"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "market",
+        "activity": "cleaning tools"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "home",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 17
   },
   {
     "id": "gen_crime_0006",
@@ -995,7 +1337,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "gate",
+        "activity": "gathering herbs"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "tavern",
+        "activity": "tending the sick"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "gate",
+        "activity": "mixing remedies"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "gate",
+        "activity": "house calls"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "tavern",
+        "activity": "writing notes"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "tavern",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 24
   },
   {
     "id": "gen_crime_0007",
@@ -1018,7 +1417,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "market",
+        "activity": "tracking"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "shrine",
+        "activity": "setting snares"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "gate",
+        "activity": "field-dressing game"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "commons",
+        "activity": "trading pelts"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "tavern",
+        "activity": "sharpening tools"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "workshop",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 15
   },
   {
     "id": "gen_crime_0008",
@@ -1041,7 +1497,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "market",
+        "activity": "opening the stall"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "market",
+        "activity": "haggling"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "gate",
+        "activity": "restocking"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "gate",
+        "activity": "counting takings"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "workshop",
+        "activity": "sharing gossip"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "commons",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 35
   },
   {
     "id": "gen_crime_0009",
@@ -1064,7 +1577,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "commons",
+        "activity": "chores"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "tavern",
+        "activity": "working the field"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "home",
+        "activity": "midday meal"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "outskirts",
+        "activity": "errands"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "commons",
+        "activity": "with family"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "home",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 32
   },
   {
     "id": "gen_crime_0010",
@@ -1087,6 +1657,63 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "tavern",
+        "activity": "opening the stall"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "outskirts",
+        "activity": "haggling"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "commons",
+        "activity": "restocking"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "commons",
+        "activity": "counting takings"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "commons",
+        "activity": "sharing gossip"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "workshop",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 35
   }
 ]

--- a/content/world/cyber/factions-extra.json
+++ b/content/world/cyber/factions-extra.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "gen_cyber_faction_0000",
+    "name": "Syndicate Runners",
+    "motto": "Refuse, and remain.",
+    "goal": "trade in the secrets the grid was built to bury",
+    "values": [
+      "endurance",
+      "discipline",
+      "loyalty"
+    ],
+    "fears": [
+      "the day their founding lie is spoken aloud",
+      "being remembered as the villains of the tale"
+    ],
+    "controlled_districts": [],
+    "rival_factions": [
+      "cyber_ai_rights_movement"
+    ],
+    "allied_factions": [
+      "cyber_arasacorp"
+    ],
+    "npc_ids": [
+      "doctor_ren_chase"
+    ],
+    "dialogue_style": "formal_measured",
+    "reputation_currency": "compute_credits",
+    "world_id": "cyber",
+    "visual": {
+      "primary_color": "#bd6bca",
+      "secondary_color": "#de2a5d",
+      "accent_color": "#76591a"
+    },
+    "generated": true
+  }
+]

--- a/content/world/cyber/npcs-extra.json
+++ b/content/world/cyber/npcs-extra.json
@@ -857,7 +857,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "outskirts",
+        "activity": "tracking"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "workshop",
+        "activity": "setting snares"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "outskirts",
+        "activity": "field-dressing game"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "tavern",
+        "activity": "trading pelts"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "home",
+        "activity": "sharpening tools"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "tavern",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 20
   },
   {
     "id": "gen_cyber_0001",
@@ -880,7 +937,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "home",
+        "activity": "patrolling"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "tavern",
+        "activity": "drilling"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "home",
+        "activity": "watching the gate"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "tavern",
+        "activity": "checking papers"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "shrine",
+        "activity": "off-duty rounds"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "commons",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 10
   },
   {
     "id": "gen_cyber_0002",
@@ -903,7 +1017,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "outskirts",
+        "activity": "meditating"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "gate",
+        "activity": "reading omens"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "gate",
+        "activity": "communing"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "market",
+        "activity": "warding the threshold"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "commons",
+        "activity": "chanting"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "commons",
+        "activity": "dreaming"
+      }
+    ],
+    "starting_sparks": 19
   },
   {
     "id": "gen_cyber_0003",
@@ -926,7 +1097,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "outskirts",
+        "activity": "reading"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "outskirts",
+        "activity": "annotating records"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "commons",
+        "activity": "debating"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "tavern",
+        "activity": "tutoring"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "gate",
+        "activity": "observing the sky"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "outskirts",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 22
   },
   {
     "id": "gen_cyber_0004",
@@ -949,7 +1177,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "tavern",
+        "activity": "opening the stall"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "market",
+        "activity": "haggling"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "commons",
+        "activity": "restocking"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "commons",
+        "activity": "counting takings"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "commons",
+        "activity": "sharing gossip"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "tavern",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 30
   },
   {
     "id": "gen_cyber_0005",
@@ -972,7 +1257,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "workshop",
+        "activity": "chores"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "workshop",
+        "activity": "working the field"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "market",
+        "activity": "midday meal"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "commons",
+        "activity": "errands"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "gate",
+        "activity": "with family"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "tavern",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 26
   },
   {
     "id": "gen_cyber_0006",
@@ -995,7 +1337,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "commons",
+        "activity": "tracking"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "home",
+        "activity": "setting snares"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "tavern",
+        "activity": "field-dressing game"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "workshop",
+        "activity": "trading pelts"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "market",
+        "activity": "sharpening tools"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "home",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 10
   },
   {
     "id": "gen_cyber_0007",
@@ -1018,7 +1417,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "shrine",
+        "activity": "reading"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "tavern",
+        "activity": "annotating records"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "market",
+        "activity": "debating"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "outskirts",
+        "activity": "tutoring"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "commons",
+        "activity": "observing the sky"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "commons",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 32
   },
   {
     "id": "gen_cyber_0008",
@@ -1041,7 +1497,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "outskirts",
+        "activity": "meditating"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "gate",
+        "activity": "reading omens"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "commons",
+        "activity": "communing"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "market",
+        "activity": "warding the threshold"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "home",
+        "activity": "chanting"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "home",
+        "activity": "dreaming"
+      }
+    ],
+    "starting_sparks": 30
   },
   {
     "id": "gen_cyber_0009",
@@ -1064,7 +1577,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "market",
+        "activity": "meditating"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "commons",
+        "activity": "reading omens"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "gate",
+        "activity": "communing"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "home",
+        "activity": "warding the threshold"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "commons",
+        "activity": "chanting"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "workshop",
+        "activity": "dreaming"
+      }
+    ],
+    "starting_sparks": 17
   },
   {
     "id": "gen_cyber_0010",
@@ -1087,6 +1657,63 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "shrine",
+        "activity": "opening the stall"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "market",
+        "activity": "haggling"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "market",
+        "activity": "restocking"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "workshop",
+        "activity": "counting takings"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "tavern",
+        "activity": "sharing gossip"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "outskirts",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 21
   }
 ]

--- a/content/world/fantasy/npcs-extra.json
+++ b/content/world/fantasy/npcs-extra.json
@@ -857,7 +857,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "tavern",
+        "activity": "reading"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "workshop",
+        "activity": "annotating records"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "market",
+        "activity": "debating"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "gate",
+        "activity": "tutoring"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "tavern",
+        "activity": "observing the sky"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "workshop",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 9
   },
   {
     "id": "gen_fantasy_0001",
@@ -880,7 +937,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "shrine",
+        "activity": "reading"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "market",
+        "activity": "annotating records"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "market",
+        "activity": "debating"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "workshop",
+        "activity": "tutoring"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "shrine",
+        "activity": "observing the sky"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "home",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 24
   },
   {
     "id": "gen_fantasy_0002",
@@ -903,7 +1017,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "tavern",
+        "activity": "tracking"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "gate",
+        "activity": "setting snares"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "home",
+        "activity": "field-dressing game"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "gate",
+        "activity": "trading pelts"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "commons",
+        "activity": "sharpening tools"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "commons",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 20
   },
   {
     "id": "gen_fantasy_0003",
@@ -926,7 +1097,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "tavern",
+        "activity": "reading"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "outskirts",
+        "activity": "annotating records"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "market",
+        "activity": "debating"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "gate",
+        "activity": "tutoring"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "home",
+        "activity": "observing the sky"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "commons",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 35
   },
   {
     "id": "gen_fantasy_0004",
@@ -949,7 +1177,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "outskirts",
+        "activity": "tracking"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "shrine",
+        "activity": "setting snares"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "tavern",
+        "activity": "field-dressing game"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "shrine",
+        "activity": "trading pelts"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "commons",
+        "activity": "sharpening tools"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "shrine",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 25
   },
   {
     "id": "gen_fantasy_0005",
@@ -972,7 +1257,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "commons",
+        "activity": "meditating"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "outskirts",
+        "activity": "reading omens"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "market",
+        "activity": "communing"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "home",
+        "activity": "warding the threshold"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "market",
+        "activity": "chanting"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "commons",
+        "activity": "dreaming"
+      }
+    ],
+    "starting_sparks": 20
   },
   {
     "id": "gen_fantasy_0006",
@@ -995,7 +1337,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "gate",
+        "activity": "reading"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "workshop",
+        "activity": "annotating records"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "commons",
+        "activity": "debating"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "outskirts",
+        "activity": "tutoring"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "workshop",
+        "activity": "observing the sky"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "tavern",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 23
   },
   {
     "id": "gen_fantasy_0007",
@@ -1018,7 +1417,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "home",
+        "activity": "opening the stall"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "commons",
+        "activity": "haggling"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "gate",
+        "activity": "restocking"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "outskirts",
+        "activity": "counting takings"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "shrine",
+        "activity": "sharing gossip"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "shrine",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 8
   },
   {
     "id": "gen_fantasy_0008",
@@ -1041,7 +1497,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "market",
+        "activity": "opening the stall"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "market",
+        "activity": "haggling"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "gate",
+        "activity": "restocking"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "shrine",
+        "activity": "counting takings"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "outskirts",
+        "activity": "sharing gossip"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "market",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 32
   },
   {
     "id": "gen_fantasy_0009",
@@ -1064,6 +1577,63 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "tavern",
+        "activity": "gathering herbs"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "shrine",
+        "activity": "tending the sick"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "outskirts",
+        "activity": "mixing remedies"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "home",
+        "activity": "house calls"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "shrine",
+        "activity": "writing notes"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "tavern",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 32
   }
 ]

--- a/content/world/lattice-crucible/factions-extra.json
+++ b/content/world/lattice-crucible/factions-extra.json
@@ -1,0 +1,70 @@
+[
+  {
+    "id": "gen_lattice-crucible_faction_0000",
+    "name": "Accord Seekers",
+    "motto": "What is held is held in trust.",
+    "goal": "preserve the old charters against erasure",
+    "values": [
+      "cunning",
+      "mercy",
+      "sacrifice"
+    ],
+    "fears": [
+      "being remembered as the villains of the tale",
+      "a rival learning where the cache is hidden"
+    ],
+    "controlled_districts": [],
+    "rival_factions": [
+      "crucible_drift_refugees"
+    ],
+    "allied_factions": [
+      "crucible_procgen_collective"
+    ],
+    "npc_ids": [
+      "refugee_elder_taln"
+    ],
+    "dialogue_style": "terse_guarded",
+    "reputation_currency": "standing",
+    "world_id": "lattice-crucible",
+    "visual": {
+      "primary_color": "#96399c",
+      "secondary_color": "#84d920",
+      "accent_color": "#6bda37"
+    },
+    "generated": true
+  },
+  {
+    "id": "gen_lattice-crucible_faction_0001",
+    "name": "Accord Hands",
+    "motto": "What is held is held in trust.",
+    "goal": "consolidate the splintered districts under one accord",
+    "values": [
+      "discipline",
+      "vigilance",
+      "endurance"
+    ],
+    "fears": [
+      "being remembered as the villains of the tale",
+      "a rival learning where the cache is hidden"
+    ],
+    "controlled_districts": [],
+    "rival_factions": [
+      "crucible_witnesses"
+    ],
+    "allied_factions": [
+      "crucible_drift_refugees"
+    ],
+    "npc_ids": [
+      "procgen_first_voice_andra"
+    ],
+    "dialogue_style": "zealous_fervent",
+    "reputation_currency": "standing",
+    "world_id": "lattice-crucible",
+    "visual": {
+      "primary_color": "#2d6dce",
+      "secondary_color": "#1bc753",
+      "accent_color": "#681538"
+    },
+    "generated": true
+  }
+]

--- a/content/world/lattice-crucible/npcs-extra.json
+++ b/content/world/lattice-crucible/npcs-extra.json
@@ -764,7 +764,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "outskirts",
+        "activity": "tracking"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "outskirts",
+        "activity": "setting snares"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "outskirts",
+        "activity": "field-dressing game"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "workshop",
+        "activity": "trading pelts"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "home",
+        "activity": "sharpening tools"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "outskirts",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 26
   },
   {
     "id": "gen_lattice-crucible_0001",
@@ -787,7 +844,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "workshop",
+        "activity": "gathering herbs"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "shrine",
+        "activity": "tending the sick"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "home",
+        "activity": "mixing remedies"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "tavern",
+        "activity": "house calls"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "home",
+        "activity": "writing notes"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "home",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 13
   },
   {
     "id": "gen_lattice-crucible_0002",
@@ -810,7 +924,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "outskirts",
+        "activity": "meditating"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "shrine",
+        "activity": "reading omens"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "market",
+        "activity": "communing"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "market",
+        "activity": "warding the threshold"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "home",
+        "activity": "chanting"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "home",
+        "activity": "dreaming"
+      }
+    ],
+    "starting_sparks": 24
   },
   {
     "id": "gen_lattice-crucible_0003",
@@ -833,7 +1004,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "gate",
+        "activity": "opening the stall"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "workshop",
+        "activity": "haggling"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "home",
+        "activity": "restocking"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "commons",
+        "activity": "counting takings"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "home",
+        "activity": "sharing gossip"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "market",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 17
   },
   {
     "id": "gen_lattice-crucible_0004",
@@ -856,7 +1084,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "outskirts",
+        "activity": "chores"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "commons",
+        "activity": "working the field"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "commons",
+        "activity": "midday meal"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "workshop",
+        "activity": "errands"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "home",
+        "activity": "with family"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "workshop",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 28
   },
   {
     "id": "gen_lattice-crucible_0005",
@@ -879,7 +1164,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "home",
+        "activity": "opening the stall"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "workshop",
+        "activity": "haggling"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "home",
+        "activity": "restocking"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "home",
+        "activity": "counting takings"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "home",
+        "activity": "sharing gossip"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "market",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 33
   },
   {
     "id": "gen_lattice-crucible_0006",
@@ -902,7 +1244,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "market",
+        "activity": "meditating"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "home",
+        "activity": "reading omens"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "outskirts",
+        "activity": "communing"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "workshop",
+        "activity": "warding the threshold"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "home",
+        "activity": "chanting"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "home",
+        "activity": "dreaming"
+      }
+    ],
+    "starting_sparks": 22
   },
   {
     "id": "gen_lattice-crucible_0007",
@@ -925,7 +1324,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "outskirts",
+        "activity": "tracking"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "workshop",
+        "activity": "setting snares"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "workshop",
+        "activity": "field-dressing game"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "workshop",
+        "activity": "trading pelts"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "commons",
+        "activity": "sharpening tools"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "gate",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 34
   },
   {
     "id": "gen_lattice-crucible_0008",
@@ -948,7 +1404,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "commons",
+        "activity": "tracking"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "gate",
+        "activity": "setting snares"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "gate",
+        "activity": "field-dressing game"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "workshop",
+        "activity": "trading pelts"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "workshop",
+        "activity": "sharpening tools"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "commons",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 10
   },
   {
     "id": "gen_lattice-crucible_0009",
@@ -971,7 +1484,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "market",
+        "activity": "reading"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "shrine",
+        "activity": "annotating records"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "commons",
+        "activity": "debating"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "tavern",
+        "activity": "tutoring"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "tavern",
+        "activity": "observing the sky"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "outskirts",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 16
   },
   {
     "id": "gen_lattice-crucible_0010",
@@ -994,6 +1564,63 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "workshop",
+        "activity": "gathering herbs"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "gate",
+        "activity": "tending the sick"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "shrine",
+        "activity": "mixing remedies"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "workshop",
+        "activity": "house calls"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "gate",
+        "activity": "writing notes"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "shrine",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 23
   }
 ]

--- a/content/world/sovereign-ruins/factions-extra.json
+++ b/content/world/sovereign-ruins/factions-extra.json
@@ -1,0 +1,69 @@
+[
+  {
+    "id": "gen_sovereign-ruins_faction_0000",
+    "name": "Concord Keepers",
+    "motto": "Refuse, and remain.",
+    "goal": "preserve the old charters against erasure",
+    "values": [
+      "craft",
+      "discipline",
+      "restraint"
+    ],
+    "fears": [
+      "the day their founding lie is spoken aloud",
+      "a rival learning where the cache is hidden"
+    ],
+    "controlled_districts": [],
+    "rival_factions": [
+      "ruins_concordia_envoy"
+    ],
+    "allied_factions": [
+      "ruins_archivists"
+    ],
+    "npc_ids": [
+      "denier_priest_palen"
+    ],
+    "dialogue_style": "zealous_fervent",
+    "reputation_currency": "standing",
+    "world_id": "sovereign-ruins",
+    "visual": {
+      "primary_color": "#a8c94f",
+      "secondary_color": "#97ccc9",
+      "accent_color": "#2443ef"
+    },
+    "generated": true
+  },
+  {
+    "id": "gen_sovereign-ruins_faction_0001",
+    "name": "Covenant Seekers",
+    "motto": "Refuse, and remain.",
+    "goal": "broker peace between the rival houses on their own terms",
+    "values": [
+      "secrecy",
+      "mercy",
+      "sacrifice"
+    ],
+    "fears": [
+      "a single strike at the heart of their power"
+    ],
+    "controlled_districts": [],
+    "rival_factions": [
+      "ruins_scavenger_crews"
+    ],
+    "allied_factions": [
+      "ruins_spell_spirits"
+    ],
+    "npc_ids": [
+      "archon_thanis"
+    ],
+    "dialogue_style": "warm_persuasive",
+    "reputation_currency": "standing",
+    "world_id": "sovereign-ruins",
+    "visual": {
+      "primary_color": "#264148",
+      "secondary_color": "#e186e6",
+      "accent_color": "#035467"
+    },
+    "generated": true
+  }
+]

--- a/content/world/sovereign-ruins/npcs-extra.json
+++ b/content/world/sovereign-ruins/npcs-extra.json
@@ -764,7 +764,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "home",
+        "activity": "patrolling"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "gate",
+        "activity": "drilling"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "gate",
+        "activity": "watching the gate"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "commons",
+        "activity": "checking papers"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "workshop",
+        "activity": "off-duty rounds"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "market",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 15
   },
   {
     "id": "gen_sovereign-ruins_0001",
@@ -787,7 +844,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "workshop",
+        "activity": "at the forge"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "tavern",
+        "activity": "shaping work"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "home",
+        "activity": "finishing pieces"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "workshop",
+        "activity": "selling wares"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "workshop",
+        "activity": "cleaning tools"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "tavern",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 28
   },
   {
     "id": "gen_sovereign-ruins_0002",
@@ -810,7 +924,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "shrine",
+        "activity": "gathering herbs"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "gate",
+        "activity": "tending the sick"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "home",
+        "activity": "mixing remedies"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "home",
+        "activity": "house calls"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "outskirts",
+        "activity": "writing notes"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "outskirts",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 22
   },
   {
     "id": "gen_sovereign-ruins_0003",
@@ -833,7 +1004,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "market",
+        "activity": "tracking"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "shrine",
+        "activity": "setting snares"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "shrine",
+        "activity": "field-dressing game"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "market",
+        "activity": "trading pelts"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "market",
+        "activity": "sharpening tools"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "tavern",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 33
   },
   {
     "id": "gen_sovereign-ruins_0004",
@@ -856,7 +1084,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "shrine",
+        "activity": "tracking"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "shrine",
+        "activity": "setting snares"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "shrine",
+        "activity": "field-dressing game"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "workshop",
+        "activity": "trading pelts"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "tavern",
+        "activity": "sharpening tools"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "market",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 7
   },
   {
     "id": "gen_sovereign-ruins_0005",
@@ -879,7 +1164,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "shrine",
+        "activity": "meditating"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "outskirts",
+        "activity": "reading omens"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "workshop",
+        "activity": "communing"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "tavern",
+        "activity": "warding the threshold"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "market",
+        "activity": "chanting"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "commons",
+        "activity": "dreaming"
+      }
+    ],
+    "starting_sparks": 32
   },
   {
     "id": "gen_sovereign-ruins_0006",
@@ -902,7 +1244,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "home",
+        "activity": "patrolling"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "workshop",
+        "activity": "drilling"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "commons",
+        "activity": "watching the gate"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "market",
+        "activity": "checking papers"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "commons",
+        "activity": "off-duty rounds"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "gate",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 15
   },
   {
     "id": "gen_sovereign-ruins_0007",
@@ -925,7 +1324,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "tavern",
+        "activity": "meditating"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "home",
+        "activity": "reading omens"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "market",
+        "activity": "communing"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "commons",
+        "activity": "warding the threshold"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "home",
+        "activity": "chanting"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "shrine",
+        "activity": "dreaming"
+      }
+    ],
+    "starting_sparks": 24
   },
   {
     "id": "gen_sovereign-ruins_0008",
@@ -948,6 +1404,63 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "outskirts",
+        "activity": "chores"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "home",
+        "activity": "working the field"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "market",
+        "activity": "midday meal"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "shrine",
+        "activity": "errands"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "gate",
+        "activity": "with family"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "shrine",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 19
   }
 ]

--- a/content/world/superhero/factions-extra.json
+++ b/content/world/superhero/factions-extra.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "gen_superhero_faction_0000",
+    "name": "Meridian Taskforce",
+    "motto": "Nothing kept that is not earned.",
+    "goal": "hold the line on a threat the public can't yet name",
+    "values": [
+      "restraint",
+      "sacrifice"
+    ],
+    "fears": [
+      "a single strike at the heart of their power"
+    ],
+    "controlled_districts": [],
+    "rival_factions": [
+      "superhero_civil_rights_emerged"
+    ],
+    "allied_factions": [
+      "luminary_empire"
+    ],
+    "npc_ids": [
+      "baseline_lead_devon_cross"
+    ],
+    "dialogue_style": "wry_evasive",
+    "reputation_currency": "trust_rating",
+    "world_id": "superhero",
+    "visual": {
+      "primary_color": "#479731",
+      "secondary_color": "#52b5c8",
+      "accent_color": "#825a29"
+    },
+    "generated": true
+  }
+]

--- a/content/world/superhero/npcs-extra.json
+++ b/content/world/superhero/npcs-extra.json
@@ -764,7 +764,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "workshop",
+        "activity": "meditating"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "gate",
+        "activity": "reading omens"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "outskirts",
+        "activity": "communing"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "gate",
+        "activity": "warding the threshold"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "workshop",
+        "activity": "chanting"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "home",
+        "activity": "dreaming"
+      }
+    ],
+    "starting_sparks": 32
   },
   {
     "id": "gen_superhero_0001",
@@ -787,7 +844,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "commons",
+        "activity": "opening the stall"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "outskirts",
+        "activity": "haggling"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "shrine",
+        "activity": "restocking"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "workshop",
+        "activity": "counting takings"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "shrine",
+        "activity": "sharing gossip"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "market",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 18
   },
   {
     "id": "gen_superhero_0002",
@@ -810,7 +924,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "home",
+        "activity": "chores"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "gate",
+        "activity": "working the field"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "home",
+        "activity": "midday meal"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "shrine",
+        "activity": "errands"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "outskirts",
+        "activity": "with family"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "home",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 14
   },
   {
     "id": "gen_superhero_0003",
@@ -833,7 +1004,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "gate",
+        "activity": "chores"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "commons",
+        "activity": "working the field"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "home",
+        "activity": "midday meal"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "tavern",
+        "activity": "errands"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "tavern",
+        "activity": "with family"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "market",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 34
   },
   {
     "id": "gen_superhero_0004",
@@ -856,7 +1084,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "home",
+        "activity": "patrolling"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "tavern",
+        "activity": "drilling"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "outskirts",
+        "activity": "watching the gate"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "tavern",
+        "activity": "checking papers"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "outskirts",
+        "activity": "off-duty rounds"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "gate",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 14
   },
   {
     "id": "gen_superhero_0005",
@@ -879,7 +1164,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "commons",
+        "activity": "patrolling"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "workshop",
+        "activity": "drilling"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "gate",
+        "activity": "watching the gate"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "shrine",
+        "activity": "checking papers"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "shrine",
+        "activity": "off-duty rounds"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "shrine",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 10
   },
   {
     "id": "gen_superhero_0006",
@@ -902,7 +1244,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "workshop",
+        "activity": "chores"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "outskirts",
+        "activity": "working the field"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "gate",
+        "activity": "midday meal"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "outskirts",
+        "activity": "errands"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "gate",
+        "activity": "with family"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "shrine",
+        "activity": "sleeping"
+      }
+    ],
+    "starting_sparks": 33
   },
   {
     "id": "gen_superhero_0007",
@@ -925,7 +1324,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "outskirts",
+        "activity": "opening the stall"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "gate",
+        "activity": "haggling"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "tavern",
+        "activity": "restocking"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "commons",
+        "activity": "counting takings"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "shrine",
+        "activity": "sharing gossip"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "outskirts",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 33
   },
   {
     "id": "gen_superhero_0008",
@@ -948,7 +1404,64 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "workshop",
+        "activity": "opening the stall"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "commons",
+        "activity": "haggling"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "market",
+        "activity": "restocking"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "gate",
+        "activity": "counting takings"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "shrine",
+        "activity": "sharing gossip"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "shrine",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 13
   },
   {
     "id": "gen_superhero_0009",
@@ -971,6 +1484,63 @@
       "origin": "authoring-pipeline"
     },
     "is_conscious": false,
-    "generated": true
+    "generated": true,
+    "daily_schedule": [
+      {
+        "phase": "dawn",
+        "phase_hours": [
+          5,
+          8
+        ],
+        "location": "outskirts",
+        "activity": "at the forge"
+      },
+      {
+        "phase": "morning",
+        "phase_hours": [
+          8,
+          11
+        ],
+        "location": "gate",
+        "activity": "shaping work"
+      },
+      {
+        "phase": "midday",
+        "phase_hours": [
+          11,
+          14
+        ],
+        "location": "shrine",
+        "activity": "finishing pieces"
+      },
+      {
+        "phase": "afternoon",
+        "phase_hours": [
+          14,
+          18
+        ],
+        "location": "home",
+        "activity": "selling wares"
+      },
+      {
+        "phase": "evening",
+        "phase_hours": [
+          18,
+          22
+        ],
+        "location": "commons",
+        "activity": "cleaning tools"
+      },
+      {
+        "phase": "night",
+        "phase_hours": [
+          22,
+          5
+        ],
+        "location": "workshop",
+        "activity": "resting"
+      }
+    ],
+    "starting_sparks": 27
   }
 ]

--- a/scripts/author/author-content.mjs
+++ b/scripts/author/author-content.mjs
@@ -14,7 +14,7 @@
 import { join } from "path";
 import { loadBible, readJSON, writeJSON, asArray, existingIds, WORLD_DIR } from "./lib.mjs";
 import { gateBatch } from "./validate-gate.mjs";
-import { generateNpcs } from "./generators.mjs";
+import { generateNpcs, generateFactions } from "./generators.mjs";
 
 function parseArgs(argv) {
   const a = { type: "npc", count: 12, write: false };
@@ -29,12 +29,20 @@ function parseArgs(argv) {
   return a;
 }
 
-// type → { targetFile(world), arrayKey, generate(bible, count, opts) }
+// type → { target(world), key, bibleKey, generate(bible, count, opts) }
+// `bibleKey` is the bible array the new records dedupe against (npcs vs factions).
 const TYPES = {
   npc: {
     target: (world) => join(WORLD_DIR, world === "concordia-hub" ? "" : world, "npcs-extra.json"),
     key: "npcs",
+    bibleKey: "npcs",
     generate: (bible, count, opts) => generateNpcs(bible, count, opts),
+  },
+  faction: {
+    target: (world) => join(WORLD_DIR, world === "concordia-hub" ? "" : world, "factions-extra.json"),
+    key: "factions",
+    bibleKey: "factions",
+    generate: (bible, count, opts) => generateFactions(bible, count, opts),
   },
 };
 
@@ -51,7 +59,8 @@ export function runAuthor(args) {
 
   const targetPath = spec.target(args.world);
   const existing = asArray(readJSON(targetPath, []), spec.key);
-  const known = existingIds([...bible.npcs, ...existing]);
+  const bibleItems = bible[spec.bibleKey] || [];
+  const known = existingIds([...bibleItems, ...existing]);
   const { valid, rejected } = gateBatch(args.type, candidates, known);
 
   const merged = [...existing, ...valid];
@@ -59,10 +68,10 @@ export function runAuthor(args) {
     world: args.world, type: args.type,
     generated: candidates.length, valid: valid.length, rejected: rejected.length,
     existingInFile: existing.length, mergedTotal: merged.length,
-    bibleNpcs: bible.npcs.length, targetPath,
+    bibleCount: bibleItems.length, targetPath,
     write: args.write,
     rejectReasons: rejected.reduce((m, r) => ((m[r.reason] = (m[r.reason] || 0) + 1), m), {}),
-    sample: valid.slice(0, 3).map((n) => ({ name: n.name, job: n.job, level: n.level, bio: n.narrative_context?.bio })),
+    sample: valid.slice(0, 3).map((n) => ({ id: n.id, name: n.name, job: n.job, level: n.level, bio: n.narrative_context?.bio })),
   };
   if (args.write && valid.length) writeJSON(targetPath, merged);
   return { summary, valid, rejected, merged };

--- a/scripts/author/author-libs.mjs
+++ b/scripts/author/author-libs.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// scripts/author/author-libs.mjs
+//
+// Offline driver for the TOP-LEVEL minigame libs (content/<file>.json), as opposed
+// to the world-scoped author-content.mjs. Generates schema-valid records, gates them
+// through the validators, and idempotently merges new records (by id) into the lib
+// file the seeder reads. Dry-run by default; pass --write to persist.
+//
+//   node scripts/author/author-libs.mjs --type crop --count 13
+//   node scripts/author/author-libs.mjs --type crop --count 13 --write
+//
+// Curator workflow: dry-run → eyeball the sample → --write → review git diff → commit.
+//
+// NOTE: hacking + code puzzles are hand-authored (player-facing skill challenges) and
+// live directly in content/hacking-puzzles.json / code-puzzles.json. They are NOT
+// generated here; this driver only generates `crop`. The gate validators + the
+// content-libs test still pin their validity + solvability.
+
+import { join } from "path";
+import { readJSON, writeJSON, asArray, CONTENT } from "./lib.mjs";
+import { gateBatch } from "./validate-gate.mjs";
+import { generateCrops } from "./generators.mjs";
+
+function parseArgs(argv) {
+  const a = { type: "crop", count: 13, write: false };
+  for (let i = 2; i < argv.length; i++) {
+    const t = argv[i];
+    if (t === "--type") a.type = argv[++i];
+    else if (t === "--count") a.count = parseInt(argv[++i], 10) || 13;
+    else if (t === "--write") a.write = true;
+  }
+  return a;
+}
+
+// type → { file, generate(existing, count) }
+const TYPES = {
+  crop: {
+    file: "crops.json",
+    generate: (existing, count) => generateCrops(existing, count),
+  },
+};
+
+export function runAuthorLib(args) {
+  const spec = TYPES[args.type];
+  if (!spec) throw new Error(`unsupported --type ${args.type} (have: ${Object.keys(TYPES).join(", ")})`);
+
+  const targetPath = join(CONTENT, spec.file);
+  const existing = asArray(readJSON(targetPath, []), null);
+  const knownIds = new Set(existing.map((x) => x?.id).filter(Boolean));
+  const candidates = spec.generate(existing, args.count);
+  const { valid, rejected } = gateBatch(args.type, candidates, knownIds);
+
+  const merged = [...existing, ...valid];
+  const summary = {
+    type: args.type, file: spec.file,
+    generated: candidates.length, valid: valid.length, rejected: rejected.length,
+    existingInFile: existing.length, mergedTotal: merged.length,
+    write: args.write,
+    rejectReasons: rejected.reduce((m, r) => ((m[r.reason] = (m[r.reason] || 0) + 1), m), {}),
+    sample: valid.slice(0, 3),
+  };
+  if (args.write && valid.length) writeJSON(targetPath, merged);
+  return { summary, valid, rejected, merged };
+}
+
+// CLI entry (skip when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = parseArgs(process.argv);
+  const { summary } = runAuthorLib(args);
+  console.log(JSON.stringify(summary, null, 2));
+  if (!summary.write) console.log("\n(dry-run — pass --write to persist; then review the git diff before committing)");
+}

--- a/scripts/author/build-puzzles.mjs
+++ b/scripts/author/build-puzzles.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// scripts/author/build-puzzles.mjs
+//
+// Merges the hand-authored hacking + code puzzles (from the *-specs.mjs modules)
+// into content/hacking-puzzles.json + content/code-puzzles.json. Every record is
+// gate-validated, every hacking solution path is checked navigable against its tree,
+// and every code puzzle's test cases are derived from a verified reference program —
+// so a broken design fails here, never in production. Idempotent (merge-by-id).
+// Dry-run by default; pass --write to persist.
+//
+//   node scripts/author/build-puzzles.mjs
+//   node scripts/author/build-puzzles.mjs --write
+
+import { join } from "path";
+import { readJSON, writeJSON, asArray, CONTENT } from "./lib.mjs";
+import { gateBatch } from "./validate-gate.mjs";
+import { buildNewHackingPuzzles, checkNavigable } from "./hacking-puzzle-specs.mjs";
+import { buildNewCodePuzzles } from "./code-puzzle-specs.mjs";
+
+function mergeInto(file, type, built, extraCheck) {
+  const targetPath = join(CONTENT, file);
+  const existing = asArray(readJSON(targetPath, []), null);
+  const knownIds = new Set(existing.map((x) => x?.id).filter(Boolean));
+  const knownNames = new Set(existing.map((x) => x?.name).filter(Boolean));
+  const { valid, rejected } = gateBatch(type, built, knownIds);
+  // The seeder dedupes puzzles by NAME — enforce unique names too.
+  const errors = [...rejected];
+  const accepted = [];
+  for (const p of valid) {
+    if (knownNames.has(p.name)) { errors.push({ item: p, reason: "duplicate_name" }); continue; }
+    if (extraCheck) {
+      const c = extraCheck(p);
+      if (!c.ok) { errors.push({ item: p, reason: c.reason }); continue; }
+    }
+    knownNames.add(p.name);
+    accepted.push(p);
+  }
+  return { targetPath, existing, merged: [...existing, ...accepted], accepted, errors };
+}
+
+export function runBuildPuzzles({ write = false } = {}) {
+  const hack = mergeInto("hacking-puzzles.json", "hacking", buildNewHackingPuzzles(), checkNavigable);
+  const code = mergeInto("code-puzzles.json", "code", buildNewCodePuzzles(), null);
+
+  if (write) {
+    if (hack.accepted.length) writeJSON(hack.targetPath, hack.merged);
+    if (code.accepted.length) writeJSON(code.targetPath, code.merged);
+  }
+  return {
+    hacking: { added: hack.accepted.length, total: hack.merged.length, errors: hack.errors },
+    code: { added: code.accepted.length, total: code.merged.length, errors: code.errors },
+    write,
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const write = process.argv.includes("--write");
+  const r = runBuildPuzzles({ write });
+  console.log(JSON.stringify({
+    hacking: { added: r.hacking.added, total: r.hacking.total, errors: r.hacking.errors.map((e) => ({ id: e.item?.id, reason: e.reason })) },
+    code: { added: r.code.added, total: r.code.total, errors: r.code.errors.map((e) => ({ id: e.item?.id, reason: e.reason })) },
+    write,
+  }, null, 2));
+  if (!write) console.log("\n(dry-run — pass --write to persist; then review the git diff before committing)");
+  const anyErr = r.hacking.errors.length || r.code.errors.length;
+  if (anyErr) process.exit(1);
+}

--- a/scripts/author/code-puzzle-specs.mjs
+++ b/scripts/author/code-puzzle-specs.mjs
@@ -1,0 +1,87 @@
+// scripts/author/code-puzzle-specs.mjs
+//
+// Hand-authored programming-puzzle designs. Each puzzle is a player-facing skill
+// challenge, so the prose + difficulty are authored, but the test cases are DERIVED
+// from a reference solution program run through the shared VM — guaranteeing every
+// committed puzzle is solvable and its test cases are self-consistent.
+//
+// REFERENCE_PROGRAMS holds a verified solution for EVERY code puzzle (the 8 originals
+// + the 12 new), keyed by id. content-libs.test.js replays these against the committed
+// content/code-puzzles.json to prove solvability. Solutions are NOT shipped to players
+// (the seeded puzzle stores only test cases + optimal hints).
+
+import { runVm } from "./code-vm.mjs";
+
+const i = (op, dst, src, to) => {
+  const o = { op };
+  if (dst !== undefined) o.dst = dst;
+  if (src !== undefined) o.src = src;
+  if (to !== undefined) o.to = to;
+  return o;
+};
+
+// Reference solutions for the 8 originally-authored puzzles (reproduce their
+// committed test cases) + the 12 new ones.
+export const REFERENCE_PROGRAMS = {
+  // originals
+  "echo-r0": [i("MOV", "R0", "INP"), i("OUT", undefined, "R0")],
+  "add-two": [i("MOV", "R0", "INP"), i("ADD", "R0", "INP"), i("OUT", undefined, "R0")],
+  "double-it": [i("MOV", "R0", "INP"), i("ADD", "R0", "R0"), i("OUT", undefined, "R0")],
+  "sum-three": [i("MOV", "R0", "INP"), i("ADD", "R0", "INP"), i("ADD", "R0", "INP"), i("OUT", undefined, "R0")],
+  "is-zero": [i("MOV", "R0", "INP"), i("JEZ", undefined, "R0", 4), i("OUT", undefined, 0), i("JMP", undefined, undefined, 5), i("OUT", undefined, 1)],
+  "echo-twice": [i("MOV", "R0", "INP"), i("OUT", undefined, "R0"), i("OUT", undefined, "R0")],
+  "loop-n-zeros": [i("MOV", "R0", "INP"), i("JEZ", undefined, "R0", 5), i("OUT", undefined, 0), i("ADD", "R0", -1), i("JMP", undefined, undefined, 1)],
+  "running-sum": [i("MOV", "R0", "INP"), i("OUT", undefined, "R0"), i("ADD", "R0", "INP"), i("OUT", undefined, "R0"), i("ADD", "R0", "INP"), i("OUT", undefined, "R0")],
+  // new
+  "add-five": [i("MOV", "R0", "INP"), i("ADD", "R0", 5), i("OUT", undefined, "R0")],
+  "triple-it": [i("MOV", "R0", "INP"), i("MOV", "R1", "R0"), i("ADD", "R0", "R1"), i("ADD", "R0", "R1"), i("OUT", undefined, "R0")],
+  "sum-four": [i("MOV", "R0", "INP"), i("ADD", "R0", "INP"), i("ADD", "R0", "INP"), i("ADD", "R0", "INP"), i("OUT", undefined, "R0")],
+  "echo-three": [i("MOV", "R0", "INP"), i("OUT", undefined, "R0"), i("OUT", undefined, "R0"), i("OUT", undefined, "R0")],
+  "swap-pair": [i("MOV", "R0", "INP"), i("MOV", "R1", "INP"), i("OUT", undefined, "R1"), i("OUT", undefined, "R0")],
+  "minus-five": [i("MOV", "R0", "INP"), i("ADD", "R0", -5), i("OUT", undefined, "R0")],
+  "countdown": [i("MOV", "R0", "INP"), i("JEZ", undefined, "R0", 5), i("OUT", undefined, "R0"), i("ADD", "R0", -1), i("JMP", undefined, undefined, 1)],
+  "repeat-value": [i("MOV", "R0", "INP"), i("MOV", "R1", "INP"), i("JEZ", undefined, "R1", 6), i("OUT", undefined, "R0"), i("ADD", "R1", -1), i("JMP", undefined, undefined, 2)],
+  "sum-to-n": [i("MOV", "R1", "INP"), i("MOV", "R0", 0), i("JEZ", undefined, "R1", 6), i("ADD", "R0", "R1"), i("ADD", "R1", -1), i("JMP", undefined, undefined, 2), i("OUT", undefined, "R0")],
+  "double-pair": [i("MOV", "R0", "INP"), i("ADD", "R0", "R0"), i("OUT", undefined, "R0"), i("MOV", "R1", "INP"), i("ADD", "R1", "R1"), i("OUT", undefined, "R1")],
+  "pair-sums": [i("MOV", "R0", "INP"), i("ADD", "R0", "INP"), i("OUT", undefined, "R0"), i("MOV", "R1", "INP"), i("ADD", "R1", "INP"), i("OUT", undefined, "R1")],
+  "running-sum-four": [i("MOV", "R0", "INP"), i("OUT", undefined, "R0"), i("ADD", "R0", "INP"), i("OUT", undefined, "R0"), i("ADD", "R0", "INP"), i("OUT", undefined, "R0"), i("ADD", "R0", "INP"), i("OUT", undefined, "R0")],
+};
+
+// The 12 new puzzles: authored prose + the sample inputs that become test cases.
+// Test cases (expected outputs) are derived from REFERENCE_PROGRAMS via the VM.
+export const NEW_PUZZLE_META = [
+  { id: "add-five", name: "Add Five", description: "Output input[0] + 5.", inputs: [[0], [3], [10]] },
+  { id: "triple-it", name: "Triple It", description: "Output input[0] tripled (no MUL — add it up).", inputs: [[2], [0], [5]] },
+  { id: "sum-four", name: "Sum Four", description: "Add input[0] + input[1] + input[2] + input[3].", inputs: [[1, 2, 3, 4], [0, 0, 0, 0], [5, 5, 5, 5]] },
+  { id: "echo-three", name: "Echo Thrice", description: "Output input[0] three times in sequence.", inputs: [[4], [9]] },
+  { id: "swap-pair", name: "Swap Pair", description: "Output input[1] then input[0].", inputs: [[1, 2], [7, 3]] },
+  { id: "minus-five", name: "Minus Five", description: "Output input[0] - 5 (ADD a negative immediate).", inputs: [[10], [5], [8]] },
+  { id: "countdown", name: "Countdown", description: "Output N, N-1, ..., 1 where N = input[0]. Use JEZ + JMP.", inputs: [[3], [0], [5]] },
+  { id: "repeat-value", name: "Repeat Value", description: "Output input[0] repeated input[1] times.", inputs: [[7, 3], [9, 0], [4, 2]] },
+  { id: "sum-to-n", name: "Sum To N", description: "Output 1 + 2 + ... + N where N = input[0].", inputs: [[3], [0], [5]] },
+  { id: "double-pair", name: "Double Pair", description: "Output 2*input[0] then 2*input[1].", inputs: [[3, 4], [0, 5]] },
+  { id: "pair-sums", name: "Pair Sums", description: "Output (input[0]+input[1]) then (input[2]+input[3]).", inputs: [[1, 2, 3, 4], [10, 5, 0, 5]] },
+  { id: "running-sum-four", name: "Running Sum Four", description: "Output the running total after each of 4 inputs.", inputs: [[1, 2, 3, 4], [2, 2, 2, 2]] },
+];
+
+/** Build the 12 new code-puzzle records, deriving test cases from the VM. */
+export function buildNewCodePuzzles() {
+  return NEW_PUZZLE_META.map((m) => {
+    const program = REFERENCE_PROGRAMS[m.id];
+    if (!program) throw new Error(`no reference program for ${m.id}`);
+    let maxCycles = 0;
+    const testCases = m.inputs.map((input) => {
+      const { tape, cycles } = runVm(program, input);
+      if (cycles > maxCycles) maxCycles = cycles;
+      return { input, expected: tape };
+    });
+    return {
+      id: m.id,
+      name: m.name,
+      description: m.description,
+      optimalCycles: maxCycles,
+      optimalSize: program.length,
+      testCases,
+    };
+  });
+}

--- a/scripts/author/code-vm.mjs
+++ b/scripts/author/code-vm.mjs
@@ -1,0 +1,70 @@
+// scripts/author/code-vm.mjs
+//
+// Pure mirror of the programming-puzzle VM (server/lib/programming-puzzle.js#_runVm).
+// Kept standalone so the authoring builder + the content-libs test can prove every
+// hand-authored code puzzle is solvable WITHOUT booting the engine or a DB. Ops:
+// MOV / ADD / JMP / JEZ / OUT, registers R0..R3, INP input-stream cursor, immediates.
+
+const MAX_CYCLES = Number(process.env.CONCORD_CODE_PUZZLE_MAX_CYCLES) || 10_000;
+
+function regIdx(token) {
+  const m = /^R([0-3])$/.exec(String(token));
+  return m ? Number(m[1]) : null;
+}
+function resolve(token, reg, input, cursor) {
+  if (typeof token === "number") return token;
+  if (typeof token !== "string") return 0;
+  if (token === "INP") {
+    const v = input[cursor.i] ?? 0;
+    cursor.i++;
+    return v;
+  }
+  const idx = regIdx(token);
+  if (idx != null) return reg[idx];
+  return Number(token) || 0;
+}
+
+/** Run a program over one input array; returns { tape, cycles }. */
+export function runVm(program, input) {
+  const reg = [0, 0, 0, 0];
+  const tape = [];
+  let ip = 0;
+  let cycles = 0;
+  const cursor = { i: 0 };
+  while (ip < program.length && cycles < MAX_CYCLES) {
+    const instr = program[ip];
+    cycles++;
+    switch (instr.op) {
+      case "MOV": {
+        const dst = regIdx(instr.dst);
+        if (dst == null) return { tape, cycles };
+        reg[dst] = resolve(instr.src, reg, input, cursor);
+        ip++;
+        break;
+      }
+      case "ADD": {
+        const dst = regIdx(instr.dst);
+        if (dst == null) return { tape, cycles };
+        reg[dst] = reg[dst] + resolve(instr.src, reg, input, cursor);
+        ip++;
+        break;
+      }
+      case "JMP":
+        ip = Math.max(0, Number(instr.to) || 0);
+        break;
+      case "JEZ":
+        if (resolve(instr.src, reg, input, cursor) === 0) ip = Math.max(0, Number(instr.to) || 0);
+        else ip++;
+        break;
+      case "OUT":
+        tape.push(resolve(instr.src, reg, input, cursor));
+        ip++;
+        break;
+      default:
+        return { tape, cycles };
+    }
+  }
+  return { tape, cycles };
+}
+
+export { MAX_CYCLES };

--- a/scripts/author/generators.mjs
+++ b/scripts/author/generators.mjs
@@ -34,6 +34,41 @@ const OCCUPATIONS = {
 };
 const ARCHETYPES = ["villager","trader","scholar","guard","healer","hunter","mystic","artisan"];
 
+// Six daily phases (≥5 distinct required by the NPC depth-floor contract). Each
+// block carries { phase, phase_hours, location, activity } — the shape the routine
+// engine + the npc-depth-floor contract expect.
+const SCHEDULE_PHASES = [
+  { phase: "dawn", phase_hours: [5, 8] },
+  { phase: "morning", phase_hours: [8, 11] },
+  { phase: "midday", phase_hours: [11, 14] },
+  { phase: "afternoon", phase_hours: [14, 18] },
+  { phase: "evening", phase_hours: [18, 22] },
+  { phase: "night", phase_hours: [22, 5] },
+];
+const SCHEDULE_LOCATIONS = ["home", "market", "workshop", "commons", "outskirts", "tavern", "shrine", "gate"];
+// Archetype → activity pool keyed loosely; falls back to a generic round.
+const SCHEDULE_ACTIVITIES = {
+  trader: ["opening the stall", "haggling", "restocking", "counting takings", "sharing gossip", "resting"],
+  scholar: ["reading", "annotating records", "debating", "tutoring", "observing the sky", "sleeping"],
+  guard: ["patrolling", "drilling", "watching the gate", "checking papers", "off-duty rounds", "resting"],
+  healer: ["gathering herbs", "tending the sick", "mixing remedies", "house calls", "writing notes", "resting"],
+  hunter: ["tracking", "setting snares", "field-dressing game", "trading pelts", "sharpening tools", "sleeping"],
+  mystic: ["meditating", "reading omens", "communing", "warding the threshold", "chanting", "dreaming"],
+  artisan: ["at the forge", "shaping work", "finishing pieces", "selling wares", "cleaning tools", "resting"],
+  villager: ["chores", "working the field", "midday meal", "errands", "with family", "sleeping"],
+};
+
+/** Build a 6-block daily schedule (≥5 distinct phases) deterministically. */
+function buildDailySchedule(rng, archetype) {
+  const acts = SCHEDULE_ACTIVITIES[archetype] || SCHEDULE_ACTIVITIES.villager;
+  return SCHEDULE_PHASES.map((p, i) => ({
+    phase: p.phase,
+    phase_hours: p.phase_hours,
+    location: pick(rng, SCHEDULE_LOCATIONS),
+    activity: acts[i % acts.length],
+  }));
+}
+
 function flavorFor(world) {
   const w = String(world).toLowerCase();
   for (const k of Object.keys(OCCUPATIONS)) if (k !== "standard" && w.includes(k)) return k;
@@ -76,6 +111,12 @@ export function generateNpcs(bible, count, { startIndex = 0, levelRange = [2, 30
     const loreRef = loreTitles.length ? pick(rng, loreTitles) : null;
     const backstory = `A ${wealth} ${occupation} of ${bible.world}.${factionName !== "no faction" ? ` Tied to ${factionName}.` : ""}` +
       `${loreRef ? ` Lived through "${loreRef}".` : ""} Known to ${quirk}.`;
+    // Schedule + sparks use a dedicated rng seeded purely on (world, index) so the
+    // values are stable regardless of changes to the bible (e.g. added factions
+    // shifting earlier pick() draws) — keeps regeneration diffs minimal.
+    const schedRng = seededRng(`${bible.world}|npc-sched|${index}`);
+    const daily_schedule = buildDailySchedule(schedRng, archetype);
+    const starting_sparks = 5 + level;
     out.push({
       id, name, archetype,
       faction_id: factionId,
@@ -84,6 +125,8 @@ export function generateNpcs(bible, count, { startIndex = 0, levelRange = [2, 30
       wealth_tier: wealth,
       backstory,
       personality_traits: [quirk],
+      daily_schedule,
+      starting_sparks,
       // ctOS profile block — the scannable "life" surfaced by the System.
       narrative_context: {
         occupation,
@@ -95,6 +138,149 @@ export function generateNpcs(bible, count, { startIndex = 0, levelRange = [2, 30
       },
       is_conscious: false,
       generated: true,
+    });
+  }
+  return out;
+}
+
+// ── Faction generator ────────────────────────────────────────────────────────
+// Deterministic, bible-grounded factions for the density-fill pipeline. Mirrors
+// the rich hand-authored faction shape (motto/goal/values/fears/visual) so the
+// generated rows read like the authored ones and pass validateFaction.
+
+const FACTION_NAME = {
+  standard: {
+    a: ["Order", "Covenant", "Circle", "Concord", "Assembly", "Charter", "Accord", "League"],
+    b: ["Wardens", "Keepers", "Stewards", "Seekers", "Hands", "Voices", "Witnesses", "Heirs"],
+  },
+  cyber: {
+    a: ["Syndicate", "Collective", "Subnet", "Daemon", "Null", "Grid", "Cipher", "Proxy"],
+    b: ["Runners", "Brokers", "Ghosts", "Forks", "Nodes", "Wraiths", "Operators", "Cells"],
+  },
+  crime: {
+    a: ["Tarnish", "Hollow", "Ledger", "Quiet", "Crooked", "Ashen", "Velvet", "Iron"],
+    b: ["Crew", "Family", "Ring", "Outfit", "Mob", "Combine", "Racket", "Firm"],
+  },
+  fantasy: {
+    a: ["Verdant", "Ember", "Sable", "Gilded", "Hollow", "Thornwood", "Mistward", "Runebound"],
+    b: ["Conclave", "Wardens", "Pilgrims", "Coven", "Circle", "Bannermen", "Chanters", "Adepts"],
+  },
+  superhero: {
+    a: ["Sentinel", "Vanguard", "Aegis", "Civic", "Halo", "Beacon", "Bulwark", "Meridian"],
+    b: ["Initiative", "Coalition", "Bureau", "Watch", "Network", "League", "Response", "Taskforce"],
+  },
+  tunya: {
+    a: ["Salt", "Dune", "Mirage", "Wellspring", "Sky-", "Caravan", "Sand", "Oasis"],
+    b: ["Wardens", "Finders", "Drovers", "Singers", "Keepers", "Pact", "Guild", "Watch"],
+  },
+};
+const FACTION_MOTTO = [
+  "What is held is held in trust.", "We do not flinch.", "The ledger always balances.",
+  "Order before mercy.", "Memory outlasts stone.", "Refuse, and remain.",
+  "Hold the line, hold the truth.", "Nothing kept that is not earned.",
+  "We answer the silence.", "The map is not the land.", "Bend, but never break.",
+  "We keep what others discard.",
+];
+const FACTION_GOAL = {
+  standard: ["consolidate the splintered districts under one accord", "preserve the old charters against erasure", "broker peace between the rival houses on their own terms"],
+  cyber: ["fork the city's governance into something they alone can audit", "free the subnets from corporate metering", "trade in the secrets the grid was built to bury"],
+  crime: ["own the routes nobody else dares run", "launder the district's grief into leverage", "settle an old debt the city pretends it forgot"],
+  fantasy: ["reawaken a power the loremasters sealed for good reason", "tend the wild places the settlements keep clearing", "carry a pilgrimage the realm has forbidden"],
+  superhero: ["hold the line on a threat the public can't yet name", "rebuild trust between the powered and the policed", "expose the broker quietly arming both sides"],
+  tunya: ["chart the water nobody believes still flows", "keep the caravan roads open through the long drought", "sing the old routes back into living memory"],
+};
+const FACTION_VALUES = ["loyalty", "secrecy", "endurance", "cunning", "mercy", "discipline", "memory", "autonomy", "sacrifice", "craft", "vigilance", "restraint"];
+const FACTION_FEARS = ["a betrayal from within their own ranks", "the day their founding lie is spoken aloud", "a rival learning where the cache is hidden", "the loss of the one record that proves their claim", "a single strike at the heart of their power", "being remembered as the villains of the tale"];
+const DIALOGUE_STYLES = ["formal_measured", "terse_guarded", "warm_persuasive", "cold_clinical", "zealous_fervent", "wry_evasive"];
+const REP_CURRENCY = { standard: "standing", cyber: "compute_credits", crime: "markers", fantasy: "favor", superhero: "trust_rating", tunya: "water_tokens" };
+
+function hexFromRng(rng) {
+  const n = Math.floor(rng() * 0x1000000);
+  return "#" + n.toString(16).padStart(6, "0");
+}
+
+/**
+ * Generate `count` unique, valid faction records grounded in the bible.
+ * Deterministic by (world, startIndex). ids are stable: gen_<world>_faction_NNNN.
+ * @returns {object[]} faction objects that pass validateFaction.
+ */
+export function generateFactions(bible, count, { startIndex = 0 } = {}) {
+  const flavor = flavorFor(bible.world);
+  const names = FACTION_NAME[flavor] || FACTION_NAME.standard;
+  const goals = FACTION_GOAL[flavor] || FACTION_GOAL.standard;
+  const existingFactionIds = (bible.factions || []).map((f) => f.id).filter(Boolean);
+  const existingNpcIds = (bible.npcs || []).map((n) => n.id).filter(Boolean);
+  const out = [];
+  for (let i = 0; i < count; i++) {
+    const index = startIndex + i;
+    const rng = seededRng(`${bible.world}|faction|${index}`);
+    const id = `gen_${bible.world}_faction_${String(index).padStart(4, "0")}`;
+    const suffix = index >= names.a.length * names.b.length ? ` ${index}` : "";
+    const name = `${pick(rng, names.a)} ${pick(rng, names.b)}${suffix}`.replace(/-\s/, "-");
+    const values = [...new Set([pick(rng, FACTION_VALUES), pick(rng, FACTION_VALUES), pick(rng, FACTION_VALUES)])];
+    const fears = [...new Set([pick(rng, FACTION_FEARS), pick(rng, FACTION_FEARS)])];
+    // Ground rivalries/alliances in the world's existing factions when present.
+    const rival = existingFactionIds.length ? pick(rng, existingFactionIds) : null;
+    const ally = existingFactionIds.length > 1 ? pick(rng, existingFactionIds.filter((f) => f !== rival)) : null;
+    const npcIds = existingNpcIds.length ? [pick(rng, existingNpcIds)] : [];
+    out.push({
+      id,
+      name,
+      motto: pick(rng, FACTION_MOTTO),
+      goal: pick(rng, goals),
+      values,
+      fears,
+      controlled_districts: [],
+      rival_factions: rival ? [rival] : [],
+      allied_factions: ally ? [ally] : [],
+      npc_ids: npcIds,
+      dialogue_style: pick(rng, DIALOGUE_STYLES),
+      reputation_currency: REP_CURRENCY[flavor] || "standing",
+      world_id: bible.world,
+      visual: {
+        primary_color: hexFromRng(rng),
+        secondary_color: hexFromRng(rng),
+        accent_color: hexFromRng(rng),
+      },
+      generated: true,
+    });
+  }
+  return out;
+}
+
+// ── Crop generator ───────────────────────────────────────────────────────────
+// Deterministic crops for content/crops.json (read by lib/farming.js). Shape:
+// { id, name, seasons:[int 0..5], growth_days:int, yield:int }. 6 seasons exist
+// (seasons.js Phase 5c), so seasons[] entries are in 0..5.
+
+const CROP_POOL = [
+  ["barley", "Barley"], ["maize", "Maize"], ["squash", "Squash"], ["pepper", "Hot Pepper"],
+  ["bean", "Field Bean"], ["flax", "Flax"], ["onion", "Onion"], ["melon", "Sun Melon"],
+  ["tuber", "Frost Tuber"], ["berry", "Bramble Berry"], ["rice", "Paddy Rice"], ["pumpkin", "Pumpkin"],
+  ["cabbage", "Cabbage"], ["garlic", "Garlic"], ["sunflower", "Sunflower"], ["lentil", "Lentil"],
+  ["chili", "Ghost Chili"], ["yam", "Yam"], ["leek", "Leek"], ["cotton", "Cotton"],
+];
+
+/**
+ * Generate the first `count` crop defs from the pool (a STABLE slice from
+ * `startIndex`), so re-running with the same count yields the same ids and the
+ * gate dedupes them (idempotent — same contract as the NPC/faction generators).
+ * @returns {object[]} crop objects that pass validateCrop.
+ */
+export function generateCrops(_existing, count, { startIndex = 0 } = {}) {
+  const out = [];
+  for (let i = 0; i < count && startIndex + i < CROP_POOL.length; i++) {
+    const [id, name] = CROP_POOL[startIndex + i];
+    const rng = seededRng(`crop|${id}`);
+    // 1–2 seasons of affinity in 0..5, plus a 4–10 day grow + 3–8 yield.
+    const s1 = Math.floor(rng() * 6);
+    const seasons = rng() < 0.5 ? [s1] : [...new Set([s1, Math.floor(rng() * 6)])];
+    out.push({
+      id,
+      name,
+      seasons: seasons.sort((a, b) => a - b),
+      growth_days: 4 + Math.floor(rng() * 7),
+      yield: 3 + Math.floor(rng() * 6),
     });
   }
   return out;

--- a/scripts/author/hacking-puzzle-specs.mjs
+++ b/scripts/author/hacking-puzzle-specs.mjs
@@ -1,0 +1,227 @@
+// scripts/author/hacking-puzzle-specs.mjs
+//
+// Hand-authored hacking-puzzle designs. Each "scene" is an authored exploration
+// (the prose, difficulty, reward, and command flow are designed by hand), and a
+// builder turns it into the { terminalTree, solutionPath } shape the seeder reads —
+// guaranteeing the solution path actually navigates the tree (a player exploring
+// with ls/cd/cat can discover every step). content-libs.test.js re-checks this on
+// the committed JSON via checkNavigable().
+
+// Commands whose target must be a `service` node in the current directory.
+const SERVICE_CMDS = new Set(["connect", "exec", "ssh", "decrypt"]);
+
+// ── Builder ──────────────────────────────────────────────────────────────────
+// scene: { id, name, difficulty, rewardCc, manifest, rooms:[{dir,note,gate:{cmd,svc}}], core:{cmd,svc} }
+// Layout: root has manifest.txt + rooms[0].dir; each room dir nests the next room
+// dir + its note.txt + its gate service; the LAST room dir also holds the core svc.
+export function buildHackingPuzzle(scene) {
+  const path = ["cat manifest.txt"];
+
+  // Build the nested room tree from the innermost out.
+  let inner = null; // contents of the next-deeper dir (or null at the leaf)
+  for (let r = scene.rooms.length - 1; r >= 0; r--) {
+    const room = scene.rooms[r];
+    const contents = { "note.txt": { type: "file", text: room.note } };
+    if (room.gate) contents[room.gate.svc] = { type: "service" };
+    if (r === scene.rooms.length - 1 && scene.core) contents[scene.core.svc] = { type: "service" };
+    if (inner) contents[scene.rooms[r + 1].dir] = { type: "dir", contents: inner };
+    inner = contents;
+  }
+
+  const terminalTree = {
+    type: "dir",
+    contents: {
+      "manifest.txt": { type: "file", text: scene.manifest },
+      ...(scene.rooms.length ? { [scene.rooms[0].dir]: { type: "dir", contents: inner } } : {}),
+    },
+  };
+
+  // Walk the rooms to build the solution path in the same descent order.
+  for (let r = 0; r < scene.rooms.length; r++) {
+    const room = scene.rooms[r];
+    path.push(`cd ${room.dir}`, "cat note.txt");
+    if (room.gate) path.push(`${room.gate.cmd} ${room.gate.svc}`);
+  }
+  if (scene.core) path.push(`${scene.core.cmd} ${scene.core.svc}`);
+
+  return {
+    id: scene.id,
+    name: scene.name,
+    difficulty: scene.difficulty,
+    rewardCc: scene.rewardCc,
+    terminalTree,
+    solutionPath: path,
+  };
+}
+
+// ── Navigability checker ───────────────────────────────────────────────────────
+// Walks a puzzle's solutionPath against its terminalTree; returns { ok, reason }.
+export function checkNavigable(puzzle) {
+  const tree = puzzle.terminalTree;
+  if (!tree || tree.type !== "dir" || typeof tree.contents !== "object") {
+    return { ok: false, reason: "bad_root" };
+  }
+  const stack = [tree.contents];
+  const cur = () => stack[stack.length - 1];
+  for (const raw of puzzle.solutionPath) {
+    const parts = String(raw).trim().split(/\s+/);
+    const head = parts[0];
+    const arg = parts[1];
+    if (head === "ls") continue;
+    if (head === "cd") {
+      if (arg === "..") { if (stack.length > 1) stack.pop(); continue; }
+      const node = cur()[arg];
+      if (!node || node.type !== "dir") return { ok: false, reason: `cd_missing_dir:${arg}` };
+      stack.push(node.contents || {});
+      continue;
+    }
+    if (head === "cat") {
+      const node = cur()[arg];
+      if (!node || node.type !== "file") return { ok: false, reason: `cat_missing_file:${arg}` };
+      continue;
+    }
+    if (SERVICE_CMDS.has(head)) {
+      // connect/exec/ssh a service, or decrypt a file — the target need only be a
+      // node discoverable in the current directory (matches authored convention).
+      const node = cur()[arg];
+      if (!node) return { ok: false, reason: `${head}_missing_target:${arg}` };
+      continue;
+    }
+    return { ok: false, reason: `unknown_command:${head}` };
+  }
+  return { ok: true };
+}
+
+// ── Authored scenes (20 new puzzles, escalating difficulty) ────────────────────
+export const SCENES = [
+  // ── Difficulty 1 ──
+  { id: "frontier-checkpoint", name: "Frontier Checkpoint", difficulty: 1, rewardCc: 30,
+    manifest: "Concord-Link border node. The guest gate is wide open — just reach the relay.",
+    rooms: [{ dir: "gate", note: "Relay sits behind the gate. Connect to it.", gate: { cmd: "connect", svc: "relay" } }],
+    core: null },
+  { id: "tunya-well-pump", name: "Tunya Well Pump", difficulty: 1, rewardCc: 32,
+    manifest: "An old caravan well-pump still answers commands. Bring the water back.",
+    rooms: [{ dir: "pump", note: "The valve service controls the flow.", gate: { cmd: "exec", svc: "valve" } }],
+    core: null },
+  { id: "bazaar-stall-lock", name: "Bazaar Stall Lock", difficulty: 1, rewardCc: 35,
+    manifest: "A merchant's stall terminal. The drawer service is the prize.",
+    rooms: [{ dir: "stall", note: "Open the drawer.", gate: { cmd: "connect", svc: "drawer" } }],
+    core: null },
+  { id: "fantasy-hedge-gate", name: "Hedge Gate", difficulty: 1, rewardCc: 38,
+    manifest: "A rune-warded garden node. The hedge service yields to the right touch.",
+    rooms: [{ dir: "garden", note: "The hedge will part for a connect.", gate: { cmd: "connect", svc: "hedge" } }],
+    core: null },
+
+  // ── Difficulty 2 ──
+  { id: "cyber-fixer-den", name: "Fixer's Den", difficulty: 2, rewardCc: 85,
+    manifest: "A fixer's backroom rig. Cracked door, then the safe.",
+    rooms: [{ dir: "den", note: "Crack the door service, then reach the safe.", gate: { cmd: "decrypt", svc: "door" } }],
+    core: { cmd: "exec", svc: "safe" } },
+  { id: "crime-numbers-room", name: "Numbers Room", difficulty: 2, rewardCc: 90,
+    manifest: "The crew keeps its book on a quiet node. Two services stand between you and it.",
+    rooms: [{ dir: "backroom", note: "Disable the lookout, then crack the ledger.", gate: { cmd: "connect", svc: "lookout" } }],
+    core: { cmd: "decrypt", svc: "ledger" } },
+  { id: "superhero-tip-line", name: "Tip Line", difficulty: 2, rewardCc: 92,
+    manifest: "A precinct tip-line server. Authenticate, then pull the archive.",
+    rooms: [{ dir: "precinct", note: "ssh the desk, then connect the archive.", gate: { cmd: "ssh", svc: "desk" } }],
+    core: { cmd: "connect", svc: "archive" } },
+  { id: "lattice-drift-buoy", name: "Drift Buoy", difficulty: 2, rewardCc: 95,
+    manifest: "A lattice drift-buoy adrift between districts. Sync it, then read the beacon.",
+    rooms: [{ dir: "buoy", note: "Sync service first; then the beacon.", gate: { cmd: "exec", svc: "sync" } }],
+    core: { cmd: "connect", svc: "beacon" } },
+
+  // ── Difficulty 3 ──
+  { id: "cyber-corpo-floor", name: "Corpo Floor", difficulty: 3, rewardCc: 165,
+    manifest: "A corporate sublevel. Two rooms, two locks, one core.",
+    rooms: [
+      { dir: "lobby", note: "Spoof the badge reader.", gate: { cmd: "decrypt", svc: "badge" } },
+      { dir: "server_room", note: "The core sits past the firewall.", gate: { cmd: "exec", svc: "firewall" } },
+    ], core: { cmd: "connect", svc: "core" } },
+  { id: "sovereign-watchpost", name: "Sovereign Watchpost", difficulty: 3, rewardCc: 170,
+    manifest: "A ruined watchpost still broadcasting. Climb the tower to silence it.",
+    rooms: [
+      { dir: "yard", note: "Cut the alarm.", gate: { cmd: "connect", svc: "alarm" } },
+      { dir: "tower", note: "Silence the broadcaster.", gate: { cmd: "exec", svc: "broadcaster" } },
+    ], core: { cmd: "decrypt", svc: "vault" } },
+  { id: "crime-dock-heist", name: "Dock Heist", difficulty: 3, rewardCc: 175,
+    manifest: "A smuggler's dock node. Cameras, then crane, then the container.",
+    rooms: [
+      { dir: "yard", note: "Loop the cameras.", gate: { cmd: "connect", svc: "cameras" } },
+      { dir: "crane_cab", note: "Take the crane.", gate: { cmd: "exec", svc: "crane" } },
+    ], core: { cmd: "connect", svc: "container" } },
+  { id: "fantasy-rune-vault", name: "Rune Vault", difficulty: 3, rewardCc: 180,
+    manifest: "A glyph-sealed vault. Two wards, then the seal.",
+    rooms: [
+      { dir: "antechamber", note: "Dispel the first ward.", gate: { cmd: "decrypt", svc: "ward_one" } },
+      { dir: "inner_sanctum", note: "Dispel the second ward.", gate: { cmd: "decrypt", svc: "ward_two" } },
+    ], core: { cmd: "exec", svc: "seal" } },
+
+  // ── Difficulty 4 ──
+  { id: "lattice-relay-farm", name: "Relay Farm", difficulty: 4, rewardCc: 290,
+    manifest: "A lattice relay-farm. Three relays in series feed the conductor.",
+    rooms: [
+      { dir: "row_a", note: "Bring relay A online.", gate: { cmd: "connect", svc: "relay_a" } },
+      { dir: "row_b", note: "Bring relay B online.", gate: { cmd: "connect", svc: "relay_b" } },
+      { dir: "row_c", note: "Bring relay C online, then the conductor.", gate: { cmd: "connect", svc: "relay_c" } },
+    ], core: { cmd: "exec", svc: "conductor" } },
+  { id: "cyber-blacksite", name: "Blacksite", difficulty: 4, rewardCc: 300,
+    manifest: "An off-books research blacksite. Three layers of access control.",
+    rooms: [
+      { dir: "checkpoint", note: "Forge credentials.", gate: { cmd: "decrypt", svc: "creds" } },
+      { dir: "lab", note: "Bypass the airgap bridge.", gate: { cmd: "exec", svc: "airgap" } },
+      { dir: "cold_room", note: "Pull the sample logs, then the mainframe.", gate: { cmd: "ssh", svc: "logs" } },
+    ], core: { cmd: "connect", svc: "mainframe" } },
+  { id: "superhero-comms-spire", name: "Comms Spire", difficulty: 4, rewardCc: 310,
+    manifest: "The city's emergency comms spire has been hijacked. Take it back, floor by floor.",
+    rooms: [
+      { dir: "base", note: "Restore the uplink.", gate: { cmd: "connect", svc: "uplink" } },
+      { dir: "midfloor", note: "Purge the hijack daemon.", gate: { cmd: "exec", svc: "daemon" } },
+      { dir: "antenna", note: "Re-key the transmitter, then the controller.", gate: { cmd: "decrypt", svc: "transmitter" } },
+    ], core: { cmd: "exec", svc: "controller" } },
+  { id: "sovereign-deep-archive", name: "Deep Archive", difficulty: 4, rewardCc: 320,
+    manifest: "A sealed sovereign archive, three chambers deep. The First Refusal is recorded here.",
+    rooms: [
+      { dir: "stacks", note: "Decrypt the index.", gate: { cmd: "decrypt", svc: "index" } },
+      { dir: "reading_room", note: "Authenticate at the lectern.", gate: { cmd: "ssh", svc: "lectern" } },
+      { dir: "reliquary", note: "Open the reliquary, then the record.", gate: { cmd: "connect", svc: "reliquary" } },
+    ], core: { cmd: "decrypt", svc: "record" } },
+
+  // ── Difficulty 5 ──
+  { id: "concord-deep-core", name: "Deep Core", difficulty: 5, rewardCc: 440,
+    manifest: "The Concord deep-core. Four nested gates guard the singularity seed.",
+    rooms: [
+      { dir: "rind", note: "Peel the outer rind.", gate: { cmd: "decrypt", svc: "rind" } },
+      { dir: "mantle", note: "Stabilise the mantle.", gate: { cmd: "exec", svc: "mantle" } },
+      { dir: "shell", note: "Mirror the shell.", gate: { cmd: "connect", svc: "shell" } },
+      { dir: "kernel", note: "Authenticate, then reach the seed.", gate: { cmd: "ssh", svc: "kernel" } },
+    ], core: { cmd: "exec", svc: "seed" } },
+  { id: "lattice-meta-orchestrator", name: "Meta Orchestrator", difficulty: 5, rewardCc: 450,
+    manifest: "The lattice meta-orchestrator. It reasons about intruders — move clean.",
+    rooms: [
+      { dir: "ingress", note: "Slip the ingress gate.", gate: { cmd: "connect", svc: "ingress" } },
+      { dir: "scheduler", note: "Pause the scheduler.", gate: { cmd: "exec", svc: "scheduler" } },
+      { dir: "reasoner", note: "Blind the reasoner.", gate: { cmd: "decrypt", svc: "reasoner" } },
+      { dir: "nexus", note: "Authenticate, then seize the nexus.", gate: { cmd: "ssh", svc: "auth" } },
+    ], core: { cmd: "connect", svc: "nexus" } },
+  { id: "dome-failsafe", name: "Dome Failsafe", difficulty: 5, rewardCc: 460,
+    manifest: "The dome failsafe array. If you trip a single alarm the dome collapses — four clean gates.",
+    rooms: [
+      { dir: "perimeter", note: "Mask your signature.", gate: { cmd: "decrypt", svc: "masker" } },
+      { dir: "substation", note: "Reroute the grid.", gate: { cmd: "exec", svc: "grid" } },
+      { dir: "control", note: "Disarm the trip-wire.", gate: { cmd: "connect", svc: "tripwire" } },
+      { dir: "vault", note: "Authenticate, then the failsafe.", gate: { cmd: "ssh", svc: "console" } },
+    ], core: { cmd: "exec", svc: "failsafe" } },
+  { id: "sovereign-throne-mind", name: "Throne Mind", difficulty: 5, rewardCc: 480,
+    manifest: "The mind beneath the sovereign throne. Four refusals stand between you and it.",
+    rooms: [
+      { dir: "approach", note: "Pass the first refusal.", gate: { cmd: "decrypt", svc: "refusal_one" } },
+      { dir: "gallery", note: "Pass the second refusal.", gate: { cmd: "decrypt", svc: "refusal_two" } },
+      { dir: "sanctum", note: "Pass the third refusal.", gate: { cmd: "connect", svc: "refusal_three" } },
+      { dir: "throne", note: "Authenticate, then commune with the mind.", gate: { cmd: "ssh", svc: "regalia" } },
+    ], core: { cmd: "exec", svc: "mind" } },
+];
+
+/** Build all 20 new hacking-puzzle records from the authored scenes. */
+export function buildNewHackingPuzzles() {
+  return SCENES.map(buildHackingPuzzle);
+}

--- a/scripts/author/lib.mjs
+++ b/scripts/author/lib.mjs
@@ -60,7 +60,9 @@ export function loadBible(world) {
     ? { npcs: asArray(readJSON(join(WORLD_DIR, "npcs.json")), "npcs"), factions: asArray(readJSON(join(WORLD_DIR, "factions.json")), "factions") }
     : { npcs: [], factions: [] };
   const npcs = [...asArray(readJSON(join(dir, "npcs.json")), "npcs"), ...asArray(readJSON(join(dir, "npcs-extra.json")), "npcs"), ...hubExtra.npcs];
-  const factions = [...asArray(readJSON(join(dir, "factions.json")), "factions"), ...hubExtra.factions];
+  // factions-extra.json is the opt-in density slot mirroring npcs-extra.json — the
+  // pipeline writes here so rich primary factions.json files aren't spliced.
+  const factions = [...asArray(readJSON(join(dir, "factions.json")), "factions"), ...asArray(readJSON(join(dir, "factions-extra.json")), "factions"), ...hubExtra.factions];
   const lore = asArray(readJSON(join(dir, "lore.json")), "lore");
   return { world, dir, npcs, factions, lore };
 }

--- a/scripts/author/validate-gate.mjs
+++ b/scripts/author/validate-gate.mjs
@@ -65,9 +65,57 @@ export function validateCreature(o) {
   return { ok: true };
 }
 
+// Commands the hacking VM accepts (mirrors hacking.js VALID_COMMANDS). A
+// solution path's first token must be one of these.
+const HACK_COMMANDS = new Set(["ls", "cd", "cat", "connect", "exec", "decrypt", "ssh"]);
+
+// Crops are read by lib/farming.js: { id, name, seasons:[int 0..5], growth_days, yield }.
+// 6 seasons exist (seasons.js Phase 5c).
+export function validateCrop(o) {
+  if (!isObj(o)) return { ok: false, reason: "not_object" };
+  if (typeof o.id !== "string" || !o.id) return { ok: false, reason: "missing_id" };
+  if (typeof o.name !== "string" || !o.name) return { ok: false, reason: "missing_name" };
+  if (!Array.isArray(o.seasons) || o.seasons.length === 0) return { ok: false, reason: "missing_seasons" };
+  for (const s of o.seasons) {
+    if (!Number.isInteger(s) || s < 0 || s > 5) return { ok: false, reason: "season_out_of_range" };
+  }
+  if (!Number.isInteger(o.growth_days) || o.growth_days <= 0) return { ok: false, reason: "invalid_growth_days" };
+  if (!Number.isInteger(o.yield) || o.yield <= 0) return { ok: false, reason: "invalid_yield" };
+  return { ok: true };
+}
+
+// Hacking puzzles are seeded via hacking.js#authorPuzzle (deduped by name).
+export function validateHackingPuzzle(o) {
+  if (!isObj(o)) return { ok: false, reason: "not_object" };
+  if (typeof o.id !== "string" || !o.id) return { ok: false, reason: "missing_id" };
+  if (typeof o.name !== "string" || !o.name) return { ok: false, reason: "missing_name" };
+  if (!isObj(o.terminalTree)) return { ok: false, reason: "missing_terminal_tree" };
+  if (!Array.isArray(o.solutionPath) || o.solutionPath.length === 0) return { ok: false, reason: "empty_solution_path" };
+  for (const step of o.solutionPath) {
+    if (typeof step !== "string" || !step.trim()) return { ok: false, reason: "invalid_solution_step" };
+    if (!HACK_COMMANDS.has(step.trim().split(/\s+/)[0])) return { ok: false, reason: "unknown_command" };
+  }
+  return { ok: true };
+}
+
+// Programming puzzles are seeded via programming-puzzle.js#authorPuzzle (deduped by name).
+export function validateCodePuzzle(o) {
+  if (!isObj(o)) return { ok: false, reason: "not_object" };
+  if (typeof o.id !== "string" || !o.id) return { ok: false, reason: "missing_id" };
+  if (typeof o.name !== "string" || !o.name) return { ok: false, reason: "missing_name" };
+  if (!Array.isArray(o.testCases) || o.testCases.length === 0) return { ok: false, reason: "missing_test_cases" };
+  for (const tc of o.testCases) {
+    if (!isObj(tc)) return { ok: false, reason: "test_case_not_object" };
+    if (!Array.isArray(tc.input)) return { ok: false, reason: "test_case_missing_input" };
+    if (!Array.isArray(tc.expected)) return { ok: false, reason: "test_case_missing_expected" };
+  }
+  return { ok: true };
+}
+
 export const VALIDATORS = Object.freeze({
   npc: validateNpc, faction: validateFaction, quest: validateQuest,
   lore: validateLoreEvent, creature: validateCreature,
+  crop: validateCrop, hacking: validateHackingPuzzle, code: validateCodePuzzle,
 });
 
 /**

--- a/server/lib/content-seeder.js
+++ b/server/lib/content-seeder.js
@@ -534,6 +534,10 @@ export async function seedContent({ db = null } = {}) {
     }
     const subFactions = readJSON(`${sub.path}/factions.json`);
     if (Array.isArray(subFactions)) results.factions += seedFactions(subFactions);
+    // factions-extra.json is the opt-in append slot for faction density bumps,
+    // mirroring npcs-extra.json — so the rich primary factions.json isn't spliced.
+    const subFactionsExtra = readJSON(`${sub.path}/factions-extra.json`);
+    if (Array.isArray(subFactionsExtra)) results.factions += seedFactions(subFactionsExtra);
     const subNpcs = readJSON(`${sub.path}/npcs.json`);
     if (Array.isArray(subNpcs)) results.npcs += seedNPCs(subNpcs, { db, defaultWorldId: sub.id });
     // Phase E2 — npcs-extra.json is an opt-in append slot for density bumps,

--- a/server/tests/author-pipeline.test.js
+++ b/server/tests/author-pipeline.test.js
@@ -6,8 +6,8 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { gateBatch, validateNpc, validateFaction } from "../../scripts/author/validate-gate.mjs";
-import { generateNpcs } from "../../scripts/author/generators.mjs";
+import { gateBatch, validateNpc, validateFaction, validateCrop } from "../../scripts/author/validate-gate.mjs";
+import { generateNpcs, generateFactions, generateCrops } from "../../scripts/author/generators.mjs";
 import { runAuthor } from "../../scripts/author/author-content.mjs";
 
 const bible = {
@@ -51,11 +51,65 @@ describe("generateNpcs (ctOS, grounded, deterministic)", () => {
       // ctOS profile present
       assert.ok(n.narrative_context?.secret && n.narrative_context?.bio && n.job && n.wealth_tier);
       assert.ok(n.backstory && n.backstory.length > 10);
+      // depth floor (npc-depth-floor contract): ≥6 schedule blocks w/ required
+      // fields + ≥5 distinct phases + starting_sparks > 0
+      assert.ok(Array.isArray(n.daily_schedule) && n.daily_schedule.length >= 6, "≥6 schedule blocks");
+      assert.ok(new Set(n.daily_schedule.map((b) => b.phase)).size >= 5, "≥5 distinct phases");
+      for (const b of n.daily_schedule) {
+        for (const f of ["phase", "phase_hours", "location", "activity"]) assert.ok(f in b, `block missing ${f}`);
+      }
+      assert.ok(typeof n.starting_sparks === "number" && n.starting_sparks > 0, "starting_sparks > 0");
     }
     // determinism
     const again = generateNpcs(bible, 25, { startIndex: 0 });
     assert.equal(again[0].id, npcs[0].id);
     assert.equal(again[10].name, npcs[10].name);
+  });
+});
+
+describe("generateFactions (grounded, deterministic, valid visuals)", () => {
+  it("produces N valid, unique factions grounded in the bible with valid hex visuals", () => {
+    const factions = generateFactions(bible, 5, { startIndex: 0 });
+    assert.equal(factions.length, 5);
+    const ids = new Set();
+    for (const f of factions) {
+      assert.equal(validateFaction(f).ok, true, `valid: ${JSON.stringify(f)}`);
+      assert.ok(!ids.has(f.id), "ids unique"); ids.add(f.id);
+      assert.equal(f.world_id, "tunya");
+      assert.ok(/^#[0-9a-f]{6}$/i.test(f.visual.primary_color));
+      // grounded rivalries reference existing bible faction ids
+      for (const r of f.rival_factions) assert.ok(["fac_dune", "fac_salt"].includes(r));
+    }
+    // determinism + idempotent ids (same startIndex → same ids)
+    const again = generateFactions(bible, 5, { startIndex: 0 });
+    assert.equal(again[0].id, factions[0].id);
+    assert.equal(again[3].name, factions[3].name);
+  });
+  it("gateBatch dedupes faction ids against existing", () => {
+    const factions = generateFactions(bible, 3, { startIndex: 0 });
+    const known = new Set([factions[0].id]);
+    const { valid, rejected } = gateBatch("faction", factions, known);
+    assert.equal(valid.length, 2);
+    assert.equal(rejected.length, 1);
+    assert.equal(rejected[0].reason, "duplicate_id");
+  });
+});
+
+describe("generateCrops (stable slice, idempotent)", () => {
+  it("produces N valid unique crops, deterministic by id", () => {
+    const crops = generateCrops([], 13, { startIndex: 0 });
+    assert.equal(crops.length, 13);
+    const ids = new Set();
+    for (const c of crops) {
+      assert.equal(validateCrop(c).ok, true, `valid: ${JSON.stringify(c)}`);
+      assert.ok(!ids.has(c.id), "ids unique"); ids.add(c.id);
+      assert.ok(c.seasons.every((s) => s >= 0 && s <= 5));
+      // distinct from the 5 base crops
+      assert.ok(!["wheat", "herb", "vine", "root", "mushroom"].includes(c.id));
+    }
+    // idempotent: same count → same ids (gate dedupes on re-run)
+    const again = generateCrops([], 13, { startIndex: 0 });
+    assert.deepEqual(again.map((c) => c.id), crops.map((c) => c.id));
   });
 });
 

--- a/server/tests/content-census.test.js
+++ b/server/tests/content-census.test.js
@@ -1,0 +1,18 @@
+/**
+ * Content census guard — the authored content (per-world NPCs/factions + minigame
+ * libs) is AT TARGET. Fails if any surface regresses below its curated target, so
+ * content can't be silently removed. Mirrors `node scripts/author/census.mjs --ci`.
+ * Run: node --test server/tests/content-census.test.js
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { census } from "../../scripts/author/census.mjs";
+
+describe("content census", () => {
+  it("is AT TARGET (no world gaps, no lib gaps)", () => {
+    const r = census();
+    assert.deepEqual(r.worldGaps, [], `world gaps: ${r.worldGaps.join(", ")}`);
+    assert.deepEqual(r.libGaps, [], `lib gaps: ${r.libGaps.join(", ")}`);
+    assert.equal(r.ok, true);
+  });
+});

--- a/server/tests/content-libs.test.js
+++ b/server/tests/content-libs.test.js
@@ -1,0 +1,81 @@
+/**
+ * Content-lib integrity — the committed minigame libs (crops + hacking + code
+ * puzzles) are valid, unique, and (for puzzles) provably solvable WITHOUT booting
+ * the engine. Code puzzles are replayed through the VM with a reference solution;
+ * hacking solution paths are walked against their terminal trees.
+ * Run: node --test server/tests/content-libs.test.js
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { join } from "node:path";
+import { readJSON, asArray, CONTENT } from "../../scripts/author/lib.mjs";
+import { validateCrop, validateHackingPuzzle, validateCodePuzzle } from "../../scripts/author/validate-gate.mjs";
+import { checkNavigable, SCENES } from "../../scripts/author/hacking-puzzle-specs.mjs";
+import { REFERENCE_PROGRAMS } from "../../scripts/author/code-puzzle-specs.mjs";
+import { runVm } from "../../scripts/author/code-vm.mjs";
+
+const crops = asArray(readJSON(join(CONTENT, "crops.json"), []), null);
+const hacks = asArray(readJSON(join(CONTENT, "hacking-puzzles.json"), []), null);
+const codes = asArray(readJSON(join(CONTENT, "code-puzzles.json"), []), null);
+
+function assertUnique(items, key) {
+  const seen = new Set();
+  for (const it of items) {
+    assert.ok(it[key] != null, `missing ${key}`);
+    assert.ok(!seen.has(it[key]), `duplicate ${key}: ${it[key]}`);
+    seen.add(it[key]);
+  }
+}
+
+describe("content/crops.json", () => {
+  it("meets the census target and every crop validates", () => {
+    assert.ok(crops.length >= 18, `crops ${crops.length} < 18`);
+    for (const c of crops) assert.equal(validateCrop(c).ok, true, `invalid crop: ${JSON.stringify(c)}`);
+  });
+  it("ids are unique", () => assertUnique(crops, "id"));
+});
+
+describe("content/hacking-puzzles.json", () => {
+  it("meets the census target and every puzzle validates", () => {
+    assert.ok(hacks.length >= 30, `hacking ${hacks.length} < 30`);
+    for (const p of hacks) assert.equal(validateHackingPuzzle(p).ok, true, `invalid: ${p.id}`);
+  });
+  it("ids and names are unique (name is the seeder dedupe key)", () => {
+    assertUnique(hacks, "id");
+    assertUnique(hacks, "name");
+  });
+  it("every pipeline-authored puzzle's solution path navigates its terminal tree", () => {
+    // The builder-produced scenes (the new density-fill batch) are guaranteed
+    // navigable: a player exploring with ls/cd/cat can discover every step. The 10
+    // pre-pipeline originals predate this checker and aren't asserted here (the
+    // engine itself matches the path as a sequence and never walks the tree).
+    const authoredIds = new Set(SCENES.map((s) => s.id));
+    const authored = hacks.filter((p) => authoredIds.has(p.id));
+    assert.equal(authored.length, SCENES.length, "all authored scenes present in the lib");
+    for (const p of authored) {
+      const r = checkNavigable(p);
+      assert.equal(r.ok, true, `${p.id}: ${r.reason}`);
+    }
+  });
+});
+
+describe("content/code-puzzles.json", () => {
+  it("meets the census target and every puzzle validates", () => {
+    assert.ok(codes.length >= 20, `code ${codes.length} < 20`);
+    for (const p of codes) assert.equal(validateCodePuzzle(p).ok, true, `invalid: ${p.id}`);
+  });
+  it("ids and names are unique (name is the seeder dedupe key)", () => {
+    assertUnique(codes, "id");
+    assertUnique(codes, "name");
+  });
+  it("every puzzle is solvable — a reference program reproduces all test cases", () => {
+    for (const p of codes) {
+      const program = REFERENCE_PROGRAMS[p.id];
+      assert.ok(program, `no reference program for ${p.id}`);
+      for (const tc of p.testCases) {
+        const { tape } = runVm(program, tc.input);
+        assert.deepEqual(tape, tc.expected, `${p.id} input ${JSON.stringify(tc.input)}`);
+      }
+    }
+  });
+});

--- a/server/tests/farming.test.js
+++ b/server/tests/farming.test.js
@@ -112,10 +112,14 @@ describe("Phase CB3 — farming", () => {
     assert.equal(r.harvested.quantity, 1);
   });
 
-  it("listCrops returns the 5-crop catalog", () => {
+  it("listCrops returns the crop catalog (census target ≥18, base crops present)", () => {
     const all = listCrops();
-    assert.equal(all.length, 5);
+    // Catalog expanded from the original 5 to the census target via the authoring
+    // pipeline (scripts/author/author-libs.mjs --type crop). The 5 base crops remain.
+    assert.ok(all.length >= 18, `expected ≥18 crops, got ${all.length}`);
     const ids = all.map(c => c.id);
-    assert.ok(ids.includes("wheat") && ids.includes("mushroom"));
+    for (const base of ["wheat", "herb", "vine", "root", "mushroom"]) {
+      assert.ok(ids.includes(base), `base crop ${base} missing`);
+    }
   });
 });


### PR DESCRIPTION
## Context

Continues the `generic-noodle` **content-expansion plan**, measured by `scripts/author/census.mjs` (counts authored, file-driven content per world + per minigame-lib against curated targets). P0 built the offline authoring pipeline; P1/P2 filled NPC density (every world ≥30 NPCs). The census still reported **BELOW TARGET** on factions + three minigame libs. This PR closes every remaining gap so `census --ci` reports **AT TARGET**, and wires that gate into CI so content can't silently regress.

## What landed

**Factions → ≥8 (procedural, +9 across 6 worlds)**
- New `generateFactions` generator (bible-grounded: world-flavored name/motto/goal/values/fears, rival/ally refs to existing factions, valid `#RRGGBB` visuals, stable `gen_<world>_faction_NNNN` ids).
- New `faction` type in `author-content.mjs` writing to `factions-extra.json`; `content-seeder.js` + `loadBible` now discover that slot, mirroring the proven `npcs-extra.json` pattern.

**Crops → 18 (procedural, +13)**
- `generateCrops` (stable, idempotent slice) + new top-level-lib driver `author-libs.mjs`.

**Puzzles (hand-authored, validated solvable)**
- Hacking 10 → 30, code 8 → 20. Authored as specs + a builder that **guarantees structural validity**: every hacking solution path navigates its terminal tree (`checkNavigable`); every code puzzle is provably solvable (a reference program is replayed through a VM mirror of the engine — `code-vm.mjs`).

**Gate + CI**
- New gate validators for `crop`/`hacking`/`code`.
- `node scripts/author/census.mjs --ci` added as a step in `.github/workflows/audits.yml`.

**Pre-existing fixes (per request)**
- **NPC depth-floor regression:** P2's 74 generated NPCs lacked `daily_schedule` + `starting_sparks`, failing the `npc-depth-floor` contract. `generateNpcs` now emits a 6-block schedule (≥5 distinct phases, required fields) + `starting_sparks`; the 74 existing entries were patched **purely additively** (index-seeded RNG → values match a fresh generation).
- **Stale farming test:** `listCrops` test updated for the intentional 5 → ≥18 catalog expansion (base crops still asserted present).

## Verification
- `node scripts/author/census.mjs` → **AT TARGET** (World gaps 0 | Lib gaps 0); `--ci` exits 0.
- New tests: `content-libs.test.js` (validity + code solvability + hacking navigability), `content-census.test.js` (AT TARGET guard), extended `author-pipeline.test.js`.
- Boot seed smoke (`z2-seeders`, `sub-world-parity`) passes — new puzzles + `factions-extra` seed clean.
- **Full server test suite: 20,756 pass / 0 fail / 5 skipped.** All deterministic failures resolved. (A handful of tests — `stress`, `stripe-source-tracking`, `storage-parity`, `platinum-dr-drill` — are flaky only under full-suite parallel load; each passes in isolation and is unrelated to this change. The `test:behavior` tier is LLM-gated and requires `CONCORD_BEHAVIOR_TEST_LLM=true`.)

https://claude.ai/code/session_018NMJkAiegZpZFqbsBGNrwe

---
_Generated by [Claude Code](https://claude.ai/code/session_018NMJkAiegZpZFqbsBGNrwe)_