### PR TITLE
WS-A5: fix hydrology so water flows downhill into a dug ditch (playtest find)

### DIFF
--- a/server/lib/terrain-water.js
+++ b/server/lib/terrain-water.js
@@ -93,7 +93,19 @@ export function totalWater(cells) {
 
 // ── DB wrappers ──────────────────────────────────────────────────────────────
 
-/** Load the water grid for a world into a solver-shaped Map (terrain injected). */
+const FLOW_NEIGHBOURS = [[1, 0], [-1, 0], [0, 1], [0, -1]];
+
+/**
+ * Load the water grid for a world into a solver-shaped Map (terrain injected).
+ *
+ * Crucially, we ALSO inject each wet cell's 4 orthogonal neighbours as DRY
+ * cells (water=0) carrying their REAL terrain top — so the flow solver can pour
+ * water DOWNHILL into an empty, lower cell (e.g. a freshly-dug ditch). Without
+ * this, `solveFlowStep`'s `makeDryNeighbour` treats any cell absent from the map
+ * as terrain=Infinity (a wall), and water could only redistribute among
+ * already-wet cells — a dug ditch would never fill. Dry cells that stay dry are
+ * GC'd by `tickWaterFlow`, so this only widens the solve frontier by one ring.
+ */
 export function loadWaterGrid(db, worldId) {
   const cells = new Map();
   try {
@@ -106,6 +118,16 @@ export function loadWaterGrid(db, worldId) {
         terrain: terrainTop(db, worldId, r.cell_x, r.cell_z),
         water: Number(r.water_height) || 0,
       });
+    }
+    // Seed dry downhill neighbours so water can flow into empty lower cells.
+    for (const r of rows) {
+      for (const [dx, dz] of FLOW_NEIGHBOURS) {
+        const ncx = r.cell_x + dx;
+        const ncz = r.cell_z + dz;
+        const nk = `${ncx},${ncz}`;
+        if (cells.has(nk)) continue;
+        cells.set(nk, { cx: ncx, cz: ncz, terrain: terrainTop(db, worldId, ncx, ncz), water: 0 });
+      }
     }
   } catch { /* table absent */ }
   return cells;

--- a/server/tests/terrain-water-flow.test.js
+++ b/server/tests/terrain-water-flow.test.js
@@ -1,0 +1,75 @@
+/**
+ * WS-A5 — the dug-ditch-fills mechanic: water must flow DOWNHILL into an empty,
+ * lower cell. Regression for the playtest find where loadWaterGrid only loaded
+ * wet cells, so makeDryNeighbour walled off every dry destination (terrain=∞)
+ * and water could never enter a freshly-dug ditch.
+ *
+ * Run: node --test tests/terrain-water-flow.test.js
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+import { setWater, waterDepthAt, tickWaterFlow, loadWaterGrid, totalWater, solveFlowStep } from "../lib/terrain-water.js";
+import { applyDeformation } from "../lib/terrain-deformation.js";
+
+const W = "concordia-hub";
+function mkDb() {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE world_terrain_deformations (
+      id TEXT PRIMARY KEY, world_id TEXT NOT NULL, cell_x INTEGER NOT NULL, cell_z INTEGER NOT NULL,
+      height_delta REAL NOT NULL DEFAULT 0, kind TEXT NOT NULL DEFAULT 'excavate',
+      material_id TEXT, created_at INTEGER DEFAULT 0, updated_at INTEGER DEFAULT 0,
+      UNIQUE (world_id, cell_x, cell_z)
+    );
+    CREATE TABLE world_water_cells (
+      world_id TEXT NOT NULL, cell_x INTEGER NOT NULL, cell_z INTEGER NOT NULL,
+      water_height REAL NOT NULL DEFAULT 0, updated_at INTEGER DEFAULT 0,
+      PRIMARY KEY (world_id, cell_x, cell_z)
+    );
+  `);
+  return db;
+}
+
+describe("WS-A5 — hydrology flows into a dug ditch", () => {
+  it("loadWaterGrid seeds dry orthogonal neighbours with real terrain", () => {
+    const db = mkDb();
+    setWater(db, W, 150, 150, 4); // one wet cell
+    const grid = loadWaterGrid(db, W);
+    // the wet cell + its 4 neighbours are present (5 total), neighbours dry
+    assert.ok(grid.size >= 5, `expected wet + 4 dry neighbours, got ${grid.size}`);
+    let dry = 0;
+    for (const c of grid.values()) { if (c.water === 0) dry++; assert.ok(Number.isFinite(c.terrain), "neighbour has real terrain"); }
+    assert.ok(dry >= 4, "the 4 neighbours are dry");
+  });
+
+  it("water drains from a high wet cell into an adjacent DUG (lower) cell", () => {
+    const db = mkDb();
+    // Dig a deep pit at a cell, then seed water in the neighbour one cell east.
+    applyDeformation(db, W, 105, 105, 12, "excavate"); // pit at cell (10,10), -12m
+    setWater(db, W, 115, 105, 6);                       // water at cell (11,10)
+    const startDepthPit = waterDepthAt(db, W, 105, 105);
+    assert.equal(startDepthPit, 0, "pit starts dry");
+
+    for (let i = 0; i < 12; i++) tickWaterFlow(db, W);
+
+    // The dug pit (the lowest cell) is now wet AND holds the most water — it
+    // pooled, exactly the dig-a-ditch-and-it-fills mechanic.
+    const pitDepth = waterDepthAt(db, W, 105, 105);
+    assert.ok(pitDepth > 1, `water should have pooled in the pit; depth=${pitDepth}`);
+    const srcDepth = waterDepthAt(db, W, 115, 105);
+    assert.ok(pitDepth > srcDepth, `pit (${pitDepth}) should hold more than the drained source (${srcDepth})`);
+  });
+
+  it("pure solveFlowStep still conserves volume with a dry lower neighbour in the map", () => {
+    const cells = new Map([
+      ["0,0", { cx: 0, cz: 0, terrain: 10, water: 5 }], // high + wet
+      ["1,0", { cx: 1, cz: 0, terrain: 2, water: 0 }],  // low + dry (the ditch)
+    ]);
+    const before = totalWater(cells);
+    const next = solveFlowStep(cells);
+    assert.ok((next.get("1,0").water || 0) > 0, "water flowed into the dry ditch");
+    assert.ok(Math.abs(totalWater(next) - before) < 1e-3, "volume conserved");
+  });
+});


### PR DESCRIPTION
## Found by playtesting the dev server

Booted the backend, registered a player, and exercised the destructible-world flow over real HTTP. Digging worked perfectly (craters persist + accumulate + change material with depth). But **water seeded next to a dug pit just pooled in place and never filled the pit** — the core "dig a ditch and it fills" mechanic was broken.

**Root cause (existing server solver, not the new client work):** `loadWaterGrid` only loaded *wet* cells, so `solveFlowStep`'s `makeDryNeighbour` treated every dry destination as `terrain: Infinity` (a wall). Water could only redistribute among already-wet cells — a freshly-dug ditch could never receive flow.

**Fix:** `loadWaterGrid` now also seeds each wet cell's 4 orthogonal neighbours as **dry** cells carrying their **real** terrain top (`base + delta`), so the solver can pour water downhill into an empty lower cell. Dry cells that stay dry are GC'd by `tickWaterFlow`, so the solve frontier only widens by one ring (cheap).

### Verified live (dev server :5052)
Dig a −13m pit at cell (10,10) → seed water one cell uphill → 10 flow ticks → **the pit holds 8.14m of pooled water**, the deepest cell, everything else draining toward it. Exactly the Minecraft-but-continuous behavior.

### Tests
- New `server/tests/terrain-water-flow.test.js` (3) — neighbour seeding carries real terrain, downhill-into-dug-pit fill + pooling, pure-solver volume conservation with a dry lower neighbour.
- Existing `terrain-deformation` + `terrain-grid-route` (11) green.

https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ)_