### PR TITLE
WS2: render world-state systems in 3D (mount node/crop/claim/VFX renderers)

### DIFF
--- a/concord-frontend/components/world-lens/ConcordiaScene.tsx
+++ b/concord-frontend/components/world-lens/ConcordiaScene.tsx
@@ -262,6 +262,9 @@ export default function ConcordiaScene({
   // Sovereign Mass Raid Phase 4 dome — listener cleanup. Set in scene init,
   // invoked during teardown so the listener disposes with the scene.
   const domeCleanupRef = useRef<(() => void) | null>(null);
+  // WS2 — world-state renderers (resource nodes / crops / claims / VFX) mounted
+  // into the infrastructure + particles layers; disposed with the scene.
+  const worldRenderersRef = useRef<{ dispose(): void } | null>(null);
   const probeManagerRef = useRef<
     import('@/lib/world-lens/reflection-probes').ReflectionProbeManager | null
   >(null);
@@ -799,6 +802,29 @@ export default function ConcordiaScene({
         layers[name] = group;
       }
       layersRef.current = layers;
+
+      // ── WS2 world-state renderers ───────────────────────────────
+      // Mount the resource-node / crop-field / claim-boundary renderers into the
+      // reserved `infrastructure` layer and the VFX bridge into `particles`. The
+      // per-frame fan-out below (LAYER_NAMES loop) calls each layer group's
+      // userData.update, so wiring the handle's update onto the infrastructure
+      // group is all that's needed to drive every data renderer; the VFX bridge
+      // is driven from the same handle (one update fans out to all four).
+      try {
+        const { attachWorldRenderers } = await import('@/lib/world-lens/attach-world-renderers');
+        const worldId =
+          (typeof window !== 'undefined' && window.localStorage?.getItem('concordia:activeWorldId')) ||
+          'concordia-hub';
+        const handle = attachWorldRenderers(layers.infrastructure, layers.particles, { worldId });
+        worldRenderersRef.current = handle;
+        (layers.infrastructure.userData as { update?: (d: number, e: number) => void }).update = (
+          d: number,
+          e: number,
+        ) => handle.update(d, e);
+      } catch {
+        // Renderers are progressive enhancement — a mount failure leaves the
+        // base scene (terrain/buildings/avatars) fully functional.
+      }
 
       // ── Sovereign Mass Raid Phase 4 dome ────────────────────────
       // Subscribes to world:refusal-field; when a dome_collapse field
@@ -1505,6 +1531,8 @@ export default function ConcordiaScene({
 
       try { domeCleanupRef.current?.(); } catch { /* ignore */ }
       domeCleanupRef.current = null;
+      try { worldRenderersRef.current?.dispose(); } catch { /* ignore */ }
+      worldRenderersRef.current = null;
 
       ssgiPassRef.current?.dispose();
       ssgiPassRef.current = null;

--- a/concord-frontend/lib/world-lens/attach-world-renderers.ts
+++ b/concord-frontend/lib/world-lens/attach-world-renderers.ts
@@ -1,0 +1,112 @@
+// concord-frontend/lib/world-lens/attach-world-renderers.ts
+//
+// Render-Everything WS2 — mount the world-state renderers into ConcordiaScene's
+// reserved `infrastructure` layer (and the VFX bridge into `particles`). This is
+// the single wiring point that takes the four already-built, already-tested
+// renderer libs from "on disk but never mounted" to "live in the 3D world":
+//
+//   • ResourceNodeRenderer  — trees / ore / crystals / springs that visibly deplete
+//   • CropFieldRenderer     — claim crops as 3D plants stepping through growth stages
+//   • ClaimBoundaryRenderer — land-claim rings + settlement tint (owned/contested)
+//   • WorldVFXBridge        — the orphan `concordia:particle-effect` consumer
+//
+// Each renderer is a pure factory `(parentGroup, opts) => { update, dispose }`.
+// This helper instantiates all four, returns one `update(delta,elapsed)` that
+// fans out + one `dispose()` that tears everything down. ConcordiaScene wires the
+// returned `update` onto `layers.infrastructure.userData.update` (the per-frame
+// fan-out already walks every layer) and calls `dispose` in teardown.
+//
+// Auth: the world data endpoints honour the JWT cookie on same-origin requests;
+// for the mobile AuthedWebView wrapper we also pass the injected-JWT accessor so
+// the Authorization header is set when a cookie isn't available. No token → the
+// renderers fetch with the cookie only and render nothing on a 401 (honest-empty).
+
+import * as THREE from 'three';
+import { getInjectedJwt } from '@/lib/auth-bridge';
+import { createResourceNodeRenderer } from './resource-node-renderer';
+import { createCropFieldRenderer } from './crop-field-renderer';
+import { createClaimBoundaryRenderer } from './claim-boundary-renderer';
+import { createWorldVFXBridge } from './world-vfx-bridge';
+
+export interface WorldRenderersHandle {
+  /** Call every frame. Fans out to every mounted renderer. */
+  update(delta: number, elapsed: number): void;
+  /** Tear down every renderer + remove window listeners. Idempotent. */
+  dispose(): void;
+}
+
+export interface AttachWorldRenderersOpts {
+  worldId: string;
+  /** Override the API base (default same-origin ''). */
+  apiBase?: string;
+  /** Override poll cadence for the data renderers (ms). */
+  pollMs?: number;
+  /** Cap on simultaneous VFX bursts. */
+  maxBursts?: number;
+}
+
+/**
+ * Mount the world-state renderers under `infrastructureGroup` and the VFX bridge
+ * under `particlesGroup`. Returns a single update/dispose handle.
+ *
+ * Pure-defensive: every renderer is wrapped so one throwing factory can't stop
+ * the others from mounting; `update`/`dispose` swallow per-renderer throws so a
+ * single bad frame never kills the render loop.
+ */
+export function attachWorldRenderers(
+  infrastructureGroup: THREE.Group,
+  particlesGroup: THREE.Group,
+  opts: AttachWorldRenderersOpts,
+): WorldRenderersHandle {
+  const authToken = () => getInjectedJwt();
+  const dataOpts = {
+    worldId: opts.worldId,
+    apiBase: opts.apiBase,
+    pollMs: opts.pollMs,
+    authToken,
+  };
+
+  const updaters: Array<{ update(delta: number, elapsed: number): void; dispose(): void }> = [];
+
+  function mount<T extends { update(d: number, e: number): void; dispose(): void }>(
+    factory: () => T,
+  ): void {
+    try {
+      updaters.push(factory());
+    } catch {
+      // A renderer that fails to construct simply isn't mounted — the rest still are.
+    }
+  }
+
+  mount(() => createResourceNodeRenderer(infrastructureGroup, dataOpts));
+  mount(() => createCropFieldRenderer(infrastructureGroup, dataOpts));
+  mount(() => createClaimBoundaryRenderer(infrastructureGroup, dataOpts));
+  mount(() => createWorldVFXBridge(particlesGroup, { maxBursts: opts.maxBursts }));
+
+  let disposed = false;
+
+  return {
+    update(delta: number, elapsed: number): void {
+      if (disposed) return;
+      for (const u of updaters) {
+        try {
+          u.update(delta, elapsed);
+        } catch {
+          // One renderer's bad frame must not stop the others / the loop.
+        }
+      }
+    },
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      for (const u of updaters) {
+        try {
+          u.dispose();
+        } catch {
+          // idempotent teardown
+        }
+      }
+      updaters.length = 0;
+    },
+  };
+}

--- a/concord-frontend/tests/concordia/attach-world-renderers.test.ts
+++ b/concord-frontend/tests/concordia/attach-world-renderers.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as THREE from 'three';
+import { attachWorldRenderers } from '@/lib/world-lens/attach-world-renderers';
+
+// WS2 — the single mount point that takes the four already-tested renderer libs
+// live. This test pins the contract ConcordiaScene relies on: one update/dispose
+// handle, defensive against per-renderer throws, no network in a headless test.
+
+describe('WS2 — attachWorldRenderers mount point', () => {
+  beforeEach(() => {
+    // No real fetch in jsdom — the data renderers fire one on construct.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }));
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns an update/dispose handle and mounts objects into the layers', () => {
+    const infra = new THREE.Group();
+    const particles = new THREE.Group();
+    const handle = attachWorldRenderers(infra, particles, { worldId: 'concordia-hub' });
+    expect(typeof handle.update).toBe('function');
+    expect(typeof handle.dispose).toBe('function');
+    // update is callable for many frames without throwing
+    expect(() => {
+      for (let i = 0; i < 10; i++) handle.update(0.016, i * 0.016);
+    }).not.toThrow();
+    handle.dispose();
+  });
+
+  it('dispose is idempotent and stops further updates', () => {
+    const infra = new THREE.Group();
+    const particles = new THREE.Group();
+    const handle = attachWorldRenderers(infra, particles, { worldId: 'w' });
+    handle.dispose();
+    expect(() => handle.dispose()).not.toThrow();
+    // post-dispose update is a no-op (does not throw)
+    expect(() => handle.update(0.016, 1)).not.toThrow();
+  });
+
+  it('the VFX bridge picks up a concordia:particle-effect after mount', () => {
+    const infra = new THREE.Group();
+    const particles = new THREE.Group();
+    const handle = attachWorldRenderers(infra, particles, { worldId: 'w', maxBursts: 4 });
+    // Fire the orphan event the bridge consumes.
+    window.dispatchEvent(
+      new CustomEvent('concordia:particle-effect', {
+        detail: { type: 'sparkle', position: { x: 0, y: 1, z: 0 }, intensity: 1, duration: 500 },
+      }),
+    );
+    handle.update(0.016, 0.016);
+    // A burst should now live under the particles group.
+    expect(particles.children.length).toBeGreaterThan(0);
+    handle.dispose();
+  });
+});


### PR DESCRIPTION
## Render-Everything WS2 — mount the world-state renderers

Four renderer libs were already built + unit-tested but never mounted into the live scene. This wires them in via a single mount point so the 3D world finally shows the Living Society substrate:

- **ResourceNodeRenderer** → trees / ore / crystals / springs that visibly deplete (scale-shrink + material change as `quantity_remaining` drops).
- **CropFieldRenderer** → `claim_crops` as 3D plants stepping through growth stages.
- **ClaimBoundaryRenderer** → land-claim rings + owned/contested tint.
- **WorldVFXBridge** → finally a consumer for the orphan `concordia:particle-effect` event (the single VFX hook every system can call).

### How
- New `lib/world-lens/attach-world-renderers.ts`: instantiates all four, returns one `update(delta,elapsed)` / `dispose()` handle, defensive so one renderer's throw can't stop the others or kill the render loop.
- `ConcordiaScene` mounts the data renderers into the reserved `infrastructure` layer + the VFX bridge into `particles`, wires the handle onto `layers.infrastructure.userData.update` (the per-frame fan-out already walks every layer group), and disposes in teardown.
- Auth: `getInjectedJwt()` for the mobile AuthedWebView; same-origin cookie otherwise. 401 → render nothing (honest-empty, no fake nodes).

### Verify
- New `tests/concordia/attach-world-renderers.test.ts` (3) — update/dispose contract, idempotent dispose, VFX burst on event.
- Full concordia vitest suite **192/192 green**; scoped `tsc` clean on the touched files.

Progressive enhancement: a mount failure leaves the base scene (terrain/buildings/avatars) fully functional.

https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ)_