### PR TITLE
WS-B4: action chaining (queue the next verb instead of cutting the current)

### DIFF
--- a/concord-frontend/components/world-lens/AvatarSystem3D.tsx
+++ b/concord-frontend/components/world-lens/AvatarSystem3D.tsx
@@ -338,6 +338,8 @@ export default function AvatarSystem3D({
   const playerRotationRef = useRef(playerAvatar.rotation);
   // B1b — double-tap dash memory (traversal dodge).
   const dashTapRef = useRef<{ key: string; t: number }>({ key: '', t: 0 });
+  // B4 — action chaining queue (lazy-constructed).
+  const actionQueueRef = useRef<import('@/lib/concordia/action-queue').ActionQueue | null>(null);
   const [activeAnimation, setActiveAnimation] = useState<AnimationClip>(
     playerAvatar.currentAnimation
   );
@@ -1420,6 +1422,23 @@ export default function AvatarSystem3D({
         const mixer = mixersRef.current.get(entityId) as MixerType | undefined;
         if (!mixer) return;
         try {
+          // B4 — action chaining: protect the current action's core window
+          // (windup+action) so a rapid second verb queues + flushes after,
+          // instead of hard-cutting the first. Only gate the LOCAL player; NPC
+          // activity clips and looped actions play immediately. Replayed flushes
+          // carry __chained so they don't re-queue.
+          const isPlayer = entityId === playerAvatar.id;
+          const replayed = (detail as { __chained?: boolean })?.__chained === true;
+          if (isPlayer && !detail?.loop && !replayed) {
+            const aqmod = await import('@/lib/concordia/action-queue');
+            if (!actionQueueRef.current) actionQueueRef.current = new aqmod.ActionQueue({ maxQueue: 1 });
+            const amod0 = await import('@/lib/concordia/action-biomechanics');
+            const d0 = amod0.resolveActionDescriptor(verb);
+            const protectMs = (d0.phases?.[0] ?? 150) + (d0.phases?.[1] ?? 100);
+            if (!actionQueueRef.current.request(detail, performance.now(), protectMs)) {
+              return; // queued; the per-frame flush will replay it
+            }
+          }
           // B3 — skill-modulated motion: the element biases the effective tier so
           // a fire slash arcs bigger, ice strikes sharp/small, lightning snaps.
           const sm = await import('@/lib/concordia/skill-motion');
@@ -2042,6 +2061,20 @@ export default function AvatarSystem3D({
         if (pauseMap.size > 0) {
           for (const [k, until] of pauseMap) {
             if (until <= now) pauseMap.delete(k);
+          }
+        }
+
+        // B4 — flush a queued chained action once the current one's core window
+        // has elapsed: replay its detail (tagged __chained so it plays straight
+        // through) so harvest→plant etc. flows out of the recovery.
+        if (actionQueueRef.current && actionQueueRef.current.pending > 0) {
+          const next = actionQueueRef.current.flush(performance.now());
+          if (next && typeof window !== 'undefined') {
+            try {
+              window.dispatchEvent(new CustomEvent('concordia:action-anim', {
+                detail: { ...(next as object), __chained: true },
+              }));
+            } catch { /* flush is best-effort */ }
           }
         }
 

--- a/concord-frontend/lib/concordia/action-queue.ts
+++ b/concord-frontend/lib/concordia/action-queue.ts
@@ -1,0 +1,61 @@
+// concord-frontend/lib/concordia/action-queue.ts
+//
+// Part B (B4) — action chaining. Today a second action verb fired while the
+// first is still playing hard-cuts the first's follow-through (or snaps to
+// idle). This small queue lets a verb COMMIT its core window, then flushes the
+// next queued verb — so harvest→plant, or a quick combo of station actions,
+// flows instead of clipping. Pure + tested; AvatarSystem3D holds one instance
+// and flushes it from the per-frame loop.
+//
+// Only the ACTION window is protected (windup+action); the follow-through can be
+// interrupted by the next queued verb (a short blend), which is the responsive
+// sweet spot — you commit the swing but chain smoothly out of the recovery.
+
+export interface QueuedAction {
+  detail: unknown; // the original concordia:action-anim detail, replayed verbatim
+}
+
+export interface ActionQueueOpts {
+  /** Max queued actions (older ones drop). Default 1 — chain, don't buffer a combo. */
+  maxQueue?: number;
+}
+
+export class ActionQueue {
+  private busyUntil = 0;          // wall-clock ms the current action's protected window ends
+  private queue: QueuedAction[] = [];
+  private readonly maxQueue: number;
+
+  constructor(opts: ActionQueueOpts = {}) {
+    this.maxQueue = Math.max(1, opts.maxQueue ?? 1);
+  }
+
+  /**
+   * Decide whether a verb plays now or is queued. `protectMs` is how long the
+   * current action's core (windup+action) commits before the next can flush.
+   * Returns true to PLAY NOW (caller starts the clip); false = enqueued.
+   */
+  request(detail: unknown, now: number, protectMs: number): boolean {
+    if (now >= this.busyUntil) {
+      this.busyUntil = now + Math.max(0, protectMs);
+      return true;
+    }
+    // Busy — enqueue (drop oldest beyond the cap so we never build a backlog).
+    this.queue.push({ detail });
+    while (this.queue.length > this.maxQueue) this.queue.shift();
+    return false;
+  }
+
+  /**
+   * If the protected window has elapsed and something is queued, pop it. The
+   * caller replays its detail (re-dispatch the event) and then calls `request`
+   * again for it (which re-arms busyUntil). Returns the detail or null.
+   */
+  flush(now: number): unknown | null {
+    if (now < this.busyUntil) return null;
+    const next = this.queue.shift();
+    return next ? next.detail : null;
+  }
+
+  get pending(): number { return this.queue.length; }
+  clear(): void { this.queue = []; this.busyUntil = 0; }
+}

--- a/concord-frontend/tests/concordia/action-queue.test.ts
+++ b/concord-frontend/tests/concordia/action-queue.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { ActionQueue } from '@/lib/concordia/action-queue';
+
+describe('B4 — action chaining queue', () => {
+  it('plays immediately when idle, arming the protected window', () => {
+    const q = new ActionQueue();
+    expect(q.request({ verb: 'harvest' }, 1000, 300)).toBe(true); // plays now
+    // a second verb during the window is queued, not played
+    expect(q.request({ verb: 'plant' }, 1100, 300)).toBe(false);
+    expect(q.pending).toBe(1);
+  });
+
+  it('flush returns nothing until the window elapses, then pops the queued verb', () => {
+    const q = new ActionQueue();
+    q.request({ verb: 'harvest' }, 1000, 300); // window ends at 1300
+    q.request({ verb: 'plant' }, 1100, 300);   // queued
+    expect(q.flush(1200)).toBeNull();           // still committed to harvest
+    expect(q.flush(1350)).toEqual({ verb: 'plant' }); // window passed → flush plant
+    expect(q.pending).toBe(0);
+  });
+
+  it('a verb after the window plays immediately (no queue)', () => {
+    const q = new ActionQueue();
+    q.request({ verb: 'a' }, 0, 200);
+    expect(q.request({ verb: 'b' }, 500, 200)).toBe(true); // 500 > 200 → plays now
+    expect(q.pending).toBe(0);
+  });
+
+  it('caps the queue (maxQueue=1 by default — chain, do not buffer a combo)', () => {
+    const q = new ActionQueue();
+    q.request({ verb: 'a' }, 0, 1000); // busy until 1000
+    q.request({ verb: 'b' }, 100, 1000);
+    q.request({ verb: 'c' }, 200, 1000);
+    expect(q.pending).toBe(1);
+    expect(q.flush(1001)).toEqual({ verb: 'c' }); // newest kept, older dropped
+  });
+
+  it('clear resets busy + queue', () => {
+    const q = new ActionQueue();
+    q.request({ verb: 'a' }, 0, 1000);
+    q.request({ verb: 'b' }, 100, 1000);
+    q.clear();
+    expect(q.pending).toBe(0);
+    expect(q.request({ verb: 'c' }, 200, 1000)).toBe(true); // idle again
+  });
+});


### PR DESCRIPTION
## Part B (final) — actions chain instead of snapping

A rapid second action verb used to hard-cut the first's follow-through (or snap to idle). New pure, tested `action-queue.ts`:

- an action commits its **core window** (windup + action ms, from the descriptor);
- a verb fired during that window is **queued** (cap 1 — chain, don't buffer a whole combo);
- the per-frame loop **flushes** it once the window elapses (replayed tagged `__chained` so it plays straight through).

So **harvest → plant** flows out of the recovery instead of clipping. Only the local player is gated; NPC activity clips and looped actions play immediately.

### Verify
- New `tests/concordia/action-queue.test.ts` (5) — play-when-idle + arm window, queue-during-window, flush-after-window, post-window plays immediately, cap=1 keeps newest, clear resets.
- Full concordia vitest suite **258/258 green**; scoped `tsc` clean incl. AvatarSystem3D.
- **In-engine (user):** fire two station actions back-to-back — the first should finish its commit then the second flows in.

**This completes the planned Part B fluidity arc (B1 → B4).**

https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ)_