### PR TITLE
WS-B3: skill-modulated motion (fire/ice/lightning move differently)

### DIFF
--- a/concord-frontend/components/world-lens/AvatarSystem3D.tsx
+++ b/concord-frontend/components/world-lens/AvatarSystem3D.tsx
@@ -1410,7 +1410,7 @@ export default function AvatarSystem3D({
       const actionClipMaps = new Map<string, import('three').AnimationClip>();
       async function handleActionAnim(e: Event) {
         const detail = (e as CustomEvent).detail as
-          | { entityId?: string; verb?: string; tier?: number; loop?: boolean;
+          | { entityId?: string; verb?: string; tier?: number; loop?: boolean; element?: string;
               pos?: { x: number; y?: number; z: number };
               descriptor?: { juiceId?: string; sfxId?: string; vfx?: string } }
           | undefined;
@@ -1420,7 +1420,10 @@ export default function AvatarSystem3D({
         const mixer = mixersRef.current.get(entityId) as MixerType | undefined;
         if (!mixer) return;
         try {
-          const tier = Math.max(1, Math.min(5, Math.floor(detail?.tier ?? 3)));
+          // B3 — skill-modulated motion: the element biases the effective tier so
+          // a fire slash arcs bigger, ice strikes sharp/small, lightning snaps.
+          const sm = await import('@/lib/concordia/skill-motion');
+          const tier = sm.effectiveTier(detail?.tier ?? 3, detail?.element);
           const clipKey = `${verb}-t${tier}`;
           let clip = actionClipMaps.get(clipKey);
           if (!clip) {
@@ -1441,11 +1444,15 @@ export default function AvatarSystem3D({
           const pa = await import('@/lib/concordia/play-action');
           const ju = await import('@/lib/concordia/juice');
           try { ju.juice(pa.juiceTriggerFor(d?.juiceId)); } catch { /* juice optional */ }
-          if (d?.sfxId) { try { ju.sfx(d.sfxId); } catch { /* sfx optional */ } }
-          if (d?.vfx) {
+          // B3 — element overrides the descriptor's default sfx/vfx so fire/ice/
+          // lightning READ different, not just recolour.
+          const sfxId = sm.modulatedSfx(d?.sfxId, detail?.element);
+          const vfxId = sm.modulatedVfx(d?.vfx, detail?.element);
+          if (sfxId) { try { ju.sfx(sfxId); } catch { /* sfx optional */ } }
+          if (vfxId) {
             const pos = detail?.pos;
             window.dispatchEvent(new CustomEvent('concordia:particle-effect', {
-              detail: { type: d.vfx, position: pos ?? { x: 0, y: 1, z: 0 }, duration: 600, intensity: 1 },
+              detail: { type: vfxId, position: pos ?? { x: 0, y: 1, z: 0 }, duration: 600, intensity: 1 },
             }));
           }
         } catch { /* action clip generation/playback silent */ }

--- a/concord-frontend/lib/concordia/play-action.ts
+++ b/concord-frontend/lib/concordia/play-action.ts
@@ -22,6 +22,8 @@ export interface PlayActionOpts {
   body?: 'slim' | 'average' | 'stocky' | 'tall';
   /** loop the action (sustained verbs: fishing line tension, forge hammer) */
   loop?: boolean;
+  /** skill element (fire/ice/lightning/…) — modulates motion amplitude + VFX (B3) */
+  element?: string;
 }
 
 /**

--- a/concord-frontend/lib/concordia/skill-motion.ts
+++ b/concord-frontend/lib/concordia/skill-motion.ts
@@ -1,0 +1,61 @@
+// concord-frontend/lib/concordia/skill-motion.ts
+//
+// Part B (B3) — skill-modulated motion. Today a fire slash and an ice slash play
+// the identical clip and differ only by particle colour. This maps a skill's
+// ELEMENT to (a) a distinct VFX + SFX and (b) a tier BIAS that scales the
+// procedural clip's amplitude/anticipation — so fire reads as a big aggressive
+// arc, ice as a controlled sharp strike, lightning as a fast snap. Pure +
+// data-driven (a table), so it's unit-testable and "adding an element = a row".
+//
+// The clip engine (buildActionClip / buildBiomechClipMap) already scales motion
+// by tier 1..5; we just bias the effective tier by element and swap the VFX.
+
+export interface ElementMotion {
+  /** concordia:particle-effect type for this element. */
+  vfx: string;
+  /** soundscape sfx id. */
+  sfx: string;
+  /** added to the base tier (clamped 1..5) → bigger/smaller motion. */
+  tierBias: number;
+}
+
+// element → motion flavour. Unknown/physical → neutral (no override).
+const ELEMENT_MOTION: Record<string, ElementMotion> = {
+  fire:      { vfx: 'flame',  sfx: 'fire_whoosh',  tierBias: +1 }, // big aggressive arc
+  ice:       { vfx: 'frost',  sfx: 'ice_crackle',  tierBias: -1 }, // controlled, sharp + small
+  frost:     { vfx: 'frost',  sfx: 'ice_crackle',  tierBias: -1 },
+  lightning: { vfx: 'spark',  sfx: 'thunder',      tierBias: +1 }, // fast snap
+  water:     { vfx: 'splash', sfx: 'water_surge',  tierBias: 0 },
+  poison:    { vfx: 'toxin',  sfx: 'hiss',         tierBias: 0 },
+  bio:       { vfx: 'toxin',  sfx: 'hiss',         tierBias: 0 },
+  energy:    { vfx: 'arcane', sfx: 'energy_hum',   tierBias: +1 },
+  earth:     { vfx: 'rock_debris', sfx: 'stone_grind', tierBias: +1 }, // heavy
+};
+
+/** Look up an element's motion flavour (null when none/physical/unknown). */
+export function elementMotion(element: string | null | undefined): ElementMotion | null {
+  if (!element) return null;
+  return ELEMENT_MOTION[String(element).toLowerCase()] ?? null;
+}
+
+/** Effective tier after element bias, clamped to the engine's 1..5 range. */
+export function effectiveTier(baseTier: number, element: string | null | undefined): number {
+  const base = Math.max(1, Math.min(5, Math.floor(Number(baseTier) || 3)));
+  const m = elementMotion(element);
+  if (!m) return base;
+  return Math.max(1, Math.min(5, base + m.tierBias));
+}
+
+/** VFX to spawn: the element's (if any) else the descriptor's default. */
+export function modulatedVfx(baseVfx: string | undefined, element: string | null | undefined): string | undefined {
+  const m = elementMotion(element);
+  return m ? m.vfx : baseVfx;
+}
+
+/** SFX to play: the element's (if any) else the descriptor's default. */
+export function modulatedSfx(baseSfx: string | undefined, element: string | null | undefined): string | undefined {
+  const m = elementMotion(element);
+  return m ? m.sfx : baseSfx;
+}
+
+export const ELEMENT_MOTION_TABLE = ELEMENT_MOTION;

--- a/concord-frontend/tests/concordia/skill-motion.test.ts
+++ b/concord-frontend/tests/concordia/skill-motion.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import {
+  elementMotion, effectiveTier, modulatedVfx, modulatedSfx, ELEMENT_MOTION_TABLE,
+} from '@/lib/concordia/skill-motion';
+
+describe('B3 — skill-modulated motion (pure)', () => {
+  it('fire biases the tier UP (bigger arc), ice DOWN (sharp/small)', () => {
+    expect(effectiveTier(3, 'fire')).toBe(4);
+    expect(effectiveTier(3, 'ice')).toBe(2);
+    expect(effectiveTier(3, 'lightning')).toBe(4);
+  });
+
+  it('tier bias clamps to the engine 1..5 range', () => {
+    expect(effectiveTier(5, 'fire')).toBe(5);   // can't exceed 5
+    expect(effectiveTier(1, 'ice')).toBe(1);    // can't drop below 1
+  });
+
+  it('no element / physical / unknown → base tier + base vfx/sfx unchanged', () => {
+    expect(effectiveTier(3, null)).toBe(3);
+    expect(effectiveTier(3, 'physical')).toBe(3);
+    expect(modulatedVfx('woodchips', null)).toBe('woodchips');
+    expect(modulatedSfx('axe_chop', 'physical')).toBe('axe_chop');
+  });
+
+  it('element overrides vfx + sfx so fire ≠ ice visually/audibly', () => {
+    expect(modulatedVfx('arcane', 'fire')).toBe('flame');
+    expect(modulatedVfx('arcane', 'ice')).toBe('frost');
+    expect(modulatedSfx('spell_cast', 'lightning')).toBe('thunder');
+    expect(modulatedVfx('arcane', 'fire')).not.toBe(modulatedVfx('arcane', 'ice'));
+  });
+
+  it('elementMotion is null for non-elements, a row for elements', () => {
+    expect(elementMotion('')).toBeNull();
+    expect(elementMotion('fire')).toEqual(ELEMENT_MOTION_TABLE.fire);
+  });
+});


### PR DESCRIPTION
## Part B — closes the audit's "fire slash and ice slash look identical" gap

New pure, tested `skill-motion.ts` maps a skill's **element** to:
- a **tier bias** that scales the procedural clip's amplitude/anticipation — fire `+1` (big aggressive arc), ice `−1` (controlled, sharp + small), lightning `+1` (fast snap), earth/energy `+1` (heavy) — clamped to the engine's 1..5 range;
- a **distinct VFX + SFX** (flame / frost / spark / toxin / arcane / rock_debris …), so elements read different rather than just recolouring.

Wired into `handleActionAnim`: `playAction` now takes an `element` opt; the effective tier drives `buildActionClip`, and the element overrides the descriptor's default vfx/sfx. So the ~45 action verbs — including `cast` / `commune` / `compose_spell` — animate per-element.

### Verify
- New `tests/concordia/skill-motion.test.ts` (5) — fire-up/ice-down tier bias, 1..5 clamp, neutral passthrough for physical/unknown, vfx/sfx override, table lookup.
- Full concordia vitest suite **253/253 green**; scoped `tsc` clean incl. AvatarSystem3D.
- **In-engine (user):** cast a fire vs an ice skill — the motion size + VFX should differ.

Follow-on: bias the combat-melee biomech path (`handleCombatAnim`) by element too. Then B4 (action chaining).

https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ)_