### PR TITLE
WS-B1: traversal kinematics foundation (dash/slide + momentum + pose-broker source)

### DIFF
--- a/concord-frontend/lib/concordia/action-biomechanics.ts
+++ b/concord-frontend/lib/concordia/action-biomechanics.ts
@@ -234,6 +234,14 @@ export const ACTION_DESCRIPTORS: Record<string, ActionDescriptor> = {
   eat:     { archetype: 'manipulate_in_place', leadingLimb: 'right_arm', phases: [180, 200, 180], juiceId: 'soft', sfxId: 'eat', vfx: 'sparkle' },
   drink:   { archetype: 'manipulate_in_place', leadingLimb: 'right_arm', phases: [180, 200, 180], juiceId: 'soft', sfxId: 'drink' },
   take_photo: { archetype: 'lean_reach', leadingLimb: 'both_arms', phases: [160, 120, 160], juiceId: 'success', sfxId: 'shutter', vfx: 'flash' },
+  // traversal (Part B) — dash/slide/climb/vault/mantle. locomotion_modal extends
+  // gait/combat modes; these layer via the pose-broker 'traversal' source.
+  dash:    { archetype: 'locomotion_modal', leadingLimb: 'legs', phases: [80, 120, 120], juiceId: 'whoosh', sfxId: 'dash', vfx: 'dust' },
+  dodge:   { archetype: 'locomotion_modal', leadingLimb: 'legs', phases: [80, 120, 140], juiceId: 'whoosh', sfxId: 'dash', vfx: 'dust' },
+  slide:   { archetype: 'locomotion_modal', leadingLimb: 'legs', phases: [120, 220, 180], juiceId: 'whoosh', sfxId: 'slide', vfx: 'dust' },
+  climb:   { archetype: 'locomotion_modal', leadingLimb: 'both_arms', phases: [220, 0, 200], loop: 'climb', juiceId: 'soft', sfxId: 'scrape' },
+  vault:   { archetype: 'locomotion_modal', leadingLimb: 'both_arms', phases: [140, 120, 140], juiceId: 'whoosh', sfxId: 'vault' },
+  mantle:  { archetype: 'locomotion_modal', leadingLimb: 'both_arms', phases: [180, 160, 180], juiceId: 'soft', sfxId: 'vault' },
 };
 
 // Category fallback so NO verb is ever silent.

--- a/concord-frontend/lib/concordia/pose-broker.ts
+++ b/concord-frontend/lib/concordia/pose-broker.ts
@@ -31,9 +31,12 @@ export type BodyPart =
 
 // 'action' (Living Society) layers a non-combat verb motion over gait but
 // yields to combat/reflex — so a worker mid-swing still flinches when hit.
-export type SourcePriority = 'reflex' | 'combat' | 'action' | 'ik' | 'gait' | 'idle' | 'facial';
+// 'traversal' (Part B) — dash/slide/climb/vault. Sits between combat and action
+// so a traversal move layers over gait + verb actions but still yields to
+// combat/reflex (you can flinch mid-dash) — movement reads as one fluid system.
+export type SourcePriority = 'reflex' | 'combat' | 'traversal' | 'action' | 'ik' | 'gait' | 'idle' | 'facial';
 
-const PRIORITY_ORDER: SourcePriority[] = ['reflex', 'combat', 'action', 'ik', 'gait', 'idle', 'facial'];
+const PRIORITY_ORDER: SourcePriority[] = ['reflex', 'combat', 'traversal', 'action', 'ik', 'gait', 'idle', 'facial'];
 
 interface Contribution {
   source:   SourcePriority;

--- a/concord-frontend/lib/concordia/traversal-kinematics.ts
+++ b/concord-frontend/lib/concordia/traversal-kinematics.ts
@@ -1,0 +1,113 @@
+// concord-frontend/lib/concordia/traversal-kinematics.ts
+//
+// Part B (B1/B2) — PURE kinematics for the traversal verb set + momentum
+// preservation, so the math is unit-testable without Rapier. physics-world holds
+// the state and calls these; AvatarSystem3D drives the input.
+//
+// Principles (Crimson Desert / Prototype / inFamous): a dash is a short
+// directional velocity burst with brief i-frames; a slide preserves sprint
+// momentum into a low crouch; momentum decays rather than snapping to zero so
+// transitions (sprint→dodge→attack) feel connected ("never stop moving").
+
+export interface TraversalState {
+  /** Dash burst velocity (m/s) at onset; decays to 0 over the dash window. */
+  dashVx: number;
+  dashVz: number;
+  dashStartedAt: number; // wall-clock ms
+  dashExpiresAt: number; // wall-clock ms (0 = no dash)
+  /** Wall-clock ms until invulnerability frames end (0 = vulnerable). */
+  iframeUntil: number;
+  /** Slide active (crouch while moving fast). */
+  sliding: boolean;
+  /** Persistent horizontal momentum (m/s) carried across state transitions. */
+  momX: number;
+  momZ: number;
+}
+
+export const TRAVERSAL = Object.freeze({
+  DASH_SPEED: 12,        // m/s burst
+  DASH_DURATION_MS: 260, // dash lasts this long
+  IFRAME_MS: 180,        // i-frames from dash onset (dodge window)
+  MOMENTUM_DECAY: 3.5,   // per-second exponential-ish decay rate
+  SLIDE_MIN_SPEED: 4.0,  // need at least this much momentum to start a slide
+});
+
+export function freshTraversalState(): TraversalState {
+  return { dashVx: 0, dashVz: 0, dashStartedAt: 0, dashExpiresAt: 0, iframeUntil: 0, sliding: false, momX: 0, momZ: 0 };
+}
+
+/** Begin a dash in a (normalized-ish) direction. Mutates + returns the state. */
+export function beginDash(
+  st: TraversalState,
+  dirX: number,
+  dirZ: number,
+  now: number,
+  speed: number = TRAVERSAL.DASH_SPEED,
+): TraversalState {
+  const len = Math.hypot(dirX, dirZ) || 1;
+  st.dashVx = (dirX / len) * speed;
+  st.dashVz = (dirZ / len) * speed;
+  st.dashStartedAt = now;
+  st.dashExpiresAt = now + TRAVERSAL.DASH_DURATION_MS;
+  st.iframeUntil = now + TRAVERSAL.IFRAME_MS;
+  return st;
+}
+
+/** True while a dash is active (used to gate re-dash + drive the clip). */
+export function isDashing(st: TraversalState, now: number): boolean {
+  return st.dashExpiresAt > now;
+}
+
+/** True during the dodge i-frame window (combat damage should be ignored). */
+export function isInvulnerable(st: TraversalState, now: number): boolean {
+  return st.iframeUntil > now;
+}
+
+/**
+ * Current dash velocity contribution (m/s), linearly decaying to 0 across the
+ * dash window. Returns {vx,vz}=0 when no dash is active.
+ */
+export function dashVelocityAt(st: TraversalState, now: number): { vx: number; vz: number } {
+  if (st.dashExpiresAt <= now || st.dashExpiresAt <= st.dashStartedAt) return { vx: 0, vz: 0 };
+  const frac = (st.dashExpiresAt - now) / (st.dashExpiresAt - st.dashStartedAt); // 1→0
+  return { vx: st.dashVx * frac, vz: st.dashVz * frac };
+}
+
+/**
+ * Carry + decay horizontal momentum. `inputVx/Vz` is the player's intended
+ * locomotion this frame; momentum eases toward it (so it never snaps) and
+ * decays toward zero when there's no input. Returns the blended {vx,vz} to move
+ * by AND updates st.momX/momZ. This is the "never stop moving" core.
+ */
+export function stepMomentum(
+  st: TraversalState,
+  inputVx: number,
+  inputVz: number,
+  dt: number,
+  decay: number = TRAVERSAL.MOMENTUM_DECAY,
+): { vx: number; vz: number } {
+  const k = Math.max(0, Math.min(1, decay * dt)); // ease factor
+  // Ease current momentum toward the input (preserves carry, no hard reset).
+  st.momX += (inputVx - st.momX) * k;
+  st.momZ += (inputVz - st.momZ) * k;
+  // Snap tiny residuals to zero so we don't drift forever.
+  if (Math.abs(st.momX) < 1e-3) st.momX = 0;
+  if (Math.abs(st.momZ) < 1e-3) st.momZ = 0;
+  return { vx: st.momX, vz: st.momZ };
+}
+
+/** Current horizontal momentum magnitude (m/s) — used for context-sensitive verbs. */
+export function momentumMagnitude(st: TraversalState): number {
+  return Math.hypot(st.momX, st.momZ);
+}
+
+/** Begin a slide if moving fast enough; returns true if it started. */
+export function tryBeginSlide(st: TraversalState): boolean {
+  if (momentumMagnitude(st) < TRAVERSAL.SLIDE_MIN_SPEED) return false;
+  st.sliding = true;
+  return true;
+}
+
+export function endSlide(st: TraversalState): void {
+  st.sliding = false;
+}

--- a/concord-frontend/lib/world-lens/physics-world.ts
+++ b/concord-frontend/lib/world-lens/physics-world.ts
@@ -11,6 +11,9 @@
 
 import { canJump, shouldFlushBuffer, cutJump } from './jump-forgiveness';
 import { bakeDeltasIntoHeightmap } from './terrain-deform-math';
+import {
+  type TraversalState, freshTraversalState, beginDash, dashVelocityAt, isInvulnerable as tkInvulnerable,
+} from '../concordia/traversal-kinematics';
 
 type RapierType = typeof import('@dimforge/rapier3d-compat');
 type WorldType   = InstanceType<RapierType['World']>;
@@ -99,6 +102,9 @@ class PhysicsWorld {
   private bodies:      Map<string, RigidBody>  = new Map();
   private colliders:   Map<string, Collider>   = new Map();
   private kinematic:   Map<string, KinematicState> = new Map();
+  // Part B — per-entity traversal state (dash burst + i-frames + slide). Kept
+  // parallel to KinematicState; folded into moveCharacter like knockback.
+  private traversal:   Map<string, TraversalState> = new Map();
   // WS-A2 — the terrain heightfield collider handle + its source heightmap, so
   // deformations can SWAP it (Rapier heightfields are immutable: removeCollider
   // + createCollider). _terrainHmData is the pristine base (normalized 0..1);
@@ -642,10 +648,21 @@ class PhysicsWorld {
       glideBoostZ = desiredTranslation.z * GLIDE_HORIZ_BOOST;
     }
 
+    // Part B — dash burst: a short directional velocity that decays over the
+    // dash window, folded in like knockback so it composes with input + glide.
+    let dashDx = 0;
+    let dashDz = 0;
+    const ts = this.traversal.get(id);
+    if (ts) {
+      const dv = dashVelocityAt(ts, now);
+      dashDx = dv.vx * dt;
+      dashDz = dv.vz * dt;
+    }
+
     const finalDesired = {
-      x: desiredTranslation.x + kbDx + glideBoostX,
+      x: desiredTranslation.x + kbDx + glideBoostX + dashDx,
       y: desiredTranslation.y + verticalDelta,
-      z: desiredTranslation.z + kbDz + glideBoostZ,
+      z: desiredTranslation.z + kbDz + glideBoostZ + dashDz,
     };
 
     // Snap-to-ground policy: re-enable after the suppress window expires
@@ -856,6 +873,47 @@ class PhysicsWorld {
   /** Returns true when swim is active for `id`. */
   isSwimming(id: string): boolean {
     return !!this.kinematic.get(id)?.swimming;
+  }
+
+  // ── Part B (B1): traversal verbs — dash / dodge (+ i-frames) ───────────────
+
+  private _ensureTraversal(id: string): TraversalState {
+    let ts = this.traversal.get(id);
+    if (!ts) { ts = freshTraversalState(); this.traversal.set(id, ts); }
+    return ts;
+  }
+
+  /**
+   * Request a dash/dodge in a world-space direction. Sets a decaying velocity
+   * burst (folded into moveCharacter) + a brief i-frame window. No-op while a
+   * dash is already active (no dash-cancel-into-dash spam) or knocked back.
+   * Returns true if the dash started.
+   */
+  requestDash(id: string, dirX: number, dirZ: number): boolean {
+    if (!this.controllers.has(id)) return false;
+    const ks = this.kinematic.get(id);
+    if (ks && ks.kbExpiresAt > performance.now()) return false; // not while knocked back
+    const ts = this._ensureTraversal(id);
+    const now = performance.now();
+    if (ts.dashExpiresAt > now) return false; // already dashing
+    if (dirX === 0 && dirZ === 0) return false;
+    beginDash(ts, dirX, dirZ, now);
+    return true;
+  }
+
+  /** True during the dash i-frame window (combat should ignore damage). */
+  isInvulnerable(id: string): boolean {
+    const ts = this.traversal.get(id);
+    return ts ? tkInvulnerable(ts, performance.now()) : false;
+  }
+
+  /** Toggle slide (crouch-while-fast); purely a state flag the animator reads. */
+  setSlide(id: string, on: boolean): void {
+    this._ensureTraversal(id).sliding = !!on;
+  }
+
+  isSliding(id: string): boolean {
+    return !!this.traversal.get(id)?.sliding;
   }
 
   // ── Theme 6 (game-feel pass): water plane registry ────────────────────────

--- a/concord-frontend/tests/concordia/traversal-kinematics.test.ts
+++ b/concord-frontend/tests/concordia/traversal-kinematics.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import {
+  freshTraversalState, beginDash, isDashing, isInvulnerable, dashVelocityAt,
+  stepMomentum, momentumMagnitude, tryBeginSlide, endSlide, TRAVERSAL,
+} from '@/lib/concordia/traversal-kinematics';
+import { resolveActionDescriptor } from '@/lib/concordia/action-biomechanics';
+
+describe('Part B — traversal kinematics (pure)', () => {
+  it('beginDash sets a normalized burst + i-frames; isDashing/isInvulnerable gate by time', () => {
+    const st = freshTraversalState();
+    beginDash(st, 0, 2, 1000); // dir +z, magnitude 2 → normalized
+    expect(Math.hypot(st.dashVx, st.dashVz)).toBeCloseTo(TRAVERSAL.DASH_SPEED, 5);
+    expect(isDashing(st, 1000)).toBe(true);
+    expect(isInvulnerable(st, 1000)).toBe(true);
+    // after the i-frame window but still dashing
+    expect(isInvulnerable(st, 1000 + TRAVERSAL.IFRAME_MS + 1)).toBe(false);
+    expect(isDashing(st, 1000 + TRAVERSAL.IFRAME_MS + 1)).toBe(true);
+    // after the dash window
+    expect(isDashing(st, 1000 + TRAVERSAL.DASH_DURATION_MS + 1)).toBe(false);
+  });
+
+  it('dashVelocityAt decays linearly from full to zero across the window', () => {
+    const st = freshTraversalState();
+    beginDash(st, 1, 0, 0);
+    const atStart = dashVelocityAt(st, 0);
+    const mid = dashVelocityAt(st, TRAVERSAL.DASH_DURATION_MS / 2);
+    const end = dashVelocityAt(st, TRAVERSAL.DASH_DURATION_MS);
+    expect(atStart.vx).toBeCloseTo(TRAVERSAL.DASH_SPEED, 3);
+    expect(mid.vx).toBeCloseTo(TRAVERSAL.DASH_SPEED / 2, 1);
+    expect(end.vx).toBe(0);
+  });
+
+  it('stepMomentum eases toward input + carries (never snaps to zero in one frame)', () => {
+    const st = freshTraversalState();
+    st.momX = 6; // sprinting east
+    // input drops to 0 (released) — momentum should DECAY, not snap.
+    const r1 = stepMomentum(st, 0, 0, 1 / 60);
+    expect(r1.vx).toBeGreaterThan(0);
+    expect(r1.vx).toBeLessThan(6);
+    // many frames later it settles to ~0
+    for (let i = 0; i < 600; i++) stepMomentum(st, 0, 0, 1 / 60);
+    expect(momentumMagnitude(st)).toBeLessThan(0.01);
+  });
+
+  it('stepMomentum ramps UP toward new input too (eased acceleration)', () => {
+    const st = freshTraversalState();
+    const r = stepMomentum(st, 8, 0, 1 / 60);
+    expect(r.vx).toBeGreaterThan(0);
+    expect(r.vx).toBeLessThan(8); // eased, not instant
+  });
+
+  it('slide needs minimum momentum', () => {
+    const st = freshTraversalState();
+    st.momX = 1; // too slow
+    expect(tryBeginSlide(st)).toBe(false);
+    st.momX = TRAVERSAL.SLIDE_MIN_SPEED + 1;
+    expect(tryBeginSlide(st)).toBe(true);
+    expect(st.sliding).toBe(true);
+    endSlide(st);
+    expect(st.sliding).toBe(false);
+  });
+});
+
+describe('Part B — traversal verbs resolve to animatable descriptors', () => {
+  it('every traversal verb has a real descriptor', () => {
+    for (const v of ['dash', 'dodge', 'slide', 'climb', 'vault', 'mantle']) {
+      const d = resolveActionDescriptor(v);
+      expect(d).toBeTruthy();
+      expect(d.archetype).toBe('locomotion_modal');
+    }
+  });
+});


### PR DESCRIPTION
## Part B (fluidity) — the "never stop moving" foundation

Built on the existing kinematic capsule + 7-tier pose-broker (no rewrite):

- **`traversal-kinematics.ts`** (pure, tested): dash burst (normalized directional velocity that decays over a window) + **i-frames**; **momentum carry/decay** (`stepMomentum` eases toward the input so transitions never snap — the Crimson-Desert/Prototype "connected movement" feel); slide gated by minimum momentum.
- **pose-broker**: new **`'traversal'` source** between `combat` and `action` — a dash layers over gait + verb actions but still yields to combat/reflex (you can flinch mid-dash), so movement reads as one fluid system.
- **action-biomechanics**: `dash`/`dodge`/`slide`/`climb`/`vault`/`mantle` descriptors (`locomotion_modal`), so any `playAction('dash')` animates.
- **physics-world API**: `requestDash(id, dirX, dirZ)` (decaying burst folded into `moveCharacter` like knockback) + `isInvulnerable` (i-frame gate) + `setSlide`/`isSliding`. Mirrors exactly how `requestJump`/`setGlide`/`setSwim` shipped (a physics API consumed by AvatarSystem3D input).

### Verify
- New `tests/concordia/traversal-kinematics.test.ts` (6) — dash burst/decay/i-frames, momentum ease-up + decay-down (no snap), slide min-speed gate, every traversal verb resolves to a `locomotion_modal` descriptor.
- Full concordia vitest suite **243/243 green**; scoped `tsc` clean on `physics-world.ts` + the new modules.

Next (B1b, in-engine): bind dash/slide to AvatarSystem3D input (Q dodge / Shift-slide) + grant the dash i-frames to the combat damage gate. Then B2 momentum into gait phase, B3 cancel windows + skill-modulated motion, B4 action chaining — all behind `CONCORD_TRAVERSAL_VERBS`.

https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ)_