### PR TITLE
WS-A3: deform the terrain mesh + avatar surface + collider from server deltas

### DIFF
--- a/concord-frontend/components/world-lens/ConcordiaScene.tsx
+++ b/concord-frontend/components/world-lens/ConcordiaScene.tsx
@@ -265,6 +265,9 @@ export default function ConcordiaScene({
   // WS2 — world-state renderers (resource nodes / crops / claims / VFX) mounted
   // into the infrastructure + particles layers; disposed with the scene.
   const worldRenderersRef = useRef<{ dispose(): void } | null>(null);
+  // WS-A3 — terrain-deformation orchestrator (mesh re-push + collider rebuild
+  // from server deltas); disposed with the scene.
+  const terrainDeformRef = useRef<{ dispose(): void } | null>(null);
   const probeManagerRef = useRef<
     import('@/lib/world-lens/reflection-probes').ReflectionProbeManager | null
   >(null);
@@ -341,13 +344,42 @@ export default function ConcordiaScene({
 
       // Listen for terrain-ready to register heightfield collider
       function onTerrainPhysics(e: Event) {
-        const { hmData, hmWidth, hmHeight } = (e as CustomEvent).detail ?? {};
+        const { hmData, hmWidth, hmHeight, terrainGroup } = (e as CustomEvent).detail ?? {};
         if (hmData) {
           physicsWorld.createHeightfieldCollider(hmData, hmWidth, hmHeight, {
             x: 2000, // TERRAIN_SIZE
             y: 80, // maxElevation
             z: 2000,
           });
+        }
+        // WS-A3 — once terrain + its collider exist, attach the deformation
+        // orchestrator: replay GET /terrain + live concordia:terrain-deformed →
+        // deform the mesh chunks + debounced collider rebuild. Kill-switch
+        // CONCORD_TERRAIN_DEFORM_RENDER (default on). One-shot per scene.
+        if (terrainGroup && !terrainDeformRef.current) {
+          void (async () => {
+            try {
+              const [{ attachTerrainDeformation }, { getSocket }] = await Promise.all([
+                import('@/lib/world-lens/attach-terrain-deformation'),
+                import('@/lib/realtime/socket'),
+              ]);
+              if (disposed) return;
+              const worldId =
+                (typeof window !== 'undefined' && window.localStorage?.getItem('concordia:activeWorldId')) ||
+                'concordia-hub';
+              const enabled = (window as { __concordClientConfig?: { CONCORD_TERRAIN_DEFORM_RENDER?: unknown } })
+                .__concordClientConfig?.CONCORD_TERRAIN_DEFORM_RENDER !== 0;
+              terrainDeformRef.current = attachTerrainDeformation({
+                worldId,
+                getTerrainGroup: () => terrainGroup as { children: unknown[] },
+                physicsWorld: physicsWorld as unknown as {
+                  rebuildHeightfieldWithDeltas?: (m: Map<string, number>, cell?: number, maxElev?: number) => void;
+                },
+                socket: getSocket() as unknown as { on(ev: string, cb: (p: unknown) => void): void; off(ev: string, cb: (p: unknown) => void): void },
+                enabled,
+              });
+            } catch { /* deformation is progressive enhancement */ }
+          })();
         }
       }
       // @resource-leak-ok: terrain-ready is a one-shot scene-init signal; ConcordiaScene unmounts the whole canvas, not the listener individually
@@ -1533,6 +1565,8 @@ export default function ConcordiaScene({
       domeCleanupRef.current = null;
       try { worldRenderersRef.current?.dispose(); } catch { /* ignore */ }
       worldRenderersRef.current = null;
+      try { terrainDeformRef.current?.dispose(); } catch { /* ignore */ }
+      terrainDeformRef.current = null;
 
       ssgiPassRef.current?.dispose();
       ssgiPassRef.current = null;

--- a/concord-frontend/components/world-lens/TerrainRenderer.tsx
+++ b/concord-frontend/components/world-lens/TerrainRenderer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef, useCallback } from 'react';
+import { getDeltaAt as getTerrainDeltaAt } from '@/lib/world-lens/terrain-deform-store';
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -239,7 +240,10 @@ export default function TerrainRenderer({
     const bottom = h01 * (1 - fx) + h11 * fx;
     const elevation = top * (1 - fz) + bottom * fz;
 
-    return elevation * 80; // maxElevation
+    // WS-A3 — add the live deformation delta so the avatar Y-clamp + raycasts
+    // sit on the DEFORMED surface (the store is base+delta's delta half; matches
+    // the deformed mesh chunks + the rebuilt collider). 0 when undeformed.
+    return elevation * 80 + getTerrainDeltaAt(worldX, worldZ); // maxElevation
   }, []);
 
   // ── Build terrain geometry ────────────────────────────────────

--- a/concord-frontend/lib/world-lens/attach-terrain-deformation.ts
+++ b/concord-frontend/lib/world-lens/attach-terrain-deformation.ts
@@ -1,0 +1,208 @@
+// concord-frontend/lib/world-lens/attach-terrain-deformation.ts
+//
+// Destructible-world Part A (A3) — the orchestrator that makes terrain
+// deformation real end-to-end on the client. It:
+//   1. fetches GET /api/worlds/:id/terrain on load → seeds the delta store;
+//   2. subscribes to `concordia:terrain-deformed` socket events → patches one
+//      cell in the store live;
+//   3. on any store change, re-pushes the affected terrain mesh chunk vertices
+//      (visual) AND schedules a DEBOUNCED Rapier heightfield collider rebuild
+//      (physics) so a dug pit is a real, walk-into-able hole;
+//   4. fires a dust `concordia:particle-effect` at the dug cell.
+//
+// The store is the single source of truth (TerrainRenderer.getElevationAt also
+// reads it, so the avatar Y-clamp + raycasts follow the deformed surface).
+//
+// Guarded by `CONCORD_TERRAIN_DEFORM_RENDER` (default on): when 0, attach is a
+// no-op and the scene keeps today's static terrain.
+//
+// Pure helper `planChunkVertexUpdates` (no three) is unit-tested; the
+// orchestrator is a thin consumer.
+
+import { authedHeaders, getInjectedJwt } from '@/lib/auth-bridge';
+import {
+  setAllDeltas, setCellDelta, setCellSize, snapshotDeltas, subscribe, resetDeformStore, getCellSize,
+} from './terrain-deform-store';
+import { deltaMapFromRows } from './terrain-deform-math';
+import { TERRAIN_MAX_ELEV } from './terrain-deform-constants';
+
+type Vec3 = { x: number; y: number; z: number };
+
+/** Minimal three-ish shapes we touch (kept loose to avoid a hard three dep). */
+interface PositionAttr {
+  count: number;
+  getX(i: number): number;
+  getY(i: number): number;
+  getZ(i: number): number;
+  setY(i: number, v: number): void;
+  needsUpdate: boolean;
+}
+interface ChunkGeometry {
+  getAttribute(name: 'position'): PositionAttr;
+  computeVertexNormals(): void;
+}
+interface ChunkMesh {
+  position: Vec3;
+  geometry: ChunkGeometry;
+}
+
+export interface PlannedUpdate {
+  i: number;
+  newY: number;
+}
+
+/**
+ * PURE: given a chunk's vertices (local positions + the chunk's world offset),
+ * the cumulative cell→delta map, and what's ALREADY baked into the mesh
+ * (appliedByCell), return the Y updates needed + the new applied map for the
+ * cells this chunk touched. Increments are `cumulative - applied` so repeated
+ * events never double-count.
+ */
+export function planChunkVertexUpdates(
+  verts: Array<{ i: number; wx: number; wz: number; curY: number }>,
+  cumulative: Map<string, number>,
+  appliedByCell: Map<string, number>,
+  cellSize: number,
+): { updates: PlannedUpdate[]; touchedCells: Map<string, number> } {
+  const updates: PlannedUpdate[] = [];
+  const touchedCells = new Map<string, number>();
+  for (const v of verts) {
+    const cx = Math.floor(v.wx / cellSize);
+    const cz = Math.floor(v.wz / cellSize);
+    const key = `${cx},${cz}`;
+    const want = cumulative.get(key) || 0;
+    const have = appliedByCell.get(key) || 0;
+    const inc = want - have;
+    if (inc === 0) continue;
+    updates.push({ i: v.i, newY: v.curY + inc });
+    touchedCells.set(key, want);
+  }
+  return { updates, touchedCells };
+}
+
+export interface TerrainDeformHandle {
+  dispose(): void;
+}
+
+export interface AttachTerrainDeformationOpts {
+  worldId: string;
+  apiBase?: string;
+  /** Returns the live terrain THREE.Group (chunk meshes are its children). */
+  getTerrainGroup: () => { children: unknown[] } | null;
+  /** physics-world singleton with rebuildHeightfieldWithDeltas. */
+  physicsWorld: { rebuildHeightfieldWithDeltas?: (m: Map<string, number>, cell?: number, maxElev?: number) => void } | null;
+  /** Socket.io-ish client for `concordia:terrain-deformed`. */
+  socket?: { on(ev: string, cb: (p: unknown) => void): void; off(ev: string, cb: (p: unknown) => void): void } | null;
+  /** Debounce window for the collider rebuild (ms). */
+  rebuildDebounceMs?: number;
+  enabled?: boolean;
+}
+
+export function attachTerrainDeformation(opts: AttachTerrainDeformationOpts): TerrainDeformHandle {
+  if (opts.enabled === false) return { dispose() { /* disabled */ } };
+
+  const apiBase = opts.apiBase ?? '';
+  const appliedByCell = new Map<string, number>();
+  let rebuildTimer: ReturnType<typeof setTimeout> | null = null;
+  let disposed = false;
+  const debounceMs = opts.rebuildDebounceMs ?? 450;
+
+  function scheduleColliderRebuild(): void {
+    if (rebuildTimer) clearTimeout(rebuildTimer);
+    rebuildTimer = setTimeout(() => {
+      rebuildTimer = null;
+      if (disposed) return;
+      try {
+        opts.physicsWorld?.rebuildHeightfieldWithDeltas?.(snapshotDeltas(), undefined, TERRAIN_MAX_ELEV);
+      } catch { /* physics optional */ }
+    }, debounceMs);
+  }
+
+  // Walk the terrain chunk meshes and push the deformed Y onto changed cells.
+  function applyToMesh(): void {
+    const group = opts.getTerrainGroup?.();
+    if (!group || !Array.isArray(group.children)) return;
+    const cumulative = snapshotDeltas();
+    const cellSize = getCellSizeSafe();
+    for (const child of group.children as ChunkMesh[]) {
+      const geo = child?.geometry;
+      const pos = geo?.getAttribute?.('position');
+      if (!pos) continue;
+      const ox = child.position?.x ?? 0;
+      const oz = child.position?.z ?? 0;
+      const verts: Array<{ i: number; wx: number; wz: number; curY: number }> = [];
+      for (let i = 0; i < pos.count; i++) {
+        verts.push({ i, wx: pos.getX(i) + ox, wz: pos.getZ(i) + oz, curY: pos.getY(i) });
+      }
+      const { updates } = planChunkVertexUpdates(verts, cumulative, appliedByCell, cellSize);
+      if (updates.length === 0) continue;
+      for (const u of updates) pos.setY(u.i, u.newY);
+      pos.needsUpdate = true;
+      try { geo.computeVertexNormals(); } catch { /* ok */ }
+    }
+    // Mark every cumulative cell as applied (mesh now matches the store).
+    appliedByCell.clear();
+    for (const [k, v] of cumulative) appliedByCell.set(k, v);
+  }
+
+  function getCellSizeSafe(): number {
+    return getCellSize();
+  }
+
+  // Initial load: fetch the bulk terrain state.
+  async function loadInitial(): Promise<void> {
+    try {
+      const headers = authedHeaders();
+      const tok = getInjectedJwt();
+      if (tok) headers.Authorization = `Bearer ${tok}`;
+      const res = await fetch(`${apiBase}/api/worlds/${opts.worldId}/terrain`, { headers });
+      if (!res.ok) return;
+      const data = (await res.json()) as { cellSize?: number; deformations?: Array<{ cell_x: number; cell_z: number; height_delta: number }> };
+      if (data?.cellSize) setCellSize(data.cellSize);
+      if (Array.isArray(data?.deformations) && data.deformations.length > 0) {
+        setAllDeltas(deltaMapFromRows(data.deformations));
+      }
+    } catch { /* render nothing new on failure */ }
+  }
+
+  // Live patch from the socket.
+  function onDeformed(payload: unknown): void {
+    const p = payload as { cell?: { cx: number; cz: number }; newDelta?: number } | undefined;
+    if (!p?.cell || typeof p.newDelta !== 'number') return;
+    const key = `${p.cell.cx},${p.cell.cz}`;
+    if (setCellDelta(key, p.newDelta)) {
+      // dust at the dug cell
+      try {
+        const cs = getCellSizeSafe();
+        const wx = p.cell.cx * cs + cs / 2;
+        const wz = p.cell.cz * cs + cs / 2;
+        window.dispatchEvent(new CustomEvent('concordia:particle-effect', {
+          detail: { type: 'dust', position: { x: wx, y: 1, z: wz }, duration: 700, intensity: 1 },
+        }));
+      } catch { /* vfx optional */ }
+    }
+  }
+
+  // React to any store change → mesh re-push + debounced collider rebuild.
+  const unsub = subscribe(() => {
+    if (disposed) return;
+    applyToMesh();
+    scheduleColliderRebuild();
+  });
+
+  if (opts.socket) opts.socket.on('concordia:terrain-deformed', onDeformed);
+  void loadInitial();
+
+  return {
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      if (rebuildTimer) clearTimeout(rebuildTimer);
+      rebuildTimer = null;
+      try { unsub(); } catch { /* ok */ }
+      if (opts.socket) { try { opts.socket.off('concordia:terrain-deformed', onDeformed); } catch { /* ok */ } }
+      resetDeformStore();
+      appliedByCell.clear();
+    },
+  };
+}

--- a/concord-frontend/lib/world-lens/terrain-deform-constants.ts
+++ b/concord-frontend/lib/world-lens/terrain-deform-constants.ts
@@ -1,0 +1,12 @@
+// Destructible-world Part A — shared constants for the terrain-deform client.
+// Kept in their own tiny module so the pure store + the orchestrator + tests
+// don't pull in three/Rapier.
+
+/** Default deformation cell size in metres (server CONCORD_TERRAIN_CELL_M, 10). */
+export const CELL_SIZE_DEFAULT = 10;
+
+/** Terrain max elevation in metres (client maxElevation, server WORLD scale.y). */
+export const TERRAIN_MAX_ELEV = 80;
+
+/** Terrain world size in metres (TERRAIN_SIZE / WORLD_SIZE — both 2000). */
+export const TERRAIN_WORLD_SIZE = 2000;

--- a/concord-frontend/lib/world-lens/terrain-deform-store.ts
+++ b/concord-frontend/lib/world-lens/terrain-deform-store.ts
@@ -1,0 +1,81 @@
+// concord-frontend/lib/world-lens/terrain-deform-store.ts
+//
+// Destructible-world Part A — the single source of truth for terrain
+// deformation deltas on the client. The server's getElevationAt is base+delta;
+// this store holds the per-cell delta (metres) so EVERY client consumer agrees:
+//   • TerrainRenderer.getElevationAt adds getDeltaAt() → avatar Y-clamp + raycasts
+//     sit on the deformed surface;
+//   • the terrain mesh chunks displace by the delta (visual);
+//   • physics-world.rebuildHeightfieldWithDeltas bakes the same map (collider).
+//
+// One module-level singleton (the scene is a single world at a time). Pure
+// readers (`getDeltaAt`, `cellKeyForWorld`) are unit-testable with no three/DOM.
+
+import { CELL_SIZE_DEFAULT } from './terrain-deform-constants';
+
+let cellSize = CELL_SIZE_DEFAULT;
+const deltas = new Map<string, number>(); // "cx,cz" → cumulative delta (metres)
+const listeners = new Set<(changed: Set<string>) => void>();
+
+/** Cell key for a world position, using the active cell size. */
+export function cellKeyForWorld(wx: number, wz: number): string {
+  const cx = Math.floor(wx / cellSize);
+  const cz = Math.floor(wz / cellSize);
+  return `${cx},${cz}`;
+}
+
+/** Delta (metres) at a world position; 0 when undeformed. Hot path — cheap. */
+export function getDeltaAt(wx: number, wz: number): number {
+  if (deltas.size === 0) return 0;
+  return deltas.get(cellKeyForWorld(wx, wz)) || 0;
+}
+
+/** Set the active cell size (from the server's GET …/terrain `cellSize`). */
+export function setCellSize(size: number): void {
+  if (Number.isFinite(size) && size > 0) cellSize = size;
+}
+
+export function getCellSize(): number {
+  return cellSize;
+}
+
+/** Replace the whole delta map (initial load from GET …/terrain). */
+export function setAllDeltas(map: Map<string, number>): void {
+  const changed = new Set<string>([...deltas.keys(), ...map.keys()]);
+  deltas.clear();
+  for (const [k, v] of map) if (v !== 0) deltas.set(k, v);
+  emit(changed);
+}
+
+/** Patch a single cell (live `concordia:terrain-deformed`). Returns true if changed. */
+export function setCellDelta(cellKey: string, delta: number): boolean {
+  const prev = deltas.get(cellKey) || 0;
+  if (prev === delta) return false;
+  if (delta === 0) deltas.delete(cellKey);
+  else deltas.set(cellKey, delta);
+  emit(new Set([cellKey]));
+  return true;
+}
+
+/** Snapshot of all deltas (for the collider rebuild + mesh apply). */
+export function snapshotDeltas(): Map<string, number> {
+  return new Map(deltas);
+}
+
+export function subscribe(cb: (changed: Set<string>) => void): () => void {
+  listeners.add(cb);
+  return () => listeners.delete(cb);
+}
+
+/** Reset (scene teardown / world switch). */
+export function resetDeformStore(): void {
+  deltas.clear();
+  cellSize = CELL_SIZE_DEFAULT;
+  listeners.clear();
+}
+
+function emit(changed: Set<string>): void {
+  for (const cb of listeners) {
+    try { cb(changed); } catch { /* listener must not break the store */ }
+  }
+}

--- a/concord-frontend/tests/concordia/terrain-deform-store.test.ts
+++ b/concord-frontend/tests/concordia/terrain-deform-store.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getDeltaAt, setAllDeltas, setCellDelta, setCellSize, getCellSize,
+  cellKeyForWorld, snapshotDeltas, subscribe, resetDeformStore,
+} from '@/lib/world-lens/terrain-deform-store';
+import { planChunkVertexUpdates } from '@/lib/world-lens/attach-terrain-deformation';
+
+describe('WS-A3 — terrain deform store', () => {
+  beforeEach(() => resetDeformStore());
+
+  it('getDeltaAt is 0 when undeformed', () => {
+    expect(getDeltaAt(123, 456)).toBe(0);
+  });
+
+  it('cellKeyForWorld floors by the active cell size', () => {
+    setCellSize(10);
+    expect(cellKeyForWorld(0, 0)).toBe('0,0');
+    expect(cellKeyForWorld(15, 25)).toBe('1,2');
+    expect(cellKeyForWorld(-5, -5)).toBe('-1,-1');
+  });
+
+  it('setAllDeltas replaces, getDeltaAt resolves a world point to its cell delta', () => {
+    setCellSize(10);
+    setAllDeltas(new Map([['0,0', -8], ['1,2', 4]]));
+    expect(getDeltaAt(5, 5)).toBe(-8);   // cell 0,0
+    expect(getDeltaAt(15, 25)).toBe(4);  // cell 1,2
+    expect(getDeltaAt(999, 999)).toBe(0); // untouched
+  });
+
+  it('setCellDelta patches one cell + notifies subscribers; 0 removes it', () => {
+    setCellSize(10);
+    const changed: string[] = [];
+    const unsub = subscribe((c) => changed.push(...c));
+    expect(setCellDelta('3,3', -5)).toBe(true);
+    expect(getDeltaAt(35, 35)).toBe(-5);
+    expect(setCellDelta('3,3', -5)).toBe(false); // no-op when unchanged
+    expect(setCellDelta('3,3', 0)).toBe(true);   // 0 clears
+    expect(snapshotDeltas().has('3,3')).toBe(false);
+    unsub();
+    expect(changed).toContain('3,3');
+  });
+
+  it('reset clears deltas + restores default cell size', () => {
+    setCellSize(25);
+    setCellDelta('0,0', -3);
+    resetDeformStore();
+    expect(snapshotDeltas().size).toBe(0);
+    expect(getCellSize()).toBe(10);
+  });
+});
+
+describe('WS-A3 — planChunkVertexUpdates (pure mesh plan)', () => {
+  it('returns increment = cumulative - applied so repeated events never double-count', () => {
+    const verts = [
+      { i: 0, wx: 5, wz: 5, curY: 40 },   // cell 0,0
+      { i: 1, wx: 95, wz: 5, curY: 40 },  // cell 9,0 (untouched)
+    ];
+    const cumulative = new Map([['0,0', -8]]);
+    const applied = new Map<string, number>();
+    const r1 = planChunkVertexUpdates(verts, cumulative, applied, 10);
+    expect(r1.updates).toEqual([{ i: 0, newY: 32 }]); // 40 + (-8 - 0)
+    expect(r1.touchedCells.get('0,0')).toBe(-8);
+
+    // Now applied catches up; a re-run with the SAME cumulative yields no update.
+    const r2 = planChunkVertexUpdates(verts, cumulative, new Map([['0,0', -8]]), 10);
+    expect(r2.updates).toEqual([]);
+
+    // A deeper dig only applies the increment.
+    const r3 = planChunkVertexUpdates(verts, new Map([['0,0', -12]]), new Map([['0,0', -8]]), 10);
+    expect(r3.updates).toEqual([{ i: 0, newY: 36 }]); // 40 + (-12 - -8) = 40 - 4
+  });
+});


### PR DESCRIPTION
## Destructible-world Part A (A3) — the integration that makes digging real, end-to-end

Ties A1 (server read) + A2 (collider swap) together on the client, behind `CONCORD_TERRAIN_DEFORM_RENDER` (default on):

- **`terrain-deform-store.ts`** — the single source of truth for per-cell deltas. The mesh, the Rapier collider (A2), **and** `TerrainRenderer.getElevationAt` all read it, so the avatar Y-clamp + raycasts sit on the *deformed* surface (no visual/physics mismatch).
- **`attach-terrain-deformation.ts`** — the orchestrator:
  - fetch `GET /api/worlds/:id/terrain` on load → seed the store;
  - subscribe `concordia:terrain-deformed` → patch one cell + fire a dust `concordia:particle-effect`;
  - on any store change → re-push the affected terrain mesh-chunk vertices (pure `planChunkVertexUpdates` computes `increment = cumulative − applied` so repeated events never double-count) + a **debounced (450ms)** `physicsWorld.rebuildHeightfieldWithDeltas` (A2 — the expensive collider recreate).
  - Mounted in `ConcordiaScene.onTerrainPhysics` once terrain is ready; disposed with the scene.

### Verify
- New `tests/concordia/terrain-deform-store.test.ts` (6) — store get/set/patch/reset/notify + the `planChunkVertexUpdates` no-double-count contract.
- Full concordia vitest suite **232/232 green**; scoped `tsc` clean on the new files + no new errors on the edited `TerrainRenderer`/`ConcordiaScene`.
- **In-engine (user):** dig via `terrain.dig` → crater appears in the mesh + walk into a real hole (collider rebuilt) + dust puff. Kill-switch off → today's static terrain.

Next: A4 (dynamic water surface from `world_water_cells`, behind `CONCORD_HYDRO_RENDER`).

https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ)_