### PR TITLE
WS-A1: bulk terrain-state read route + water-updated realtime hint

### DIFF
--- a/server/emergent/water-flow-cycle.js
+++ b/server/emergent/water-flow-cycle.js
@@ -7,7 +7,7 @@
 
 import { tickWaterFlow } from "../lib/terrain-water.js";
 
-export function runWaterFlowCycle({ db } = {}) {
+export function runWaterFlowCycle({ db, io } = {}) {
   if (!db) return { ok: false, reason: "no_db" };
   let worlds = [];
   try {
@@ -15,8 +15,19 @@ export function runWaterFlowCycle({ db } = {}) {
   } catch { return { ok: true, worlds: 0 }; } // table absent
   let moved = 0;
   for (const w of worlds) {
-    try { const r = tickWaterFlow(db, w); moved += r?.cellsMoved || 0; }
-    catch { /* per-world isolation */ }
+    try {
+      const r = tickWaterFlow(db, w);
+      const cellsMoved = r?.cellsMoved || 0;
+      moved += cellsMoved;
+      // WS-A1 — hint the 3D client to refetch the water grid when the surface
+      // actually changed. A hint, not a payload: the client owns the full read
+      // via GET /api/worlds/:id/terrain. Floor-only — never break the tick.
+      if (cellsMoved > 0) {
+        try {
+          io?.to?.(`world:${w}`)?.emit?.("concordia:water-updated", { worldId: w, changed: cellsMoved });
+        } catch { /* realtime optional */ }
+      }
+    } catch { /* per-world isolation */ }
   }
   return { ok: true, worlds: worlds.length, cellsMoved: moved };
 }

--- a/server/lib/terrain-water.js
+++ b/server/lib/terrain-water.js
@@ -125,6 +125,21 @@ export function setWater(db, worldId, wx, wz, height) {
   } catch (e) { return { ok: false, error: e?.message }; }
 }
 
+/**
+ * All wet cells in a world (water_height > MIN_WATER), for the 3D client's
+ * dynamic water-surface renderer. Returns `[{ cell_x, cell_z, water_height }]`.
+ * Never throws — minimal builds without the table get `[]`.
+ */
+export function waterGridForWorld(db, worldId) {
+  if (!db || !worldId) return [];
+  try {
+    return db.prepare(`
+      SELECT cell_x, cell_z, water_height FROM world_water_cells
+      WHERE world_id = ? AND water_height > ?
+    `).all(worldId, MIN_WATER);
+  } catch { return []; }
+}
+
 /** Per-cell water depth at a world position (swim/drown reads this, not a plane). */
 export function waterDepthAt(db, worldId, wx, wz) {
   if (!db) return 0;

--- a/server/routes/worlds.js
+++ b/server/routes/worlds.js
@@ -26,6 +26,8 @@ import {
 } from "../lib/quests/quest-engine.js";
 import * as cityPresence from "../lib/city-presence.js";
 import { listActiveUprisingsWithLocation } from "../lib/uprising.js";
+import { deformationsForWorld, CELL_SIZE as TERRAIN_CELL_SIZE } from "../lib/terrain-deformation.js";
+import { waterGridForWorld } from "../lib/terrain-water.js";
 import { serverError } from "../lib/http-errors.js";
 
 // Combat anti-cheat constants. Server-side validation prevents a modified
@@ -1564,6 +1566,21 @@ export default function createWorldsRouter({ requireAuth, db }) {
       const { worldId } = req.params;
       const uprisings = listActiveUprisingsWithLocation(db, worldId);
       res.json({ ok: true, uprisings, count: uprisings.length });
+    } catch (e) {
+      res.status(500).json({ ok: false, error: e.message });
+    }
+  });
+
+  // WS-A1 — bulk terrain state for the 3D client: persisted deformation deltas +
+  // the wet-cell water grid. The client replays this on load to deform the
+  // terrain mesh + rebuild the heightfield collider, and to render the dynamic
+  // water surface. Public read (no secrets); mirrors the /nodes + /buildings GETs.
+  router.get("/:worldId/terrain", (req, res) => {
+    try {
+      const { worldId } = req.params;
+      const deformations = deformationsForWorld(db, worldId);
+      const water = waterGridForWorld(db, worldId);
+      res.json({ ok: true, cellSize: TERRAIN_CELL_SIZE, deformations, water });
     } catch (e) {
       res.status(500).json({ ok: false, error: e.message });
     }

--- a/server/server.js
+++ b/server/server.js
@@ -144,7 +144,8 @@ registerHeartbeat("signal-propagation-cycle", {
 import { runWaterFlowCycle } from "./emergent/water-flow-cycle.js";
 registerHeartbeat("water-flow-cycle", {
   frequency: 4,
-  handler: runWaterFlowCycle,
+  // Inject io so the cycle can emit concordia:water-updated hints (WS-A1).
+  handler: ({ db } = {}) => runWaterFlowCycle({ db, io: REALTIME?.io }),
 });
 
 // Living Society Phase 3 — sparks-flow payday. Pay moves along employment edges;

--- a/server/tests/terrain-grid-route.test.js
+++ b/server/tests/terrain-grid-route.test.js
@@ -1,0 +1,76 @@
+/**
+ * WS-A1 — the bulk terrain read the 3D client consumes: deformation deltas +
+ * the wet-cell water grid. Pins waterGridForWorld + the shape the route returns.
+ *
+ * Run: node --test tests/terrain-grid-route.test.js
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+import { deformationsForWorld, applyDeformation, CELL_SIZE } from "../lib/terrain-deformation.js";
+import { waterGridForWorld, setWater } from "../lib/terrain-water.js";
+
+const W = "concordia-hub";
+function mkDb() {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE world_terrain_deformations (
+      id TEXT PRIMARY KEY, world_id TEXT NOT NULL, cell_x INTEGER NOT NULL, cell_z INTEGER NOT NULL,
+      height_delta REAL NOT NULL DEFAULT 0, kind TEXT NOT NULL DEFAULT 'excavate',
+      material_id TEXT, created_at INTEGER DEFAULT 0, updated_at INTEGER DEFAULT 0,
+      UNIQUE (world_id, cell_x, cell_z)
+    );
+    CREATE TABLE world_water_cells (
+      world_id TEXT NOT NULL, cell_x INTEGER NOT NULL, cell_z INTEGER NOT NULL,
+      water_height REAL NOT NULL DEFAULT 0, updated_at INTEGER DEFAULT 0,
+      PRIMARY KEY (world_id, cell_x, cell_z)
+    );
+  `);
+  return db;
+}
+
+describe("WS-A1 — terrain grid readers", () => {
+  it("deformationsForWorld returns persisted dig deltas", () => {
+    const db = mkDb();
+    const r = applyDeformation(db, W, 100, 100, 3, "excavate");
+    assert.equal(r.ok, true);
+    const defs = deformationsForWorld(db, W);
+    assert.equal(defs.length, 1);
+    assert.ok(defs[0].height_delta < 0, "excavate lowers the cell");
+    assert.equal(typeof defs[0].cell_x, "number");
+  });
+
+  it("waterGridForWorld returns only wet cells (water_height > MIN)", () => {
+    const db = mkDb();
+    setWater(db, W, 50, 50, 1.5);  // wet
+    setWater(db, W, 70, 70, 0.0);  // dry — excluded
+    const water = waterGridForWorld(db, W);
+    assert.equal(water.length, 1);
+    assert.ok(water[0].water_height > 1, `expected wet cell, got ${water[0].water_height}`);
+  });
+
+  it("the route payload shape composes both readers + a cell size", () => {
+    const db = mkDb();
+    applyDeformation(db, W, 100, 100, 2, "excavate");
+    setWater(db, W, 50, 50, 0.8);
+    // Mirror exactly what GET /api/worlds/:worldId/terrain returns.
+    const payload = {
+      ok: true,
+      cellSize: CELL_SIZE,
+      deformations: deformationsForWorld(db, W),
+      water: waterGridForWorld(db, W),
+    };
+    assert.equal(payload.ok, true);
+    assert.equal(payload.cellSize, CELL_SIZE);
+    assert.equal(payload.deformations.length, 1);
+    assert.equal(payload.water.length, 1);
+  });
+
+  it("absent tables → empty arrays, never throws", () => {
+    const db = new Database(":memory:");
+    assert.deepEqual(deformationsForWorld(db, W), []);
+    assert.deepEqual(waterGridForWorld(db, W), []);
+    assert.deepEqual(waterGridForWorld(null, W), []);
+  });
+});


### PR DESCRIPTION
## Destructible-world Part A (server) — give the 3D client a way to read terrain state

The deformation + hydrology substrate is already live (`world_terrain_deformations`, the `terrain-water.js` flow solver, the `water-flow-cycle` heartbeat). The client just had no bulk read. This is the server enabler:

- **`GET /api/worlds/:worldId/terrain`** → `{ ok, cellSize, deformations: [{cell_x,cell_z,height_delta,kind,material_id}], water: [{cell_x,cell_z,water_height}] }`. Mirrors the existing `/nodes` + `/buildings` GETs (public read, cookie/header auth, never throws → `[]` on minimal builds). Wraps the existing `deformationsForWorld` + a new tiny `waterGridForWorld` reader in `terrain-water.js`.
- **`concordia:water-updated` hint**: `water-flow-cycle` now emits a throttled `{worldId, changed}` when cells actually move, so the client refetches the grid. A *hint*, not a payload — the client owns the full read. The registration injects `REALTIME.io` (same pattern as `npc-conversation-initiator`); the handler closure runs post-boot so the pre-declaration reference is safe.

Next slices (this PR is the enabler): A2 (store+rebuild the Rapier heightfield collider), A3 (deform the terrain mesh), A4 (dynamic water surface) — all behind `CONCORD_TERRAIN_DEFORM_RENDER` / `CONCORD_HYDRO_RENDER` kill-switches, verified in-engine.

### Verify
- New `server/tests/terrain-grid-route.test.js` (4) — deformation read, wet-cell-only water read, composed payload shape, absent-table safety.
- Existing `terrain-deformation.test.js` (7) green; `node --check` clean on worlds.js / terrain-water.js / water-flow-cycle.js / server.js.

https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ)_