### PR TITLE
WS-B1b: bind dash/dodge + slide to player input (traversal goes live)

### DIFF
--- a/concord-frontend/components/world-lens/AvatarSystem3D.tsx
+++ b/concord-frontend/components/world-lens/AvatarSystem3D.tsx
@@ -336,6 +336,8 @@ export default function AvatarSystem3D({
   const planarMoveRef = useRef<{ x: number; z: number }>({ x: 0, z: 0 });
   const playerPositionRef = useRef({ ...playerAvatar.position });
   const playerRotationRef = useRef(playerAvatar.rotation);
+  // B1b — double-tap dash memory (traversal dodge).
+  const dashTapRef = useRef<{ key: string; t: number }>({ key: '', t: 0 });
   const [activeAnimation, setActiveAnimation] = useState<AnimationClip>(
     playerAvatar.currentAnimation
   );
@@ -1914,7 +1916,55 @@ export default function AvatarSystem3D({
 
       function handleKeyDown(e: KeyboardEvent) {
         const k = e.key.toLowerCase();
+        const wasDown = keysRef.current.has(k);
         keysRef.current.add(k);
+
+        // B1b — traversal dash/dodge: a double-tap of a movement key fires a
+        // dash in the current move direction (or facing when stationary), with
+        // i-frames, animated via the WS1 'dash' verb. Behind CONCORD_TRAVERSAL_VERBS.
+        const traversalOn = (window as { __concordClientConfig?: { CONCORD_TRAVERSAL_VERBS?: unknown } })
+          .__concordClientConfig?.CONCORD_TRAVERSAL_VERBS !== 0;
+        if (traversalOn && !wasDown && (k === 'w' || k === 'a' || k === 's' || k === 'd')) {
+          const tgt = e.target as HTMLElement | null;
+          const typing = tgt && (tgt.tagName === 'INPUT' || tgt.tagName === 'TEXTAREA' || tgt.isContentEditable);
+          if (!typing) {
+            void (async () => {
+              try {
+                const { isDoubleTap } = await import('@/lib/concordia/dash-input');
+                if (!isDoubleTap(dashTapRef.current, k, performance.now())) return;
+                // Direction: current planar move, else facing (sinθ, -cosθ).
+                const pm = planarMoveRef.current;
+                let dx = pm.x, dz = pm.z;
+                if (Math.hypot(dx, dz) < 0.05) {
+                  const rot = playerRotationRef.current;
+                  dx = Math.sin(rot); dz = -Math.cos(rot);
+                }
+                const started = (physicsWorld as { requestDash?: (id: string, x: number, z: number) => boolean })
+                  .requestDash?.('player', dx, dz);
+                if (started) {
+                  const pa = await import('@/lib/concordia/play-action');
+                  const p = playerPositionRef.current;
+                  pa.playAction('dodge', { pos: { x: p.x, y: p.y + 1, z: p.z } });
+                }
+              } catch { /* traversal optional */ }
+            })();
+          }
+        }
+        // B1b — slide: crouch (C) while moving fast preserves momentum into a slide.
+        if (traversalOn && k === 'c' && !wasDown) {
+          void (async () => {
+            try {
+              const moving = Math.hypot(planarMoveRef.current.x, planarMoveRef.current.z) > 0.05;
+              const running = keysRef.current.has('shift');
+              if (moving && running) {
+                (physicsWorld as { setSlide?: (id: string, on: boolean) => void }).setSlide?.('player', true);
+                const pa = await import('@/lib/concordia/play-action');
+                const p = playerPositionRef.current;
+                pa.playAction('slide', { pos: { x: p.x, y: p.y + 0.5, z: p.z } });
+              }
+            } catch { /* slide optional */ }
+          })();
+        }
         // Theme 6 (game-feel pass): Space = jump (when grounded) or
         // toggle glide (when airborne already and falling). We trigger
         // off keydown so a tap registers a single jump and a hold flips
@@ -1942,6 +1992,10 @@ export default function AvatarSystem3D({
       function handleKeyUp(e: KeyboardEvent) {
         const k = e.key.toLowerCase();
         keysRef.current.delete(k);
+        // B1b — end slide on crouch release.
+        if (k === 'c') {
+          (physicsWorld as { setSlide?: (id: string, on: boolean) => void }).setSlide?.('player', false);
+        }
         if (k === ' ' || k === 'spacebar') {
           // B1 — variable jump height: releasing Space early cuts an ascending
           // jump for a shorter hop (no-op while falling/grounded).

--- a/concord-frontend/lib/concordia/dash-input.ts
+++ b/concord-frontend/lib/concordia/dash-input.ts
@@ -1,0 +1,31 @@
+// concord-frontend/lib/concordia/dash-input.ts
+//
+// Part B (B1b) — PURE double-tap detection for the traversal dash/dodge. A
+// double-tap of a movement key (W/A/S/D) within a short window fires a dash in
+// that direction (Prototype/character-action standard) — no dedicated key, so
+// it conflicts with nothing in combat input. Pure so it's unit-testable.
+
+export interface TapMemory {
+  key: string;
+  t: number; // wall-clock ms of the last tap
+}
+
+export const DOUBLE_TAP_MS = 260;
+
+/**
+ * Returns true when `key` (lowercased) is the SAME as the remembered tap and
+ * arrived within `windowMs`. Mutates `mem` to record this tap either way, so the
+ * caller just calls it on every relevant keydown.
+ */
+export function isDoubleTap(mem: TapMemory, key: string, now: number, windowMs: number = DOUBLE_TAP_MS): boolean {
+  const k = String(key).toLowerCase();
+  const hit = mem.key === k && now - mem.t <= windowMs && now - mem.t >= 0;
+  mem.key = k;
+  mem.t = now;
+  // After a successful double-tap, clear so a 3rd tap isn't also a dash.
+  if (hit) { mem.key = ''; mem.t = 0; }
+  return hit;
+}
+
+/** Movement keys that can trigger a dash. */
+export const DASH_KEYS = new Set(['w', 'a', 's', 'd']);

--- a/concord-frontend/tests/concordia/dash-input.test.ts
+++ b/concord-frontend/tests/concordia/dash-input.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { isDoubleTap, DOUBLE_TAP_MS, DASH_KEYS } from '@/lib/concordia/dash-input';
+
+describe('B1b — double-tap dash detection (pure)', () => {
+  it('a single tap is not a dash; a quick second tap of the SAME key is', () => {
+    const mem = { key: '', t: 0 };
+    expect(isDoubleTap(mem, 'w', 1000)).toBe(false); // first tap
+    expect(isDoubleTap(mem, 'w', 1000 + DOUBLE_TAP_MS - 10)).toBe(true); // double-tap
+  });
+
+  it('a slow second tap is NOT a dash', () => {
+    const mem = { key: '', t: 0 };
+    isDoubleTap(mem, 'w', 1000);
+    expect(isDoubleTap(mem, 'w', 1000 + DOUBLE_TAP_MS + 50)).toBe(false);
+  });
+
+  it('tapping a DIFFERENT key resets — not a dash', () => {
+    const mem = { key: '', t: 0 };
+    isDoubleTap(mem, 'w', 1000);
+    expect(isDoubleTap(mem, 'd', 1010)).toBe(false);
+  });
+
+  it('a triple-tap fires only ONE dash (memory clears after a hit)', () => {
+    const mem = { key: '', t: 0 };
+    isDoubleTap(mem, 'a', 0);                 // tap 1
+    expect(isDoubleTap(mem, 'a', 100)).toBe(true);  // tap 2 → dash
+    expect(isDoubleTap(mem, 'a', 200)).toBe(false); // tap 3 → not another dash
+  });
+
+  it('only WASD are dash keys', () => {
+    expect(DASH_KEYS.has('w')).toBe(true);
+    expect(DASH_KEYS.has('q')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Part B — the traversal engine becomes playable

Wires B1's tested traversal kinematics to AvatarSystem3D input, behind `CONCORD_TRAVERSAL_VERBS`:

- **Double-tap a movement key (W/A/S/D) → dash/dodge** in the current move direction (or facing when stationary): `physicsWorld.requestDash` (decaying velocity burst + i-frames) + `playAction('dodge')` for the procedural clip. Double-tap-direction is the character-action/Prototype standard and **conflicts with nothing** in combat input (no shared key).
- **Hold C while sprinting + moving → momentum slide**: `setSlide(true)` + `playAction('slide')`, released on key-up.

The detection is a pure, tested helper: `dash-input.ts#isDoubleTap` (same key within 260ms, clears after a hit so a triple-tap fires only one dash). Never fires while typing in an input.

### Verify
- New `tests/concordia/dash-input.test.ts` (5) — single≠dash, quick-second=dash, slow/different-key reset, triple-tap fires once, WASD-only.
- Full concordia vitest suite **248/248 green**; scoped `tsc` clean, no new AvatarSystem3D errors.
- **In-engine (user):** double-tap a direction to dash; sprint + C to slide. Kill-switch off → today's walk/run/jump/glide/swim only.

Next: B2 (carry momentum into gait phase), B3 (attack cancel-windows + dash i-frame damage-gating + skill-modulated motion), B4 (action chaining).

https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ)_