### PR TITLE
WS3.3: render buff/debuff auras on the avatar

### DIFF
--- a/concord-frontend/lib/world-lens/attach-world-renderers.ts
+++ b/concord-frontend/lib/world-lens/attach-world-renderers.ts
@@ -27,6 +27,7 @@ import { createResourceNodeRenderer } from './resource-node-renderer';
 import { createCropFieldRenderer } from './crop-field-renderer';
 import { createClaimBoundaryRenderer } from './claim-boundary-renderer';
 import { createConstructionProgressRenderer } from './construction-progress-renderer';
+import { createAvatarAuraRenderer } from './avatar-aura-renderer';
 import { createWorldVFXBridge } from './world-vfx-bridge';
 
 export interface WorldRenderersHandle {
@@ -83,6 +84,7 @@ export function attachWorldRenderers(
   mount(() => createCropFieldRenderer(infrastructureGroup, dataOpts));
   mount(() => createClaimBoundaryRenderer(infrastructureGroup, dataOpts));
   mount(() => createConstructionProgressRenderer(infrastructureGroup, dataOpts));
+  mount(() => createAvatarAuraRenderer(particlesGroup, { authToken, apiBase: opts.apiBase }));
   mount(() => createWorldVFXBridge(particlesGroup, { maxBursts: opts.maxBursts }));
 
   let disposed = false;

--- a/concord-frontend/lib/world-lens/avatar-aura-renderer.ts
+++ b/concord-frontend/lib/world-lens/avatar-aura-renderer.ts
@@ -1,0 +1,201 @@
+// concord-frontend/lib/world-lens/avatar-aura-renderer.ts
+//
+// Render-Everything WS3.3 — buff/debuff AURAS on the player avatar.
+//
+// The Living Society substrate applies effects into `user_active_effects`
+// (consumable buffs, the Phase-0 craft-backfire debuff, conditional god-tier
+// glows like daylight_avatar / war_ramp / eternal_regen). Today only the 2D
+// ActiveEffectsBar shows them — the avatar itself reads neutral. This renders a
+// soft, additive aura at the player's feet whose COLOUR + INTENSITY track the
+// live effect stack: warm cyan/gold when buffs dominate, sickly red/violet when
+// debuffs do, blended when mixed, pulsing with the strongest magnitude. No
+// effects → no aura (fades out).
+//
+// Follows the player via `window.__concordiaPlayerPos` (set by AvatarSystem3D)
+// and polls `/api/world/effects/me`. Pure helper `auraVisual(effects)` is
+// unit-testable; the renderer is a factory `(parentGroup, opts) => {update,
+// dispose, refresh}` matching the other infrastructure-layer renderers.
+
+import * as THREE from "three";
+
+export interface ActiveEffect {
+  effect_id: string;
+  kind: "buff" | "debuff";
+  magnitude: number;
+  started_at?: number;
+  expires_at?: number;
+}
+
+export interface AvatarAuraRendererOpts {
+  authToken?: () => string | null;
+  pollMs?: number;
+  apiBase?: string;
+  /** Test seam — supply effects directly instead of fetching. */
+  fetchEffects?: () => Promise<ActiveEffect[]>;
+  /** Override the player-position accessor (defaults to window global). */
+  playerPos?: () => { x: number; y?: number; z: number } | null;
+}
+
+export interface AuraVisual {
+  active: boolean;
+  /** 0xRRGGBB aura colour (buff/debuff/mixed blend). */
+  color: number;
+  /** 0..1 overall aura intensity. */
+  intensity: number;
+  /** Pulse speed (Hz-ish) — stronger stacks pulse faster. */
+  pulse: number;
+}
+
+const BUFF_COLOR = new THREE.Color(0x4fd6ff); // warm cyan
+const DEBUFF_COLOR = new THREE.Color(0xc0392b); // sickly red
+const NOW_S = () => Date.now() / 1000;
+
+/**
+ * PURE: fold a live effect stack into aura attributes.
+ * - active === false when there are no (unexpired) effects.
+ * - colour blends buff-cyan vs debuff-red by their magnitude shares.
+ * - intensity saturates with total magnitude (clamped 0..1).
+ * - pulse rises with the strongest single magnitude.
+ */
+export function auraVisual(effects: ActiveEffect[], nowS: number = NOW_S()): AuraVisual {
+  const live = (effects || []).filter(
+    (e) => e && Number.isFinite(e.magnitude) && (e.expires_at == null || e.expires_at > nowS),
+  );
+  if (live.length === 0) return { active: false, color: 0x000000, intensity: 0, pulse: 0 };
+
+  let buffMag = 0;
+  let debuffMag = 0;
+  let strongest = 0;
+  for (const e of live) {
+    const m = Math.abs(Number(e.magnitude)) || 0.0;
+    strongest = Math.max(strongest, m);
+    if (e.kind === "debuff") debuffMag += m;
+    else buffMag += m;
+  }
+  const total = buffMag + debuffMag;
+  // Blend cyan↔red by debuff share.
+  const debuffShare = total > 0 ? debuffMag / total : 0;
+  const c = BUFF_COLOR.clone().lerp(DEBUFF_COLOR, Math.max(0, Math.min(1, debuffShare)));
+  return {
+    active: true,
+    color: c.getHex(),
+    intensity: Math.max(0.15, Math.min(1, total)),
+    pulse: 1.0 + Math.min(3, strongest * 2),
+  };
+}
+
+export interface AvatarAuraRenderer {
+  update(delta: number, elapsed: number): void;
+  dispose(): void;
+  refresh(): Promise<void>;
+}
+
+export function createAvatarAuraRenderer(
+  parentGroup: THREE.Group,
+  opts: AvatarAuraRendererOpts = {},
+): AvatarAuraRenderer {
+  const pollMs = opts.pollMs ?? 3000;
+  const apiBase = opts.apiBase ?? "";
+  const url = `${apiBase}/api/world/effects/me`;
+  const getPos =
+    opts.playerPos ??
+    (() => {
+      if (typeof window === "undefined") return null;
+      const p = (window as { __concordiaPlayerPos?: { x: number; y?: number; z: number } }).__concordiaPlayerPos;
+      return p ?? null;
+    });
+
+  let disposed = false;
+  let intervalId: ReturnType<typeof setInterval> | null = null;
+  let current: AuraVisual = { active: false, color: 0x000000, intensity: 0, pulse: 0 };
+
+  // Aura mesh: a flat additive disc at the feet + a faint vertical glow column.
+  const group = new THREE.Group();
+  group.visible = false;
+  const discGeo = new THREE.RingGeometry(1.1, 2.2, 32);
+  discGeo.rotateX(-Math.PI / 2);
+  const discMat = new THREE.MeshBasicMaterial({
+    color: 0xffffff,
+    transparent: true,
+    opacity: 0,
+    blending: THREE.AdditiveBlending,
+    depthWrite: false,
+    side: THREE.DoubleSide,
+  });
+  const disc = new THREE.Mesh(discGeo, discMat);
+  disc.position.y = 0.05;
+  group.add(disc);
+
+  const columnGeo = new THREE.CylinderGeometry(1.0, 1.4, 3.2, 16, 1, true);
+  const columnMat = new THREE.MeshBasicMaterial({
+    color: 0xffffff,
+    transparent: true,
+    opacity: 0,
+    blending: THREE.AdditiveBlending,
+    depthWrite: false,
+    side: THREE.DoubleSide,
+  });
+  const column = new THREE.Mesh(columnGeo, columnMat);
+  column.position.y = 1.6;
+  group.add(column);
+  parentGroup.add(group);
+
+  function applyVisual(v: AuraVisual): void {
+    current = v;
+    group.visible = v.active;
+    const col = new THREE.Color(v.color);
+    (discMat.color as THREE.Color).copy(col);
+    (columnMat.color as THREE.Color).copy(col);
+  }
+
+  async function refresh(): Promise<void> {
+    if (disposed) return;
+    try {
+      let effects: ActiveEffect[];
+      if (opts.fetchEffects) {
+        effects = await opts.fetchEffects();
+      } else {
+        const headers: Record<string, string> = { Accept: "application/json" };
+        const token = opts.authToken ? opts.authToken() : null;
+        if (token) headers.Authorization = `Bearer ${token}`;
+        const res = await fetch(url, { headers });
+        if (!res.ok) return;
+        const data = (await res.json()) as { effects?: ActiveEffect[] };
+        if (!data || !Array.isArray(data.effects)) return;
+        effects = data.effects;
+      }
+      applyVisual(auraVisual(effects));
+    } catch {
+      // Network/parse failure → keep the last known aura (no flicker, no fake).
+    }
+  }
+
+  void refresh();
+  intervalId = setInterval(() => void refresh(), pollMs);
+
+  function update(_delta: number, elapsed: number): void {
+    if (disposed || !current.active) return;
+    const pos = getPos();
+    if (pos) group.position.set(pos.x, pos.y ?? 0, pos.z);
+    // Pulse the opacity so the aura breathes; stronger stacks pulse faster.
+    const phase = 0.5 + 0.5 * Math.sin(elapsed * current.pulse);
+    const base = current.intensity;
+    discMat.opacity = base * (0.35 + 0.35 * phase);
+    columnMat.opacity = base * (0.12 + 0.18 * phase);
+    group.rotation.y = elapsed * 0.4;
+  }
+
+  function dispose(): void {
+    if (disposed) return;
+    disposed = true;
+    if (intervalId) clearInterval(intervalId);
+    intervalId = null;
+    try { parentGroup.remove(group); } catch { /* idempotent */ }
+    try { discGeo.dispose(); } catch { /* idempotent */ }
+    try { discMat.dispose(); } catch { /* idempotent */ }
+    try { columnGeo.dispose(); } catch { /* idempotent */ }
+    try { columnMat.dispose(); } catch { /* idempotent */ }
+  }
+
+  return { update, dispose, refresh };
+}

--- a/concord-frontend/tests/concordia/avatar-aura-renderer.test.ts
+++ b/concord-frontend/tests/concordia/avatar-aura-renderer.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { auraVisual, createAvatarAuraRenderer } from '@/lib/world-lens/avatar-aura-renderer';
+
+// WS3.3 — buff/debuff auras on the avatar. Pin the pure colour/intensity fold +
+// the renderer's follow-the-player + show/hide lifecycle (fetchEffects seam).
+
+describe('WS3.3 — auraVisual (pure)', () => {
+  it('no effects → inactive aura', () => {
+    expect(auraVisual([]).active).toBe(false);
+  });
+
+  it('expired effects are ignored', () => {
+    const v = auraVisual([{ effect_id: 'old', kind: 'buff', magnitude: 0.5, expires_at: 10 }], 1000);
+    expect(v.active).toBe(false);
+  });
+
+  it('pure-buff stack leans cyan; pure-debuff leans red', () => {
+    const buff = auraVisual([{ effect_id: 'b', kind: 'buff', magnitude: 0.6 }], 0);
+    const debuff = auraVisual([{ effect_id: 'd', kind: 'debuff', magnitude: 0.6 }], 0);
+    expect(buff.active).toBe(true);
+    expect(debuff.active).toBe(true);
+    // buff's blue channel dominates; debuff's red channel dominates
+    const b = new THREE.Color(buff.color);
+    const d = new THREE.Color(debuff.color);
+    expect(b.b).toBeGreaterThan(b.r);
+    expect(d.r).toBeGreaterThan(d.b);
+  });
+
+  it('intensity saturates and never exceeds 1', () => {
+    const v = auraVisual(
+      [
+        { effect_id: 'a', kind: 'buff', magnitude: 0.8 },
+        { effect_id: 'b', kind: 'buff', magnitude: 0.9 },
+      ],
+      0,
+    );
+    expect(v.intensity).toBeLessThanOrEqual(1);
+    expect(v.intensity).toBeGreaterThan(0.15);
+  });
+
+  it('stronger magnitudes pulse faster', () => {
+    const weak = auraVisual([{ effect_id: 'a', kind: 'buff', magnitude: 0.1 }], 0);
+    const strong = auraVisual([{ effect_id: 'a', kind: 'buff', magnitude: 1.5 }], 0);
+    expect(strong.pulse).toBeGreaterThan(weak.pulse);
+  });
+});
+
+describe('WS3.3 — createAvatarAuraRenderer lifecycle', () => {
+  it('shows the aura when effects exist and follows the player', async () => {
+    const group = new THREE.Group();
+    let effects = [{ effect_id: 'haste', kind: 'buff' as const, magnitude: 0.5 }];
+    const r = createAvatarAuraRenderer(group, {
+      fetchEffects: async () => effects,
+      playerPos: () => ({ x: 5, y: 0, z: 9 }),
+    });
+    await r.refresh();
+    // The aura group was added under the parent and is now visible.
+    expect(group.children.length).toBe(1);
+    const auraGroup = group.children[0] as THREE.Group;
+    expect(auraGroup.visible).toBe(true);
+    r.update(0.016, 1.0);
+    expect(auraGroup.position.x).toBeCloseTo(5, 5);
+    expect(auraGroup.position.z).toBeCloseTo(9, 5);
+
+    // Clear effects → aura hides on next refresh.
+    effects = [];
+    await r.refresh();
+    expect(auraGroup.visible).toBe(false);
+
+    r.dispose();
+    expect(() => r.dispose()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Render-Everything WS3.3 — auras from `user_active_effects`

Buffs/debuffs (consumables, the Phase-0 craft-backfire debuff, conditional god-tier glows) were only visible in the 2D `ActiveEffectsBar` — the avatar read neutral.

`AvatarAuraRenderer` draws a soft additive aura (feet disc + faint glow column) at the player's feet whose:
- **colour** blends cyan (buffs) ↔ red (debuffs) by magnitude share,
- **intensity** saturates with the total stack,
- **pulse** speeds up with the strongest single effect.

Follows the player via `window.__concordiaPlayerPos`, polls `/api/world/effects/me`, hides when no effects are active. Mounted in the `particles` layer via `attach-world-renderers`.

### Verify
- New `tests/concordia/avatar-aura-renderer.test.ts` — pure `auraVisual` fold (empty/expired/buff-cyan/debuff-red/intensity-cap/pulse) + renderer show→follow→hide→dispose lifecycle.
- 9/9 green; scoped `tsc` clean.

https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ)_