### PR TITLE
WS2.7: render uprisings as a visible 3D crowd

### DIFF
--- a/concord-frontend/lib/world-lens/attach-world-renderers.ts
+++ b/concord-frontend/lib/world-lens/attach-world-renderers.ts
@@ -28,6 +28,7 @@ import { createCropFieldRenderer } from './crop-field-renderer';
 import { createClaimBoundaryRenderer } from './claim-boundary-renderer';
 import { createConstructionProgressRenderer } from './construction-progress-renderer';
 import { createAvatarAuraRenderer } from './avatar-aura-renderer';
+import { createUprisingCrowdRenderer } from './uprising-crowd-renderer';
 import { createWorldVFXBridge } from './world-vfx-bridge';
 
 export interface WorldRenderersHandle {
@@ -84,6 +85,7 @@ export function attachWorldRenderers(
   mount(() => createCropFieldRenderer(infrastructureGroup, dataOpts));
   mount(() => createClaimBoundaryRenderer(infrastructureGroup, dataOpts));
   mount(() => createConstructionProgressRenderer(infrastructureGroup, dataOpts));
+  mount(() => createUprisingCrowdRenderer(infrastructureGroup, dataOpts));
   mount(() => createAvatarAuraRenderer(particlesGroup, { authToken, apiBase: opts.apiBase }));
   mount(() => createWorldVFXBridge(particlesGroup, { maxBursts: opts.maxBursts }));
 

--- a/concord-frontend/lib/world-lens/uprising-crowd-renderer.ts
+++ b/concord-frontend/lib/world-lens/uprising-crowd-renderer.ts
@@ -1,0 +1,206 @@
+// concord-frontend/lib/world-lens/uprising-crowd-renderer.ts
+//
+// Render-Everything WS2.7 — uprisings are a VISIBLE CROWD.
+//
+// The Living Society keystone: a grievance seeds a movement, the movement
+// recruits, and at threshold it ERUPTS (status 'acting'). Until now that drama
+// lived in server tables + a 2D feed. This renders an erupted uprising as a real
+// crowd at the centroid of its rebels' positions (server-resolved): a cluster of
+// raised-banner poles + a flickering torch glow, the cluster sized by member
+// count, pulsing an angry red. When the uprising resolves (no longer 'acting'),
+// the crowd disperses (disposed).
+//
+// Polls `GET /api/worlds/:id/uprisings` (rows already carry the member centroid;
+// rows with null position are skipped — no fake crowds). Pure helper
+// `crowdVisual(uprising)` is unit-testable; the renderer is a factory matching
+// the other infrastructure-layer renderers.
+
+import * as THREE from "three";
+
+export interface UprisingRow {
+  movementId: string;
+  targetKind?: string;
+  targetId?: string;
+  memberCount: number;
+  grievance?: number;
+  x: number | null;
+  z: number | null;
+}
+
+export interface UprisingCrowdRendererOpts {
+  worldId: string;
+  authToken?: () => string | null;
+  pollMs?: number;
+  apiBase?: string;
+  /** Test seam — supply rows directly instead of fetching. */
+  fetchUprisings?: () => Promise<UprisingRow[]>;
+}
+
+export interface CrowdVisual {
+  /** True when this uprising can be rendered (has a resolved position). */
+  renderable: boolean;
+  /** Number of banner markers to show (capped). */
+  bannerCount: number;
+  /** Crowd cluster radius in metres (grows with member count). */
+  radius: number;
+  /** Anger tint intensity 0..1 (grievance-driven). */
+  heat: number;
+}
+
+const MAX_BANNERS = 12;
+const BANNER_PER_MEMBERS = 3; // one banner per ~3 rebels
+
+/**
+ * PURE: map an uprising row to crowd render attributes.
+ * renderable === false when the server couldn't resolve a member centroid.
+ * bannerCount scales with memberCount (1..MAX_BANNERS); radius grows with the
+ * crowd; heat rises with grievance severity (0..10 → 0..1).
+ */
+export function crowdVisual(u: UprisingRow): CrowdVisual {
+  const renderable = u && Number.isFinite(u.x as number) && Number.isFinite(u.z as number);
+  const members = Math.max(0, Number(u?.memberCount) || 0);
+  const bannerCount = Math.max(1, Math.min(MAX_BANNERS, Math.ceil(members / BANNER_PER_MEMBERS)));
+  const radius = Math.max(2, Math.min(12, 2 + members * 0.4));
+  const heat = Math.max(0.3, Math.min(1, (Number(u?.grievance) || 0) / 10));
+  return { renderable: !!renderable, bannerCount, radius, heat };
+}
+
+interface TrackedCrowd {
+  group: THREE.Group;
+  torch: THREE.PointLight;
+  bannerMat: THREE.MeshStandardMaterial;
+  heat: number;
+}
+
+const BANNER_COLOR = 0x8a1c1c; // rebel crimson
+
+function buildCrowd(visual: CrowdVisual): TrackedCrowd {
+  const group = new THREE.Group();
+  const bannerMat = new THREE.MeshStandardMaterial({
+    color: BANNER_COLOR,
+    emissive: new THREE.Color(0x3a0a0a),
+    roughness: 0.8,
+  });
+  const poleMat = new THREE.MeshStandardMaterial({ color: 0x3b2a17, roughness: 1.0 });
+
+  for (let i = 0; i < visual.bannerCount; i++) {
+    const angle = (i / visual.bannerCount) * Math.PI * 2;
+    const r = visual.radius * (0.5 + 0.5 * ((i % 3) / 2));
+    const bx = Math.cos(angle) * r;
+    const bz = Math.sin(angle) * r;
+
+    const pole = new THREE.Mesh(new THREE.CylinderGeometry(0.06, 0.06, 2.4, 5), poleMat);
+    pole.position.set(bx, 1.2, bz);
+    group.add(pole);
+
+    const banner = new THREE.Mesh(new THREE.PlaneGeometry(0.8, 0.9), bannerMat);
+    banner.position.set(bx + 0.45, 1.9, bz);
+    banner.rotation.y = angle;
+    group.add(banner);
+  }
+
+  // A flickering torch glow at the crowd's heart.
+  const torch = new THREE.PointLight(0xff5522, 1.5 * visual.heat, visual.radius * 3, 2);
+  torch.position.set(0, 2.0, 0);
+  group.add(torch);
+
+  return { group, torch, bannerMat, heat: visual.heat };
+}
+
+function disposeCrowd(c: TrackedCrowd, parent: THREE.Group): void {
+  try { parent.remove(c.group); } catch { /* idempotent */ }
+  c.group.traverse((o) => {
+    const mesh = o as THREE.Mesh;
+    if (mesh.geometry) { try { mesh.geometry.dispose(); } catch { /* idempotent */ } }
+  });
+  try { c.bannerMat.dispose(); } catch { /* idempotent */ }
+}
+
+export interface UprisingCrowdRenderer {
+  update(delta: number, elapsed: number): void;
+  dispose(): void;
+  refresh(): Promise<void>;
+}
+
+export function createUprisingCrowdRenderer(
+  parentGroup: THREE.Group,
+  opts: UprisingCrowdRendererOpts,
+): UprisingCrowdRenderer {
+  const pollMs = opts.pollMs ?? 6000;
+  const apiBase = opts.apiBase ?? "";
+  const url = `${apiBase}/api/worlds/${opts.worldId}/uprisings`;
+  const tracked = new Map<string, TrackedCrowd>();
+  let disposed = false;
+  let intervalId: ReturnType<typeof setInterval> | null = null;
+
+  function reconcile(rows: UprisingRow[]): void {
+    if (disposed) return;
+    const seen = new Set<string>();
+    for (const u of rows) {
+      if (!u || !u.movementId) continue;
+      const visual = crowdVisual(u);
+      if (!visual.renderable) continue;
+      seen.add(u.movementId);
+      if (!tracked.has(u.movementId)) {
+        const crowd = buildCrowd(visual);
+        crowd.group.position.set(Number(u.x), 0, Number(u.z));
+        parentGroup.add(crowd.group);
+        tracked.set(u.movementId, crowd);
+      }
+    }
+    // Crowds that resolved / dispersed.
+    for (const [id, crowd] of tracked) {
+      if (!seen.has(id)) {
+        disposeCrowd(crowd, parentGroup);
+        tracked.delete(id);
+      }
+    }
+  }
+
+  async function refresh(): Promise<void> {
+    if (disposed) return;
+    try {
+      let rows: UprisingRow[];
+      if (opts.fetchUprisings) {
+        rows = await opts.fetchUprisings();
+      } else {
+        const headers: Record<string, string> = { Accept: "application/json" };
+        const token = opts.authToken ? opts.authToken() : null;
+        if (token) headers.Authorization = `Bearer ${token}`;
+        const res = await fetch(url, { headers });
+        if (!res.ok) return;
+        const data = (await res.json()) as { uprisings?: UprisingRow[] };
+        if (!data || !Array.isArray(data.uprisings)) return;
+        rows = data.uprisings;
+      }
+      reconcile(rows);
+    } catch {
+      // Network/parse failure → render nothing new.
+    }
+  }
+
+  void refresh();
+  intervalId = setInterval(() => void refresh(), pollMs);
+
+  function update(_delta: number, elapsed: number): void {
+    if (disposed) return;
+    for (const crowd of tracked.values()) {
+      // Torch flicker — pseudo-random brightness modulation.
+      const flicker = 0.75 + 0.25 * Math.sin(elapsed * 9 + crowd.group.position.x);
+      crowd.torch.intensity = 1.5 * crowd.heat * flicker;
+      // Banners sway in the unrest.
+      crowd.group.rotation.y = 0.05 * Math.sin(elapsed * 0.8);
+    }
+  }
+
+  function dispose(): void {
+    if (disposed) return;
+    disposed = true;
+    if (intervalId) clearInterval(intervalId);
+    intervalId = null;
+    for (const crowd of tracked.values()) disposeCrowd(crowd, parentGroup);
+    tracked.clear();
+  }
+
+  return { update, dispose, refresh };
+}

--- a/concord-frontend/tests/concordia/uprising-crowd-renderer.test.ts
+++ b/concord-frontend/tests/concordia/uprising-crowd-renderer.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { crowdVisual, createUprisingCrowdRenderer } from '@/lib/world-lens/uprising-crowd-renderer';
+
+// WS2.7 — uprisings render as a visible crowd at their rebels' centroid. Pin the
+// pure visual map + the renderer's erupt→render→disperse lifecycle.
+
+describe('WS2.7 — crowdVisual (pure)', () => {
+  it('an uprising without a resolved position is not renderable (no fake crowd)', () => {
+    expect(crowdVisual({ movementId: 'm', memberCount: 5, x: null, z: null }).renderable).toBe(false);
+  });
+
+  it('a positioned uprising is renderable with banners scaled to members', () => {
+    const small = crowdVisual({ movementId: 'm', memberCount: 3, x: 0, z: 0 });
+    const big = crowdVisual({ movementId: 'm', memberCount: 30, x: 0, z: 0 });
+    expect(small.renderable).toBe(true);
+    expect(big.bannerCount).toBeGreaterThan(small.bannerCount);
+    expect(big.radius).toBeGreaterThan(small.radius);
+  });
+
+  it('banner count is capped and radius is clamped', () => {
+    const huge = crowdVisual({ movementId: 'm', memberCount: 10000, x: 1, z: 1 });
+    expect(huge.bannerCount).toBeLessThanOrEqual(12);
+    expect(huge.radius).toBeLessThanOrEqual(12);
+  });
+
+  it('heat rises with grievance', () => {
+    const calm = crowdVisual({ movementId: 'm', memberCount: 4, grievance: 1, x: 0, z: 0 });
+    const furious = crowdVisual({ movementId: 'm', memberCount: 4, grievance: 10, x: 0, z: 0 });
+    expect(furious.heat).toBeGreaterThan(calm.heat);
+  });
+});
+
+describe('WS2.7 — createUprisingCrowdRenderer lifecycle', () => {
+  it('spawns a crowd for an acting uprising and disperses it on resolution', async () => {
+    const group = new THREE.Group();
+    let rows = [{ movementId: 'm1', memberCount: 9, grievance: 8, x: 50, z: -20 }];
+    const r = createUprisingCrowdRenderer(group, {
+      worldId: 'w',
+      fetchUprisings: async () => rows,
+    });
+    await r.refresh();
+    expect(group.children.length).toBe(1);
+    const crowd = group.children[0] as THREE.Group;
+    expect(crowd.position.x).toBeCloseTo(50, 5);
+    expect(crowd.position.z).toBeCloseTo(-20, 5);
+
+    for (let i = 0; i < 5; i++) r.update(0.016, i * 0.1);
+
+    // resolved → no longer returned → crowd disperses
+    rows = [];
+    await r.refresh();
+    expect(group.children.length).toBe(0);
+
+    r.dispose();
+    expect(() => r.dispose()).not.toThrow();
+  });
+
+  it('skips null-position uprisings entirely', async () => {
+    const group = new THREE.Group();
+    const r = createUprisingCrowdRenderer(group, {
+      worldId: 'w',
+      fetchUprisings: async () => [{ movementId: 'm2', memberCount: 5, x: null, z: null }],
+    });
+    await r.refresh();
+    expect(group.children.length).toBe(0);
+    r.dispose();
+  });
+});

--- a/server/lib/uprising.js
+++ b/server/lib/uprising.js
@@ -126,3 +126,67 @@ export function listPlayerMovementQuests(db, playerId, status = null) {
       : db.prepare(`SELECT * FROM movement_quests WHERE player_id = ? ORDER BY created_at DESC`).all(playerId);
   } catch { return []; }
 }
+
+/**
+ * Active uprisings in a world, each LOCATED at the centroid of its NPC members'
+ * live positions — because a crowd is where its people actually stand, not at an
+ * abstract target. Returns `[{ movementId, targetKind, targetId, memberCount,
+ * x, z, grievance }]`; rows whose members have no resolvable position are
+ * returned with `x/z = null` so the client can skip rendering them (no fake
+ * crowds). Never throws — minimal builds without the tables get `[]`.
+ *
+ * WS2.7: the render surface for the Living Society uprising keystone.
+ */
+export function listActiveUprisingsWithLocation(db, worldId) {
+  if (!db || !worldId) return [];
+  let rows;
+  try {
+    rows = db.prepare(`
+      SELECT u.movement_id, u.target_kind, u.target_id, u.member_count,
+             m.grievance_severity AS grievance
+        FROM movement_uprisings u
+        JOIN movements m ON m.id = u.movement_id
+       WHERE u.world_id = ? AND m.status = 'acting'
+    `).all(worldId);
+  } catch { return []; }
+  if (!Array.isArray(rows) || rows.length === 0) return [];
+
+  function parseXZ(raw) {
+    if (raw == null) return null;
+    try {
+      const o = typeof raw === "string" ? JSON.parse(raw) : raw;
+      const x = Number(o?.x);
+      const z = Number(o?.z);
+      if (Number.isFinite(x) && Number.isFinite(z)) return { x, z };
+    } catch { /* not JSON */ }
+    return null;
+  }
+
+  return rows.map((r) => {
+    let x = null;
+    let z = null;
+    try {
+      const members = db.prepare(`
+        SELECT n.current_location
+          FROM movement_members mm
+          JOIN world_npcs n ON n.id = mm.member_id
+         WHERE mm.movement_id = ? AND mm.member_kind = 'npc' AND mm.left_at IS NULL
+      `).all(r.movement_id);
+      let sx = 0, sz = 0, n = 0;
+      for (const mem of members) {
+        const p = parseXZ(mem.current_location);
+        if (p) { sx += p.x; sz += p.z; n += 1; }
+      }
+      if (n > 0) { x = sx / n; z = sz / n; }
+    } catch { /* world_npcs absent / no members → null position */ }
+    return {
+      movementId: r.movement_id,
+      targetKind: r.target_kind,
+      targetId: r.target_id,
+      memberCount: Number(r.member_count) || 0,
+      grievance: Number(r.grievance) || 0,
+      x,
+      z,
+    };
+  });
+}

--- a/server/routes/worlds.js
+++ b/server/routes/worlds.js
@@ -25,6 +25,7 @@ import {
   checkQuestCompletion,
 } from "../lib/quests/quest-engine.js";
 import * as cityPresence from "../lib/city-presence.js";
+import { listActiveUprisingsWithLocation } from "../lib/uprising.js";
 import { serverError } from "../lib/http-errors.js";
 
 // Combat anti-cheat constants. Server-side validation prevents a modified
@@ -1551,6 +1552,18 @@ export default function createWorldsRouter({ requireAuth, db }) {
         'SELECT * FROM world_buildings WHERE world_id = ? AND state != ? ORDER BY created_at ASC'
       ).all(worldId, 'collapsed');
       res.json({ ok: true, buildings, count: buildings.length });
+    } catch (e) {
+      res.status(500).json({ ok: false, error: e.message });
+    }
+  });
+
+  // WS2.7 — active uprisings located at their members' centroid, for the
+  // 3D crowd renderer. Public read (no secrets — member positions + counts).
+  router.get("/:worldId/uprisings", (req, res) => {
+    try {
+      const { worldId } = req.params;
+      const uprisings = listActiveUprisingsWithLocation(db, worldId);
+      res.json({ ok: true, uprisings, count: uprisings.length });
     } catch (e) {
       res.status(500).json({ ok: false, error: e.message });
     }

--- a/server/tests/uprising-location.test.js
+++ b/server/tests/uprising-location.test.js
@@ -1,0 +1,73 @@
+/**
+ * WS2.7 — listActiveUprisingsWithLocation: an uprising renders where its NPC
+ * members actually stand (their position centroid), not at an abstract target.
+ *
+ * Run: node --test tests/uprising-location.test.js
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+import { listActiveUprisingsWithLocation } from "../lib/uprising.js";
+
+const W = "concordia-hub";
+function mkDb() {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE movements (
+      id TEXT PRIMARY KEY, world_id TEXT, status TEXT, target_kind TEXT, target_id TEXT,
+      grievance_severity INTEGER DEFAULT 0
+    );
+    CREATE TABLE movement_uprisings (
+      movement_id TEXT PRIMARY KEY, world_id TEXT, target_kind TEXT, target_id TEXT,
+      member_count INTEGER, strategy_log_id TEXT, world_event_id TEXT
+    );
+    CREATE TABLE movement_members (
+      movement_id TEXT, member_kind TEXT, member_id TEXT, left_at INTEGER
+    );
+    CREATE TABLE world_npcs (id TEXT PRIMARY KEY, current_location TEXT);
+  `);
+  return db;
+}
+
+describe("WS2.7 — uprising located at member centroid", () => {
+  it("centroid of NPC members' positions is returned", () => {
+    const db = mkDb();
+    db.prepare(`INSERT INTO movements (id, world_id, status, target_kind, target_id, grievance_severity) VALUES ('m1', ?, 'acting', 'faction', 'fac1', 7)`).run(W);
+    db.prepare(`INSERT INTO movement_uprisings (movement_id, world_id, target_kind, target_id, member_count) VALUES ('m1', ?, 'faction', 'fac1', 2)`).run(W);
+    db.prepare(`INSERT INTO world_npcs (id, current_location) VALUES ('n1', ?), ('n2', ?)`)
+      .run(JSON.stringify({ x: 10, z: 20 }), JSON.stringify({ x: 30, z: 40 }));
+    db.prepare(`INSERT INTO movement_members (movement_id, member_kind, member_id, left_at) VALUES ('m1','npc','n1',NULL), ('m1','npc','n2',NULL)`).run();
+
+    const out = listActiveUprisingsWithLocation(db, W);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].movementId, "m1");
+    assert.equal(out[0].memberCount, 2);
+    assert.equal(out[0].grievance, 7);
+    assert.ok(Math.abs(out[0].x - 20) < 0.001, `x centroid ${out[0].x}`);
+    assert.ok(Math.abs(out[0].z - 30) < 0.001, `z centroid ${out[0].z}`);
+  });
+
+  it("only 'acting' movements count (recruiting ones are excluded)", () => {
+    const db = mkDb();
+    db.prepare(`INSERT INTO movements (id, world_id, status, target_kind, target_id) VALUES ('m2', ?, 'recruiting', 'faction', 'f')`).run(W);
+    db.prepare(`INSERT INTO movement_uprisings (movement_id, world_id, target_kind, target_id, member_count) VALUES ('m2', ?, 'faction', 'f', 1)`).run(W);
+    assert.equal(listActiveUprisingsWithLocation(db, W).length, 0);
+  });
+
+  it("an uprising with no positioned members returns x/z=null (no fake crowd)", () => {
+    const db = mkDb();
+    db.prepare(`INSERT INTO movements (id, world_id, status, target_kind, target_id) VALUES ('m3', ?, 'acting', 'faction', 'f')`).run(W);
+    db.prepare(`INSERT INTO movement_uprisings (movement_id, world_id, target_kind, target_id, member_count) VALUES ('m3', ?, 'faction', 'f', 5)`).run(W);
+    const out = listActiveUprisingsWithLocation(db, W);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].x, null);
+    assert.equal(out[0].z, null);
+  });
+
+  it("never throws on a minimal/absent-table build", () => {
+    const db = new Database(":memory:");
+    assert.deepEqual(listActiveUprisingsWithLocation(db, W), []);
+    assert.deepEqual(listActiveUprisingsWithLocation(null, W), []);
+  });
+});


### PR DESCRIPTION
## Render-Everything WS2.7 — the Living Society uprising keystone, made visible

A grievance seeds a movement, the movement recruits, and at threshold it **erupts** (`status='acting'`). Until now that whole arc lived in server tables + a 2D feed. This renders an erupted uprising as a real 3D crowd.

**Located where the rebels actually stand** — the centroid of the movement's NPC members' live positions, not an abstract target (a faction/realm has no single point).

- **server**: `listActiveUprisingsWithLocation(db, worldId)` joins `movement_members` → `world_npcs` positions; `GET /api/worlds/:worldId/uprisings` exposes it. Rows whose members have no resolvable position return `x/z=null` so the client skips them — **no fake crowds**. Never throws on minimal builds.
- **client**: `UprisingCrowdRenderer` draws a cluster of raised-banner poles + a flickering torch glow, banner count scaled to member count, heat by grievance, swaying crimson. Disperses (disposed) when the uprising resolves. Mounted in the `infrastructure` layer.

### Verify
- New `server/tests/uprising-location.test.js` (4) — member centroid, acting-only filter, null-position no-crowd, absent-table safety.
- New `tests/concordia/uprising-crowd-renderer.test.ts` (banners/radius/heat scaling + erupt→render→disperse + null-skip).
- Scoped `tsc` + `node --check` clean.

https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ)_