### PR TITLE
WS0: make the NPCs walk — let the heretic pace the Unburned Court

### DIFF
--- a/server/lib/npc-routines.js
+++ b/server/lib/npc-routines.js
@@ -23,6 +23,14 @@ const BLOCK_HOURS = 24 / BLOCKS_PER_DAY;
 const NUDGE_M_PER_TICK = 6;                // distance NPC moves toward target per advance
 const ARRIVAL_RADIUS_M = 4;
 const SIGNAL_EMIT_INTERVAL_S = 120;        // throttle env signal writes per NPC
+// Living Society WS0 — idle ambient motion. An NPC that has ARRIVED at its
+// activity station must not freeze as a statue (a priest communing at the
+// temple stood perfectly still — the first playtester's bug). When arrived it
+// instead PACES toward a gentle, deterministic point within this radius of the
+// station. < ARRIVAL_RADIUS_M so the NPC stays "arrived" (signals keep firing).
+const IDLE_WANDER_RADIUS_M = Number(process.env.CONCORD_IDLE_WANDER_RADIUS_M) || 2.5;
+const IDLE_NUDGE_M_PER_TICK = Number(process.env.CONCORD_IDLE_NUDGE_M) || 1.2; // slow amble at station
+const IDLE_WANDER_PERIOD_S = Number(process.env.CONCORD_IDLE_WANDER_PERIOD_S) || 18; // re-pick a pace point ~every 18s
 
 // Activity → embodied signal table (channel, delta, ttlSeconds).
 // Reuses Layer 7 channels; values are deltas added on top of baseline.
@@ -301,6 +309,20 @@ function deterministicOffset(npc, dayBlockKey) {
   return { dx, dz };
 }
 
+/**
+ * Living Society WS0 — a gentle pacing point within IDLE_WANDER_RADIUS_M of an
+ * NPC's station. Deterministic (seeded by npc id + a slow time-bucket) so it's
+ * testable and changes only ~every IDLE_WANDER_PERIOD_S — a slow amble, not a
+ * jitter. Returns the absolute world point to drift toward.
+ */
+export function idlePaceTarget(npcId, baseX, baseZ, now) {
+  const bucket = Math.floor((Number(now) || 0) / IDLE_WANDER_PERIOD_S);
+  const seed = crypto.createHash("sha1").update(`${npcId}|${bucket}|pace`).digest();
+  const angle = (seed[0] / 255) * Math.PI * 2;
+  const radius = (seed[1] / 255) * IDLE_WANDER_RADIUS_M;
+  return { x: baseX + Math.cos(angle) * radius, z: baseZ + Math.sin(angle) * radius };
+}
+
 // ── Public: deterministic schedule generation ───────────────────────────────
 
 /**
@@ -438,23 +460,35 @@ export async function advanceRoutine(db, npc, opts = {}) {
     transitioned = true;
   }
 
-  // Nudge position toward target.
-  const cur = parseLocation(npc.current_location) || { x: 0, z: 0 };
-  const dx = block.target_x - cur.x;
-  const dz = block.target_z - cur.z;
-  const dist = Math.hypot(dx, dz);
+  // Nudge position toward the station — or, once arrived, PACE around it so the
+  // NPC is never a frozen statue (WS0). Start position falls back to spawn, then
+  // to the station itself (never the {0,0} garbage step the bare boot produced).
+  const cur = parseLocation(npc.current_location)
+    || parseLocation(npc.spawn_location)
+    || { x: block.target_x, z: block.target_z };
+  const dist = Math.hypot(block.target_x - cur.x, block.target_z - cur.z);
+  const arrived = dist <= ARRIVAL_RADIUS_M;
 
+  // Choose this tick's move target + step size.
+  let moveX = block.target_x;
+  let moveZ = block.target_z;
+  let stepCap = NUDGE_M_PER_TICK;
+  if (arrived && IDLE_WANDER_RADIUS_M > 0) {
+    const pace = idlePaceTarget(npc.id, block.target_x, block.target_z, now);
+    moveX = pace.x;
+    moveZ = pace.z;
+    stepCap = IDLE_NUDGE_M_PER_TICK; // slow amble at the station
+  }
+  const mdx = moveX - cur.x;
+  const mdz = moveZ - cur.z;
+  const mdist = Math.hypot(mdx, mdz);
   let nx = cur.x;
   let nz = cur.z;
-  let arrived = dist <= ARRIVAL_RADIUS_M;
-  if (!arrived) {
-    const step = Math.min(NUDGE_M_PER_TICK, dist);
-    const nrm = step / dist;
-    nx = cur.x + dx * nrm;
-    nz = cur.z + dz * nrm;
-  } else {
-    nx = block.target_x;
-    nz = block.target_z;
+  if (mdist > 0.05) {
+    const step = Math.min(stepCap, mdist);
+    const nrm = step / mdist;
+    nx = cur.x + mdx * nrm;
+    nz = cur.z + mdz * nrm;
   }
   db.prepare(`UPDATE world_npcs SET current_location = ? WHERE id = ?`)
     .run(JSON.stringify({ x: nx, z: nz }), npc.id);
@@ -533,9 +567,13 @@ export const _internal = {
   NUDGE_M_PER_TICK,
   ARRIVAL_RADIUS_M,
   SIGNAL_EMIT_INTERVAL_S,
+  IDLE_WANDER_RADIUS_M,
+  IDLE_NUDGE_M_PER_TICK,
+  IDLE_WANDER_PERIOD_S,
   ACTIVITY_SIGNALS,
   ARCHETYPE_ROUTINES,
   preoccupationOverrides,
   parseLocation,
   deterministicOffset,
+  idlePaceTarget,
 };

--- a/server/server.js
+++ b/server/server.js
@@ -30543,6 +30543,18 @@ if (db) {
     // Seed authored world content (factions, NPCs, lore, quest chains) into
     // in-memory systems. Must run after world seed so history engine is ready.
     try { await seedContent({ db }); } catch (e) { console.warn("[content-seeder]", e.message); }
+    // Living Society WS0 — the world breathes immediately. The heartbeat
+    // dispatcher only starts at boot+50s (then npc-routine-cycle every ~75s),
+    // so a bare boot leaves NPCs frozen for the first 1–2 minutes (the first
+    // playtester watched a priest stand still in a dying city). Run a couple of
+    // early routine passes ~8s + ~20s after the seed so NPCs take their first
+    // steps within seconds. Guarded + idempotent (the cycle is the same one the
+    // heartbeat runs).
+    try {
+      for (const delayMs of [8000, 20000]) {
+        setTimeout(() => { runNpcRoutineCycle({ db }).catch(() => {}); }, delayMs).unref?.();
+      }
+    } catch { /* early warm pass is best-effort */ }
     // Phase G — load per-world flavor JSONs (loops.json per sub-world).
     // Loops + climate + skill ceilings + NPC density + world voice all
     // resolve through this cache. Idempotent.

--- a/server/tests/npc-idle-pacing.test.js
+++ b/server/tests/npc-idle-pacing.test.js
@@ -1,0 +1,112 @@
+/**
+ * Living Society WS0 — make the NPCs WALK (the first playtester's bug).
+ *
+ * An NPC that ARRIVED at its activity station used to be pinned to the exact
+ * target every tick — a priest communing at the temple stood frozen as a
+ * statue. Now it PACES within a small radius. These pin:
+ *   - idlePaceTarget is deterministic (seeded by id + a slow time-bucket),
+ *     stays within IDLE_WANDER_RADIUS_M of the station, and re-picks across
+ *     buckets (a slow amble, not a jitter);
+ *   - advanceRoutine moves an ARRIVED npc OFF the exact target (it paces),
+ *     stays "arrived", and never lands back on {0,0} from a null position.
+ *
+ * Run: node --test tests/npc-idle-pacing.test.js
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+import { advanceRoutine, _internal } from "../lib/npc-routines.js";
+
+const { idlePaceTarget, IDLE_WANDER_RADIUS_M, ARRIVAL_RADIUS_M } = _internal;
+
+describe("WS0 — idlePaceTarget (the pacing point)", () => {
+  it("is deterministic for the same id + time bucket", () => {
+    const a = idlePaceTarget("priest_1", 100, 200, 1_000_000);
+    const b = idlePaceTarget("priest_1", 100, 200, 1_000_000);
+    assert.deepEqual(a, b);
+  });
+
+  it("stays within IDLE_WANDER_RADIUS_M of the station", () => {
+    for (let t = 0; t < 50; t++) {
+      const p = idlePaceTarget("priest_1", 100, 200, t * 1000);
+      const d = Math.hypot(p.x - 100, p.z - 200);
+      assert.ok(d <= IDLE_WANDER_RADIUS_M + 1e-6, `paced ${d}m from station (> ${IDLE_WANDER_RADIUS_M})`);
+    }
+  });
+
+  it("re-picks a pace point across time buckets (it ambles, not freezes)", () => {
+    // Two timestamps far enough apart to be different buckets.
+    const p1 = idlePaceTarget("priest_1", 100, 200, 0);
+    const p2 = idlePaceTarget("priest_1", 100, 200, 10_000);
+    assert.notDeepEqual(p1, p2, "the pace point never changes — still a statue");
+  });
+
+  it("stays inside the arrival radius so the NPC keeps its 'arrived' status", () => {
+    assert.ok(IDLE_WANDER_RADIUS_M < ARRIVAL_RADIUS_M,
+      "pacing radius must be < arrival radius or the NPC flickers in/out of 'arrived'");
+  });
+});
+
+// ── Integration: advanceRoutine actually paces an arrived NPC ─────────────────
+
+function mkDb() {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE world_npcs (id TEXT PRIMARY KEY, world_id TEXT, archetype TEXT, faction TEXT,
+      current_location TEXT, spawn_location TEXT, is_dead INTEGER DEFAULT 0);
+    CREATE TABLE npc_schedules (npc_id TEXT, day_seed INTEGER, block_idx INTEGER, activity_kind TEXT,
+      location_kind TEXT, target_x REAL, target_z REAL, generated_at INTEGER,
+      preoccupation_signature TEXT, PRIMARY KEY (npc_id, day_seed, block_idx));
+    CREATE TABLE npc_routine_state (npc_id TEXT PRIMARY KEY, current_block INTEGER, activity_kind TEXT,
+      location_kind TEXT, target_x REAL, target_z REAL, started_at INTEGER, arrived_at INTEGER,
+      expected_end_at INTEGER, last_signal_at INTEGER);
+  `);
+  return db;
+}
+
+const DAY = 1, BLK = 0;
+function seedSchedule(db, npcId, x, z) {
+  db.prepare(`INSERT INTO npc_schedules (npc_id, day_seed, block_idx, activity_kind, location_kind, target_x, target_z, generated_at)
+              VALUES (?, ?, ?, 'commune', 'temple', ?, ?, 0)`).run(npcId, DAY, BLK, x, z);
+}
+
+describe("WS0 — advanceRoutine paces an arrived NPC (no statue)", () => {
+  it("moves an at-station NPC OFF the exact target across ticks, staying bounded", async () => {
+    const db = mkDb();
+    const ST = { x: 100, z: 200 };
+    db.prepare(`INSERT INTO world_npcs (id, world_id, archetype, current_location, spawn_location)
+                VALUES ('priest', 'concordia-hub', 'mystic', ?, ?)`)
+      .run(JSON.stringify(ST), JSON.stringify(ST));
+    seedSchedule(db, "priest", ST.x, ST.z);
+
+    const positions = [];
+    for (let i = 0; i < 8; i++) {
+      const npc = db.prepare(`SELECT * FROM world_npcs WHERE id='priest'`).get();
+      const r = await advanceRoutine(db, npc, { daySeed: DAY, blockIdx: BLK });
+      assert.equal(r.ok, true, `tick ${i}: ${r.reason}`);
+      positions.push(JSON.parse(db.prepare(`SELECT current_location FROM world_npcs WHERE id='priest'`).get().current_location));
+    }
+    // Pinned-to-exact-target would mean every position == ST. It must DRIFT.
+    const moved = positions.some((p) => Math.hypot(p.x - ST.x, p.z - ST.z) > 0.05);
+    const bounded = positions.every((p) => Math.hypot(p.x - ST.x, p.z - ST.z) <= IDLE_WANDER_RADIUS_M + 0.5);
+    assert.ok(moved, "the priest never moved off his station — still frozen");
+    assert.ok(bounded, "the priest wandered past the pacing radius");
+    // and he stayed 'arrived' (within arrival radius the whole time)
+    assert.ok(positions.every((p) => Math.hypot(p.x - ST.x, p.z - ST.z) <= ARRIVAL_RADIUS_M));
+  });
+
+  it("a null current_location never steps toward {0,0} (no bare-boot garbage step)", async () => {
+    const db = mkDb();
+    const SPAWN = { x: 50, z: 60 };
+    db.prepare(`INSERT INTO world_npcs (id, world_id, archetype, current_location, spawn_location)
+                VALUES ('p2', 'concordia-hub', 'mystic', NULL, ?)`).run(JSON.stringify(SPAWN));
+    seedSchedule(db, "p2", SPAWN.x, SPAWN.z); // station == spawn (he's home)
+    const npc = db.prepare(`SELECT * FROM world_npcs WHERE id='p2'`).get();
+    const r = await advanceRoutine(db, npc, { daySeed: DAY, blockIdx: BLK });
+    assert.equal(r.ok, true);
+    const loc = JSON.parse(db.prepare(`SELECT current_location FROM world_npcs WHERE id='p2'`).get().current_location);
+    // Near spawn (50,60), NEVER near {0,0}.
+    assert.ok(Math.hypot(loc.x, loc.z) > 10, "a null-position NPC stepped toward {0,0}");
+  });
+});


### PR DESCRIPTION
## WS0 — make the NPCs walk (the first playtester's one feature request)

The first playtester booted bare, stood in concordia-hub's **Unburned Court**, and watched the heretic priest **stand frozen in a dying city**. This fixes it.

### Root cause
`lib/npc-routines.js#advanceRoutine` walked an NPC toward its activity-block target, but once `arrived` (within 4m) it **pinned the NPC to the EXACT `target_x/target_z` every tick** for the whole block. A priest communing at the temple = a statue for hours of game-time.

### The fix
- **Idle pacing:** when arrived, the NPC now drifts toward a gentle, deterministic point within `IDLE_WANDER_RADIUS_M` (2.5m, < the 4m arrival radius so it stays "arrived" and keeps emitting activity signals) at a slow amble, re-picking the point ~every 18s (`idlePaceTarget`, seeded by id + a time-bucket — testable + network-cheap). A communing priest paces his temple; a guard shifts at his post.
- **No bare-boot garbage step:** the start position falls back `spawn_location` → station instead of the `{0,0}` step a null `current_location` produced.
- **The world breathes immediately:** two early one-shot routine passes (+8s/+20s after the content seed) so NPCs move within seconds instead of waiting out the ~50s heartbeat warmup + ~75s routine cadence.
- Dials: `CONCORD_IDLE_WANDER_RADIUS_M` / `CONCORD_IDLE_NUDGE_M` / `CONCORD_IDLE_WANDER_PERIOD_S`.

### Verification
- `tests/npc-idle-pacing.test.js` (6/6): `idlePaceTarget` deterministic + bounded + re-picks across buckets; `advanceRoutine` drifts an arrived NPC off the exact target while staying arrived; a null position never steps toward `{0,0}`.
- Existing `npc-routines` + cycle + civilian regressions green; lint + server syntax clean.
- **Live, end-to-end:** booted bare (no Ollama, **zero active players** — the cycle's all-NPC fallback), **129/377 NPCs moved** over one routine cadence (real walking + pacing). The city is alive before anyone logs in.

> First playtester's feature request: *"let him walk. The world that can't finish dying deserves a heretic who can at least pace."* — done.

(Speech-without-a-brain and the null-parse seams were already covered: `religion-engine.sermon` is a deterministic counter (no LLM), and the `/dialogue` greeting + NPC-conversation paths already have the deterministic fallbacks built earlier; the two position parses found are null-guarded. This PR is the movement fix.)

https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ)_