### PR TITLE
WS1.5: wire playAction into station trigger sites (doing embodies the avatar)

### DIFF
--- a/concord-frontend/components/world/CodePuzzleEditor.tsx
+++ b/concord-frontend/components/world/CodePuzzleEditor.tsx
@@ -9,6 +9,7 @@ import { Cpu, Play, Send, Trash2, Loader2 } from 'lucide-react';
 import { StationOverlayShell } from './_StationOverlayShell';
 import type { OverlayProps } from './StationInteractionRouter';
 import { successJuice, milestoneJuice, failureJuice } from '@/lib/concordia/juice';
+import { playActionAtPlayer } from '@/lib/concordia/play-action';
 
 interface PuzzleStub { id: string; name: string; description?: string; optimal_cycles?: number; optimal_size?: number; }
 interface TestCase { input: number[]; expected: number[]; }
@@ -60,6 +61,7 @@ export function CodePuzzleEditor({ building, onClose, worldId }: OverlayProps) {
       });
       const j = await r.json();
       if (j?.ok) {
+        playActionAtPlayer('hack'); // typing at the console
         setResult(j);
         if (j.passed) successJuice('ui_code_test_pass');
         else failureJuice('ui_code_test_fail');

--- a/concord-frontend/components/world/CreatureBreedingPanel.tsx
+++ b/concord-frontend/components/world/CreatureBreedingPanel.tsx
@@ -9,6 +9,7 @@ import { Dna, Sparkles, Loader2 } from 'lucide-react';
 import { StationOverlayShell } from './_StationOverlayShell';
 import type { OverlayProps } from './StationInteractionRouter';
 import { milestoneJuice, failureJuice } from '@/lib/concordia/juice';
+import { playActionAtPlayer } from '@/lib/concordia/play-action';
 
 interface Population {
   id: string;
@@ -57,7 +58,7 @@ export function CreatureBreedingPanel({ building, onClose, worldId }: OverlayPro
         }),
       });
       const j = await r.json();
-      if (j?.ok && j.hybrid) milestoneJuice('ui_hybrid_minted');
+      if (j?.ok && j.hybrid) { playActionAtPlayer('commune'); milestoneJuice('ui_hybrid_minted'); }
       else failureJuice('ui_breed_failed');
       setResult(j);
     } finally { setPending(false); }

--- a/concord-frontend/components/world/FactoryEditor.tsx
+++ b/concord-frontend/components/world/FactoryEditor.tsx
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Box, ArrowRight, Cog, Loader2 } from 'lucide-react';
 import type { LucideIcon } from "lucide-react";
 import { StationOverlayShell } from './_StationOverlayShell';
+import { playActionAtPlayer } from '@/lib/concordia/play-action';
 import type { OverlayProps } from './StationInteractionRouter';
 
 const GRID_W = 10;
@@ -86,7 +87,7 @@ export function FactoryEditor({ building, onClose, worldId }: OverlayProps) {
         body: JSON.stringify({ claimId, entityType, tileX: picker.x, tileY: picker.y }),
       });
       const j = await r.json();
-      if (j?.ok) { setMsg(`placed ${entityType}`); setPicker(null); refresh(); }
+      if (j?.ok) { playActionAtPlayer('build'); setMsg(`placed ${entityType}`); setPicker(null); refresh(); }
       else setMsg(j?.error || 'place_failed');
     } finally { setPending(false); }
   }, [picker, claimId, refresh]);

--- a/concord-frontend/components/world/FarmTileEditor.tsx
+++ b/concord-frontend/components/world/FarmTileEditor.tsx
@@ -9,6 +9,7 @@ import { Sprout, Wheat, Loader2 } from 'lucide-react';
 import { StationOverlayShell } from './_StationOverlayShell';
 import type { OverlayProps } from './StationInteractionRouter';
 import { successJuice, failureJuice, milestoneJuice } from '@/lib/concordia/juice';
+import { playActionAtPlayer } from '@/lib/concordia/play-action';
 
 interface Crop {
   claim_id: string;
@@ -63,6 +64,7 @@ export function FarmTileEditor({ building, onClose, worldId }: OverlayProps) {
       });
       const j = await r.json();
       if (j?.ok) {
+        playActionAtPlayer('plant');
         successJuice('ui_seed_plant');
         setMsg(`planted ${cropKind}`);
         setPicker(null);
@@ -84,6 +86,7 @@ export function FarmTileEditor({ building, onClose, worldId }: OverlayProps) {
       });
       const j = await r.json();
       if (j?.ok) {
+        playActionAtPlayer('harvest');
         milestoneJuice('ui_crop_harvest');
         setMsg(`harvested ${j.harvested?.quantity ?? 1} × ${j.harvested?.itemId}`);
         refresh();

--- a/concord-frontend/components/world/HackingTerminal.tsx
+++ b/concord-frontend/components/world/HackingTerminal.tsx
@@ -11,6 +11,7 @@ import { Terminal, Trophy, Loader2 } from 'lucide-react';
 import { StationOverlayShell } from './_StationOverlayShell';
 import type { OverlayProps } from './StationInteractionRouter';
 import { successJuice, failureJuice, milestoneJuice, sfx } from '@/lib/concordia/juice';
+import { playActionAtPlayer } from '@/lib/concordia/play-action';
 
 interface PuzzleStub {
   id: string; name: string; difficulty: number; reward_cc: number;
@@ -135,6 +136,7 @@ export function HackingTerminal({ building, onClose, worldId }: OverlayProps) {
       });
       const j = await r.json();
       if (j?.ok) {
+        playActionAtPlayer('hack'); // lean-reach typing at the terminal
         if (j.completed) {
           milestoneJuice('ui_hack_complete');
           setCompleted({ rewardCc: j.rewardCc });

--- a/concord-frontend/components/world/KaraokeMicrophone.tsx
+++ b/concord-frontend/components/world/KaraokeMicrophone.tsx
@@ -10,6 +10,7 @@ import { Mic, Square, Loader2, Music } from 'lucide-react';
 import { StationOverlayShell } from './_StationOverlayShell';
 import type { OverlayProps } from './StationInteractionRouter';
 import { successJuice, milestoneJuice, sfx } from '@/lib/concordia/juice';
+import { playActionAtPlayer } from '@/lib/concordia/play-action';
 
 interface Song { id: string; name: string; difficulty: number; bpm: number; key?: string; }
 interface Result { score: number; xpGained: number; payload: { grade: string; pitchScore: number; rhythmScore: number; }; }
@@ -137,6 +138,7 @@ export function KaraokeMicrophone({ building, onClose, worldId }: OverlayProps) 
       });
       const j = await r.json();
       if (j?.ok) {
+        playActionAtPlayer('sing'); // performance flourish
         const grade = j?.payload?.grade;
         if (grade === 'S' || grade === 'A') milestoneJuice('ui_karaoke_top_grade');
         else if (grade === 'B' || grade === 'C') successJuice('ui_karaoke_finish');

--- a/concord-frontend/components/world/MahjongTable.tsx
+++ b/concord-frontend/components/world/MahjongTable.tsx
@@ -14,6 +14,7 @@ import { Sparkles, Hand, Loader2, Trophy, AlertTriangle } from 'lucide-react';
 import { StationOverlayShell } from './_StationOverlayShell';
 import type { OverlayProps } from './StationInteractionRouter';
 import { successJuice, milestoneJuice, failureJuice } from '@/lib/concordia/juice';
+import { playActionAtPlayer } from '@/lib/concordia/play-action';
 import { Tile } from './mahjong/Tile';
 
 interface Seat {
@@ -110,6 +111,7 @@ export function MahjongTable({ building, onClose, worldId }: OverlayProps) {
       });
       const j = await r.json();
       if (j?.ok) {
+        playActionAtPlayer('craft'); // tile placement — hand manipulation in place
         successJuice('ui_mahjong_discard');
         setPicked(null);
         refresh();
@@ -130,6 +132,7 @@ export function MahjongTable({ building, onClose, worldId }: OverlayProps) {
       });
       const j = await r.json();
       if (j?.ok) {
+        playActionAtPlayer('wave'); // victory flourish on the winning hand
         milestoneJuice('ui_mahjong_tsumo');
         setEndResult({ winnerSeat: 0, reason: 'tsumo', scoring: j.scoring });
         refresh();

--- a/concord-frontend/components/world/RestaurantDashboard.tsx
+++ b/concord-frontend/components/world/RestaurantDashboard.tsx
@@ -11,6 +11,7 @@ import { ChefHat, Clock, AlertTriangle, Loader2 } from 'lucide-react';
 import { StationOverlayShell } from './_StationOverlayShell';
 import type { OverlayProps } from './StationInteractionRouter';
 import { successJuice } from '@/lib/concordia/juice';
+import { playActionAtPlayer } from '@/lib/concordia/play-action';
 
 interface Order {
   id: string;
@@ -67,6 +68,7 @@ export function RestaurantDashboard({ building, onClose, worldId }: OverlayProps
       });
       const j = await r.json().catch(() => null);
       if (j?.ok !== false) {
+        playActionAtPlayer('serve');
         successJuice('ui_dish_serve');
         // E5 — flash the batching combo on a rush.
         if (typeof j?.combo === 'number' && j.combo >= 2) {

--- a/concord-frontend/components/world/TriviaKioskPanel.tsx
+++ b/concord-frontend/components/world/TriviaKioskPanel.tsx
@@ -10,6 +10,7 @@ import { Sparkles, CheckCircle2, XCircle, Loader2 } from 'lucide-react';
 import { StationOverlayShell } from './_StationOverlayShell';
 import type { OverlayProps } from './StationInteractionRouter';
 import { successJuice, failureJuice } from '@/lib/concordia/juice';
+import { playActionAtPlayer } from '@/lib/concordia/play-action';
 
 interface Choice { dtuId: string; title: string; }
 interface Question {
@@ -65,6 +66,7 @@ export function TriviaKioskPanel({ building, onClose, worldId }: OverlayProps) {
       const j = await r.json();
       setResult(j);
       if (j?.ok && j.isCorrect) {
+        playActionAtPlayer('wave'); // celebratory gesture on a correct answer
         successJuice('ui_trivia_correct');
         setTimeout(() => { setActive(null); setPicked(null); setResult(null); }, 1500);
       } else if (j?.ok && !j.isCorrect) {

--- a/concord-frontend/lib/concordia/play-action.ts
+++ b/concord-frontend/lib/concordia/play-action.ts
@@ -53,3 +53,19 @@ export function playAction(verb: string, opts: PlayActionOpts = {}): ActionDescr
   }
   return descriptor;
 }
+
+/**
+ * Convenience for station/labor UI: embody the verb on the LOCAL player and
+ * anchor the VFX burst at the player's live world position (set on
+ * `window.__concordiaPlayerPos` by AvatarSystem3D). Falls back to the bridge's
+ * default position when the player position isn't known yet. This is the one
+ * call a station overlay makes on a successful action so "doing" moves the body.
+ */
+export function playActionAtPlayer(verb: string, opts: PlayActionOpts = {}): ActionDescriptor {
+  let pos = opts.pos;
+  if (!pos && typeof window !== 'undefined') {
+    const p = (window as { __concordiaPlayerPos?: { x: number; y?: number; z: number } }).__concordiaPlayerPos;
+    if (p) pos = { x: p.x, y: p.y ?? 1, z: p.z };
+  }
+  return playAction(verb, { ...opts, pos });
+}

--- a/concord-frontend/tests/concordia/play-action.test.ts
+++ b/concord-frontend/tests/concordia/play-action.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { playAction, playActionAtPlayer } from '@/lib/concordia/play-action';
+
+// WS1.5 — the dispatch every station/labor verb now calls. Pin that it emits a
+// concordia:action-anim with a resolved descriptor, and that playActionAtPlayer
+// anchors the VFX at the live player position when one is known.
+
+describe('WS1.5 — playAction dispatch', () => {
+  let events: CustomEvent[];
+  const listener = (e: Event) => events.push(e as CustomEvent);
+
+  beforeEach(() => {
+    events = [];
+    window.addEventListener('concordia:action-anim', listener);
+  });
+  afterEach(() => {
+    window.removeEventListener('concordia:action-anim', listener);
+    delete (window as { __concordiaPlayerPos?: unknown }).__concordiaPlayerPos;
+    vi.restoreAllMocks();
+  });
+
+  it('playAction emits an action-anim event carrying verb + resolved descriptor', () => {
+    const d = playAction('forge');
+    expect(d).toBeTruthy();
+    expect(d.archetype).toBeTruthy();
+    expect(events.length).toBe(1);
+    expect(events[0].detail.verb).toBe('forge');
+    expect(events[0].detail.descriptor.archetype).toBe(d.archetype);
+  });
+
+  it('an unknown verb still dispatches (category fallback, never silent)', () => {
+    const d = playAction('zorp-the-thing');
+    expect(d).toBeTruthy();
+    expect(events.length).toBe(1);
+  });
+
+  it('playActionAtPlayer anchors pos at window.__concordiaPlayerPos when set', () => {
+    (window as { __concordiaPlayerPos?: { x: number; z: number } }).__concordiaPlayerPos = { x: 12, z: -7 };
+    playActionAtPlayer('plant');
+    expect(events[0].detail.pos).toEqual({ x: 12, y: 1, z: -7 });
+  });
+
+  it('playActionAtPlayer omits pos gracefully when player pos unknown', () => {
+    playActionAtPlayer('harvest');
+    expect(events[0].detail.pos).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Render-Everything WS1.5 — make every station verb move the body

The action-animation framework (descriptors + `playAction` dispatch + `AvatarSystem3D.handleActionAnim` bridge + the now-mounted `WorldVFXBridge`) was fully built — but had **zero callers**. Every station action left the player standing frozen while a 2D panel did the work.

This wires the first verbs through:

- New `playActionAtPlayer(verb)` — anchors the VFX burst at the live `window.__concordiaPlayerPos` (set by AvatarSystem3D), the one call a station makes on a successful action.
- Fired from the success path of **nine stations**: farm plant/harvest, restaurant serve, mahjong discard + tsumo flourish, hacking step, code run, trivia correct, karaoke finish, creature breed, factory place.

Now doing anything plays the procedural clip on the avatar + fires juice/sfx/particles (the bridge already wires descriptor `vfx` → `concordia:particle-effect`, which the mounted VFX bridge now renders).

### Verify
- New `tests/concordia/play-action.test.ts` (4) — dispatch shape, unknown-verb fallback, player-pos anchoring, graceful no-pos.
- Full concordia vitest suite 198/198 green; scoped `tsc` clean on `play-action.ts` (the lone scoped error is `_StationOverlayShell`'s styled-jsx `<style jsx>`, a pre-existing config-scoping artifact unrelated to these edits).

https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ)_