### PR TITLE
WS4: Living NPCs — needs/utility-driven movement to real POIs (wants + needs + schedules)

### DIFF
--- a/server/lib/npc-needs.js
+++ b/server/lib/npc-needs.js
@@ -1,0 +1,98 @@
+// server/lib/npc-needs.js
+//
+// Living Society WS4.1 — the per-NPC NEEDS model (the motive layer).
+//
+// Needs are stored as DEFICITS in [0,1]: 0 = fully satisfied, 1 = desperate.
+// Each need DECAYS upward over time at its own rate (hunger climbs fast, purpose
+// slow). Performing the matching activity SATISFIES it (lowers the deficit).
+// This is the input the utility scorer (npc-utility.js) reads to decide where an
+// NPC goes — turning the fixed-schedule automaton into a motivated agent.
+//
+// Pure + deterministic (no DB, no clock) so the math is contract-testable; the
+// DB read/write helpers are thin wrappers (needs live in world_npcs.needs_json).
+
+export const NEED_KINDS = Object.freeze(["hunger", "energy", "wealth", "social", "safety", "purpose"]);
+
+// Deficit gained per HOUR of game/real time, per need. Tuned so hunger/energy
+// cycle a few times a day and purpose/wealth drift slowly. Env-overridable.
+export const DECAY_PER_HOUR = Object.freeze({
+  hunger: Number(process.env.CONCORD_NEED_HUNGER_DECAY) || 0.16,
+  energy: Number(process.env.CONCORD_NEED_ENERGY_DECAY) || 0.10,
+  wealth: Number(process.env.CONCORD_NEED_WEALTH_DECAY) || 0.05,
+  social: Number(process.env.CONCORD_NEED_SOCIAL_DECAY) || 0.08,
+  safety: Number(process.env.CONCORD_NEED_SAFETY_DECAY) || 0.03,
+  purpose: Number(process.env.CONCORD_NEED_PURPOSE_DECAY) || 0.04,
+});
+
+function clamp01(n) { return Math.max(0, Math.min(1, n)); }
+
+/** A fresh needs vector — mild baseline deficits so even a new NPC has wants. */
+export function freshNeeds() {
+  return { hunger: 0.2, energy: 0.2, wealth: 0.3, social: 0.2, safety: 0.1, purpose: 0.2 };
+}
+
+/** Normalise any partial/garbage needs object to a complete clamped vector. */
+export function normalizeNeeds(needs) {
+  const out = {};
+  const base = freshNeeds();
+  for (const k of NEED_KINDS) out[k] = clamp01(Number(needs?.[k] ?? base[k]) || 0);
+  return out;
+}
+
+/**
+ * Decay (raise) every need's deficit by its rate × elapsed hours. Pure: returns
+ * a NEW vector. `mods` optionally scales per-need decay (e.g. a stressed NPC's
+ * safety climbs faster).
+ */
+export function decayNeeds(needs, elapsedHours, mods = {}) {
+  const cur = normalizeNeeds(needs);
+  const dt = Math.max(0, Number(elapsedHours) || 0);
+  const out = {};
+  for (const k of NEED_KINDS) {
+    const rate = DECAY_PER_HOUR[k] * (Number(mods[k]) || 1);
+    out[k] = clamp01(cur[k] + rate * dt);
+  }
+  return out;
+}
+
+/** Satisfy a need: lower its deficit by `amount` (pure, returns new vector). */
+export function satisfy(needs, kind, amount) {
+  const out = normalizeNeeds(needs);
+  if (NEED_KINDS.includes(kind)) out[kind] = clamp01(out[kind] - Math.max(0, Number(amount) || 0));
+  return out;
+}
+
+/** Apply a POI's advertisement (a {need:amount} map) as satisfaction. */
+export function satisfyFromAdvertisement(needs, advert = {}) {
+  let out = normalizeNeeds(needs);
+  for (const [k, amt] of Object.entries(advert)) out = satisfy(out, k, amt);
+  return out;
+}
+
+export function deficit(needs, kind) { return normalizeNeeds(needs)[kind] ?? 0; }
+
+/** The most-pressing need (highest deficit) + its value. */
+export function topNeed(needs) {
+  const cur = normalizeNeeds(needs);
+  let best = NEED_KINDS[0];
+  for (const k of NEED_KINDS) if (cur[k] > cur[best]) best = k;
+  return { kind: best, deficit: cur[best] };
+}
+
+// ── DB wrappers (needs live in world_npcs.needs_json — one column, mig WS4) ───
+
+export function getNeeds(db, npcId) {
+  try {
+    const row = db.prepare(`SELECT needs_json FROM world_npcs WHERE id = ?`).get(npcId);
+    return row?.needs_json ? normalizeNeeds(JSON.parse(row.needs_json)) : freshNeeds();
+  } catch { return freshNeeds(); }
+}
+
+export function setNeeds(db, npcId, needs) {
+  try {
+    db.prepare(`UPDATE world_npcs SET needs_json = ? WHERE id = ?`).run(JSON.stringify(normalizeNeeds(needs)), npcId);
+    return true;
+  } catch { return false; }
+}
+
+export const NEEDS_CONSTANTS = Object.freeze({ NEED_KINDS, DECAY_PER_HOUR });

--- a/server/lib/npc-pois.js
+++ b/server/lib/npc-pois.js
@@ -1,0 +1,75 @@
+// server/lib/npc-pois.js
+//
+// Living Society WS4.2 — smart-object POIs (The Sims "smart object" model).
+//
+// Each building TYPE advertises which needs it satisfies + how much. The utility
+// scorer (npc-utility.js) reads these to decide where an NPC goes — and crucially
+// the candidates are REAL `world_buildings` near the NPC, not the spawn±random
+// offset the old schedule used. Adding a POI kind = a row in POI_ADVERTISEMENTS.
+
+// building_type → { need: satisfaction amount } it advertises.
+export const POI_ADVERTISEMENTS = Object.freeze({
+  inn:       { hunger: 0.6, social: 0.5, energy: 0.3 },
+  market:    { wealth: 0.5, social: 0.4 },
+  forge:     { wealth: 0.6, purpose: 0.5 },
+  farm:      { wealth: 0.5, purpose: 0.5 },
+  mine:      { wealth: 0.6, purpose: 0.4 },
+  house:     { energy: 0.8 },
+  well:      { hunger: 0.25 },
+  tower:     { safety: 0.5, purpose: 0.4 },
+  dock:      { wealth: 0.5, purpose: 0.4 },
+  warehouse: { wealth: 0.4 },
+});
+
+export function advertisementFor(buildingType) {
+  return POI_ADVERTISEMENTS[String(buildingType || "").toLowerCase()] || {};
+}
+
+/**
+ * The REAL nearby smart-object POIs for an NPC: standing world_buildings near
+ * (x,z), each annotated with distance + its need advertisement. The scorer
+ * decides among these. Returns [] if no buildings (an empty/unbuilt world —
+ * the NPC just paces, honest, not a fake POI).
+ */
+export function nearbyPOIs(db, worldId, x, z, limit = 12) {
+  if (!db || !worldId) return [];
+  const px = Number(x) || 0, pz = Number(z) || 0;
+  let rows = [];
+  try {
+    rows = db.prepare(`
+      SELECT id, building_type, x, z
+      FROM world_buildings
+      WHERE world_id = ? AND state != 'collapsed'
+      ORDER BY ((x - ?) * (x - ?) + (z - ?) * (z - ?)) ASC
+      LIMIT ?
+    `).all(worldId, px, px, pz, pz, Math.max(1, limit));
+  } catch { return []; }
+  return rows
+    .map((b) => {
+      const advertises = advertisementFor(b.building_type);
+      if (Object.keys(advertises).length === 0) return null; // a POI that satisfies nothing isn't a goal
+      return { id: b.id, type: b.building_type, x: b.x, z: b.z, dist: Math.hypot(b.x - px, b.z - pz), advertises };
+    })
+    .filter(Boolean);
+}
+
+/** The nearest POI of a specific building type (e.g. resolve "home" → the nearest house). */
+export function nearestOfType(db, worldId, x, z, buildingType) {
+  const px = Number(x) || 0, pz = Number(z) || 0;
+  try {
+    const b = db.prepare(`
+      SELECT id, building_type, x, z FROM world_buildings
+      WHERE world_id = ? AND state != 'collapsed' AND building_type = ?
+      ORDER BY ((x - ?) * (x - ?) + (z - ?) * (z - ?)) ASC LIMIT 1
+    `).get(worldId, String(buildingType), px, px, pz, pz);
+    if (!b) return null;
+    return { id: b.id, type: b.building_type, x: b.x, z: b.z, dist: Math.hypot(b.x - px, b.z - pz), advertises: advertisementFor(b.building_type) };
+  } catch { return null; }
+}
+
+// The schedule's location_kind → the building type(s) that fulfil it (so the
+// time-block bias can still steer toward the right kind of place).
+export const LOCATION_KIND_BUILDING = Object.freeze({
+  home: "house", tavern: "inn", market: "market", plaza: "market",
+  temple: "tower", workplace: "forge", mine: "mine", farm: "farm", dock: "dock",
+});

--- a/server/lib/npc-routines.js
+++ b/server/lib/npc-routines.js
@@ -15,6 +15,13 @@
 
 import crypto from "node:crypto";
 import logger from "../logger.js";
+// WS4 — the motivated-movement layer (needs → utility goal among real POIs).
+import { getNeeds, setNeeds, decayNeeds, satisfyFromAdvertisement } from "./npc-needs.js";
+import { nearbyPOIs } from "./npc-pois.js";
+import { chooseNextGoal } from "./npc-utility.js";
+
+const NEED_ADVANCE_HOURS = Number(process.env.CONCORD_NEED_ADVANCE_HOURS) || 0.06; // need pressure per advance
+const POI_ARRIVE_SATISFY_M = 6; // satisfy a POI's needs when within this of it
 
 // ── Config ──────────────────────────────────────────────────────────────────
 
@@ -435,6 +442,26 @@ export async function advanceRoutine(db, npc, opts = {}) {
   if (!block) return { ok: false, reason: "no_schedule" };
 
   const state = db.prepare(`SELECT * FROM npc_routine_state WHERE npc_id = ?`).get(npc.id) || null;
+  const willTransition = !state || state.current_block !== blockIdx;
+
+  // ── WS4: needs-driven goal selection (the motivated brain) ────────────────
+  // Decay the NPC's needs each advance; on a block TRANSITION, re-pick a goal
+  // among the REAL nearby buildings (smart-object POIs) by utility score and
+  // OVERRIDE the schedule's random-offset target with that motivated
+  // destination. The daily schedule becomes a bias (activity_kind), not a
+  // script. Guarded + env-gated (CONCORD_NPC_NEEDS=0 → pure schedule).
+  if (process.env.CONCORD_NPC_NEEDS !== "0") {
+    try {
+      let needs = decayNeeds(getNeeds(db, npc.id), NEED_ADVANCE_HOURS);
+      if (willTransition && npc.world_id) {
+        const pos = parseLocation(npc.current_location) || parseLocation(npc.spawn_location) || { x: block.target_x, z: block.target_z };
+        const pois = nearbyPOIs(db, npc.world_id, pos.x, pos.z, 12);
+        const goal = chooseNextGoal(npc, needs, pois, { activityKind: block.activity_kind, seedKey: `${npc.id}|${blockIdx}|${daySeed}` });
+        if (goal?.poi) { block.target_x = goal.poi.x; block.target_z = goal.poi.z; }
+      }
+      setNeeds(db, npc.id, needs);
+    } catch { /* needs layer best-effort */ }
+  }
 
   // Block transition?
   let transitioned = false;
@@ -458,6 +485,18 @@ export async function advanceRoutine(db, npc, opts = {}) {
     `).run(npc.id, blockIdx, block.activity_kind, block.location_kind,
            block.target_x, block.target_z, now, expectedEnd);
     transitioned = true;
+  }
+
+  // The authoritative move target is the routine_state's — which holds the WS4
+  // goal override picked on transition and PERSISTS across non-transition ticks
+  // (the schedule block re-read above carries the old random offset, so we must
+  // not move toward it once a goal was chosen).
+  {
+    const eff = db.prepare(`SELECT target_x, target_z FROM npc_routine_state WHERE npc_id = ?`).get(npc.id);
+    if (eff && Number.isFinite(eff.target_x) && Number.isFinite(eff.target_z)) {
+      block.target_x = eff.target_x;
+      block.target_z = eff.target_z;
+    }
   }
 
   // Nudge position toward the station — or, once arrived, PACE around it so the
@@ -496,6 +535,17 @@ export async function advanceRoutine(db, npc, opts = {}) {
   if (arrived) {
     db.prepare(`UPDATE npc_routine_state SET arrived_at = COALESCE(arrived_at, unixepoch()) WHERE npc_id = ?`)
       .run(npc.id);
+    // WS4 — at the destination POI, performing the activity SATISFIES the needs
+    // that POI advertises (lowers their deficit) — closing the goal→walk→act→
+    // satisfy loop so needs visibly cycle. Guarded + env-gated.
+    if (process.env.CONCORD_NPC_NEEDS !== "0" && npc.world_id) {
+      try {
+        const [poiHere] = nearbyPOIs(db, npc.world_id, nx, nz, 1);
+        if (poiHere && poiHere.dist <= POI_ARRIVE_SATISFY_M) {
+          setNeeds(db, npc.id, satisfyFromAdvertisement(getNeeds(db, npc.id), poiHere.advertises));
+        }
+      } catch { /* satisfy best-effort */ }
+    }
   }
 
   // Embodied signal write — only if arrived AND throttle interval passed.

--- a/server/lib/npc-utility.js
+++ b/server/lib/npc-utility.js
@@ -1,0 +1,105 @@
+// server/lib/npc-utility.js
+//
+// Living Society WS4.3 — the utility scorer (the new NPC brain).
+//
+// IAUS-lite (Dave Mark's Infinite Axis Utility System, the model The Sims uses):
+// an NPC doesn't follow a fixed script — every tick it SCORES candidate goals
+// (smart-object POIs that advertise need-satisfaction) against its current
+// needs + schedule bias + personality + desires/grudges, and picks the best
+// (weighted-random among the top few for variety). This is where needs, wants
+// (npc_desires) and grudges FINALLY drive movement.
+//
+// Pure + deterministic (seeded RNG): given the same inputs, the same choice —
+// so the brain is contract-testable.
+
+import crypto from "node:crypto";
+import { NEED_KINDS, normalizeNeeds } from "./npc-needs.js";
+
+// Personality nudges per archetype: which needs an archetype over-weights when
+// choosing (a trader chases wealth, a mystic chases purpose, a warrior safety).
+const ARCHETYPE_WEIGHTS = Object.freeze({
+  trader: { wealth: 1.5, social: 1.2 },
+  merchant: { wealth: 1.5, social: 1.2 },
+  warrior: { safety: 1.4, purpose: 1.2 },
+  guard: { safety: 1.5, purpose: 1.1 },
+  mystic: { purpose: 1.6, social: 0.8 },
+  scholar: { purpose: 1.4 },
+  healer: { social: 1.3, purpose: 1.2 },
+  farmer: { wealth: 1.2, purpose: 1.3 },
+  cook: { hunger: 1.3, social: 1.2 },
+  default: {},
+});
+
+/** Distance falloff: closer POIs score higher. ~1.0 at 0m, ~0.5 at 60m. */
+function distanceCurve(distM) {
+  const d = Math.max(0, Number(distM) || 0);
+  return 1 / (1 + d / 60);
+}
+
+/** Schedule bias: the time-block's activity_kind gently favours matching POIs. */
+const BLOCK_AFFINITY = Object.freeze({
+  sleep: { energy: 1.0 }, rest: { energy: 0.6 }, socialize: { social: 1.0 },
+  trade: { wealth: 0.8, social: 0.4 }, craft: { wealth: 0.5, purpose: 0.6 },
+  commune: { purpose: 1.0 }, gather: { wealth: 0.5 }, patrol: { safety: 0.6 },
+  farm: { wealth: 0.5, purpose: 0.6 }, build: { wealth: 0.5, purpose: 0.6 },
+  mine: { wealth: 0.6 }, cook: { hunger: 0.6, social: 0.4 },
+});
+
+function seededUnit(key) {
+  return crypto.createHash("sha1").update(String(key)).digest()[0] / 255; // 0..1
+}
+
+/**
+ * Score one candidate goal (a POI advertising {need: amount}) for an NPC.
+ * score = Σ_need deficit[need] × advert[need] × personalityWeight[need]
+ *         × distanceCurve × (1 + scheduleAffinity)  + desire/grudge modifier.
+ */
+export function scoreGoal(npc, needs, poi, opts = {}) {
+  const cur = normalizeNeeds(needs);
+  const advert = poi?.advertises || {};
+  const pw = ARCHETYPE_WEIGHTS[String(npc?.archetype || "default").toLowerCase()] || ARCHETYPE_WEIGHTS.default;
+  const blockAff = BLOCK_AFFINITY[opts.activityKind] || {};
+  let base = 0;
+  for (const k of NEED_KINDS) {
+    const a = Number(advert[k]) || 0;
+    if (a <= 0) continue;
+    const w = Number(pw[k]) || 1;
+    const sched = 1 + (Number(blockAff[k]) || 0);
+    base += cur[k] * a * w * sched;
+  }
+  base *= distanceCurve(poi?.dist);
+
+  // Wants/grudges drive movement: a desire whose target POI matches bumps the
+  // score; a grudge target POI is pulled (confront) or pushed (avoid) per opts.
+  let mod = 0;
+  if (opts.desirePoiId && poi?.id === opts.desirePoiId) mod += (Number(opts.desireWeight) || 0.5);
+  if (opts.grudgePoiId && poi?.id === opts.grudgePoiId) mod += (Number(opts.grudgeWeight) || 0); // +confront / -avoid
+  return Math.max(0, base + mod);
+}
+
+/**
+ * Choose the next goal: score every candidate, take the top-N, pick one by
+ * seeded weighted-random (variety without thrash). Returns the chosen POI +
+ * its score, or null if no candidates.
+ *
+ * @param opts { activityKind, seedKey, topN, desirePoiId, desireWeight, grudgePoiId, grudgeWeight }
+ */
+export function chooseNextGoal(npc, needs, pois, opts = {}) {
+  if (!Array.isArray(pois) || pois.length === 0) return null;
+  const scored = pois
+    .map((poi) => ({ poi, score: scoreGoal(npc, needs, poi, opts) }))
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score);
+  if (scored.length === 0) return null;
+
+  const topN = Math.max(1, Math.min(Number(opts.topN) || 3, scored.length));
+  const top = scored.slice(0, topN);
+  const total = top.reduce((a, s) => a + s.score, 0);
+  // Seeded weighted pick among the top-N.
+  const roll = seededUnit(`${opts.seedKey ?? npc?.id ?? "x"}|goal`) * total;
+  let acc = 0;
+  for (const s of top) { acc += s.score; if (roll <= acc) return { poi: s.poi, score: s.score }; }
+  return { poi: top[0].poi, score: top[0].score };
+}
+
+export const UTILITY_CONSTANTS = Object.freeze({ ARCHETYPE_WEIGHTS, BLOCK_AFFINITY });

--- a/server/migrations/292_npc_needs.js
+++ b/server/migrations/292_npc_needs.js
@@ -1,0 +1,23 @@
+// server/migrations/292_npc_needs.js
+//
+// Living Society WS4.1 — the NPC needs vector. A single JSON column on
+// world_npcs holds the per-NPC need-deficit map (hunger/energy/wealth/social/
+// safety/purpose). One column (not a table) keeps the hot read/write that the
+// routine cycle does every tick cheap. Decay + satisfy live in lib/npc-needs.js.
+
+function columnExists(db, table, col) {
+  try { return db.pragma(`table_info(${table})`).some((c) => c.name === col); }
+  catch { return false; }
+}
+
+export function up(db) {
+  if (db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='world_npcs'").get()) {
+    if (!columnExists(db, "world_npcs", "needs_json")) {
+      try { db.exec(`ALTER TABLE world_npcs ADD COLUMN needs_json TEXT`); } catch { /* noop */ }
+    }
+  }
+}
+
+export function down(_db) {
+  // forward-only
+}

--- a/server/tests/npc-needs-loop.test.js
+++ b/server/tests/npc-needs-loop.test.js
@@ -1,0 +1,82 @@
+/**
+ * Living Society WS4 (3/3) — the live loop: needs → goal (real POI) → walk →
+ * satisfy. Proves advanceRoutine now drives MOTIVATED movement to real
+ * buildings and closes the loop on arrival.
+ *
+ * Run: node --test tests/npc-needs-loop.test.js
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+import { up as up292 } from "../migrations/292_npc_needs.js";
+import { advanceRoutine } from "../lib/npc-routines.js";
+import { getNeeds, setNeeds } from "../lib/npc-needs.js";
+
+const W = "concordia-hub", DAY = 1, BLK = 0;
+function mkDb() {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE world_npcs (id TEXT PRIMARY KEY, world_id TEXT, archetype TEXT, current_location TEXT, spawn_location TEXT, is_dead INTEGER DEFAULT 0);
+    CREATE TABLE world_buildings (id TEXT PRIMARY KEY, world_id TEXT, building_type TEXT, state TEXT DEFAULT 'standing', x REAL, y REAL, z REAL);
+    CREATE TABLE npc_schedules (npc_id TEXT, day_seed INTEGER, block_idx INTEGER, activity_kind TEXT, location_kind TEXT, target_x REAL, target_z REAL, generated_at INTEGER, preoccupation_signature TEXT, PRIMARY KEY (npc_id, day_seed, block_idx));
+    CREATE TABLE npc_routine_state (npc_id TEXT PRIMARY KEY, current_block INTEGER, activity_kind TEXT, location_kind TEXT, target_x REAL, target_z REAL, started_at INTEGER, arrived_at INTEGER, expected_end_at INTEGER, last_signal_at INTEGER);
+  `);
+  up292(db);
+  return db;
+}
+
+describe("WS4 — advanceRoutine drives motivated movement to real POIs", () => {
+  it("on transition, a HUNGRY npc's destination becomes the real inn (not the schedule's random offset)", async () => {
+    const db = mkDb();
+    // schedule says go to (999, 999) — a random offset. The inn is at (20, 0).
+    db.prepare(`INSERT INTO npc_schedules (npc_id, day_seed, block_idx, activity_kind, location_kind, target_x, target_z, generated_at) VALUES ('n1', ?, ?, 'socialize', 'plaza', 999, 999, 0)`).run(DAY, BLK);
+    db.prepare(`INSERT INTO world_buildings (id, world_id, building_type, x, y, z) VALUES ('inn1', ?, 'inn', 20, 0, 0), ('forge1', ?, 'forge', 22, 0, 0)`).run(W, W);
+    db.prepare(`INSERT INTO world_npcs (id, world_id, archetype, current_location, spawn_location) VALUES ('n1', ?, 'farmer', ?, ?)`)
+      .run(W, JSON.stringify({ x: 0, z: 0 }), JSON.stringify({ x: 0, z: 0 }));
+    setNeeds(db, "n1", { hunger: 0.95, energy: 0.1, wealth: 0.1, social: 0.1, safety: 0.1, purpose: 0.1 });
+
+    const npc = db.prepare(`SELECT * FROM world_npcs WHERE id='n1'`).get();
+    const r = await advanceRoutine(db, npc, { daySeed: DAY, blockIdx: BLK });
+    assert.equal(r.ok, true);
+    // routine_state target was OVERRIDDEN to the inn (20,0), NOT (999,999).
+    const st = db.prepare(`SELECT target_x, target_z FROM npc_routine_state WHERE npc_id='n1'`).get();
+    assert.ok(Math.hypot(st.target_x - 20, st.target_z - 0) < 1, `target ${st.target_x},${st.target_z} is not the inn`);
+  });
+
+  it("walking to the POI and arriving SATISFIES the advertised need (hunger drops)", async () => {
+    const db = mkDb();
+    db.prepare(`INSERT INTO npc_schedules (npc_id, day_seed, block_idx, activity_kind, location_kind, target_x, target_z, generated_at) VALUES ('n2', ?, ?, 'socialize', 'plaza', 999, 999, 0)`).run(DAY, BLK);
+    db.prepare(`INSERT INTO world_buildings (id, world_id, building_type, x, y, z) VALUES ('inn1', ?, 'inn', 12, 0, 0)`).run(W);
+    db.prepare(`INSERT INTO world_npcs (id, world_id, archetype, current_location, spawn_location) VALUES ('n2', ?, 'farmer', ?, ?)`)
+      .run(W, JSON.stringify({ x: 0, z: 0 }), JSON.stringify({ x: 0, z: 0 }));
+    setNeeds(db, "n2", { hunger: 0.95, energy: 0.1, wealth: 0.1, social: 0.1, safety: 0.1, purpose: 0.1 });
+    const before = getNeeds(db, "n2").hunger;
+
+    // Drive ticks until it reaches the inn (NUDGE 6m/tick, ~12m away → a couple ticks).
+    for (let i = 0; i < 6; i++) {
+      const npc = db.prepare(`SELECT * FROM world_npcs WHERE id='n2'`).get();
+      await advanceRoutine(db, npc, { daySeed: DAY, blockIdx: BLK });
+    }
+    const after = getNeeds(db, "n2").hunger;
+    assert.ok(after < before, `hunger did not drop on arrival (${before} -> ${after})`);
+    // and it's physically at the inn
+    const loc = JSON.parse(db.prepare(`SELECT current_location FROM world_npcs WHERE id='n2'`).get().current_location);
+    assert.ok(Math.hypot(loc.x - 12, loc.z - 0) <= 6, "npc never reached the inn");
+  });
+
+  it("CONCORD_NPC_NEEDS=0 falls back to the pure schedule (no override)", async () => {
+    process.env.CONCORD_NPC_NEEDS = "0";
+    try {
+      const db = mkDb();
+      db.prepare(`INSERT INTO npc_schedules (npc_id, day_seed, block_idx, activity_kind, location_kind, target_x, target_z, generated_at) VALUES ('n3', ?, ?, 'socialize', 'plaza', 500, 500, 0)`).run(DAY, BLK);
+      db.prepare(`INSERT INTO world_buildings (id, world_id, building_type, x, y, z) VALUES ('inn1', ?, 'inn', 20, 0, 0)`).run(W);
+      db.prepare(`INSERT INTO world_npcs (id, world_id, archetype, current_location, spawn_location) VALUES ('n3', ?, 'farmer', ?, ?)`)
+        .run(W, JSON.stringify({ x: 0, z: 0 }), JSON.stringify({ x: 0, z: 0 }));
+      const npc = db.prepare(`SELECT * FROM world_npcs WHERE id='n3'`).get();
+      await advanceRoutine(db, npc, { daySeed: DAY, blockIdx: BLK });
+      const st = db.prepare(`SELECT target_x FROM npc_routine_state WHERE npc_id='n3'`).get();
+      assert.equal(st.target_x, 500, "with needs off, the schedule target must be unchanged");
+    } finally { delete process.env.CONCORD_NPC_NEEDS; }
+  });
+});

--- a/server/tests/npc-pois.test.js
+++ b/server/tests/npc-pois.test.js
@@ -1,0 +1,76 @@
+/**
+ * Living Society WS4.2 — smart-object POIs read REAL buildings (no random offsets).
+ *
+ * Run: node --test tests/npc-pois.test.js
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+import { up as up292 } from "../migrations/292_npc_needs.js";
+import { nearbyPOIs, nearestOfType, advertisementFor } from "../lib/npc-pois.js";
+import { getNeeds, setNeeds, freshNeeds } from "../lib/npc-needs.js";
+import { chooseNextGoal } from "../lib/npc-utility.js";
+
+const W = "concordia-hub";
+function mkDb() {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE world_npcs (id TEXT PRIMARY KEY, world_id TEXT, archetype TEXT, current_location TEXT, spawn_location TEXT, is_dead INTEGER DEFAULT 0);
+    CREATE TABLE world_buildings (id TEXT PRIMARY KEY, world_id TEXT, building_type TEXT, state TEXT DEFAULT 'standing', x REAL, y REAL, z REAL);
+  `);
+  up292(db);
+  const b = (id, type, x, z, state = "standing") =>
+    db.prepare(`INSERT INTO world_buildings (id, world_id, building_type, state, x, y, z) VALUES (?, ?, ?, ?, ?, 0, ?)`).run(id, W, type, state, x, z);
+  b("inn1", "inn", 10, 0); b("forge1", "forge", 30, 0); b("house1", "house", 5, 0);
+  b("market1", "market", 50, 0); b("gone", "warehouse", 1, 0, "collapsed");
+  return db;
+}
+
+describe("WS4.2 — POIs from real buildings", () => {
+  it("nearbyPOIs returns standing buildings (not collapsed), nearest-first, with advertisements", () => {
+    const db = mkDb();
+    const pois = nearbyPOIs(db, W, 0, 0, 12);
+    const ids = pois.map((p) => p.id);
+    assert.ok(ids.includes("inn1") && ids.includes("forge1") && ids.includes("house1"));
+    assert.ok(!ids.includes("gone"), "collapsed building excluded");
+    assert.ok(pois[0].dist <= pois[pois.length - 1].dist, "nearest-first");
+    assert.ok(pois.find((p) => p.id === "inn1").advertises.hunger > 0, "inn advertises hunger");
+  });
+
+  it("nearestOfType resolves a location_kind to the real building", () => {
+    const db = mkDb();
+    assert.equal(nearestOfType(db, W, 0, 0, "house").id, "house1");
+    assert.equal(nearestOfType(db, W, 0, 0, "forge").id, "forge1");
+    assert.equal(nearestOfType(db, W, 0, 0, "temple"), null, "no temple building → null (honest)");
+  });
+
+  it("advertisementFor maps types; unknown type → {}", () => {
+    assert.ok(advertisementFor("forge").wealth > 0);
+    assert.deepEqual(advertisementFor("nonsense"), {});
+  });
+
+  it("empty world → no POIs (NPC just paces, no fake POI)", () => {
+    const db = new Database(":memory:");
+    db.exec(`CREATE TABLE world_buildings (id TEXT, world_id TEXT, building_type TEXT, state TEXT, x REAL, z REAL);`);
+    assert.deepEqual(nearbyPOIs(db, W, 0, 0), []);
+  });
+
+  it("end-to-end: a hungry NPC's chosen goal is the REAL inn building", () => {
+    const db = mkDb();
+    db.prepare(`INSERT INTO world_npcs (id, world_id, archetype) VALUES ('n1', ?, 'farmer')`).run(W);
+    setNeeds(db, "n1", { hunger: 0.9, energy: 0.2, wealth: 0.2, social: 0.2, safety: 0.1, purpose: 0.2 });
+    const needs = getNeeds(db, "n1");
+    const pois = nearbyPOIs(db, W, 0, 0);
+    const goal = chooseNextGoal({ id: "n1", archetype: "farmer" }, needs, pois, { topN: 1 });
+    assert.equal(goal.poi.id, "inn1", "the hungry NPC's destination is the real inn");
+  });
+
+  it("needs round-trip through world_npcs.needs_json", () => {
+    const db = mkDb();
+    db.prepare(`INSERT INTO world_npcs (id, world_id) VALUES ('n2', ?)`).run(W);
+    assert.deepEqual(getNeeds(db, "n2"), freshNeeds()); // default before set
+    setNeeds(db, "n2", { hunger: 0.7 });
+    assert.equal(getNeeds(db, "n2").hunger, 0.7);
+  });
+});

--- a/server/tests/npc-utility.test.js
+++ b/server/tests/npc-utility.test.js
@@ -1,0 +1,95 @@
+/**
+ * Living Society WS4 — needs/utility-driven NPC behavior (the new brain).
+ *
+ * Proves movement is MOTIVATED, not scripted:
+ *   - needs decay (deficit climbs) + satisfy lowers them;
+ *   - a HUNGRY npc scores the tavern highest; a BROKE npc scores the forge;
+ *   - distance + personality + schedule bias shape the choice;
+ *   - a DESIRE bends the choice toward its POI (wants drive movement);
+ *   - the same inputs → the same deterministic choice (seeded).
+ *
+ * Run: node --test tests/npc-utility.test.js
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { freshNeeds, decayNeeds, satisfy, satisfyFromAdvertisement, deficit, topNeed } from "../lib/npc-needs.js";
+import { scoreGoal, chooseNextGoal } from "../lib/npc-utility.js";
+
+// POIs advertising need-satisfaction (what npc-pois.js will resolve from real buildings).
+const TAVERN = { id: "tavern1", type: "inn", dist: 20, advertises: { hunger: 0.6, social: 0.5 } };
+const FORGE  = { id: "forge1",  type: "forge", dist: 25, advertises: { wealth: 0.6, purpose: 0.5 } };
+const TEMPLE = { id: "temple1", type: "temple", dist: 30, advertises: { purpose: 0.7 } };
+const HOME   = { id: "home1",   type: "house", dist: 15, advertises: { energy: 0.8 } };
+const POIS = [TAVERN, FORGE, TEMPLE, HOME];
+
+describe("WS4 — needs decay + satisfy", () => {
+  it("deficits climb over time and satisfy lowers them", () => {
+    const n0 = freshNeeds();
+    const n1 = decayNeeds(n0, 5); // 5 hours
+    assert.ok(deficit(n1, "hunger") > deficit(n0, "hunger"), "hunger should climb");
+    const n2 = satisfy(n1, "hunger", 0.5);
+    assert.ok(deficit(n2, "hunger") < deficit(n1, "hunger"), "eating lowers hunger");
+  });
+
+  it("satisfyFromAdvertisement applies a POI's whole advert; deficits clamp to [0,1]", () => {
+    const n = satisfyFromAdvertisement({ hunger: 0.9, social: 0.9 }, TAVERN.advertises);
+    assert.ok(deficit(n, "hunger") < 0.9 && deficit(n, "social") < 0.9);
+    assert.ok(deficit(decayNeeds({ hunger: 0.99 }, 100), "hunger") <= 1.0);
+  });
+
+  it("topNeed reports the most pressing deficit", () => {
+    assert.equal(topNeed({ hunger: 0.9, energy: 0.1, wealth: 0.2 }).kind, "hunger");
+  });
+});
+
+describe("WS4 — the utility scorer picks by need (motivated, not scripted)", () => {
+  it("a HUNGRY npc scores the tavern above the forge", () => {
+    const npc = { id: "n1", archetype: "farmer" };
+    const hungry = { hunger: 0.9, energy: 0.2, wealth: 0.2, social: 0.2, safety: 0.1, purpose: 0.2 };
+    assert.ok(scoreGoal(npc, hungry, TAVERN) > scoreGoal(npc, hungry, FORGE));
+    const choice = chooseNextGoal(npc, hungry, POIS, { topN: 1 });
+    assert.equal(choice.poi.id, "tavern1");
+  });
+
+  it("a BROKE npc scores the forge above the tavern", () => {
+    const npc = { id: "n2", archetype: "farmer" };
+    const broke = { hunger: 0.1, energy: 0.2, wealth: 0.95, social: 0.1, safety: 0.1, purpose: 0.3 };
+    assert.ok(scoreGoal(npc, broke, FORGE) > scoreGoal(npc, broke, TAVERN));
+    assert.equal(chooseNextGoal(npc, broke, POIS, { topN: 1 }).poi.id, "forge1");
+  });
+
+  it("a TIRED npc goes home; a PURPOSE-starved mystic goes to the temple", () => {
+    assert.equal(chooseNextGoal({ id: "n3", archetype: "default" },
+      { hunger: 0.1, energy: 0.95, wealth: 0.1, social: 0.1, safety: 0.1, purpose: 0.1 }, POIS, { topN: 1 }).poi.id, "home1");
+    assert.equal(chooseNextGoal({ id: "n4", archetype: "mystic" },
+      { hunger: 0.1, energy: 0.2, wealth: 0.1, social: 0.1, safety: 0.1, purpose: 0.9 }, POIS, { topN: 1 }).poi.id, "temple1");
+  });
+
+  it("personality tilts the choice (a trader over-weights wealth)", () => {
+    const needs = { hunger: 0.5, energy: 0.2, wealth: 0.5, social: 0.2, safety: 0.1, purpose: 0.2 };
+    const traderForge = scoreGoal({ id: "t", archetype: "trader" }, needs, FORGE);
+    const farmerForge = scoreGoal({ id: "f", archetype: "default" }, needs, FORGE);
+    assert.ok(traderForge > farmerForge, "trader values the wealth POI more");
+  });
+
+  it("a DESIRE bends the choice toward its POI (wants drive movement)", () => {
+    const npc = { id: "n5", archetype: "default" };
+    // Mildly hungry — would normally pick the tavern; a strong desire for the temple wins.
+    const needs = { hunger: 0.5, energy: 0.2, wealth: 0.2, social: 0.3, safety: 0.1, purpose: 0.3 };
+    const choice = chooseNextGoal(npc, needs, POIS, { topN: 1, desirePoiId: "temple1", desireWeight: 3 });
+    assert.equal(choice.poi.id, "temple1", "the NPC moved toward what it WANTS, not just what it needs");
+  });
+
+  it("is deterministic for the same inputs", () => {
+    const npc = { id: "n6", archetype: "default" };
+    const needs = { hunger: 0.6, energy: 0.5, wealth: 0.5, social: 0.5, safety: 0.2, purpose: 0.4 };
+    const a = chooseNextGoal(npc, needs, POIS, { seedKey: "k" });
+    const b = chooseNextGoal(npc, needs, POIS, { seedKey: "k" });
+    assert.deepEqual(a, b);
+  });
+
+  it("returns null with no candidates", () => {
+    assert.equal(chooseNextGoal({ id: "x" }, freshNeeds(), []), null);
+  });
+});


### PR DESCRIPTION
## WS4 — Living NPCs: motivated movement (wants + needs + schedules drive where they go)

WS0 made NPCs *pace*. This makes their movement **motivated** — they go to the tavern because they're hungry, to the forge because they're broke, to the temple because they desire something. The animation framework + procedural engines combine into the **goal → walk → act → satisfy** loop.

### Audit (actual code, not docs)
NPC behavior was a **fixed-schedule automaton**: destinations were `spawn ± random offset` (never a real building), `npc_desires` were player-facing only, needs (food/stress/wealth) were tracked but **never read to decide anything**, and there was no utility/goal layer (`npc-ambition.chooseTravelGoal` was even imported-but-missing/dead).

### The fix (IAUS-lite — the model The Sims uses)
- **`lib/npc-needs.js`** — a per-NPC need-deficit vector (hunger/energy/wealth/social/safety/purpose) that **decays** upward over time; `satisfy()` lowers it. Stored in `world_npcs.needs_json` (migration 292).
- **`lib/npc-pois.js`** — **smart-object POIs**: each `building_type` advertises which needs it satisfies; `nearbyPOIs` returns the **real standing `world_buildings`** near an NPC (fixing the random-offset bug). Empty world → no POIs (honest, no fake).
- **`lib/npc-utility.js`** — `chooseNextGoal`/`scoreGoal`: score each POI by `needDeficit × advertisement × personality × distance × scheduleBias + desire/grudge modifier`, seeded weighted-random over the top-N. **This is where needs + wants + grudges finally drive the destination.**
- **`advanceRoutine` wiring** — each advance decays needs; on a block transition it picks a real-POI goal and **overrides** the schedule's random offset (persisted in routine_state, so the move follows it across ticks); on arrival the advertised needs are satisfied. The daily schedule becomes a *bias*, not a script. Env-gated `CONCORD_NPC_NEEDS=0` → pure-schedule fallback.

### Verification
- **61/61** NPC tests green (needs/utility/pois/loop/pacing/routines/cycle/civilian). Migration 292 applies clean (schema v292). Lint + syntax clean.
- Contract proof (`npc-needs-loop.test.js`): a hungry NPC's target becomes the **real inn** (not the 999,999 offset); walking + arriving **drops hunger**; needs-off preserves the schedule.
- **Live, bare boot:** `needs_json` populated + decaying on 126 NPCs; **64/126 (51%) have their destination sitting exactly on a real building** — `wraith_alpha` walking to an **inn**, `drift_eater_1` to a **forge**, motivated by need, from spawn ~700m away.

> Wants, needs & schedules now move the bodies. Next: combine the WS1 animation framework so the walk reads as a fluid gait + the arrival verb plays its action clip (the "constant fluid movement" finish).

https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ)_