### PR TITLE
WS-A2: store + rebuild the Rapier heightfield collider (terrain deform unblocker)

### DIFF
--- a/concord-frontend/lib/world-lens/physics-world.ts
+++ b/concord-frontend/lib/world-lens/physics-world.ts
@@ -10,6 +10,7 @@
  */
 
 import { canJump, shouldFlushBuffer, cutJump } from './jump-forgiveness';
+import { bakeDeltasIntoHeightmap } from './terrain-deform-math';
 
 type RapierType = typeof import('@dimforge/rapier3d-compat');
 type WorldType   = InstanceType<RapierType['World']>;
@@ -98,6 +99,15 @@ class PhysicsWorld {
   private bodies:      Map<string, RigidBody>  = new Map();
   private colliders:   Map<string, Collider>   = new Map();
   private kinematic:   Map<string, KinematicState> = new Map();
+  // WS-A2 — the terrain heightfield collider handle + its source heightmap, so
+  // deformations can SWAP it (Rapier heightfields are immutable: removeCollider
+  // + createCollider). _terrainHmData is the pristine base (normalized 0..1);
+  // rebuildHeightfieldWithDeltas bakes deltas into a copy and re-creates.
+  private _terrainCollider: Collider | null = null;
+  private _terrainHmData: Float32Array | null = null;
+  private _terrainHmW = 0;
+  private _terrainHmH = 0;
+  private _terrainScale: { x: number; y: number; z: number } = { x: 2000, y: 80, z: 2000 };
   // Re-entrancy guard. Rapier's WASM bindings panic ("recursive use of an
   // object detected which would lead to unsafe aliasing in rust") if JS
   // re-enters the world while another method is still executing on it —
@@ -181,7 +191,47 @@ class PhysicsWorld {
         { x: worldScale.x, y: worldScale.y, z: worldScale.z },
       );
       desc.setTranslation(0, 0, 0);
-      this.world.createCollider(desc);
+      // WS-A2 — keep the handle + a pristine copy of the source heightmap so the
+      // terrain can be deformed later via removeCollider + re-create.
+      this._terrainCollider = this.world.createCollider(desc);
+      this._terrainHmData = new Float32Array(hmData);
+      this._terrainHmW = hmWidth;
+      this._terrainHmH = hmHeight;
+      this._terrainScale = { x: worldScale.x, y: worldScale.y, z: worldScale.z };
+    }, undefined);
+  }
+
+  /**
+   * WS-A2 — deform the terrain collider to match server deformations. Bakes the
+   * per-cell height deltas (metres, keyed "cx,cz") into a copy of the pristine
+   * base heightmap, removes the current heightfield collider, and creates a new
+   * one. Rapier heightfields are immutable, so this swap is the only path.
+   *
+   * CALLER MUST DEBOUNCE — collider recreate is the expensive op; never call
+   * per-frame. No-op until a base heightfield has been registered.
+   */
+  rebuildHeightfieldWithDeltas(cellDeltas: Map<string, number>, cellSize = 10, maxElev?: number): void {
+    this._guard('rebuildHeightfieldWithDeltas', () => {
+      if (!this.RAPIER || !this.world || !this._terrainHmData) return;
+      const RAPIER = this.RAPIER;
+      const elev = Number.isFinite(maxElev as number) ? (maxElev as number) : this._terrainScale.y;
+      const baked = bakeDeltasIntoHeightmap(
+        this._terrainHmData, this._terrainHmW, this._terrainHmH,
+        cellDeltas, cellSize, elev, this._terrainScale.x,
+      );
+      // Remove the old heightfield, then create the deformed one.
+      if (this._terrainCollider) {
+        try { this.world.removeCollider(this._terrainCollider, false); } catch { /* already gone */ }
+        this._terrainCollider = null;
+      }
+      const desc = RAPIER.ColliderDesc.heightfield(
+        this._terrainHmH - 1,
+        this._terrainHmW - 1,
+        baked,
+        { x: this._terrainScale.x, y: this._terrainScale.y, z: this._terrainScale.z },
+      );
+      desc.setTranslation(0, 0, 0);
+      this._terrainCollider = this.world.createCollider(desc);
     }, undefined);
   }
 

--- a/concord-frontend/lib/world-lens/terrain-deform-math.ts
+++ b/concord-frontend/lib/world-lens/terrain-deform-math.ts
@@ -1,0 +1,107 @@
+// concord-frontend/lib/world-lens/terrain-deform-math.ts
+//
+// Destructible-world Part A — PURE math for baking server terrain-deformation
+// deltas into the client heightmap (so the Rapier heightfield collider + the
+// rendered mesh agree with the server's getElevationAt = base + delta).
+//
+// Coordinate conventions (must match both ends, verified against the code):
+//   • Server cell (cx,cz): cellOf(wx,wz) = floor(wx/CELL_SIZE) — terrain-deformation.js.
+//     A cell spans world x∈[cx*CELL, (cx+1)*CELL), z∈[cz*CELL, (cz+1)*CELL).
+//   • Client heightmap sample: nx = (wx + WORLD_SIZE/2)/WORLD_SIZE,
+//     ix = clamp(floor(nx*hmW), 0, hmW-1); hm value is normalized 0..1, ×maxElev
+//     gives metres — TerrainRenderer.getElevationAt.
+//
+// These two functions have NO three/Rapier dependency so they're fully
+// unit-testable; the physics + mesh code consumes them.
+
+export interface HmSample {
+  ix: number;
+  iz: number;
+}
+
+/** Parse a "cx,cz" cell key into numbers (null on malformed). */
+export function parseCellKey(key: string): { cx: number; cz: number } | null {
+  const m = /^(-?\d+),(-?\d+)$/.exec(String(key));
+  if (!m) return null;
+  return { cx: Number(m[1]), cz: Number(m[2]) };
+}
+
+/** World X (metres) → heightmap column index, clamped. */
+export function worldXToSample(wx: number, hmW: number, worldSize: number): number {
+  const nx = (wx + worldSize / 2) / worldSize;
+  return Math.max(0, Math.min(hmW - 1, Math.floor(nx * hmW)));
+}
+
+/**
+ * The set of heightmap samples (ix,iz) covered by deformation cell (cx,cz).
+ * Maps the cell's world rectangle to the inclusive sample-index range it spans
+ * (a 10m cell covers ≥1 sample at any resolution; at coarse resolution several
+ * cells can share a sample, which is fine — the last bake wins per sample but we
+ * sum deltas before baking so order is irrelevant).
+ */
+export function terrainCellToHmSamples(
+  cx: number,
+  cz: number,
+  cellSize: number,
+  hmW: number,
+  hmH: number,
+  worldSize: number,
+): HmSample[] {
+  const xLo = worldXToSample(cx * cellSize, hmW, worldSize);
+  const xHi = worldXToSample((cx + 1) * cellSize - 1e-3, hmW, worldSize);
+  const zLo = worldXToSample(cz * cellSize, hmH, worldSize);
+  const zHi = worldXToSample((cz + 1) * cellSize - 1e-3, hmH, worldSize);
+  const out: HmSample[] = [];
+  for (let iz = zLo; iz <= zHi; iz++) {
+    for (let ix = xLo; ix <= xHi; ix++) out.push({ ix, iz });
+  }
+  return out;
+}
+
+/**
+ * Bake per-cell height deltas (metres) into a COPY of the base heightmap.
+ * Each affected sample's normalized height gets `+= delta / maxElev`. The result
+ * is clamped to a sane band so a deep dig can't drive the heightfield wild.
+ * Returns a new Float32Array (base is never mutated).
+ */
+export function bakeDeltasIntoHeightmap(
+  baseHm: Float32Array,
+  hmW: number,
+  hmH: number,
+  cellDeltas: Map<string, number>,
+  cellSize: number,
+  maxElev: number,
+  worldSize: number,
+): Float32Array {
+  const out = new Float32Array(baseHm); // copy
+  if (!cellDeltas || cellDeltas.size === 0) return out;
+  for (const [key, delta] of cellDeltas) {
+    if (!Number.isFinite(delta) || delta === 0) continue;
+    const cell = parseCellKey(key);
+    if (!cell) continue;
+    const dNorm = delta / maxElev;
+    for (const { ix, iz } of terrainCellToHmSamples(cell.cx, cell.cz, cellSize, hmW, hmH, worldSize)) {
+      const idx = iz * hmW + ix;
+      if (idx < 0 || idx >= out.length) continue;
+      // clamp to [-0.5, 1.5] normalized (×maxElev metres) — generous but bounded
+      out[idx] = Math.max(-0.5, Math.min(1.5, out[idx] + dNorm));
+    }
+  }
+  return out;
+}
+
+/**
+ * Fold a list of server deformation rows into a Map<"cx,cz", summedDelta>.
+ * Rows: [{ cell_x, cell_z, height_delta }]. Multiple rows for one cell sum.
+ */
+export function deltaMapFromRows(
+  rows: Array<{ cell_x: number; cell_z: number; height_delta: number }>,
+): Map<string, number> {
+  const m = new Map<string, number>();
+  for (const r of rows || []) {
+    if (r == null || !Number.isFinite(r.height_delta)) continue;
+    const key = `${r.cell_x},${r.cell_z}`;
+    m.set(key, (m.get(key) || 0) + Number(r.height_delta));
+  }
+  return m;
+}

--- a/concord-frontend/tests/concordia/terrain-deform-math.test.ts
+++ b/concord-frontend/tests/concordia/terrain-deform-math.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseCellKey,
+  worldXToSample,
+  terrainCellToHmSamples,
+  bakeDeltasIntoHeightmap,
+  deltaMapFromRows,
+} from '@/lib/world-lens/terrain-deform-math';
+
+// WS-A2 — pure heightmap-bake math. These functions keep the Rapier collider +
+// the rendered mesh agreeing with the server's getElevationAt (base + delta).
+
+const WORLD = 2000;
+const MAXELEV = 80;
+const CELL = 10;
+
+describe('WS-A2 — terrain deform math (pure)', () => {
+  it('parseCellKey handles negatives + rejects garbage', () => {
+    expect(parseCellKey('3,-5')).toEqual({ cx: 3, cz: -5 });
+    expect(parseCellKey('nope')).toBeNull();
+  });
+
+  it('worldXToSample maps world centre to mid heightmap + clamps the edges', () => {
+    expect(worldXToSample(0, 256, WORLD)).toBe(128); // centre
+    expect(worldXToSample(-99999, 256, WORLD)).toBe(0); // clamp low
+    expect(worldXToSample(99999, 256, WORLD)).toBe(255); // clamp high
+  });
+
+  it('a deformation cell maps to at least one heightmap sample', () => {
+    const samples = terrainCellToHmSamples(0, 0, CELL, 256, 256, WORLD);
+    expect(samples.length).toBeGreaterThanOrEqual(1);
+    // cell (0,0) spans world x∈[0,10) → just east of centre
+    for (const s of samples) {
+      expect(s.ix).toBeGreaterThanOrEqual(128);
+      expect(s.ix).toBeLessThan(132);
+    }
+  });
+
+  it('baking a dig delta LOWERS the covered samples; base is untouched', () => {
+    const base = new Float32Array(256 * 256).fill(0.5);
+    const deltas = new Map<string, number>([['0,0', -8]]); // dig 8m
+    const out = bakeDeltasIntoHeightmap(base, 256, 256, deltas, CELL, MAXELEV, WORLD);
+    // base unchanged (copy semantics)
+    expect(base[128 * 256 + 128]).toBeCloseTo(0.5, 6);
+    // covered sample lowered by 8/80 = 0.1
+    const s = terrainCellToHmSamples(0, 0, CELL, 256, 256, WORLD)[0];
+    expect(out[s.iz * 256 + s.ix]).toBeCloseTo(0.4, 5);
+    // an untouched far sample is unchanged
+    expect(out[0]).toBeCloseTo(0.5, 6);
+  });
+
+  it('baking clamps to the sane normalized band', () => {
+    const base = new Float32Array(16 * 16).fill(0.0);
+    const deltas = new Map<string, number>([['0,0', -9999]]);
+    const out = bakeDeltasIntoHeightmap(base, 16, 16, deltas, CELL, MAXELEV, WORLD);
+    for (const v of out) expect(v).toBeGreaterThanOrEqual(-0.5);
+  });
+
+  it('empty deltas → an unchanged copy', () => {
+    const base = new Float32Array([0.1, 0.2, 0.3, 0.4]);
+    const out = bakeDeltasIntoHeightmap(base, 2, 2, new Map(), CELL, MAXELEV, WORLD);
+    for (let i = 0; i < base.length; i++) expect(out[i]).toBeCloseTo(base[i], 6);
+    expect(out).not.toBe(base); // still a copy
+  });
+
+  it('deltaMapFromRows sums multiple rows per cell', () => {
+    const m = deltaMapFromRows([
+      { cell_x: 1, cell_z: 2, height_delta: -3 },
+      { cell_x: 1, cell_z: 2, height_delta: -2 },
+      { cell_x: 5, cell_z: 5, height_delta: 4 },
+    ]);
+    expect(m.get('1,2')).toBe(-5);
+    expect(m.get('5,5')).toBe(4);
+  });
+});


### PR DESCRIPTION
## Destructible-world Part A — the one real physics blocker, fixed

`createHeightfieldCollider` discarded the collider handle, so the terrain could never change (Rapier heightfields are immutable — you swap, not mutate). This stores the handle + a pristine copy of the source heightmap and adds:

- **`rebuildHeightfieldWithDeltas(cellDeltas, cellSize?, maxElev?)`** — bakes the server's per-cell height deltas into a copy of the base heightmap, `removeCollider(old)` + `createCollider(new)`. The swap that makes "dig a pit, walk into a real hole" possible. Caller **must debounce** (the recreate is the expensive op; never per-frame). No-op until a base heightfield is registered.

- New **`lib/world-lens/terrain-deform-math.ts`** (pure, no three/Rapier): `terrainCellToHmSamples`, `bakeDeltasIntoHeightmap`, `deltaMapFromRows`, `parseCellKey`, `worldXToSample`. These match the **server `cellOf` = `floor(wx/10)`** and the **client `getElevationAt` `nx=(wx+1000)/2000`** conventions exactly, so the collider + the rendered mesh + the server `getElevationAt` all agree.

### Verify
- New `tests/concordia/terrain-deform-math.test.ts` (7) — cell→sample mapping, dig lowers samples, copy semantics, clamp band, multi-row delta sum.
- Scoped `tsc` clean on `terrain-deform-math.ts` + `physics-world.ts`.
- The Rapier swap is a thin `_guard`-wrapped wrapper following the existing collider pattern; the walk-into-hole behavior is verified in-engine by the user (per plan). Next: A3 wires this to the mesh + replays `GET …/terrain` on load + `concordia:terrain-deformed`, behind `CONCORD_TERRAIN_DEFORM_RENDER`.

https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ)_