### PR TITLE
WS-B2: momentum-eased gait cadence (legs ramp on start/stop)

### DIFF
--- a/concord-frontend/components/world-lens/AvatarSystem3D.tsx
+++ b/concord-frontend/components/world-lens/AvatarSystem3D.tsx
@@ -2254,9 +2254,16 @@ export default function AvatarSystem3D({
                 1.0
               : 0;
 
+            // B2 — momentum-eased gait cadence. Drive leg speed from the
+            // accel-smoothed throttle (|pm|, the eased WASD magnitude 0→~1,
+            // diagonal up to 1.41 → clamped) × target speed, so cadence RAMPS on
+            // start/stop instead of snapping. The stride phase itself is already
+            // continuous (stridePhaseRef persists across stops — no reset).
+            const throttle = Math.hypot(planarMoveRef.current.x, planarMoveRef.current.z);
+            const gaitSpeed = Math.min(physicsSpeed, throttle * physicsSpeed);
             stridePhaseRef.current = advanceGaitPhase(
               stridePhaseRef.current,
-              physicsSpeed,
+              gaitSpeed,
               playerAvatar.appearance.bodyType as BodyType,
               delta
             );
@@ -2298,7 +2305,7 @@ export default function AvatarSystem3D({
             }
 
             const gaitParams: GaitParams = {
-              speed: physicsSpeed,
+              speed: gaitSpeed,
               direction: 0,
               slope: Math.atan(slopeAhead),
               load: physics.mass > 70 ? (physics.mass - 70) * 0.1 : 0,


### PR DESCRIPTION
## Part B — gait cadence ramps with momentum (no snap)

Drives the gait leg speed from the accel-smoothed movement throttle (`|planarMove|` — the eased WASD magnitude) × target speed, so leg **cadence ramps** on start/stop instead of snapping between idle and full stride.

Note: the stride **phase** was already continuous (`stridePhaseRef` persists across stops — the audit's "phase reset on transition" turned out not to be a real bug), so this completes B2 by easing the *speed* the phase advances at.

Scoped `tsc` caught a real aliasing bug while writing this — in the gait block `pm` is the player **mesh Group**, not `planarMoveRef`; reading `.x/.z` off it would've produced a NaN gait speed (frozen legs). Fixed to use `planarMoveRef.current`.

### Verify
- Full concordia vitest suite **248/248 green**; scoped `tsc` clean.
- **In-engine (user):** start/stop/turn — the leg cadence should ease rather than pop.

Next: B3 (skill-modulated motion — fire vs ice move differently — + attack cancel-windows + dash i-frame damage gate), B4 (action chaining).

https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ)_