### PR TITLE
docs: the full plan + research — 4 missing strategy/research docs (DESIGN_NORTH_STAR, USERBUG_TAXONOMY, BEYOND_CORRECTNESS, COLD_START_STRATEGY)

### DIFF
--- a/docs/BEYOND_CORRECTNESS.md
+++ b/docs/BEYOND_CORRECTNESS.md
@@ -1,0 +1,109 @@
+# Beyond Correctness — the five frontiers
+
+Past the gates, "does it work" gives way to five harder questions. **Two are not
+agent-executable** (craft + go-to-market — the human's). **Three have real engineering
+substrate** (mostly instrumentation that makes the unfalsifiable *legible*, plus monitors that
+extend the user-bug intake). Being straight about the line is the point. Track F (decided scope)
+builds the engineering slices of all five **including the measurement scaffolding for the two
+human-owned ones** — the verdict/GTM stays the human's; only the instrumentation is built.
+
+---
+
+## Frontier 1 — Judgment (is it *good*, not just correct) ❌ Human-owned
+
+Not "does combat crash" but "is combat *satisfying*"; not "does the economy balance
+arithmetically" but "is it fun to play, fair to lose at, worth grinding." Unfalsifiable, never
+done — craft, playtesting, taste, iteration forever. A game is never "correct," only "good or
+not." An agent can't decide it.
+
+**What CAN be built — the cold-watcher (F1):** fun-funnel telemetry — where players stall,
+rage-quit, abandon a quest/run/craft — surfaced so the judgment *you* make is data-informed.
+The **tool-first funnel split** distinguishes solo-tool engagement (lenses/OS — value with zero
+network) from network engagement (world/economy/MP), so "come for the tool, stay for the network"
+is measurable. The verdict stays yours.
+
+---
+
+## Frontier 2 — Liveness (a reason to come back tomorrow) ✅ Tractable
+
+A live world needs the content treadmill: events, seasons, new reasons. The question flips from
+"does it work" to "does it *hold people*." Concordia's treadmill substrate already exists
+(`world-event-scheduler`, seasons, festivals, `lattice-born-quests`, `weekly_objectives`
+mig 272).
+
+**Build (F2):** a **liveness dashboard** + a daily/weekly "reason to return" surface, measuring
+the *right* things for a tool-first, MMO-clock, solo product (see `COLD_START_STRATEGY.md`):
+- **Retention on the MMO clock** — track D1/D7/D30 for first-impression health, but **optimize
+  for patch-cycle return** (a player gone 4 months who returns for a season/patch is the model
+  working, not churn). Return-cohort keyed to season/event cadence, not a 7-day window.
+- **Atomic-network cohort metrics** — not global DAU; **utility × density in ONE world/niche**
+  (the first ~100), sliced by world + creator-niche.
+- **Self-moving-world novelty health** — a heartbeat-health check that the emergent sim
+  (drift→quest, faction war, scheduler, seasons) **actually emits novelty between patches** (a
+  frozen sim is the failure mode — this gate catches it). This is the asset that lets a solo
+  cadence be quarterly instead of a WoW treadmill.
+- Discovery loop (DESIGN_NORTH_STAR §1): lean into lore mysteries/quest markers/lattice-born
+  quests as undiscovered markers that keep generating breadcrumbs.
+
+---
+
+## Frontier 3 — People (the bugs become human) ✅ Tractable, extends Track E
+
+Once players are in, exploits stop being `runMacro` and start being coordinated social
+manipulation: cartels cornering the royalty economy, griefing, abuse. You built a world that
+defends itself from NPCs (the temperament engine) — now it has to defend itself from *people*,
+which is harder.
+
+**Build (F3):** **anti-cartel / royalty-cornering detection** (extends `detectWashTrading` + E2's
+economy-anomaly cycle to multi-account collusion patterns); a **griefing/abuse report path**
+(extends E4 client-intake with a player-report kind); a **moderation queue + governance surface**
+(reuses the existing org-governance voting). Observe + route, **no economy-behavior change.**
+**Community-ops are config, not build** — governance/voting/council + volunteer-mod roles already
+exist; "turn it on for the real community" is positioning the human owns.
+
+---
+
+## Frontier 4 — Economics (does it sustain) ✅ Tractable instrumentation
+
+Five Ollama brains, compute, storage, the perpetual-royalty cascade balancing over years. Unit
+economics. A beautiful system that costs more to run than it returns is a candle that burns out.
+*(Note: at a flat compute cost, idle GPUs aren't the worry — they run the whole cognitive
+substrate with zero players online; cost scales as a step-function in GPUs only if you grow huge,
+which is a good problem.)*
+
+**Build (F4) — can't *make* it profitable, can make it legible:** cost telemetry (Ollama
+GPU-hours, DTU-storage growth curve, per-active-user compute); a **royalty-cascade solvency sim**
+(does the perpetual cascade stay bounded over N years at projected volume — extends the cascade
+math in `server/economy/royalty-cascade.js`); a unit-economics dashboard panel.
+
+---
+
+## Frontier 5 — Distribution (does anyone come) ❌ Human-owned — the dominant risk
+
+The honest one: a flawless, gated, gorgeous, unique world with no players is a tree falling in an
+empty forest — and Concordia has the **hardest** version of cold-start (a two-sided creator-
+economy AND a multiplayer world, both needing critical mass). Most beautiful solo projects don't
+die in the code; they die here. The skills that built it (relentless verifiable engineering) are
+not the skills that get the first thousand people through the door. **This is now the dominant,
+least-controllable risk — bigger than any bug.**
+
+**What CAN be built (F5) — the shareability substrate:** FTUE polish (Gap-closure Track 1),
+invite/referral mechanics (`world_invites` exists), share-card / deep-link instrumentation so
+growth is *measurable*. **Bringing the people is yours** (see `COLD_START_STRATEGY.md` — and the
+genuinely hopeful part: Concordia's architecture pre-solves much of the cold-start trap because
+the *tool works solo*).
+
+---
+
+## The human-vs-engineering line (summary)
+
+| Frontier | Owner | What the agent builds |
+|---|---|---|
+| 1 Judgment | **Human** (taste) | cold-watcher fun-funnel telemetry + tool/network funnel split |
+| 2 Liveness | Engineering | liveness dashboard + return surface + novelty-health gate |
+| 3 People | Engineering (+ human community-ops) | anti-cartel/abuse monitors + moderation queue |
+| 4 Economics | Engineering (legibility) | cost + cascade-solvency telemetry + unit-econ panel |
+| 5 Distribution | **Human** (GTM) | share/referral/deep-link instrumentation + FTUE |
+
+All Track-F builds are kill-switched, tested, and **make no economy-behavior change.** The
+strategy is the human's to execute; the docs + the instrumentation make it data-informed.

--- a/docs/COLD_START_STRATEGY.md
+++ b/docs/COLD_START_STRATEGY.md
@@ -1,0 +1,142 @@
+# Cold-Start, Retention & Solo-LiveOps — the "then what" after correctness
+
+Once the gates are green and the user-bug intake is running, the remaining risk is **not
+technical**. It's the open-ended, never-"done" reality of a living product: **does anyone come,
+do they stay, and can one person run it without burning out.** This is the dominant — and least
+controllable — risk, bigger than any bug. The hopeful part this research lands on:
+**Concordia's technical design unusually de-risks all three**, because the same architecture that
+makes it unique also pre-solves the classic traps. The strategy here is the human's to execute;
+the engineering (Track F instrumentation) makes it data-informed.
+
+---
+
+## 1. Cold-start — getting the first network (the hardest problem)
+
+**The framework (Andrew Chen, *The Cold Start Problem*):** a network has zero value until it
+exists — a marketplace with no sellers is dead on arrival. You don't launch broad; you build the
+smallest functioning **atomic network** (a tight early cohort where utility + density already
+click), prove it, then **link atomic networks** until the **tipping point.**
+
+**Concordia's structural advantages (rare — most two-sided platforms have none):**
+1. **"Come for the tool, stay for the network" — and Concordia already IS this.** The 253 lenses
+   are a *single-player tool* (a cognitive OS genuinely useful to ONE person, zero network
+   required). The world + creator-economy + multiplayer are the *network*. This is the textbook
+   solution to chicken-and-egg: **Concordia delivers value before any critical mass exists.**
+   Most marketplaces/MMOs are *worthless* until populated; Concordia isn't. **Lead with the tool.**
+2. **Seed the hard side first (creators).** Two-sided economies live or die on *supply* (the hard
+   side). Concordia pre-seeds it three ways: the dev as first creator (authored DTUs/lenses/
+   worlds); authored content as supply (128 NPCs, 66 factions, 84 lore items, quests — the world
+   feels *populated* before real players arrive); and **the emergent sim as supply** — NPCs
+   scheme, factions war, drift spawns quests *autonomously*, so the world generates its own
+   activity with zero players online. Almost nothing else has this.
+3. **Atomic network = one world, one niche, one tight cohort.** Don't open all 9 sub-worlds to
+   everyone. Pick ONE corner (the hub, or one themed world + one creator niche — e.g. music-DTU
+   creators, or the Concordia builders) and get utility + density clicking *there* first, then
+   link outward.
+
+**The honest risk:** even tool-first, getting the first ~100 genuinely-engaged people is hard,
+uncertain, and where most beautiful solo projects die. The tool-first structure means you can
+recruit them on the *lens/OS value alone* (no "trust me the world will be populated") — that's
+the lever to pull.
+
+---
+
+## 2. Retention — keeping them (on the right timescale)
+
+**The framework:** D1/D7/D30 are standard, BUT — and the MMO research is explicit — **MMOs run on
+a different clock: months, years, expansion cycles.** A player who leaves for four months and
+returns for the next patch *is not churned — that's the model working.* So track D1/D7/D30 for
+first-impression health, but **optimize for the patch-cycle return**, not the mobile
+"hooked-in-a-week-or-gone" frame.
+
+**Habit-loop layering (Concordia already has the substrate):**
+| Stage | Mechanic | Concordia has |
+|---|---|---|
+| D1 | personalized onboarding, first-win | FirstWinWizard, cook→eat→fight→commune, the Concord Link boot |
+| D7 | daily/weekly loops | daily rituals, weekly objectives, seasons |
+| D30+ | long-arc collection/commitment | skill trees, the creator economy, dynasties, faction arcs, the 7-quest main arc |
+
+**Content cadence — pick the *sustainable* one.** The spectrum runs WoW (8-week, needs a studio)
+→ FFXIV (4–4.5mo) → **EVE Online (quarterly, sustained 22+ years).** For a solo dev, the
+EVE/quarterly rhythm + **emergent content** is the survivable model — *not* the WoW treadmill that
+requires a content factory. Concordia's edge: **the emergent sim + the self-improving substrate
+generate content between patches**, so the cadence can be slow because *the world keeps moving on
+its own.* (Track F2's novelty-health gate verifies the sim actually emits novelty — the failure
+mode is a frozen sim.)
+
+---
+
+## 3. Solo sustainability — running it without burning out
+
+**The trap:** solo devs wear every hat (design, ops, support, marketing, moderation) — the
+constant juggle is the #1 cause of indie burnout, and live-service *multiplies* it (the game never
+stops needing you). Three survival strategies, each of which Concordia is unusually built for:
+1. **Automate liveops via the self-improving substrate.** The repair cortex, autogen, emergent
+   event scheduler, drift→quest spawning, and the L0–L5 gates mean **the system runs and heals
+   itself** to a degree almost no live game can — events/quests/economy activity without the dev
+   pushing a button. The single biggest solo-survival asset: *liveops that partly runs itself.*
+2. **Community-led growth + governance.** Build-in-public (Discord, devlog); let the early cohort
+   *direct* the roadmap (Concordia already has governance/voting/council — turn it on the real
+   community); **recruit volunteer moderators early** (the player-driven social layer needs human
+   stewards before it needs code). Community fills the feedback gap *and* offloads the hats.
+3. **Pick a cadence you can hold for years, not months.** Quarterly major + the emergent sim
+   filling the gaps. Resist the treadmill. The goal is a 10-year EVE, not a 1-year burnout.
+
+**The honest risk:** even with automation, a live MP economy with real people is a perpetual
+obligation (moderation, exploit response, incidents). The realistic answer is *eventually not
+solo* — community mods first, then a small team if it grows. Automation buys *time*, not
+immortality.
+
+---
+
+## 4. The synthesis — why Concordia is unusually positioned
+
+| The classic trap | Concordia's built-in answer |
+|---|---|
+| Chicken-egg (no value until populated) | **tool works solo** (the lenses/OS) — value before network |
+| Empty world on launch | authored NPCs/lore/quests + **emergent sim** = pre-populated supply |
+| Two-sided supply (creators) hardest to seed | dev-as-first-creator + authored content + sim-generated activity |
+| Mobile "hooked-in-a-week-or-gone" pressure | MMO timescale — patch-cycle return is the model |
+| Content treadmill needs a studio | emergent sim + self-improving substrate generate content between patches |
+| Solo liveops burnout | self-healing substrate + community governance (already built) + sustainable cadence |
+
+**The deep point:** the architecture that makes Concordia *unique* (one substrate; tool + world
+fused; emergent self-generating sim; self-improving/self-healing systems) is *the same
+architecture that pre-solves the cold-start and solo-liveops traps.* The engineering ambition
+wasn't just aesthetic — it **de-risks the existential phase.** Most solo founders build a thing
+that's worthless until populated, empty on launch, and a treadmill to run. Concordia is
+useful-solo, pre-populated, and self-moving.
+
+---
+
+## 5. The non-engineering shopping list (the human's to execute)
+
+1. **Lead with the tool** — launch the 253-lens cognitive OS as a genuinely useful *solo* product
+   first (the on-ramp that needs no network).
+2. **Pick the first atomic network** — ONE world + ONE creator niche + a tight early cohort
+   (~first 100). Get utility+density clicking there before opening wide.
+3. **Seed the hard side** — dev-as-creator + the authored/emergent supply already in place;
+   recruit the first *real* creators into that niche.
+4. **Turn on the habit loops + a quarterly cadence** — daily rituals / weekly objectives / seasons
+   + emergent sim filling the gaps. EVE rhythm, not WoW.
+5. **Stand up community-led ops** — Discord + build-in-public + the in-game governance on the real
+   community + volunteer mods early.
+6. **Lean on the self-healing substrate for liveops** — let the world run itself between patches.
+
+Most of this is *strategy and positioning*, not code — and the code that *would* help (governance,
+emergent events, self-healing) is already built. The engineering side (the measurable funnel) is
+Track F (`BEYOND_CORRECTNESS.md`).
+
+---
+
+## 6. Verdict
+
+The "then what" after correctness is the **cold-start → retention → solo-sustainability**
+gauntlet — where most beautiful solo projects die. But Concordia's unique architecture is **not
+just a design flex — it's a structural answer to the exact traps that kill projects at this
+stage.** The tool works without the network; the world is pre-populated and self-moving; the
+systems heal themselves; the governance for community-led ops is built. The dominant remaining
+risk — *getting the first atomic network through the door* — is real and uncertain, but Concordia
+attacks it with the rare advantage of **delivering value to a single user on day one.** Pull the
+tool-first lever, seed one tight network, hold a sustainable cadence, and let the self-moving
+world do what almost no solo project's world can: stay alive while you sleep.

--- a/docs/DESIGN_NORTH_STAR.md
+++ b/docs/DESIGN_NORTH_STAR.md
@@ -1,0 +1,200 @@
+# Design North-Star — the feel Concordia is reaching for
+
+Four framing lessons (Bethesda, High-on-Life, ARK, proper MMO stealth) plus the recurring
+**multiplayer tax** that ties them together. Each is mostly *affirmation* — Concordia already
+has the substrate — sharpened into **acceptance bars + invariants** on Tracks B/E/F. The
+strategy/taste stays the human's; the engineering + instrumentation make the feel a written
+target the gates hold themselves to.
+
+**The recurring meta-point:** every source game got its feel "for free" because it's
+single-player. Concordia is **real-time multiplayer + a real economy**, which strips away the
+crutches (the pause button, the license to be janky, free local netcode, imperfect-AI-only
+stealth). The cost of every lesson below is the same: **server-authority + client prediction +
+reconciliation** — the same desync axis **Track E1** now measures
+(`concord_combat_*_rejected` + `ConcordDesyncSpike`). Get prediction right and it feels local;
+the E1 counters tell you when reconciliation is drifting.
+
+---
+
+## 1. The Bethesda feel — curiosity, go-anywhere, emergent world, minimal-HUD/deep-menus
+
+**What it is.** (1) Core fantasy "go anywhere, be anyone" — the world is a place you inhabit,
+not a level you clear ("see that mountain, you can climb it"). (2) The **compass discovery
+loop** — undiscovered markers → "I'll just check that one icon" → three hours; discovery →
+acquisition → progression at your pace, no FOMO. (3) **Minimal HUD, deep menus** — health/
+stamina fade in only on change; the depth lives in menus you *pause into* (the Pip-Boy rhythm).
+(4) **Systemic emergence (Radiant AI)** — NPCs have schedules + wants; simple systems combine
+into "I have a story." (5) Lived-in world + ownership. (6) Jank-as-charm (single-player pass).
+
+**Two crutches Concordia DOESN'T get — and already answers:**
+- **No pause.** Bethesda's stop-time→live-in-menu→unpause is impossible in a shared world.
+  → **Concord Link's Glance → Summon → Sanctum** (Track B2) is the substitute: depth-on-demand
+  without freezing the world. **B2 acceptance bar:** Glance shows almost nothing (resource bars
+  fade in on change + crosshair); depth lives in the Summon/Sanctum panels.
+- **No license to be janky.** MP + real economy → jank = exploits/desync/lost money.
+  → **The L0–L5 gates + Track C/E verification** buy the freedom-feel without the jank-tax.
+
+**Two hard-won Radiant-AI lessons → two invariants:**
+- **Invariant 1 — safeguard the emergence.** Radiant AI NPCs committed impulsive crimes + broke
+  quests until safeguards were added. **Track B1 Temperament P4–P7** (proportionality ceiling,
+  surrender/arrest states, assistance-gate + depth-caps, the two CI gates) **IS** that guardrail
+  on the scheme/secret/hook/nemesis sim so emergence can't grief the player or soft-lock a quest.
+- **Invariant 2 — keep emergence invisible.** "Every Radiant-AI improvement makes it less
+  noticeable." The emergent sim must surface as **world-flavor** (NPC dialogue, ambient activity
+  tags, overheard scheme bids, faction-war banners), **not a debug/telemetry feed**. The
+  `EmergentEventFeed` / cold-watcher / liveness dashboards are **operator surfaces, not player
+  UI** — keep them separate. New player-facing emergent surfaces get the "reads as life or as a
+  system readout?" check; prefer the former.
+
+**Concordia's edge:** the emergent NPC sim (schemes, secrets, hooks, nemesis, dreams,
+forward-sim, temperament, faction strategy) is **Radiant AI dialed past 11** — deeper autonomous
+NPC life than Bethesda ever shipped. That's the superpower, *if* the two invariants hold.
+
+**Compass discovery loop = the retention hook (Track F2):** Concordia's equivalents already
+exist — lore mysteries (the impossible-print, the Voss question), quest markers, lattice-born
+quests, the self-moving sim's new events. F2's "reason to return" surface leans into them as
+undiscovered markers that keep generating breadcrumbs; F1's cold-watcher measures whether the
+discovery→acquisition→progression loop actually pulls, not just DAU.
+
+---
+
+## 2. High-on-Life — movement fluidity
+
+**What makes it fluid.** (1) The verbs **chain** — slide→jump→jetpack-boost→grapple→land-into-
+slide, nothing resets you to zero. (2) **Momentum preservation** — speed carries between actions
+(the opposite — every action snapping to walk-speed — is what feels janky; momentum is sacred).
+(3) Tight, low-latency, zero-floatiness controls (input delay + mushy accel is the #1 feel
+killer). (4) **Squanch fusion: gun = traversal = combat, ONE verb set** — no mode-switch between
+moving and fighting. (5) **Invisible forgiveness** — coyote time, generous air control, grapple
+snap-to-anchor (catches the nearby point; feel, not precision). (6) Camera/FOV juice (FOV widens
+with speed, slide tilt, motion lines — half the speed sensation is a visual trick). (7) Levels
+built to be flowed-through.
+
+**Where Concordia stands.** Already has the verbs: `lib/concordia/traversal-kinematics.ts`
+(dash/i-frames/momentum/slide), `flight-physics.ts`, the move-system (flight/super-speed/
+ice-slide/web-swing/blink/wall-run), and **the kinematics layer already tracks momentum** — so
+"don't reset to walk-speed across transitions" is a **tuning job, not a rebuild**. The Squanch
+fusion is **native** (the move-system composes one verb set into movement AND combat —
+fire⊕flight = fire-flight — deeper than HoL bolted on). The juice layer (`GameJuice` +
+`concordia:flight-state`) exists to wire speed-FOV/tilt to.
+
+**To add:** the forgiveness layer (coyote time, air control, web-swing snap-to-anchor) — cheap,
+huge feel payoff.
+
+**The catch that's Concordia's alone:** HoL's fluidity was free (single-player, zero netcode).
+MP demands **client-side prediction + server reconciliation** (avatar moves instantly client-
+side, quietly reconciles to the authoritative server). Get it wrong and the *same* movement code
+feels laggy/rubber-bandy — and it's the **same desync axis E1 measures**. Build the prediction
+layer as part of the world-lens/Concord-Link arc (Track B); treat a desync-spike as the signal
+it regressed.
+
+---
+
+## 3. ARK — the mount isn't a vehicle, it's a relationship you earned
+
+**The pillars.** (1) **Taming = earned, with stakes** ("your dinos are your life") — attachment
+comes from the earning, not the purchase. (2) **Imprinting — the killer feature** — raise a baby
+with care sessions → +stats, and bonus when the imprinter rides it; the creature remembers who
+raised it. (3) **Saddles = crafted gear progression** (quality tiers, blueprints, platform
+saddles = a mobile base). (4) **Role diversity** (Damage/Farmer/Supporter/Utility). (5) **The
+Mantis trick** — role changes by what it holds (pick = harvester, sword = combat).
+
+**Where Concordia stands — and can do it BETTER (generative, not hand-authored).** The bones
+exist: `bond_event`/`bond_state` + mount-care; `creature-crossbreeding` + bloodlines + the
+inheritance/dynasty substrate; `mount_gear`/saddles + the crafting engine (`resolveCraft` +
+resource properties → generative blueprint tiers); the species taxonomy + adaptation engine
+(roles **emerge** from adaptation + breeding, not a fixed roster); cross-world potency (a mount
+fit-to-context, great in its biome, weak elsewhere — better than ARK's "bigger = better"
+treadmill); the move-system (the Mantis trick — a mount carrying a move loadout = harvester vs
+combat). **Imprinting done better:** a bred+raised+imprinted creature that carries your lineage
+and fights better for **you specifically** is a creatable, tradeable, **royalty-bearing DTU
+asset** — ties the retention hook to the creator economy. ARK never had that.
+
+**The universal principle (the real lesson):** *deep, earned, persistent relationships with game
+entities are the strongest retention hook there is.* Imprinting is one instance; Concordia
+already runs others — courtship→spouse→`spouse-reactivity`, the `npc_nemesis` graph, NPC schemes/
+hooks. The **compounding-attachment engine** is "earned persistent relationships across mounts +
+NPCs + creatures + lineage assets at once." Concordia is the rare thing built to run all of them.
+
+**Two ARK things NOT to copy — both already guarded in this plan:**
+- The tame/breed **grind** → use the **fidelity dial** (delegate/sim vs. play) so it's a journey,
+  not tranq-and-wait tedium.
+- **Loss as a griefing surface** (ARK mounts die/get stolen → attachment via possible loss, but
+  in a MP real-economy that's a griefing/exploit vector — see `USERBUG_TAXONOMY.md`) → **gate
+  it:** no mount loss in the no-violence hub; Temperament/Refusal restraints in safe zones
+  (Track B1 P4–P7 + `world-zones` sanctuary). Stakes with guardrails — the same safeguard + E2
+  economy-anomaly spine.
+
+---
+
+## 4. Proper MMO stealth = information control, not invisibility
+
+**Why single-player stealth is deep.** Light/shadow as a **gradient** (Thief's light gem →
+MGSV/Dishonored/Last-of-Us detection meter from light + distance + movement); **sound** (noise =
+movement speed × surface, observers listen); line-of-sight + cover; **alert states as a
+gradient** (unaware → suspicious/searching → alerted/hunting → lost/return — the "searching"
+phase is where the tension lives). It works *only because the AI's knowledge is restricted.*
+
+**Why MMO stealth collapses.** The moment the observer is human, MMOs throw away imperfect
+information and fall back to "invisible + a detection stat" → either **oppressive** (free ganks,
+rogue overpopulation) or **useless** (a see-invis counter-stat arms race). It degrades to binary,
+losing every gradient. The immersion-break: "a ninja turns invisible in front of you and walks
+behind you."
+
+**The design thesis — information control, not invisibility.** You don't vanish; you control
+what others can *perceive* about you, and every observer (human or NPC) gets a **gradient of
+partial information + the agency to investigate.** The pillars:
+1. **Gradient detection from real factors, not a stat** — light, noise (speed × surface),
+   distance, line-of-sight, observer facing/attention — a perception check *per observer* from
+   the actual situation.
+2. **Partial-information reveal, not binary** — the server sends graded signals: far + cover =
+   nothing; closer = a footstep cue; closer still = a silhouette/shimmer; in light or moving fast
+   = revealed. Footprints + last-known-position give the target something to chase. Asymmetric-
+   info done *right*.
+3. **Social stealth — the MMO-native superpower** — blend into a crowd, disguise, impersonate a
+   faction (AC/Hitman). Stealth that's *better* in an MMO, not worse.
+4. **Meaningful cost + commitment** — slow, resource-draining (a stealth gauge), punishing if
+   caught. High-risk/high-reward, not a spammable escape.
+5. **Counterplay for the observer** — tells (a guard "looks twice"), search/investigate,
+   perception skills, reveal tools. A real-time **duel of attention**, both sides playing.
+
+**Why Concordia is freakishly well-positioned.** The reason nobody builds proper MMO stealth is
+the foundation — **per-cell simulation of light and sound** — is expensive and almost no MMO has
+it. Concordia does:
+- **Embodied signals (Layer 7)** simulate `sight_os.illumination` (light) + `sonic_os.ambient_db`
+  (sound) **per 50m cell** — the Thief light-gem + the noise gradient, natively. The hard part,
+  already running.
+- **`stealth-perception.js`** — a real stealth-perception system (a backstab gate on perception
+  vs stealth). **Step-zero fix SHIPPED:** it was querying the wrong table and returning skill 0
+  for everyone; now reads the authoritative `player_skill_levels` (`tests/stealth-perception.js`).
+- **Footprints + tracking** (`FootprintLayer`, `tracking_skill_xp`, skill-gated) = the
+  partial-info / last-known-position layer.
+- **Temperament's escalation ladder** (NEUTRAL → WARY → WARNING → HOSTILE) = the alert-state
+  gradient (unaware→suspicious→alerted).
+- **The detective lens** = the observer's investigation/deduction agency.
+- **Wardrobe/appearance + factions + NPC crowds** = the social-blending/disguise substrate.
+- **`world-crime.js`** (heist, lockpick, trespass) = the stealth-action context.
+
+**The honest hard parts.** (a) **Netcode/anti-cheat is the crux** — for PvP stealth the server
+must decide *per-observer* what to reveal and **not send full position to clients who shouldn't
+see it** (or wallhacks defeat it). Same server-authority + prediction problem as movement (§2);
+PvE-vs-NPC is the easier first target (the AI's imperfect info is real). (b) **Balance** —
+cost/commitment tuned so stealth isn't a gank-fest or useless (stealth-ganking is a griefing
+vector — `USERBUG_TAXONOMY.md`). (c) Step zero was the broken skill lookup — DONE.
+
+**One-liner:** server-authoritative gradient perception (light/sound/distance/facing) +
+partial-information reveal (tells, footprints, last-known-position) + social blending +
+real cost + observer counterplay (the detective layer) — a duel of attention, not
+invisible-vs-see-invis. Concordia is the rare engine that can run it, because the per-cell
+light/sound sim — the thing that makes stealth real — is already simulating.
+
+---
+
+## 5. The synthesis
+
+The architecture that makes Concordia *unique* (one substrate; tool + world fused; emergent
+self-generating sim; per-cell light/sound; self-improving/self-healing systems) is the same
+architecture that lets it **out-do the source games** on feel — *provided* the multiplayer tax
+is paid (server-authority + prediction, measured by E1) and the two emergence invariants hold
+(safeguard it; keep it invisible). The strategy and taste are the human's; the engineering and
+the instrumentation make the feel a target the gates enforce.

--- a/docs/OFFICIAL_PLAN.md
+++ b/docs/OFFICIAL_PLAN.md
@@ -171,5 +171,22 @@ cd server && node --test tests/glyph-spells-license-cast.test.js \
   tests/stealth-perception.test.js
 ```
 
-The four framing docs (Bethesda / High-on-Life / ARK / stealth) and the cold-start/retention/
-solo-liveops research live in §3 + the build-plan docs; trust the code first.
+---
+
+## 6. Companion docs — the full detail + research (all on main)
+
+This file is the **master map**. The full per-spec detail and the verbatim research live here:
+
+| Doc | Holds |
+|---|---|
+| `docs/DESIGN_NORTH_STAR.md` | The four framing lessons in full — **Bethesda** (curiosity/pause/emergence-safeguard+invisibility/compass), **High-on-Life** (movement fluidity + the prediction tax), **ARK** (earned relationships, generative+economic, the two guardrails), **proper MMO stealth** (information-control, the per-cell light/sound keystone, the netcode crux). |
+| `docs/USERBUG_TAXONOMY.md` | The ranked 10-category user-bug taxonomy (SaaS + MMO), Concordia's exposure ranking with the audit finding that previews each, the intake/observability table, the complementary-halves diagram. |
+| `docs/BEYOND_CORRECTNESS.md` | The five frontiers (Judgment/Liveness/People/Economics/Distribution), the human-vs-engineering line, the instrumentation map. |
+| `docs/COLD_START_STRATEGY.md` | Cold-start (atomic networks, tool-first), retention (the MMO clock), solo-liveops survival, the synthesis (why the architecture pre-solves the traps). |
+| `docs/TEMPERAMENT_BUILD_PLAN.md` | Track B1 Temperament P4–P7 build detail. |
+| `docs/CONCORD_LINK_BUILD_PLAN.md` | Track B2 Concord Link 8-phase build detail. |
+| `docs/FUNCTION_ASSURANCE.md` | The six-gate (L0–L5) verification method. |
+| `docs/SHIP_READINESS.md` · `docs/SSE_STREAMING.md` · `docs/CONTRACT_ENFORCEMENT_STRATEGY.md` · `docs/PLAYTEST_FINDINGS_PLAN.md` | Ship-readiness manifest, SSE hardening, contract gates A/B/C, the seven-expedition playtest findings. |
+| `docs/DATA_PROVENANCE.md` · `docs/LICENSING.md` | Track G — ingestion/training/PII + the dependency/model license pass. |
+
+Trust the code over any doc, including these. This is the map; the tree is the territory.

--- a/docs/USERBUG_TAXONOMY.md
+++ b/docs/USERBUG_TAXONOMY.md
@@ -1,0 +1,131 @@
+# User-Bug Taxonomy & Intake — what real users surface, and Concordia's exposure
+
+Once the L0–L5 gates are green, the structural bug classes (crash / wiring / schema / shape) are
+walled off. What remains is what **real users surface in production**. Concordia is the rare
+thing that is **both a web platform *and* a live multiplayer game**, so it inherits *both* bug
+ecosystems. The non-obvious gift: **Concordia's own audit findings already preview which user-bug
+categories its design most exposes.** The gates catch the *structural* version of each class; a
+user-bug intake + observability system catches the *emergent/runtime* version of the same class.
+They're complementary halves (§4).
+
+---
+
+## 1. The common categories (documented baselines)
+
+### Platform / SaaS user bugs
+| Category | What users report |
+|---|---|
+| **Broken access control** (#1 web risk) | "I can see/do something I shouldn't" — IDOR, privilege escalation |
+| **Sensitive info exposure** (#1 SaaS CWE) | verbose API returning unrendered fields, JWT carrying internal metadata |
+| **Auth / session** | can't log in, session expires, OAuth loop |
+| **Payment / billing** | double-charge, payment failed, wrong subscription |
+| **Data loss / didn't save** | "my thing disappeared" (real or perceived) |
+| **Performance / slowness / timeout** | page slow, request hangs |
+| **Browser / device compat** | works on Chrome not Safari; broken on mobile |
+| **Localization / TZ / currency** | wrong date/time, wrong currency, broken locale layout |
+| **Notifications / email** | didn't arrive |
+| **Regression from rapid releases** | "this worked yesterday" |
+
+### Game / live-multiplayer user bugs
+| Category | What players report |
+|---|---|
+| **Desync** (the dominant MP class) | teleport, phasing, invisible attacks, hitbox mismatch, rubber-banding |
+| **Desync / state EXPLOITS** | invisible+invincible exploiter, fake-lag advantage (the security side) |
+| **Progression / save loss** | lost items/levels/save — the #1 player-rage bug |
+| **Economy exploits** | dupes, gold/item generation, market manipulation |
+| **Soft-locks** | quest won't advance, stuck geometry, fell through world, match "hung" |
+| **Crashes / disconnects** | client crash, can't reconnect (often client-env: VPN/AV) |
+| **Matchmaking / party / social** | can't join, party breaks |
+| **Reward not granted** | quest completed, no reward |
+| **Balance complaints** | reported *as* bugs, aren't — but must be triaged |
+| **Visual / animation glitches** | clipping, stuck animations |
+
+---
+
+## 2. Concordia's exposure ranking — where its DESIGN concentrates risk
+
+Ranked by how much Concordia's specific architecture amplifies each class, with the audit
+finding that previews it:
+
+1. **🔴 Economy exploits (HIGHEST).** A *player-created* economy with perpetual royalties,
+   marketplace, auctions, wagers, crafting-resolve = an *infinite* exploit surface. **Preview:
+   the self-wager (#V1) — passed every crash gate, still an exploit.** Watch: dupes, royalty-
+   cascade gaming, crafting-backfire abuse, wash trading (you have `detectWashTrading`), negative/
+   overflow value. → **Track E2 economy-anomaly cycle + Track F3 anti-cartel** address this.
+2. **🔴 Desync / multiplayer state (HIGH).** Real-time MMO, ~273 socket events, action combat,
+   Phase-F world-shard write-ownership. Players report teleport/phasing/invisible-hit + desync
+   *exploits*. You have server-authoritative anti-cheat (reach/damage caps); reconciliation is the
+   runtime extension. → **Track E1 desync telemetry** is the measurement; the prediction layer
+   (DESIGN_NORTH_STAR §2/§4) is the fix.
+3. **🔴 Data-loss (real + perceived) (HIGH).** The DTU substrate + self-compressing memory +
+   forgetting-engine + per-world inventory. **Preview: `dtu.create` non-persist (#32) + the
+   consolidation crash (#15).** Plus *perceived* loss (tombstoning, MEGA/HYPER compaction,
+   per-world inventory scoping — "my items vanished when I switched worlds").
+4. **🟠 Soft-locks / progression (MED-HIGH).** Quest chains, prerequisite gates, run-modes,
+   onboarding. **Preview: the dead quest macros (#11) → `/lenses/quests` soft-locks.** A quest
+   that won't advance is a rage-quit.
+5. **🟠 Broken access control / info exposure (MED).** The three-gate permission system. Privacy
+   *held* in audit, but it's the #1 web risk. **Preview: auctions `sellerUserId` in a public
+   response — the "verbose API returns unrendered fields" pattern.** Audit every public-read
+   response for over-exposed fields.
+6. **🟠 Localization / TZ (MED).** Global player base. **Preview: hydration date renders
+   (`new Date().toLocaleDateString()`) — the exact TZ-mismatch class.**
+7. **🟠 Streaming "broken" (MED).** **Preview: the SSE buffering — "chat hangs then dumps."**
+   Fixed by the SSE spec (`SSE_STREAMING.md`).
+8. **🟡 Browser/device compat (MED).** 253 lenses × browsers × the Expo mobile app.
+9. **🟡 Performance at load (MED).** **Preview: event-loop-lag spikes** under real concurrency
+   (the L5 load test catches pre-emptively).
+10. **🟡 Client-environment false-bugs (LOW priority, HIGH volume).** VPN/antivirus disconnects
+    reported as game bugs — needs triage filtering, not code fixes.
+
+---
+
+## 3. The intake + observability system
+
+The blunt SaaS stat: **60% of bug reports never lead to a fix — vague repro, no context.** The
+system matters as much as the code. Most pieces Concordia *already has*:
+
+| Need | Tool | Concordia status |
+|---|---|---|
+| Frontend error capture | Sentry | **HAVE (dormant)** — `sentry.{client,server,edge}.config.js`; enable via `NEXT_PUBLIC_SENTRY_DSN` (Track E5 documented it) |
+| Server error alerting | error-alerting + Prometheus | **HAVE** — `lib/error-alerting.js` + Grafana |
+| In-app bug reporter (auto-context) | Gleap-style | **HAVE (no auto-context)** — `FeedbackWidget.tsx` + `/api/feedback*`; **Track E4** adds the auto-context envelope (the 60%-fix lever) |
+| Economy anomaly detection | balance invariants + `detectWashTrading` | **PARTIAL → Track E2** (counter + alert) + **F3** (anti-cartel) |
+| Desync reconciliation + telemetry | server-authoritative + desync metrics | **PARTIAL → Track E1** (counters + `ConcordDesyncSpike`) |
+| Severity taxonomy + triage funnel | Critical/Major/Moderate/Minor | **Track E3** `lib/bug-triage.js` (Critical=data-loss/exploit/security → page) |
+| Synthetic monitoring | the L5 journeys | **PLANNED** (Function-Assurance L5 / Track E6) |
+
+---
+
+## 4. The complementary-halves model
+
+```
+        STRUCTURAL bugs                         EMERGENT / RUNTIME bugs
+   (enumerable, pre-deploy)                    (user-surfaced, post-deploy)
+   ────────────────────────                    ───────────────────────────
+   L0  schema gate          ──┐            ┌── economy-exploit monitors (E2/F3)
+   L1  wiring/reachability    │            │   desync telemetry (E1)
+   L2  runtime smoke          ├─ gates ───→├── Sentry (frontend errors, E5)
+   L3  contract math          │  catch the │   error-alerting (server)
+   L4  browser smoke          │  structural│   in-app reporter + context (E4)
+   L5  synthetic + load     ──┘  version   └── severity triage funnel (E3)
+                                            ↑ catch the emergent version
+                                              of the SAME classes
+```
+
+The classes are *the same* (exploit, desync, data-loss, soft-lock, access-control, localization,
+streaming, perf). The gates prove the structural form is absent; the user-bug system catches the
+emergent form the gates can't enumerate (the self-wager that *passes* every crash gate). **You
+need both halves** — and Concordia already owns most of the right half's infrastructure (Sentry,
+Grafana, error-alerting, wash-trading detection, anti-cheat).
+
+---
+
+## 5. Verdict
+
+After the gates are green, "user bugs" isn't a vague worry — it's a **known, ranked, instrumented
+taxonomy** of ~10 categories where Concordia's design concentrates risk in **economy exploits,
+desync, and data-loss**, and the audit findings already told you which to expect. The right half
+of the diagram (Track E shipped E1/E2/E3/E5; E4/E6 remain) turns user bugs into a **triaged funnel
+with auto-context** — the difference between a platform that *reacts* and one that *expects,
+instruments, and triages*.


### PR DESCRIPTION
Completes the merged plan: the four research/strategy docs that `OFFICIAL_PLAN.md` cross-referenced everywhere but were never written. Now the *entire* plan + all detail + all research is on main for the next instance.

- **`docs/DESIGN_NORTH_STAR.md`** — the four framing lessons in full (Bethesda / High-on-Life / ARK / proper MMO stealth) + the recurring multiplayer-tax (client prediction + reconciliation, measured by E1).
- **`docs/USERBUG_TAXONOMY.md`** — the ranked 10-category user-bug taxonomy, Concordia's exposure ranking with the previewing audit finding, the complementary-halves diagram.
- **`docs/BEYOND_CORRECTNESS.md`** — the five frontiers + the human-vs-engineering line + the Track-F instrumentation map.
- **`docs/COLD_START_STRATEGY.md`** — cold-start (atomic networks, tool-first), MMO-clock retention, solo-liveops survival.
- **`docs/OFFICIAL_PLAN.md`** §6 — a companion-docs index pointing at all of the above + the existing build-plan/method docs.

Docs-only; no code change.

https://claude.ai/code/session_01FUswrJRrE4bx17BQDKGDfE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUswrJRrE4bx17BQDKGDfE)_