### PR TITLE
WS3.4: render creature corpses / butchered drops as 3D objects

### DIFF
--- a/concord-frontend/lib/world-lens/attach-world-renderers.ts
+++ b/concord-frontend/lib/world-lens/attach-world-renderers.ts
@@ -29,6 +29,7 @@ import { createClaimBoundaryRenderer } from './claim-boundary-renderer';
 import { createConstructionProgressRenderer } from './construction-progress-renderer';
 import { createAvatarAuraRenderer } from './avatar-aura-renderer';
 import { createUprisingCrowdRenderer } from './uprising-crowd-renderer';
+import { createCorpseMeshRenderer } from './corpse-mesh-renderer';
 import { createWorldVFXBridge } from './world-vfx-bridge';
 
 export interface WorldRenderersHandle {
@@ -86,6 +87,7 @@ export function attachWorldRenderers(
   mount(() => createClaimBoundaryRenderer(infrastructureGroup, dataOpts));
   mount(() => createConstructionProgressRenderer(infrastructureGroup, dataOpts));
   mount(() => createUprisingCrowdRenderer(infrastructureGroup, dataOpts));
+  mount(() => createCorpseMeshRenderer(infrastructureGroup, dataOpts));
   mount(() => createAvatarAuraRenderer(particlesGroup, { authToken, apiBase: opts.apiBase }));
   mount(() => createWorldVFXBridge(particlesGroup, { maxBursts: opts.maxBursts }));
 

--- a/concord-frontend/lib/world-lens/corpse-mesh-renderer.ts
+++ b/concord-frontend/lib/world-lens/corpse-mesh-renderer.ts
@@ -1,0 +1,187 @@
+// concord-frontend/lib/world-lens/corpse-mesh-renderer.ts
+//
+// Render-Everything WS3.4 — butchered drops / corpses are real 3D OBJECTS.
+//
+// When a creature is killed it leaves a `creature_corpses` row (x/y/z, species,
+// expiry) that the player can butcher. Today only a 2D HUD card list shows them;
+// the world itself has no corpse. This renders each active corpse as a low mound
+// mesh at its world position, tinted per-species, gently settling — a thing you
+// can see and walk up to, not an inventory row. Removed when the corpse expires
+// or is butchered (no longer returned by the endpoint). A faint glint marks an
+// un-butchered corpse so loot reads as lootable.
+//
+// Polls `GET /api/world/creature/corpses/:worldId`. Pure helper
+// `corpseVisual(corpse)` is unit-testable; the renderer is a factory matching
+// the other infrastructure-layer renderers.
+
+import * as THREE from "three";
+
+export interface CorpseRow {
+  id: string;
+  species_id?: string;
+  x?: number;
+  y?: number;
+  z?: number;
+  expires_at?: number;
+}
+
+export interface CorpseMeshRendererOpts {
+  worldId: string;
+  authToken?: () => string | null;
+  pollMs?: number;
+  apiBase?: string;
+  /** Test seam — supply rows directly instead of fetching. */
+  fetchCorpses?: () => Promise<CorpseRow[]>;
+}
+
+export interface CorpseVisual {
+  /** 0xRRGGBB tint derived deterministically from the species id. */
+  color: number;
+  /** Mound footprint scale (metres). */
+  scale: number;
+}
+
+// Deterministic hue from a species id so the same creature always tints the same.
+function hashHue(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  return (h % 360) / 360;
+}
+
+/**
+ * PURE: map a corpse to its render attributes. Colour is a desaturated,
+ * darkened hue keyed to the species (a corpse is dull, not vivid); scale is a
+ * small mound. Unknown species → a neutral grey-brown.
+ */
+export function corpseVisual(corpse: { species_id?: string }): CorpseVisual {
+  const sp = String(corpse?.species_id ?? "").trim();
+  if (!sp) return { color: 0x5a4a3a, scale: 1.4 };
+  const c = new THREE.Color();
+  c.setHSL(hashHue(sp), 0.28, 0.32); // low saturation + lightness = dull, dead
+  return { color: c.getHex(), scale: 1.4 };
+}
+
+interface TrackedCorpse {
+  group: THREE.Group;
+  glint: THREE.Mesh;
+  moundMat: THREE.MeshStandardMaterial;
+}
+
+function buildCorpse(visual: CorpseVisual): TrackedCorpse {
+  const group = new THREE.Group();
+  const moundMat = new THREE.MeshStandardMaterial({ color: visual.color, roughness: 0.95, metalness: 0 });
+  // A flattened sphere reads as a slumped carcass.
+  const moundGeo = new THREE.SphereGeometry(visual.scale, 10, 8);
+  moundGeo.scale(1, 0.45, 1.3);
+  const mound = new THREE.Mesh(moundGeo, moundMat);
+  mound.position.y = visual.scale * 0.45;
+  group.add(mound);
+
+  // A small additive glint so an un-butchered corpse reads as lootable.
+  const glintMat = new THREE.MeshBasicMaterial({
+    color: 0xffe6a0,
+    transparent: true,
+    opacity: 0.0,
+    blending: THREE.AdditiveBlending,
+    depthWrite: false,
+  });
+  const glint = new THREE.Mesh(new THREE.SphereGeometry(0.18, 6, 6), glintMat);
+  glint.position.set(0, visual.scale * 0.9, 0);
+  group.add(glint);
+
+  return { group, glint, moundMat };
+}
+
+function disposeCorpse(c: TrackedCorpse, parent: THREE.Group): void {
+  try { parent.remove(c.group); } catch { /* idempotent */ }
+  c.group.traverse((o) => {
+    const m = o as THREE.Mesh;
+    if (m.geometry) { try { m.geometry.dispose(); } catch { /* idempotent */ } }
+    if (m.material) { try { (m.material as THREE.Material).dispose(); } catch { /* idempotent */ } }
+  });
+}
+
+export interface CorpseMeshRenderer {
+  update(delta: number, elapsed: number): void;
+  dispose(): void;
+  refresh(): Promise<void>;
+}
+
+export function createCorpseMeshRenderer(
+  parentGroup: THREE.Group,
+  opts: CorpseMeshRendererOpts,
+): CorpseMeshRenderer {
+  const pollMs = opts.pollMs ?? 8000;
+  const apiBase = opts.apiBase ?? "";
+  const url = `${apiBase}/api/world/creature/corpses/${opts.worldId}`;
+  const tracked = new Map<string, TrackedCorpse>();
+  let disposed = false;
+  let intervalId: ReturnType<typeof setInterval> | null = null;
+
+  function reconcile(rows: CorpseRow[]): void {
+    if (disposed) return;
+    const seen = new Set<string>();
+    for (const c of rows) {
+      if (!c || !c.id) continue;
+      if (!Number.isFinite(Number(c.x)) || !Number.isFinite(Number(c.z))) continue;
+      seen.add(c.id);
+      if (!tracked.has(c.id)) {
+        const corpse = buildCorpse(corpseVisual(c));
+        corpse.group.position.set(Number(c.x), Number(c.y) || 0, Number(c.z));
+        parentGroup.add(corpse.group);
+        tracked.set(c.id, corpse);
+      }
+    }
+    for (const [id, corpse] of tracked) {
+      if (!seen.has(id)) {
+        disposeCorpse(corpse, parentGroup);
+        tracked.delete(id);
+      }
+    }
+  }
+
+  async function refresh(): Promise<void> {
+    if (disposed) return;
+    try {
+      let rows: CorpseRow[];
+      if (opts.fetchCorpses) {
+        rows = await opts.fetchCorpses();
+      } else {
+        const headers: Record<string, string> = { Accept: "application/json" };
+        const token = opts.authToken ? opts.authToken() : null;
+        if (token) headers.Authorization = `Bearer ${token}`;
+        const res = await fetch(url, { headers });
+        if (!res.ok) return;
+        const data = (await res.json()) as { corpses?: CorpseRow[] };
+        if (!data || !Array.isArray(data.corpses)) return;
+        rows = data.corpses;
+      }
+      reconcile(rows);
+    } catch {
+      // Network/parse failure → render nothing new.
+    }
+  }
+
+  void refresh();
+  intervalId = setInterval(() => void refresh(), pollMs);
+
+  function update(_delta: number, elapsed: number): void {
+    if (disposed) return;
+    for (const corpse of tracked.values()) {
+      // Slow glint pulse so the lootable marker breathes.
+      const phase = 0.5 + 0.5 * Math.sin(elapsed * 2 + corpse.group.position.x);
+      (corpse.glint.material as THREE.MeshBasicMaterial).opacity = 0.25 + 0.45 * phase;
+    }
+  }
+
+  function dispose(): void {
+    if (disposed) return;
+    disposed = true;
+    if (intervalId) clearInterval(intervalId);
+    intervalId = null;
+    for (const corpse of tracked.values()) disposeCorpse(corpse, parentGroup);
+    tracked.clear();
+  }
+
+  return { update, dispose, refresh };
+}

--- a/concord-frontend/tests/concordia/corpse-mesh-renderer.test.ts
+++ b/concord-frontend/tests/concordia/corpse-mesh-renderer.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { corpseVisual, createCorpseMeshRenderer } from '@/lib/world-lens/corpse-mesh-renderer';
+
+// WS3.4 — butchered drops / corpses render as real 3D objects. Pin the pure
+// tint map + the renderer's spawn→pulse→remove lifecycle.
+
+describe('WS3.4 — corpseVisual (pure)', () => {
+  it('same species → same deterministic tint', () => {
+    const a = corpseVisual({ species_id: 'dire_elk' });
+    const b = corpseVisual({ species_id: 'dire_elk' });
+    expect(a.color).toBe(b.color);
+  });
+
+  it('different species → (almost always) different tint', () => {
+    const a = corpseVisual({ species_id: 'dire_elk' });
+    const b = corpseVisual({ species_id: 'marsh_strider' });
+    expect(a.color).not.toBe(b.color);
+  });
+
+  it('missing species → neutral fallback, never throws', () => {
+    const v = corpseVisual({});
+    expect(typeof v.color).toBe('number');
+    expect(v.scale).toBeGreaterThan(0);
+  });
+});
+
+describe('WS3.4 — createCorpseMeshRenderer lifecycle', () => {
+  it('spawns a corpse mesh at its position and removes it when gone', async () => {
+    const group = new THREE.Group();
+    let rows = [{ id: 'c1', species_id: 'dire_elk', x: 7, y: 0, z: -3, expires_at: 9_999_999_999 }];
+    const r = createCorpseMeshRenderer(group, { worldId: 'w', fetchCorpses: async () => rows });
+    await r.refresh();
+    expect(group.children.length).toBe(1);
+    const corpse = group.children[0] as THREE.Group;
+    expect(corpse.position.x).toBeCloseTo(7, 5);
+    expect(corpse.position.z).toBeCloseTo(-3, 5);
+
+    for (let i = 0; i < 4; i++) r.update(0.016, i * 0.2);
+
+    // butchered / expired → no longer returned → mesh removed
+    rows = [];
+    await r.refresh();
+    expect(group.children.length).toBe(0);
+
+    r.dispose();
+    expect(() => r.dispose()).not.toThrow();
+  });
+
+  it('skips corpses with no position', async () => {
+    const group = new THREE.Group();
+    const r = createCorpseMeshRenderer(group, {
+      worldId: 'w',
+      fetchCorpses: async () => [{ id: 'c2', species_id: 'x' }],
+    });
+    await r.refresh();
+    expect(group.children.length).toBe(0);
+    r.dispose();
+  });
+});


### PR DESCRIPTION
## Render-Everything WS3.4 — loot/drops are real objects, not inventory rows

A killed creature leaves a `creature_corpses` row (x/y/z, species, expiry) the player can butcher — but only a 2D HUD card list showed them; the world itself had no corpse.

`CorpseMeshRenderer` draws each active corpse as a low slumped-carcass mound at its world position:
- tinted **deterministically per species** (dull, desaturated dead hue — same creature always the same colour),
- a pulsing additive **glint** marks an un-butchered (lootable) corpse,
- removed when the corpse expires or is butchered (no longer returned by the endpoint).

Polls `GET /api/world/creature/corpses/:worldId`; mounted in the `infrastructure` layer via `attach-world-renderers`. Corpses with no position are skipped.

### Verify
- New `tests/concordia/corpse-mesh-renderer.test.ts` — deterministic tint, fallback, spawn→pulse→remove lifecycle, null-position skip.
- 8/8 green; scoped `tsc` clean.

https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ)_