### PR TITLE
fix(ui): collapse sub-lens tree behind a toggle to declutter the sidebar

### DIFF
--- a/concord-frontend/components/shell/Sidebar.tsx
+++ b/concord-frontend/components/shell/Sidebar.tsx
@@ -39,6 +39,10 @@ export function Sidebar() {
   } = useUIStore();
   const [expandedCore, setExpandedCore] = useState<string | null>(null);
   const [showDestinations, setShowDestinations] = useState(true);
+  // The 15-root sub-lens tree is a power-user surface — tucked behind a toggle
+  // (default collapsed) so the default front door isn't 15 always-on rows deep.
+  // Auto-opens below when the active route is a sub-lens.
+  const [showSubLenses, setShowSubLenses] = useState(false);
   const [showExtensions, setShowExtensions] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(() => new Set());
@@ -68,6 +72,14 @@ export function Sidebar() {
       }
     }
   }, [pathname, userRole]);
+
+  // Auto-open the Sub-Lenses section when the active route is a sub-lens
+  // (/lenses/<parent>/<child>) so a deep link still reveals where you are.
+  useEffect(() => {
+    if (pathname && /^\/lenses\/[^/]+\/[^/]+/.test(pathname)) {
+      setShowSubLenses(true);
+    }
+  }, [pathname]);
 
   // Close mobile sidebar on escape
   useEffect(() => {
@@ -211,13 +223,21 @@ export function Sidebar() {
             </>
           )}
 
-          {/* Sub-Lens Tree — 234 sub-lenses under 15 roots */}
+          {/* Sub-Lens Tree — 234 sub-lenses under 15 roots. Collapsible (default
+              collapsed) so the default front door stays scannable; auto-opens when
+              the active route is a sub-lens. Lazy: the tree only fetches on expand. */}
           {showLabel && (
             <>
-              <p className="px-3 py-1 text-xs uppercase tracking-widest text-gray-400 font-medium mb-1 mt-3">
-                Sub-Lenses
-              </p>
-              <SubLensTreeSection pathname={pathname} />
+              <button
+                onClick={() => setShowSubLenses((v) => !v)}
+                className="w-full flex items-center gap-2 px-3 py-1 text-xs uppercase tracking-widest text-gray-400 hover:text-gray-300 font-medium mb-1 mt-3 transition-colors"
+                aria-expanded={showSubLenses}
+              >
+                <Layers className="w-3.5 h-3.5" />
+                <span>Sub-Lenses</span>
+                <ChevronDown className={cn('w-3 h-3 ml-auto transition-transform', !showSubLenses && '-rotate-90')} />
+              </button>
+              {showSubLenses && <SubLensTreeSection pathname={pathname} />}
             </>
           )}
 


### PR DESCRIPTION
Front-door polish, sidebar pass — declutter the default navigation.

## Problem
The sidebar's default expanded view stacked three always-on blocks: **Destinations** (the concentrated front door — correctly visible), the **15-root Sub-Lens tree**, and **Systems**. The sub-lens tree is a power-user surface, but all 15 roots rendered by default, making the sidebar ~15 rows deeper than necessary on first paint (the "Starfield-density" trap the design docs warn about).

## Fix
- **Sub-Lenses is now a collapsible section (default collapsed)** — matches the Destinations/Extensions toggle pattern already in this file.
- **Auto-opens** when the active route is a sub-lens (`/lenses/<parent>/<child>`) so a deep link still reveals where you are.
- **Lazy bonus:** the tree only fetches `/api/sub-lens/tree` on expand now — the default render does no tree fetch.

## Honesty / "organize, don't remove"
Nothing becomes unreachable — the tree is one click away and also lives in the Hub + ⌘K. The Destinations tier stays visible because *that* is the polish strategy.

## Verified
- Sidebar component tests 21/21
- `tsc --noEmit` 0 errors · `next lint` 0 warnings
- prod build `✓ Compiled successfully`, Prophet 0 warnings, exit 0

https://claude.ai/code/session_01RxwGhrNMhrCC9d2sWxmx5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxwGhrNMhrCC9d2sWxmx5W)_