### PR TITLE
fix: combat broken on every world (world_npcs missing rotation column)

### DIFF
--- a/server/migrations/293_world_npc_rotation.js
+++ b/server/migrations/293_world_npc_rotation.js
@@ -1,0 +1,31 @@
+// server/migrations/293_world_npc_rotation.js
+//
+// Bugfix — combat was fully down on every live world. The combat-attack path
+// (routes/worlds.js#/combat/attack) runs
+//   SELECT id, x, y, z, rotation FROM world_npcs WHERE id = ?
+// to read the target's facing for off-axis / directional-stagger logic — but no
+// migration ever added a `rotation` column to world_npcs (it only has x/y/z +
+// current_location). So every melee attack threw "no such column: rotation" and
+// 500'd, in every world. Found by actually playing (an agent-playtest swing in
+// the War Zone), not by a unit test — the test DBs build their own schemas.
+//
+// Fix: add the column the query already expects. REAL DEFAULT 0 → existing NPCs
+// face "north" until their routine/spawn logic sets a real facing; directional
+// combat keeps working, it just isn't biased by NPC facing until then.
+
+function columnExists(db, table, col) {
+  try { return db.pragma(`table_info(${table})`).some((c) => c.name === col); }
+  catch { return false; }
+}
+
+export function up(db) {
+  if (db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='world_npcs'").get()) {
+    if (!columnExists(db, "world_npcs", "rotation")) {
+      try { db.exec(`ALTER TABLE world_npcs ADD COLUMN rotation REAL NOT NULL DEFAULT 0`); } catch { /* noop */ }
+    }
+  }
+}
+
+export function down(_db) {
+  // forward-only
+}


### PR DESCRIPTION
## Combat was 100% broken on every world — found by playing

While playtesting the live dev server (an agent-playthrough as a character named Vael — swinging at an NPC in the War Zone), every melee attack 500'd with `no such column: rotation`.

**Root cause:** the combat-attack path (`routes/worlds.js:2127`) runs
```sql
SELECT id, x, y, z, rotation FROM world_npcs WHERE id = ?
```
to read the target's facing for off-axis / directional-stagger logic — but **no migration ever added a `rotation` column to `world_npcs`** (it has only `x/y/z` + `current_location`). Confirmed: no migration references it, and the live table lacks it. So melee combat was down in *every* world (war-zone, crime-city, wasteland, fantasy, superhero, cyber — all reproduced).

Unit tests missed it because their in-memory DBs build their own schemas; only a live-DB playthrough hits the gap.

**Fix:** migration `293_world_npc_rotation.js` adds `rotation REAL NOT NULL DEFAULT 0` (guarded/idempotent, mirroring the mig-292 pattern). NPCs default to facing 0 until spawn/routine logic sets a real rotation; directional combat keeps working.

**Verified live:** after the migration applied on boot, the attack path clears the crash and reaches the anti-cheat damage check (which then correctly refuses client-supplied damage). `world_npcs.rotation` confirmed present.

### Logged for follow-up (found in the same run, not fixed here)
- **Spell `cast` is also broken**: `domains/glyph-spells.js` cast macro does `SELECT id, user_id, name, components_json, dtu_id FROM player_glyph_spells`, but that table (mig 136) has no `name` and uses `component_chain`/`recipe_dtu_id` — `no such column: name`. Casting any minted spell fails. (Query-vs-schema drift; needs a query+usage remap, its own slice.)
- **Legibility**: a skill-less character attacking gets `damage_missing` with no guidance; an unknown macro action falls through to the LLM brain and returns `fetch failed` when offline instead of `unknown action`.

https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wacm8N1qzfkZ9iq7a9k6sQ)_