### PR TITLE
WS-A4: dynamic water surface from the hydrology grid (completes Part A)

### DIFF
--- a/concord-frontend/components/world-lens/ConcordiaScene.tsx
+++ b/concord-frontend/components/world-lens/ConcordiaScene.tsx
@@ -268,6 +268,8 @@ export default function ConcordiaScene({
   // WS-A3 — terrain-deformation orchestrator (mesh re-push + collider rebuild
   // from server deltas); disposed with the scene.
   const terrainDeformRef = useRef<{ dispose(): void } | null>(null);
+  // WS-A4 — dynamic water-grid surface renderer; disposed with the scene.
+  const waterGridRef = useRef<{ update(d: number, e: number): void; dispose(): void } | null>(null);
   const probeManagerRef = useRef<
     import('@/lib/world-lens/reflection-probes').ReflectionProbeManager | null
   >(null);
@@ -344,7 +346,7 @@ export default function ConcordiaScene({
 
       // Listen for terrain-ready to register heightfield collider
       function onTerrainPhysics(e: Event) {
-        const { hmData, hmWidth, hmHeight, terrainGroup } = (e as CustomEvent).detail ?? {};
+        const { hmData, hmWidth, hmHeight, terrainGroup, getElevationAt } = (e as CustomEvent).detail ?? {};
         if (hmData) {
           physicsWorld.createHeightfieldCollider(hmData, hmWidth, hmHeight, {
             x: 2000, // TERRAIN_SIZE
@@ -379,6 +381,43 @@ export default function ConcordiaScene({
                 enabled,
               });
             } catch { /* deformation is progressive enhancement */ }
+          })();
+        }
+        // WS-A4 — dynamic water surface from world_water_cells, placed on the
+        // (deformed) terrain top via getElevationAt. Kill-switch
+        // CONCORD_HYDRO_RENDER (default on). One-shot per scene.
+        if (!waterGridRef.current) {
+          void (async () => {
+            try {
+              const [{ createWaterGridRenderer }, { getSocket }, { getInjectedJwt }] = await Promise.all([
+                import('@/lib/world-lens/water-grid-renderer'),
+                import('@/lib/realtime/socket'),
+                import('@/lib/auth-bridge'),
+              ]);
+              if (disposed) return;
+              const hydroEnabled = (window as { __concordClientConfig?: { CONCORD_HYDRO_RENDER?: unknown } })
+                .__concordClientConfig?.CONCORD_HYDRO_RENDER !== 0;
+              if (!hydroEnabled) return;
+              const worldId =
+                (typeof window !== 'undefined' && window.localStorage?.getItem('concordia:activeWorldId')) ||
+                'concordia-hub';
+              const waterLayer = (layersRef.current?.['water'] ?? layersRef.current?.['particles']) as
+                InstanceType<typeof import('three').Group> | undefined;
+              if (!waterLayer) return;
+              const handle = createWaterGridRenderer(waterLayer as unknown as import('three').Group, {
+                worldId,
+                authToken: () => getInjectedJwt(),
+                elevationAt: typeof getElevationAt === 'function'
+                  ? (gx: number, gz: number) => getElevationAt(gx, gz)
+                  : undefined,
+                socket: getSocket() as unknown as { on(ev: string, cb: (p: unknown) => void): void; off(ev: string, cb: (p: unknown) => void): void },
+              });
+              waterGridRef.current = handle;
+              // Drive its per-frame update via the water layer's userData.update
+              // (the render loop's LAYER_NAMES fan-out calls this).
+              (waterLayer.userData as { update?: (d: number, e: number) => void }).update = (d: number, en: number) =>
+                handle.update(d, en);
+            } catch { /* hydrology is progressive enhancement */ }
           })();
         }
       }
@@ -1567,6 +1606,8 @@ export default function ConcordiaScene({
       worldRenderersRef.current = null;
       try { terrainDeformRef.current?.dispose(); } catch { /* ignore */ }
       terrainDeformRef.current = null;
+      try { waterGridRef.current?.dispose(); } catch { /* ignore */ }
+      waterGridRef.current = null;
 
       ssgiPassRef.current?.dispose();
       ssgiPassRef.current = null;

--- a/concord-frontend/lib/world-lens/water-grid-renderer.ts
+++ b/concord-frontend/lib/world-lens/water-grid-renderer.ts
@@ -1,0 +1,191 @@
+// concord-frontend/lib/world-lens/water-grid-renderer.ts
+//
+// Destructible-world Part A (A4) — render the hydrology grid as a DYNAMIC water
+// surface. The server flow solver (terrain-water.js) moves water cell-to-cell
+// and pools it; `GET /api/worlds/:id/terrain` returns the wet cells
+// (`water: [{cell_x,cell_z,water_height}]`). This draws one translucent quad per
+// wet cell at `terrainTop(cellCentre) + water_height`, lerps the height between
+// polls so a filling ditch reads as a rise, and refetches on the
+// `concordia:water-updated` hint (poll fallback). A splash `concordia:particle-
+// effect` fires when the player enters a wet cell.
+//
+// Factory matching the other world renderers: `(parentGroup, opts) => {update,
+// dispose, refresh}`. Pure `waterCellQuad(cell, terrainTop)` is unit-testable.
+// Guarded by the caller via `CONCORD_HYDRO_RENDER` (mounted only when enabled).
+
+import * as THREE from 'three';
+
+export interface WaterCell {
+  cell_x: number;
+  cell_z: number;
+  water_height: number;
+}
+
+export interface WaterCellVisual {
+  /** World Y of the water surface (terrain top + column). */
+  surfaceY: number;
+  /** Opacity scaling with depth (deeper = more opaque). */
+  opacity: number;
+}
+
+/** PURE: water surface attributes for a cell given its terrain top. */
+export function waterCellQuad(cell: WaterCell, terrainTop: number): WaterCellVisual {
+  const wh = Math.max(0, Number(cell?.water_height) || 0);
+  return {
+    surfaceY: terrainTop + wh,
+    opacity: Math.max(0.25, Math.min(0.75, 0.3 + wh * 0.12)),
+  };
+}
+
+export interface WaterGridRendererOpts {
+  worldId: string;
+  authToken?: () => string | null;
+  pollMs?: number;
+  apiBase?: string;
+  /** terrain top (base+delta) at a world point; defaults to 0 (flat). */
+  elevationAt?: (wx: number, wz: number) => number;
+  /** active deformation cell size (metres). */
+  cellSize?: number;
+  /** socket-ish for the concordia:water-updated refetch hint. */
+  socket?: { on(ev: string, cb: (p: unknown) => void): void; off(ev: string, cb: (p: unknown) => void): void } | null;
+  /** test seam */
+  fetchWater?: () => Promise<WaterCell[]>;
+}
+
+interface TrackedCell {
+  mesh: THREE.Mesh<THREE.PlaneGeometry, THREE.MeshStandardMaterial>;
+  targetY: number;
+  overlapping: boolean; // player currently over this cell (for splash debounce)
+}
+
+const WATER_COLOR = 0x2c6ea1;
+
+export interface WaterGridRenderer {
+  update(delta: number, elapsed: number): void;
+  dispose(): void;
+  refresh(): Promise<void>;
+}
+
+export function createWaterGridRenderer(
+  parentGroup: THREE.Group,
+  opts: WaterGridRendererOpts,
+): WaterGridRenderer {
+  const pollMs = opts.pollMs ?? 5000;
+  const apiBase = opts.apiBase ?? '';
+  const url = `${apiBase}/api/worlds/${opts.worldId}/terrain`;
+  const cellSize = opts.cellSize ?? 10;
+  const elevationAt = opts.elevationAt ?? (() => 0);
+  const tracked = new Map<string, TrackedCell>();
+  let disposed = false;
+  let intervalId: ReturnType<typeof setInterval> | null = null;
+
+  function cellCentre(cx: number, cz: number): { x: number; z: number } {
+    return { x: cx * cellSize + cellSize / 2, z: cz * cellSize + cellSize / 2 };
+  }
+
+  function reconcile(rows: WaterCell[]): void {
+    if (disposed) return;
+    const seen = new Set<string>();
+    for (const c of rows) {
+      if (!c || !Number.isFinite(c.cell_x) || !Number.isFinite(c.cell_z)) continue;
+      if ((Number(c.water_height) || 0) <= 0) continue;
+      const key = `${c.cell_x},${c.cell_z}`;
+      seen.add(key);
+      const { x, z } = cellCentre(c.cell_x, c.cell_z);
+      const visual = waterCellQuad(c, elevationAt(x, z));
+      let t = tracked.get(key);
+      if (!t) {
+        const geo = new THREE.PlaneGeometry(cellSize, cellSize);
+        geo.rotateX(-Math.PI / 2);
+        const mat = new THREE.MeshStandardMaterial({
+          color: WATER_COLOR, transparent: true, opacity: visual.opacity,
+          roughness: 0.2, metalness: 0.1, depthWrite: false,
+        });
+        const mesh = new THREE.Mesh(geo, mat);
+        mesh.position.set(x, visual.surfaceY, z);
+        parentGroup.add(mesh);
+        t = { mesh, targetY: visual.surfaceY, overlapping: false };
+        tracked.set(key, t);
+      } else {
+        t.targetY = visual.surfaceY;
+        t.mesh.material.opacity = visual.opacity;
+      }
+    }
+    for (const [key, t] of tracked) {
+      if (!seen.has(key)) {
+        try { parentGroup.remove(t.mesh); } catch { /* idempotent */ }
+        try { t.mesh.geometry.dispose(); } catch { /* idempotent */ }
+        try { t.mesh.material.dispose(); } catch { /* idempotent */ }
+        tracked.delete(key);
+      }
+    }
+  }
+
+  async function refresh(): Promise<void> {
+    if (disposed) return;
+    try {
+      let rows: WaterCell[];
+      if (opts.fetchWater) {
+        rows = await opts.fetchWater();
+      } else {
+        const headers: Record<string, string> = { Accept: 'application/json' };
+        const token = opts.authToken ? opts.authToken() : null;
+        if (token) headers.Authorization = `Bearer ${token}`;
+        const res = await fetch(url, { headers });
+        if (!res.ok) return;
+        const data = (await res.json()) as { water?: WaterCell[] };
+        if (!data || !Array.isArray(data.water)) return;
+        rows = data.water;
+      }
+      reconcile(rows);
+    } catch {
+      // Network/parse failure → keep current surface.
+    }
+  }
+
+  function onWaterUpdated(): void { void refresh(); }
+
+  void refresh();
+  intervalId = setInterval(() => void refresh(), pollMs);
+  if (opts.socket) opts.socket.on('concordia:water-updated', onWaterUpdated);
+
+  function update(delta: number): void {
+    if (disposed) return;
+    const lerp = Math.min(1, delta * 2); // ~500ms catch-up so a fill reads as a rise
+    const pp = (typeof window !== 'undefined'
+      && (window as { __concordiaPlayerPos?: { x: number; z: number } }).__concordiaPlayerPos) || null;
+    for (const [key, t] of tracked) {
+      const cur = t.mesh.position.y;
+      t.mesh.position.y = cur + (t.targetY - cur) * lerp;
+      // Splash when the player first enters this wet cell.
+      if (pp) {
+        const k = `${Math.floor(pp.x / cellSize)},${Math.floor(pp.z / cellSize)}`;
+        const over = k === key;
+        if (over && !t.overlapping) {
+          try {
+            window.dispatchEvent(new CustomEvent('concordia:particle-effect', {
+              detail: { type: 'splash', position: { x: pp.x, y: t.mesh.position.y, z: pp.z }, duration: 500, intensity: 1 },
+            }));
+          } catch { /* vfx optional */ }
+        }
+        t.overlapping = over;
+      }
+    }
+  }
+
+  function dispose(): void {
+    if (disposed) return;
+    disposed = true;
+    if (intervalId) clearInterval(intervalId);
+    intervalId = null;
+    if (opts.socket) { try { opts.socket.off('concordia:water-updated', onWaterUpdated); } catch { /* ok */ } }
+    for (const t of tracked.values()) {
+      try { parentGroup.remove(t.mesh); } catch { /* idempotent */ }
+      try { t.mesh.geometry.dispose(); } catch { /* idempotent */ }
+      try { t.mesh.material.dispose(); } catch { /* idempotent */ }
+    }
+    tracked.clear();
+  }
+
+  return { update, dispose, refresh };
+}

--- a/concord-frontend/tests/concordia/water-grid-renderer.test.ts
+++ b/concord-frontend/tests/concordia/water-grid-renderer.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { waterCellQuad, createWaterGridRenderer } from '@/lib/world-lens/water-grid-renderer';
+
+// WS-A4 — dynamic water surface from world_water_cells. Pin the pure surface map
+// + the renderer's fill→drain lifecycle (fetchWater seam, no network).
+
+describe('WS-A4 — waterCellQuad (pure)', () => {
+  it('surface sits on terrain top + water column', () => {
+    expect(waterCellQuad({ cell_x: 0, cell_z: 0, water_height: 2 }, 10).surfaceY).toBe(12);
+  });
+  it('deeper water is more opaque, clamped', () => {
+    const shallow = waterCellQuad({ cell_x: 0, cell_z: 0, water_height: 0.2 }, 0);
+    const deep = waterCellQuad({ cell_x: 0, cell_z: 0, water_height: 5 }, 0);
+    expect(deep.opacity).toBeGreaterThan(shallow.opacity);
+    expect(deep.opacity).toBeLessThanOrEqual(0.75);
+    expect(shallow.opacity).toBeGreaterThanOrEqual(0.25);
+  });
+  it('negative/garbage water height floors at 0', () => {
+    expect(waterCellQuad({ cell_x: 0, cell_z: 0, water_height: -3 }, 5).surfaceY).toBe(5);
+  });
+});
+
+describe('WS-A4 — createWaterGridRenderer lifecycle', () => {
+  it('renders a quad per wet cell at terrain top + height, drains when dry', async () => {
+    const group = new THREE.Group();
+    let rows = [{ cell_x: 2, cell_z: 3, water_height: 1.5 }];
+    const r = createWaterGridRenderer(group, {
+      worldId: 'w',
+      cellSize: 10,
+      elevationAt: () => 4, // flat terrain top at y=4
+      fetchWater: async () => rows,
+    });
+    await r.refresh();
+    expect(group.children.length).toBe(1);
+    const mesh = group.children[0] as THREE.Mesh;
+    // cell (2,3) centre = (25, 35); surface = 4 + 1.5 = 5.5
+    expect(mesh.position.x).toBeCloseTo(25, 5);
+    expect(mesh.position.z).toBeCloseTo(35, 5);
+    // a few frames lerp the y toward target without throwing
+    for (let i = 0; i < 6; i++) r.update(0.1, i * 0.1);
+    expect(mesh.position.y).toBeGreaterThan(4); // risen toward 5.5
+
+    // cell dries → quad removed
+    rows = [];
+    await r.refresh();
+    expect(group.children.length).toBe(0);
+
+    r.dispose();
+    expect(() => r.dispose()).not.toThrow();
+  });
+
+  it('skips cells with zero/absent water', async () => {
+    const group = new THREE.Group();
+    const r = createWaterGridRenderer(group, {
+      worldId: 'w',
+      fetchWater: async () => [{ cell_x: 0, cell_z: 0, water_height: 0 }],
+    });
+    await r.refresh();
+    expect(group.children.length).toBe(0);
+    r.dispose();
+  });
+});


### PR DESCRIPTION
## Destructible-world Part A (A4) — hydrology renders; ditches fill

The server flow solver (`terrain-water.js`) already moves + pools water; this draws it, behind `CONCORD_HYDRO_RENDER` (default on):

- **`water-grid-renderer.ts`** — factory that polls `GET /api/worlds/:id/terrain` (water rows) + refetches on the `concordia:water-updated` hint, renders one translucent quad per wet cell at `elevationAt(cellCentre) + water_height` (placed on the **deformed** terrain top via the A3 `getElevationAt`), lerps the surface between polls so a filling ditch reads as a rise, and fires a `concordia:particle-effect {type:'splash'}` when the player enters a wet cell. Pure `waterCellQuad(cell, terrainTop)` unit-tested.
- Mounted in `ConcordiaScene`'s terrain-ready handler (it has `getElevationAt` + worldId + socket), driven via the water layer's `userData.update` (the render-loop fan-out), disposed with the scene. The static planes stay as the no-water-cells fallback.

### Verify
- New `tests/concordia/water-grid-renderer.test.ts` (5) — surface = terrain top + column, depth→opacity, floor, fill→drain lifecycle, zero-water skip.
- Full concordia vitest suite **237/237 green**; scoped `tsc` clean; no new `ConcordiaScene` errors.
- **In-engine (user):** `terrain.set_water` upstream / dig a ditch to a source → watch it fill, splash on entry, swim. Kill-switch off → today's static planes.

**This completes Part A** (destructible terrain + hydrology). Next: Part B — the Crimson-Desert/Prototype/inFamous fluidity layer (traversal verbs, momentum, cancel windows), behind `CONCORD_TRAVERSAL_VERBS`.

https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ)_