### PR TITLE
Universal Move System: plan doc + Phase 1 resolver keystone

### DIFF
--- a/concord-frontend/lib/concordia/move-catalog/move-types.ts
+++ b/concord-frontend/lib/concordia/move-catalog/move-types.ts
@@ -1,0 +1,113 @@
+// concord-frontend/lib/concordia/move-catalog/move-types.ts
+//
+// Universal Move System — Phase 1. The canonical schema every CREATED move maps
+// to (glyph spell, fighting style, biopower, psionic, cyber ability, gun,
+// movement power, fused skill), so any creation resolves to a procedural
+// animation + effect. Stored in the recipe DTU `meta_json.motion`; the client
+// resolver derives the *active* look from it. Backward-compatible: when a move
+// has no `.motion` block (existing creations), the resolver derives one from
+// `skill_kind` + `element`.
+//
+// Pure types + catalog tables (no three/DOM), so they're shared + unit-testable.
+
+import type { ActionArchetype, LeadingLimb } from '../action-biomechanics';
+
+/** What kind of motion a move is — selects the animation family. */
+export type MotionFamily =
+  | 'combat_melee' | 'combat_ranged' | 'firearm' | 'magic' | 'movement'
+  | 'social' | 'labor' | 'creature';
+
+/** The biomech pose family. Reuses action-biomechanics' archetypes; later phases
+ *  add the firearm/flight/surface/swing/speed-trail/blink archetypes (declared
+ *  here as string-literal extensions so the catalog can reference them before the
+ *  pose generators ship). */
+export type MotionArchetype =
+  | ActionArchetype
+  | 'firearm' | 'flight' | 'surface_ride' | 'web_swing' | 'speed_trail' | 'blink';
+
+/** The structural effect category (independent of element). */
+export type EffectArchetype =
+  | 'projectile' | 'beam' | 'nova' | 'ground_zone' | 'self_aura' | 'ally_heal'
+  | 'debuff' | 'summon' | 'transform' | 'melee_imbue' | 'dash_blink' | 'shield'
+  | 'trap' | 'chain' | 'terrain_alter' | 'homing';
+
+/** The world-appropriate power source a move drains (Pillar 2 — lore-resource). */
+export type ResourceGauge = 'mana' | 'bio' | 'charge' | 'stamina' | 'none';
+
+/** The 7 authored skill kinds (server `skill-evolution.js` SKILL_KIND_LIMB_REQ). */
+export type SkillKind =
+  | 'fighting_style' | 'spell' | 'biopower' | 'cyber_ability'
+  | 'psionic' | 'tech_gadget' | 'mundane';
+
+export type TargetShape = 'self' | 'single' | 'cone' | 'line' | 'area';
+
+/**
+ * The motion block stored on a created move (`meta_json.motion`). Every field is
+ * optional so the resolver can fill gaps from skill_kind + element (backward-
+ * compat for moves minted before this system).
+ */
+export interface MoveDescriptor {
+  motionFamily?: MotionFamily;
+  motionArchetype?: MotionArchetype;
+  effectArchetype?: EffectArchetype;
+  element?: string;
+  powerCategory?: string;
+  resourceGauge?: ResourceGauge;
+  leadingLimb?: LeadingLimb;
+  targetShape?: TargetShape;
+  /** [windupMs, actionMs, followMs] */
+  phases?: [number, number, number];
+}
+
+/** The fully-resolved move the client animates + the VFX/SFX it fires. */
+export interface ResolvedMove {
+  motionFamily: MotionFamily;
+  motionArchetype: MotionArchetype;
+  effectArchetype: EffectArchetype;
+  element: string;
+  resourceGauge: ResourceGauge;
+  leadingLimb: LeadingLimb;
+  targetShape: TargetShape;
+  /** 1..5 visual tier (Pillar 1 — gated by skill level, not the description). */
+  tier: number;
+  phases: [number, number, number];
+  vfx?: string;
+  sfxId?: string;
+}
+
+// ── skill_kind → default motion (mirrors server SKILL_KIND_LIMB_REQ + adds the
+// animation archetype + effect + the lore-resource gauge each kind drains). ──
+export interface SkillKindMotion {
+  family: MotionFamily;
+  archetype: MotionArchetype;
+  effect: EffectArchetype;
+  limb: LeadingLimb;
+  gauge: ResourceGauge;
+}
+
+export const SKILL_KIND_MOTION: Record<SkillKind, SkillKindMotion> = {
+  fighting_style: { family: 'combat_melee', archetype: 'swing_down', effect: 'melee_imbue', limb: 'both_arms', gauge: 'stamina' },
+  spell:          { family: 'magic',        archetype: 'cast_channel', effect: 'projectile', limb: 'both_arms', gauge: 'mana' },
+  biopower:       { family: 'magic',        archetype: 'cast_channel', effect: 'self_aura',  limb: 'spine',     gauge: 'bio' },
+  cyber_ability:  { family: 'combat_ranged',archetype: 'lean_reach',   effect: 'beam',       limb: 'right_arm', gauge: 'charge' },
+  psionic:        { family: 'magic',        archetype: 'cast_channel', effect: 'debuff',     limb: 'head',      gauge: 'mana' },
+  tech_gadget:    { family: 'combat_ranged',archetype: 'lean_reach',   effect: 'projectile', limb: 'right_arm', gauge: 'charge' },
+  mundane:        { family: 'labor',        archetype: 'thrust',       effect: 'melee_imbue',limb: 'right_arm', gauge: 'stamina' },
+};
+
+/** Element → the effect archetype it most naturally expresses (a *default* — the
+ *  builder can override). Anchored to Concord's 9 canonical elements + families. */
+export const ELEMENT_EFFECT_BIAS: Record<string, EffectArchetype> = {
+  fire: 'projectile', ice: 'ground_zone', frost: 'ground_zone', water: 'ground_zone',
+  lightning: 'chain', energy: 'beam', bio: 'debuff', poison: 'debuff',
+  psychic: 'debuff', physical: 'melee_imbue', refusal: 'shield',
+  earth: 'terrain_alter', air: 'nova', wind: 'nova', nature: 'ground_zone',
+  light: 'beam', shadow: 'debuff', void: 'nova', arcane: 'projectile',
+};
+
+export const DEFAULT_PHASES: [number, number, number] = [200, 160, 220];
+
+/** Clamp a value to the engine's 1..5 visual tier range. */
+export function clampTier(t: number): number {
+  return Math.max(1, Math.min(5, Math.floor(Number.isFinite(t) ? t : 3)));
+}

--- a/concord-frontend/lib/concordia/move-resolver.ts
+++ b/concord-frontend/lib/concordia/move-resolver.ts
@@ -1,0 +1,92 @@
+// concord-frontend/lib/concordia/move-resolver.ts
+//
+// Universal Move System — Phase 1 keystone. THE resolver: given any created
+// move (its stored `motion` descriptor + its skill_kind/element/level), produce
+// a fully-resolved `ResolvedMove` the client animates + the VFX/SFX it fires.
+//
+// This closes the audit's core gap: before this, a minted spell stored
+// element+damage+glyph but no animation archetype, so every custom move played a
+// generic `cast`. Now `resolveMove` picks the archetype + effect + element VFX +
+// the level-gated visual tier (Pillar 1) for ANY creation — and NEVER returns
+// null (always a sensible default). Pure + unit-testable.
+
+import {
+  type MoveDescriptor, type ResolvedMove, type SkillKind, type EffectArchetype,
+  type MotionFamily, SKILL_KIND_MOTION, ELEMENT_EFFECT_BIAS, DEFAULT_PHASES, clampTier,
+} from './move-catalog/move-types';
+import { modulatedVfx, modulatedSfx, effectiveTier } from './skill-motion';
+
+export interface ResolveMoveInput {
+  /** The stored motion block (`meta_json.motion`), if the move was minted with one. */
+  motion?: MoveDescriptor | null;
+  /** Authored kind — used to derive defaults when `motion` is partial/absent. */
+  skillKind?: string | null;
+  /** Element (fire/ice/lightning/…) — drives VFX/SFX + effect bias. */
+  element?: string | null;
+  /** The move's CURRENT skill level (Pillar 1: gates the active visual tier). */
+  skillLevel?: number | null;
+  /** Explicit base tier override (else derived from skillLevel). */
+  tier?: number | null;
+}
+
+/** Skill level → 1..5 visual tier (mirrors server skill-evolution: revisions every
+ *  10 levels; tier saturates at 5 while power keeps scaling). A L1 move is tier 1
+ *  no matter how grand its description; a L150+ move is tier 5. */
+export function tierForLevel(level: number | null | undefined): number {
+  const lv = Math.max(1, Math.floor(Number(level) || 1));
+  const revision = Math.floor((lv - 1) / 10); // a revision every 10 levels
+  if (revision >= 150) return 5;
+  if (revision >= 50) return 4;
+  if (revision >= 15) return 3;
+  if (revision >= 5) return 2;
+  return 1;
+}
+
+function isSkillKind(k: string | null | undefined): k is SkillKind {
+  return !!k && k in SKILL_KIND_MOTION;
+}
+
+/**
+ * Resolve any created move to its animation + effect. Precedence: an explicit
+ * field on `motion` wins; else derive from skill_kind; else a safe generic.
+ */
+export function resolveMove(input: ResolveMoveInput): ResolvedMove {
+  const m = input.motion ?? {};
+  const kind = isSkillKind(input.skillKind) ? input.skillKind : null;
+  const base = kind ? SKILL_KIND_MOTION[kind] : null;
+  const element = (m.element ?? input.element ?? 'physical').toLowerCase();
+
+  const motionFamily: MotionFamily = m.motionFamily ?? base?.family ?? 'magic';
+  const motionArchetype = m.motionArchetype ?? base?.archetype ?? 'cast_channel';
+  const leadingLimb = m.leadingLimb ?? base?.limb ?? 'both_arms';
+  const resourceGauge = m.resourceGauge ?? base?.gauge ?? 'none';
+  const targetShape = m.targetShape ?? 'single';
+
+  // Effect archetype: authored > element bias > skill_kind default > projectile.
+  const effectArchetype: EffectArchetype =
+    m.effectArchetype ?? ELEMENT_EFFECT_BIAS[element] ?? base?.effect ?? 'projectile';
+
+  // Visual tier (Pillar 1): explicit > derived-from-level. Element nudges it
+  // (fire bigger, ice sharper) via the existing skill-motion bias.
+  const baseTier = input.tier != null ? clampTier(input.tier) : tierForLevel(input.skillLevel);
+  const tier = effectiveTier(baseTier, element);
+
+  // Element VFX/SFX (reuse the shipped skill-motion element table; default by family).
+  const fallbackVfx = motionFamily === 'combat_melee' ? 'impact' : 'arcane';
+  const vfx = modulatedVfx(fallbackVfx, element);
+  const sfxId = modulatedSfx(undefined, element);
+
+  return {
+    motionFamily,
+    motionArchetype,
+    effectArchetype,
+    element,
+    resourceGauge,
+    leadingLimb,
+    targetShape,
+    tier,
+    phases: m.phases ?? DEFAULT_PHASES,
+    vfx,
+    sfxId,
+  };
+}

--- a/concord-frontend/tests/concordia/move-resolver.test.ts
+++ b/concord-frontend/tests/concordia/move-resolver.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { resolveMove, tierForLevel } from '@/lib/concordia/move-resolver';
+import { SKILL_KIND_MOTION, clampTier } from '@/lib/concordia/move-catalog/move-types';
+
+// Universal Move System Phase 1 — the resolver closes the audit gap (no created
+// move plays a generic `cast` anymore). Pure, never-null, backward-compatible.
+
+describe('Move System P1 — tierForLevel (Pillar 1: level gates the tier)', () => {
+  it('a L1 move is tier 1 no matter the design; tiers climb with level', () => {
+    expect(tierForLevel(1)).toBe(1);
+    expect(tierForLevel(9)).toBe(1);
+    expect(tierForLevel(60)).toBe(2);   // revision 5
+    expect(tierForLevel(160)).toBe(3);  // revision 15
+    expect(tierForLevel(520)).toBe(4);  // revision 50+
+    expect(tierForLevel(1600)).toBe(5); // revision 150+ (visual ceiling)
+  });
+  it('saturates at 5 (visual ceiling) while levels keep climbing', () => {
+    expect(tierForLevel(9999)).toBe(5);
+  });
+  it('garbage level → tier 1', () => {
+    expect(tierForLevel(undefined)).toBe(1);
+    expect(tierForLevel(0)).toBe(1);
+  });
+});
+
+describe('Move System P1 — resolveMove', () => {
+  it('derives a full move from skill_kind + element when no motion block (backward-compat)', () => {
+    const r = resolveMove({ skillKind: 'spell', element: 'fire', skillLevel: 1 });
+    expect(r.motionFamily).toBe('magic');
+    expect(r.motionArchetype).toBe('cast_channel');
+    expect(r.resourceGauge).toBe('mana');       // Pillar 2: spell drains mana
+    expect(r.effectArchetype).toBe('projectile'); // fire → projectile bias
+    expect(r.element).toBe('fire');
+    expect(r.tier).toBeGreaterThanOrEqual(1);
+  });
+
+  it('a level-1 vs a level-200 SAME move differ only in tier (Pillar 1)', () => {
+    const lo = resolveMove({ skillKind: 'spell', element: 'fire', skillLevel: 1 });
+    const hi = resolveMove({ skillKind: 'spell', element: 'fire', skillLevel: 200 });
+    expect(hi.tier).toBeGreaterThan(lo.tier);
+    expect(hi.motionArchetype).toBe(lo.motionArchetype); // same design
+    expect(hi.element).toBe(lo.element);
+  });
+
+  it('each skill_kind drains its lore-appropriate gauge (Pillar 2)', () => {
+    expect(resolveMove({ skillKind: 'biopower' }).resourceGauge).toBe('bio');
+    expect(resolveMove({ skillKind: 'cyber_ability' }).resourceGauge).toBe('charge');
+    expect(resolveMove({ skillKind: 'fighting_style' }).resourceGauge).toBe('stamina');
+    expect(resolveMove({ skillKind: 'psionic' }).resourceGauge).toBe('mana');
+  });
+
+  it('an authored motion block overrides the derived defaults', () => {
+    const r = resolveMove({
+      motion: { motionArchetype: 'thrust', effectArchetype: 'beam', targetShape: 'line', resourceGauge: 'charge' },
+      skillKind: 'spell', element: 'lightning', skillLevel: 50,
+    });
+    expect(r.motionArchetype).toBe('thrust');   // authored wins over skill_kind default
+    expect(r.effectArchetype).toBe('beam');
+    expect(r.targetShape).toBe('line');
+    expect(r.resourceGauge).toBe('charge');
+  });
+
+  it('element drives distinct VFX so fire ≠ ice', () => {
+    const fire = resolveMove({ skillKind: 'spell', element: 'fire' });
+    const ice = resolveMove({ skillKind: 'spell', element: 'ice' });
+    expect(fire.vfx).not.toBe(ice.vfx);
+    expect(ice.effectArchetype).toBe('ground_zone'); // ice bias
+  });
+
+  it('never returns null / always has a sensible default (unknown kind + element)', () => {
+    const r = resolveMove({ skillKind: 'zorp', element: 'glorbo' });
+    expect(r).toBeTruthy();
+    expect(r.motionArchetype).toBeTruthy();
+    expect(r.effectArchetype).toBeTruthy();
+    expect(r.tier).toBe(1);
+  });
+
+  it('SKILL_KIND_MOTION covers all 7 authored kinds', () => {
+    expect(Object.keys(SKILL_KIND_MOTION).sort()).toEqual(
+      ['biopower', 'cyber_ability', 'fighting_style', 'mundane', 'psionic', 'spell', 'tech_gadget'],
+    );
+  });
+
+  it('clampTier bounds to 1..5', () => {
+    expect(clampTier(0)).toBe(1);
+    expect(clampTier(99)).toBe(5);
+    expect(clampTier(3)).toBe(3);
+  });
+});

--- a/docs/UNIVERSAL_MOVE_SYSTEM_PLAN.md
+++ b/docs/UNIVERSAL_MOVE_SYSTEM_PLAN.md
@@ -1,0 +1,223 @@
+# Universal Move System — Implementation Plan & Handoff
+
+> **Handoff note (for the next session).** This is the approved plan for the Universal Move System
+> (the isekai "[System]" where any user/NPC/creature creation → procedural animation + effect, fairly
+> leveled & lore-bound). It was researched across 5 deep web/code threads + a lore audit.
+>
+> **Progress so far (branch `claude/move-system-p1-resolver`, NOT yet merged):** Phase 1 keystone
+> STARTED — the pure client resolver + catalog core are built and unit-tested green (11/11):
+> - `concord-frontend/lib/concordia/move-catalog/move-types.ts` — MoveDescriptor + ResolvedMove +
+>   `SKILL_KIND_MOTION` (7 kinds → archetype/limb/effect/gauge) + `ELEMENT_EFFECT_BIAS` + `clampTier`.
+> - `concord-frontend/lib/concordia/move-resolver.ts` — `resolveMove(input)` (never-null, backward-compat
+>   derive from skill_kind+element) + `tierForLevel` (Pillar 1: level→tier, saturates at 5).
+> - `concord-frontend/tests/concordia/move-resolver.test.ts` — 11 tests, all green; scoped `tsc` clean.
+>
+> **Next steps (finish Phase 1 → then Phases 2–9):**
+> 1. Server `server/lib/move-descriptor.js#deriveMotion(...)` + stamp `meta_json.motion` at
+>    `glyph-spells.js#mintSpell` / `skill-evolution.js#applyEvolution` / recipe-create.
+> 2. Wire `resolveMove` into `lib/concordia/play-action.ts` + `AvatarSystem3D.handle{Action,Combat}Anim`,
+>    replacing the generic `cast` fallback. Behind kill-switch `CONCORD_MOVE_RESOLVER`.
+> 3. Live-server probe (register → mint a move → confirm `meta_json.motion` stamped; L1 vs L200 differ).
+> 4. Then Phase 2 (the "[System]" builder + the 3 balance pillars), Phase 3 (guns), Phase 4 (movement
+>    powers), etc. — see phases below.
+>
+> Cadence: small PRs per phase, each behind its kill-switch, merged green — same as the destructible-world
+> + fluidity work (#786–795). Pure logic unit-tested headless; visual/feel verified in-engine by the user.
+
+---
+
+# Plan — Universal Move System: the isekai "[System]" where any creation → animation + effect, fairly leveled & lore-bound
+
+## Context
+
+Concord lets users, NPCs, factions, creatures, fauna and flora *create* moves — glyph spells, fighting
+styles, biopowers, psionics, cyber abilities, guns, **movement powers** (flight/super-speed/ice-slide/
+web-swing…), and fused/evolved skills. The vision: an in-game **"[System]"** (webtoon/isekai — Solo
+Leveling / The Gamer) that is friendly, fun, and has **no learning curve**, where a player *configures* a
+move from constrained options, and the move **levels up through tiers** so power + visual grandeur grow
+with invested skill — never with how grand the description sounds — and where every move is **bound to the
+lore**: it drains the world-appropriate power gauge, is gated by what each world permits, and **loses
+potency when carried to another world** unless the skill is highly leveled.
+
+Five deep research threads + a code audit found the spine **mostly already exists**; the gaps are the
+resolver, the builder UI, guns, movement *powers*, and the fairness/lore gates. Production-grade already:
+- **Infinite, fair, per-skill progression** (`skill-progression.js`): `level = 1 + √(totalExp/2)`,
+  unbounded, mastery tiers Novice(10)→Skilled(50)→Expert(100)→Master(200)→Legendary(500)→Mythic(1000)→
+  Transcendent(5000) w/ auras, diminishing returns, **`cross_world_use` 1.5× XP** rate already defined.
+- **Tiered evolution every 10 levels** (`skill-evolution.js`): revisions, dmg ×1.15/tier, **anim tier
+  caps at 5 (visual ceiling) while power scales** — the "L1 spell weak, same move at L200 = full vision" model.
+- **Constrained builder algorithm** (`glyph-spells.js`): compose 2–5 components, element-family coherence,
+  deterministic preview — **no player UI**.
+- **Skill fusion** (`skill-fusion.js`, WIRED): two-parent hybrids, element fusions, generation decay,
+  inbreeding penalty, gen-8 singularity, LLM cap — **no player UI / level+cost gates**.
+- **The "[System]" UI substrate**: `LevelUpJuiceBridge`, `GameJuice`, `AchievementSystem`, `SkillsPanel`,
+  `EvolutionModal` (already a skill-upgrade modal w/ player input + revision lineage), `HUDOverlay`,
+  `SmartNotifications`, toast store.
+- **Movement substrate**: `flight-physics.ts` (full banking/stall/thermal aero model + `concordia:flight-
+  state`), `traversal-kinematics.ts` (dash/i-frames/momentum/slide), `physics-world.ts` (jump/glide/swim/
+  dash, `registerWaterPlane`), pose-broker `traversal` source, action-biomechanics traversal descriptors.
+- **Lore + per-world levers**: base-6 glyphs (⟐/⟲/⊚), 9 canonical elements, 7 skill_kinds (each implying a
+  power source: spell→mana, biopower→bio, cyber_ability→charge…), the Refusal anti-power class,
+  per-world `skill_affinity[domain]` + `magic_level`/`tech_level` `rule_modulators`, `native_world_type`
+  stamped on skills, acquisition via mentorship (mig 127), knowledge-trade, marketplace.
+- **Animation engine**: 10 archetypes + 51 verbs + tiered pose generators, `element-vfx.ts` (7 elements),
+  `world-vfx-bridge.ts` (19 effects), IK (`fabrik-ik`/`hand-ik`/`foot-ik`).
+
+Genuine GAPS: (1) **no universal resolver** — a minted move stores element+damage+glyph but NO animation
+archetype, so every custom move plays a generic `cast`; (2) **no player move-builder UI**; (3) **guns are
+a stub** (no ammo/reload/recoil/range; a gun user even parries as fast as a swordsman — a real bug);
+(4) **movement powers** beyond basic dash/glide are absent (no flight activation, super-speed, ice-slide/
+surface-gen, web-swing, blink, double-jump/air-dash/wall-run; no `motionFamily` field); (5) **no
+constrained modifier-budget / level-gated config layer**; (6) **no lore-resource-gauge or cross-world-
+potency rules**; (7) fusion + creatures lack UI / animation.
+
+**Decisions (locked with user):** resolver+catalog FIRST; creatures = dedicated later phase; rich
+per-genre baseline; guns **balanced, not OP**; builder is **constrained config, not free-text**; hybrid/
+cross skills; movement powers are **lore-bound sustained drain-buffs**, **acquirable (learn/buy/make)**,
+and **level-gated**; the whole thing is the friendly isekai **"[System]"**. Reuse the existing
+progression/fusion/UI/flight substrate — extend, don't reinvent.
+
+---
+
+## Three balance pillars (the spine — enforced server-side, apply to EVERY move: combat/spell/gun/movement)
+
+**Pillar 1 — Design ceiling vs. level-gated active tier.** A move's CONFIG defines its *design* (the
+aspirational ceiling). The player's SKILL LEVEL gates which *tier* is active — power dealt + visual
+grandeur. Power is NEVER a function of the description, only of invested level. A L1 "destroys everything"
+fire spell renders + hits as L1 (small flame, modest dmg); the same authored move at L10/20/30… unlocks
+its own tiers, power + fidelity scaling together (revisions ×1.15/tier; anim tier 1→5). Infinite levels +
+diminishing XP ⇒ a **L15 player with a L200 skill out-specialises a L50 generalist** (narrow-deep vs
+broad-shallow both viable via niche + gear). Built on the EXISTING `skill-progression` + `skill-evolution`.
+
+**Pillar 2 — Lore-resource matrix (per world × skill_kind).** A move is a sustained/instant cost on the
+**world-appropriate gauge**: spell/fantasy → **mana**; superhero → **biopower gauge**; cyber → **cyber
+charge**; **crime → no innate powers/flight at all** (gear/vehicle/parkour only); mundane → stamina.
+A world's `skill_affinity[domain]` + `magic_level`/`tech_level` gate **availability** (a world that
+lore-forbids a power can't host it) and the gauge it drains matches the world's power source. Movement
+powers especially are **sustained drains** (flight sips mana/bio/charge; runs out → you fall).
+
+**Pillar 3 — Cross-world potency falloff.** Every move records its `native_world_type` + that world's
+affinity for its domain. Carried to another world, potency =
+`targetAffinity(domain) + (1 − targetAffinity) × masteryFactor(skillLevel)` — full in your native/
+friendly world; in a foreign world it sags toward that world's affinity, and **skill level claws it back**
+(a Master skill travels anywhere; a novice skill collapses toward the foreign affinity → potentially
+useless, e.g. a novice fire spell in the no-magic crime world). Forces **adapt or specialise**: level a
+skill deep to travel with it, OR learn the local world's skills. Applies to users, NPCs, creatures alike;
+the existing `cross_world_use` 1.5× XP rewards pushing through, so adapting IS the grind. Reuses
+`native_world_type` + `skill_affinity` — wire them into a `crossWorldPotency()` at resolve/combat time.
+
+---
+
+## Architecture (one descriptor, one catalog, one resolver, one builder, one progression spine)
+
+- **Move Descriptor** (`meta_json.motion`, resolved client-side; derive-on-the-fly when absent):
+  `motionFamily` (combat-melee/ranged/**firearm**/magic/**movement**/social/labor/creature…),
+  `motionArchetype` (biomech pose family + new flight/surface-ride/swing/speed-trail), `effectArchetype`
+  (15: projectile/beam/nova/aura/melee-imbue/…), `element`, `powerCategory?`, **`resourceGauge`**
+  (mana/bio/charge/stamina/none), **`nativeWorld` + per-domain affinity**, `designCeiling`,
+  `leadingLimb/emissionPoint`, `targetShape`, `phases`, plus `traversalParams?` (archetypeType flight/
+  speed/surface/blink/mobility, tier, speedMs, durationMs, cooldownS, elementalDependency). Resolver
+  derives the *active* clip/vfx/sfx from descriptor × current tier × Pillar-2 gauge × Pillar-3 potency.
+- **Reference Catalog** (shared modules): `elements` (7→~18–24), `effectArchetypes` (15), `skillKindMotion`
+  (7 kinds → archetype+limb+gauge), `powerCategories` (17 + Refusal), `glyphShape` (chain → archetype),
+  `gunArchetypes` (pistol…sniper/energy), `movementArchetypes` (flight/super-speed/surface-traversal/
+  blink/mobility-mods), `creature/flora actions` (later).
+- **Resolver** — client `move-resolver.ts`; server `move-descriptor.js#deriveMotion` (stamps at mint/
+  evolve/fuse). Wired into `play-action.ts` + `AvatarSystem3D.handle{Action,Combat}Anim`.
+- **The "[System]" Move Builder** — isekai UI on the existing modal/HUD/juice pipeline.
+- **Progression spine** — REUSE `skill-progression` + `skill-evolution`; add modifier-budget + per-level
+  modifier-slot unlocks (1@L10→4@L50).
+
+---
+
+## Phases (each ships in tested slices behind a kill-switch; pure logic unit-tested headless, live-server probe, in-engine feel by user)
+
+**Phase 1 — Descriptor + Catalog + Resolver (keystone).** Move Descriptor (incl. motionFamily/resourceGauge/
+nativeWorld), catalog modules, client resolver + server `deriveMotion` stamping, wired into playAction/
+combat so **every created humanoid move animates per element + archetype + current tier** (not generic
+`cast`); backward-compat derive. Kill-switch `CONCORD_MOVE_RESOLVER`. **[client resolver + catalog DONE
+on branch `claude/move-system-p1-resolver`; server stamping + wiring REMAIN]**
+
+**Phase 2 — The "[System]" Move Builder + the 3 balance pillars.** The isekai builder (`SystemMoveBuilder`
+on `EvolutionModal`+`SkillsPanel`+`HUDOverlay`): base move + constrained **modifier-budget**, live
+deterministic preview, friendly "[System]" windows ("[New Skill: Fireball Lv.1]", "[Evolve to Lv.11?]",
+"[Reached Master]"). Enforce server-side: per-level modifier slots (1@L10→4@L50), **Pillar 1** (design
+ceiling vs active tier), **Pillar 2** (`resourceGauge` drain + per-world availability), **Pillar 3**
+(`crossWorldPotency()` at resolve/combat). Kill-switch `CONCORD_MOVE_BUILDER`.
+
+**Phase 3 — Guns, balanced.** `server/lib/firearms.js` + `domains/guns.js`: ammo/magazine + reload,
+recoil/spread bloom, range-falloff (`dmg×max(0,1−(d/maxRange)²)`), archetypes (pistol/SMG/rifle/shotgun/
+sniper/energy), Draw→Aim→Fire→Recover→Reload grammar (new `firearm` archetype + `combat-frame-data` rows).
+Anti-OP levers: **ranged parry-window=0** (fixes the bug), ammo scarcity + reload recovery, range-vs-power,
+per-world `skill_affinity.gun`, the same level ladder. Kill-switch `CONCORD_FIREARMS`.
+
+**Phase 4 — Movement powers (lore-bound, acquirable, level-gated).** New archetypes (`flight-hover/
+sustained`, `surface-ride` for ice-slide/fire-flight/water-spout, `web-swing` pendulum, `speed-trail`,
+`blink`, mobility-mods: double-jump/air-dash/wall-run/mantle) reusing `flight-physics.ts` + `traversal-
+kinematics.ts` + new activation events + anti-cheat (`_validateFlightReach`/`_validateSpeedMultiplier`).
+Each is a **sustained drain on the Pillar-2 gauge** (flight sips mana/bio/charge; crime world = none),
+**level-gated** (L1 ice-slide short/slow/thirsty → L200 freeway that sips), **cross-world-potency'd**
+(Pillar 3), and **acquirable** via mentorship/marketplace/glyph-authoring (add `wind/speed/phase` glyph
+components). Tier ladder mapped onto existing `mastery.milestones`. Kill-switch `CONCORD_MOVEMENT_POWERS`.
+
+**Phase 5 — Hybrid / cross / fusion skills.** Expose `skill-fusion.js` via the builder: preview + commit
+routes, **level + cost gates**, element-fusion table, "[Fusion complete]" notifications. Gun+magic +
+movement hybrids (e.g. fire-flight = fire ⊕ flight). Kill-switch `CONCORD_SKILL_FUSION_UI`.
+
+**Phase 6 — Effect VFX rendering.** Extend `element-vfx.ts` to the full catalog; render the 15 effect
+archetypes through `world-vfx-bridge.ts` (projectile/beam/nova/ground-zone/aura/melee-imbue/dash-afterimage/
+shield…), keyed to element color + cast→delivery→impact grammar + tier-scaled.
+
+**Phase 7 — Lore grammar + powers + rich per-genre baseline.** Glyph-shape → archetype; the 17 power
+categories for biopower/psionic/cyber/body-weapon + Refusal; **per-genre starter spell/power/gun/movement
+sets** (fantasy/superhero/cyber/sovereign/lattice) so each faction reads distinct out of the box.
+
+**Phase 8 — Procedural depth.** IK reach, layered blend (cast-while-moving, fly-while-casting), physics-
+ragdoll impact blend, 12-principles polish over resolver output.
+
+**Phase 9 — Creatures / fauna / flora (the void).** Shape-agnostic rig + retargeting (humanoid→quadruped→
+flying→exotic), creature action vocab (bite/claw/breath/roar/tail-swipe…) + flora (entangle/spore/root) +
+creature movement (flap/slither/swim). Descriptor is shape-agnostic from Phase 1 so they slot in.
+
+---
+
+## Critical files
+- **New:** `lib/concordia/move-catalog/{elements,effect-archetypes,skill-kind-motion,power-categories,
+  glyph-shape,gun-archetypes,movement-archetypes}.ts`, `lib/concordia/move-resolver.ts`,
+  `components/world/SystemMoveBuilder.tsx`, `server/lib/move-descriptor.js`, `server/lib/firearms.js` +
+  `server/domains/guns.js`, `server/lib/ammunition.js`, `server/domains/movement-powers.js`,
+  `server/lib/cross-world-potency.js`.
+- **Edit (resolver + gauges + potency wiring):** `lib/concordia/play-action.ts`, `AvatarSystem3D.tsx`
+  (`handleActionAnim`/`handleCombatAnim`/flight activation), `skill-motion.ts`, `element-vfx.ts`,
+  `world-vfx-bridge.ts`, `lib/concordia/skill-descriptors.ts` (add `motionFamily`/`traversalParams`),
+  `flight-physics.ts`/`traversal-kinematics.ts` (activation hooks).
+- **Edit (server):** `glyph-spells.js#mintSpell` (+ wind/speed/phase components), `skill-evolution.js`,
+  `skill-fusion.js` (+ routes), `combat-frame-data.js` (firearm/ranged frames), `routes/worlds.js`
+  combat/attack (ammo + range tiers + falloff + `crossWorldPotency` + gauge drain). **Reuse**
+  `skill-progression.js`, `skill-domains.js` (`skill_affinity`), `mentorship.js`, marketplace,
+  `refusal-field.js`, world `rule_modulators`/`native_world_type`.
+- **Edit (UI reuse):** `EvolutionModal.tsx`, `SkillsPanel.tsx`, `HUDOverlay.tsx`, `LevelUpJuiceBridge.tsx`,
+  `GameJuice.tsx`, `SmartNotifications.tsx`, `FlightHUD`, toast store.
+- **Phase 9 new:** `lib/concordia/creature-rig.ts`, `move-catalog/{creature-actions,flora-actions}.ts`.
+
+## Verification
+- **Headless (every slice):** pure catalog/resolver/builder-math/falloff/ammo/gate/potency logic
+  unit-tested (resolver never-null + backward-compat; modifier-budget + per-level slots; range-falloff;
+  ammo consume+shortage; fusion level/cost gate; element coherence; **Pillar-2 gauge drain**; **Pillar-3
+  cross-world potency curve** — native=full, foreign-novice≈floor, foreign-master≈full); scoped `tsc`;
+  full `concord-frontend` vitest; `node --test`; `node --check`. **Live-server probe** (the dev-server
+  playtest that caught the hydrology bug): register → build a move → confirm `meta_json.motion` stamped;
+  L1 vs simulated-L200 resolve differ in tier/power; fire a gun → ammo decrements + reload gate; activate
+  flight → mana/bio gauge drains, crime-world rejects it; same skill resolved in native vs foreign world →
+  potency differs by level.
+- **In-engine (user):** the "[System]" windows read friendly (no learning curve); L1 vs leveled moves
+  visibly differ; fire/ice/gun/flight/fused hybrid each animate + emit distinct, element-correct effects;
+  guns viable-not-OP; flight/ice-slide/web-swing feel right + drain the right gauge + lore-gated per world.
+  Kill-switch off → today's behaviour.
+- Small PRs per phase behind kill-switches, merged green — same cadence as the destructible-world +
+  fluidity work this session (#786–795).
+
+NOTE: Large multi-PR initiative; the plan is the roadmap. **Phase 1 (descriptor+catalog+resolver) is the
+keystone**; Phase 2 (builder + 3 balance pillars) is the central ask; guns + movement + hybrids are the
+named must-haves. Most of the progression/fusion/UI/flight substrate exists — this exposes, unifies,
+balances (Pillars 1–3), and renders it. Supersedes the completed destructible-world + fluidity plan (#786–795).


### PR DESCRIPTION
## Universal Move System — plan + Phase 1 keystone (client resolver)

Lands the approved plan into the repo so it's available to future sessions, plus the first green slice of Phase 1.

### Plan doc
`docs/UNIVERSAL_MOVE_SYSTEM_PLAN.md` — the research-grounded roadmap (9 phases; 3 balance pillars: design-ceiling-vs-level-gated-tier, lore-resource matrix, cross-world potency falloff) with a handoff header noting progress + next steps.

### Phase 1 keystone (client half — closes the audit's core gap)
Before this, a minted move stored element+damage+glyph but **no animation archetype**, so every custom move played a generic `cast`. Now:
- **`move-catalog/move-types.ts`** — `MoveDescriptor` + `ResolvedMove` + `SKILL_KIND_MOTION` (7 kinds → archetype/limb/effect/**lore-gauge**) + `ELEMENT_EFFECT_BIAS` + `clampTier`.
- **`move-resolver.ts`** — `resolveMove(input)` (never-null, backward-compat derive from `skill_kind`+`element`) + `tierForLevel` (Pillar 1: level→tier, saturates at 5 while power scales).

### Verify
- New `tests/concordia/move-resolver.test.ts` — **11/11 green**: level→tier ladder, backward-compat derive, per-kind lore-gauge (Pillar 2), authored-overrides-defaults, fire≠ice VFX, never-null, full skill_kind coverage. Scoped `tsc` clean.

### Remaining (next session)
Server `move-descriptor.js#deriveMotion` + stamp `meta_json.motion` at `mintSpell`/`applyEvolution`; wire `resolveMove` into `play-action.ts` + `AvatarSystem3D`, behind `CONCORD_MOVE_RESOLVER`. Then Phases 2–9.

https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ)_