### PR TITLE
feat(reason): sound Z3 proof gate on reason.verify (subconscious brain)

### DIFF
--- a/server/domains/reason.js
+++ b/server/domains/reason.js
@@ -6,6 +6,7 @@
 // the multi-brain council as the semantic judge when the brains are up.
 
 import { verifyClaim } from "../lib/reason-verify.js";
+import { proveClaim, classifyAmenable } from "../lib/proof-gate.js";
 
 export default function registerReasonMacros(register) {
   register("reason", "verify", async (ctx, input = {}) => {
@@ -19,9 +20,36 @@ export default function registerReasonMacros(register) {
         : [],
       requesterId: ctx?.actor?.userId || null,
       useCouncil: input.useCouncil !== false,
+      useProof: input.useProof !== false,
     });
   }, {
-    note: "verify a claim against its cited DTUs — deterministic citation-resolution floor + multi-brain council judge when brains are up",
+    note: "verify a claim against its cited DTUs — deterministic citation floor + multi-brain council judge + (for math/logic claims) a sound Z3 proof gate",
+    llmHint: true,
+  });
+
+  // Direct formal-proof check — answers "is this claim mathematically VALID?"
+  // (orthogonal to citation grounding). The subconscious brain formalises the
+  // claim into refutation-style SMT-LIB; Z3 rules proven/refuted/unknown. No-op
+  // (verdict:"unavailable") when Z3 isn't installed — sound or silent, never faked.
+  register("reason", "prove", async (ctx, input = {}) => {
+    const db = ctx?.db;
+    const claim = String(input.claim || "").trim();
+    if (!claim) return { ok: false, reason: "no_claim" };
+    if (!classifyAmenable(claim).amenable) {
+      return { ok: true, verdict: "not_amenable", amenable: false, claim };
+    }
+    let brainFn = null;
+    try {
+      const { brainChat } = await import("../lib/byo-router.js");
+      brainFn = async (messages) => {
+        const r = await brainChat({ db, userId: ctx?.actor?.userId || null, slot: "subconscious", messages });
+        return { text: r?.text || "" };
+      };
+    } catch { brainFn = null; }
+    const result = await proveClaim({ claim, brainFn });
+    return { ok: true, claim, ...result };
+  }, {
+    note: "formally check whether a math/logic claim is valid via the subconscious brain → SMT-LIB → Z3 (sound when Z3 is installed; degrades to verdict:'unavailable')",
     llmHint: true,
   });
 }

--- a/server/lib/proof-gate.js
+++ b/server/lib/proof-gate.js
@@ -1,0 +1,207 @@
+// server/lib/proof-gate.js
+//
+// Formal-proof gate — the SOUND layer for reason.verify, borrowed from MOTO's
+// "only store what the checker accepts" discipline and wired onto the
+// subconscious brain (the autonomous formaliser) + Z3 (the SMT checker).
+//
+// reason.verify already does two things well:
+//   • a deterministic citation-resolution floor (catches fabricated citations)
+//   • a multi-brain COUNCIL judge (semantic "do these sources support this?")
+// Both are *semantic* — a confident LLM can still be wrong. This file adds the
+// missing third layer for the one slice where soundness is achievable:
+// mathematical / logical claims. For those, we don't ask a brain "is this true?"
+// — we ask Z3.
+//
+// Flow (all three steps are cheap-gated so non-math claims cost nothing):
+//   1. classifyAmenable(claim)   — deterministic heuristic: does this LOOK like a
+//      math/logic statement worth formalising? Pure regex, no brain, no Z3.
+//   2. formaliseClaim(claim)     — the subconscious brain translates the claim into
+//      SMT-LIB that asserts the NEGATION of the claim (prove-by-refutation).
+//   3. runZ3(smtlib)             — Z3 checks: `unsat` ⇒ the negation is impossible
+//      ⇒ the claim is VALID (proven); `sat` ⇒ the negation has a model ⇒ the claim
+//      is REFUTED (and the model is a counterexample); `unknown`/timeout ⇒ inconclusive.
+//
+// HONESTY (encoded, not aspirational):
+//   • Z3's verdict is SOUND *relative to the formalisation*. The NL→SMT step is
+//     brain-dependent, so a "proven" verdict means "the SMT the subconscious brain
+//     produced was machine-checked valid" — the emitted `smt` is returned so a human
+//     can audit the translation. This is exactly MOTO's Lean caveat ("view with
+//     scrutiny"), made explicit.
+//   • If Z3 is not installed, the gate returns verdict:"unavailable" and changes
+//     NOTHING about the existing citation/council verdict — pure graceful
+//     degradation, identical to the council-offline path. Ships safely with no Z3.
+//   • Every checker call is injectable (z3Runner / brainFn) so the whole gate is
+//     deterministically testable offline — mirrors the connectorFetch fetchImpl seam.
+
+import { execFile } from "node:child_process";
+import logger from "../logger.js";
+
+const DEFAULT_TIMEOUT_MS = 8000;
+const SMT_MAX_BYTES = 20_000; // a formalisation larger than this is almost certainly garbage
+
+// ── 1. Amenability heuristic (deterministic, cheap) ──────────────────────────
+// We only spend a brain call + Z3 run on claims that read as math/logic. The
+// heuristic is intentionally conservative: false-negatives (skipping a provable
+// claim) just fall back to the council; false-positives waste one gated call.
+const AMENABLE_SIGNALS = [
+  { key: "comparison", re: /[<>]=?|≤|≥|≠|\bequals?\b|=/ },
+  { key: "quantifier", re: /\b(for all|for every|there exists|for any|forall|exists)\b/i },
+  { key: "arithmetic", re: /\b\d+\s*[+\-*/^]\s*\d+\b|\b(sum|product|divisible|modulo|remainder)\b/i },
+  { key: "number_theory", re: /\b(prime|even|odd|integer|natural number|rational|divides|gcd|factorial)\b/i },
+  { key: "logic", re: /\b(implies|if and only if|iff|therefore|contradiction|tautolog)/i },
+  { key: "algebra", re: /\b(polynomial|inequality|equation|root|monoton|convex|continuous)\b/i },
+  { key: "set", re: /\b(subset|superset|union|intersection|cardinality|element of)\b/i },
+];
+
+// A claim that is mostly prose with none of the structural signals is not worth
+// formalising. Require at least one signal AND a comparison/quantifier/logic anchor
+// (the things SMT can actually express) — otherwise it's "soft" math talk.
+const ANCHOR_KEYS = new Set(["comparison", "quantifier", "logic", "arithmetic"]);
+
+export function classifyAmenable(claim) {
+  const text = String(claim || "").trim();
+  if (!text || text.length < 3) return { amenable: false, signals: [], reason: "empty" };
+  if (text.length > 2000) return { amenable: false, signals: [], reason: "too_long" };
+  const signals = AMENABLE_SIGNALS.filter((s) => s.re.test(text)).map((s) => s.key);
+  const hasAnchor = signals.some((k) => ANCHOR_KEYS.has(k));
+  const amenable = signals.length > 0 && hasAnchor;
+  return { amenable, signals, reason: amenable ? "ok" : "no_formalisable_structure" };
+}
+
+// ── 2. SMT extraction from brain output ──────────────────────────────────────
+// The brain is asked for a fenced ```smt block; be liberal in what we accept
+// (```smt / ```smt2 / ```lisp / ```scheme) and fall back to grabbing the balanced
+// S-expression region that contains a (check-sat).
+export function extractSmt(text) {
+  const raw = String(text || "");
+  const fence = raw.match(/```(?:smt2?|lisp|scheme|z3)?\s*([\s\S]*?)```/i);
+  let body = fence ? fence[1] : raw;
+  // Keep only from the first declaration/assert to the check-sat (inclusive).
+  const start = body.search(/\(\s*(declare-|assert|set-logic|define-)/);
+  const end = body.search(/\(\s*check-sat\s*\)/);
+  if (start >= 0 && end >= 0) {
+    body = body.slice(start, end + body.slice(end).indexOf(")") + 1);
+  }
+  body = body.trim();
+  if (!body || body.length > SMT_MAX_BYTES) return null;
+  if (!/\(\s*check-sat\s*\)/.test(body)) {
+    // Be forgiving: append a check-sat if the brain forgot it but gave assertions.
+    if (/\(\s*assert\b/.test(body)) body += "\n(check-sat)";
+    else return null;
+  }
+  return body;
+}
+
+// ── 3. Z3 runner (injectable; degrades to unavailable) ───────────────────────
+function locateZ3() {
+  return process.env.CONCORD_Z3_PATH || process.env.Z3_PATH || "z3";
+}
+
+/**
+ * Run an SMT-LIB script through Z3. Returns { available, result, raw }.
+ * result ∈ "sat" | "unsat" | "unknown" | null. available:false ⇒ no Z3 binary.
+ * Injectable for tests via opts.runner(smtlib) → { available, result, raw }.
+ */
+export async function runZ3(smtlib, opts = {}) {
+  if (typeof opts.runner === "function") {
+    try { return await opts.runner(smtlib); }
+    catch (e) { return { available: false, result: null, raw: String(e?.message || e) }; }
+  }
+  const z3 = opts.z3Path || locateZ3();
+  const timeoutMs = opts.timeoutMs || DEFAULT_TIMEOUT_MS;
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = execFile(
+        z3,
+        ["-in", `-T:${Math.ceil(timeoutMs / 1000)}`],
+        { timeout: timeoutMs, maxBuffer: 1_000_000 },
+        (err, stdout, stderr) => {
+          const out = String(stdout || "");
+          // ENOENT ⇒ no binary ⇒ unavailable (the safe-degrade path).
+          if (err && (err.code === "ENOENT" || /ENOENT|not found/i.test(String(err.message)))) {
+            return resolve({ available: false, result: null, raw: String(stderr || err.message) });
+          }
+          const first = (out.match(/\b(sat|unsat|unknown)\b/) || [])[1] || null;
+          resolve({ available: true, result: first, raw: out.trim() || String(stderr || "") });
+        },
+      );
+    } catch (e) {
+      resolve({ available: false, result: null, raw: String(e?.message || e) });
+      return;
+    }
+    try { child.stdin.write(String(smtlib || "")); child.stdin.end(); } catch { /* execFile error already handled */ }
+  });
+}
+
+const FORMALISE_SYSTEM =
+  "You are a formal-methods translator. Convert the user's mathematical claim into " +
+  "an SMT-LIB 2 script that PROVES IT BY REFUTATION: declare the needed sorts/consts, " +
+  "then ASSERT THE NEGATION of the claim, and end with (check-sat). If Z3 returns " +
+  "unsat the claim is valid. Use (set-logic ...) when helpful. Output ONLY a single " +
+  "```smt code block — no prose. If the claim cannot be faithfully formalised in " +
+  "SMT-LIB, output exactly ```smt\\n; UNFORMALISABLE\\n```.";
+
+/**
+ * Ask the subconscious brain to formalise a claim into refutation-style SMT-LIB.
+ * Injectable via opts.brainFn(messages) → { ok, text }. Returns { smt, raw } | null.
+ */
+export async function formaliseClaim(claim, opts = {}) {
+  const messages = [
+    { role: "system", content: FORMALISE_SYSTEM },
+    { role: "user", content: `Claim: "${String(claim || "").trim()}"` },
+  ];
+  let text = "";
+  try {
+    if (typeof opts.brainFn === "function") {
+      const r = await opts.brainFn(messages);
+      text = String(r?.text ?? r ?? "");
+    } else {
+      return null; // no brain wired ⇒ caller degrades
+    }
+  } catch (e) {
+    try { logger.debug?.("proof-gate", "formalise_failed", { error: e?.message }); } catch { /* ignore */ }
+    return null;
+  }
+  if (/;\s*UNFORMALISABLE/i.test(text)) return { smt: null, raw: text, unformalisable: true };
+  const smt = extractSmt(text);
+  return smt ? { smt, raw: text } : { smt: null, raw: text };
+}
+
+// ── Orchestrator ─────────────────────────────────────────────────────────────
+// verdicts: proven | refuted | unknown | not_amenable | unformalisable | unavailable
+/**
+ * @param {{ claim:string, brainFn?:Function, z3Runner?:Function, z3Path?:string,
+ *           timeoutMs?:number }} opts
+ */
+export async function proveClaim(opts = {}) {
+  const claim = String(opts.claim || "").trim();
+  const out = { attempted: false, amenable: false, verdict: "not_amenable", result: null, smt: null, signals: [], z3Available: null };
+
+  const cls = classifyAmenable(claim);
+  out.amenable = cls.amenable;
+  out.signals = cls.signals;
+  if (!cls.amenable) return out;
+
+  // Check Z3 availability BEFORE spending a brain call — a quick (check-sat) on a
+  // trivial script tells us whether the binary exists without a real proof.
+  const probe = await runZ3("(check-sat)", { runner: opts.z3Runner, z3Path: opts.z3Path, timeoutMs: 2000 });
+  out.z3Available = probe.available === true;
+  if (!out.z3Available) { out.verdict = "unavailable"; return out; }
+
+  out.attempted = true;
+  const f = await formaliseClaim(claim, { brainFn: opts.brainFn });
+  if (!f) { out.verdict = "unavailable"; return out; } // no brain wired
+  if (f.unformalisable || !f.smt) { out.verdict = "unformalisable"; out.smt = f.smt || null; return out; }
+  out.smt = f.smt;
+
+  const z = await runZ3(f.smt, { runner: opts.z3Runner, z3Path: opts.z3Path, timeoutMs: opts.timeoutMs });
+  out.result = z.result;
+  out.z3Raw = z.raw;
+  if (z.result === "unsat") out.verdict = "proven";       // negation impossible ⇒ claim valid
+  else if (z.result === "sat") out.verdict = "refuted";   // negation has a model ⇒ counterexample
+  else out.verdict = "unknown";                            // unknown / timeout
+  return out;
+}
+
+export default { classifyAmenable, extractSmt, runZ3, formaliseClaim, proveClaim };

--- a/server/lib/reason-verify.js
+++ b/server/lib/reason-verify.js
@@ -51,10 +51,12 @@ function resolveCitations(db, citationIds, requesterId) {
 
 /**
  * @param {object} db
- * @param {{ claim?: string, citationIds?: string[], requesterId?: string|null, useCouncil?: boolean }} opts
+ * @param {{ claim?: string, citationIds?: string[], requesterId?: string|null,
+ *           useCouncil?: boolean, useProof?: boolean,
+ *           proofBrainFn?: Function, proofZ3Runner?: Function }} opts
  * @returns {Promise<object>} verification verdict
  */
-export async function verifyClaim(db, { claim, citationIds = [], requesterId = null, useCouncil = true } = {}) {
+export async function verifyClaim(db, { claim, citationIds = [], requesterId = null, useCouncil = true, useProof = true, proofBrainFn = null, proofZ3Runner = null } = {}) {
   if (!db) return { ok: false, reason: "no_db" };
   const ids = (Array.isArray(citationIds) ? citationIds : []).map(String).filter(Boolean);
   const claimText = String(claim || "").trim();
@@ -104,6 +106,39 @@ export async function verifyClaim(db, { claim, citationIds = [], requesterId = n
     }
   }
 
+  // Formal-proof gate (sound layer) — orthogonal to citation grounding: it answers
+  // "is this claim mathematically VALID?" not "do its sources back it?". Only fires
+  // for proof-amenable claims (cheap deterministic heuristic) and only when Z3 is
+  // installed; otherwise it's a no-op that leaves the verdict above untouched. A
+  // sound `proven`/`refuted` result is stronger than the semantic council, so it
+  // upgrades the top-level verdict; everything else is additive-only.
+  let proof = null;
+  if (useProof && claimText) {
+    try {
+      const { proveClaim, classifyAmenable } = await import("./proof-gate.js");
+      // Skip the brain-wiring cost entirely when the claim isn't proof-amenable.
+      if (classifyAmenable(claimText).amenable) {
+        // Default formaliser = the subconscious brain (the autonomous slot), via the
+        // BYO-aware brainChat router. Injectable for offline tests.
+        let brainFn = proofBrainFn;
+        if (!brainFn) {
+          try {
+            const { brainChat } = await import("./byo-router.js");
+            brainFn = async (messages) => {
+              const r = await brainChat({ db, userId: requesterId, slot: "subconscious", messages });
+              return { text: r?.text || "" };
+            };
+          } catch { brainFn = null; }
+        }
+        proof = await proveClaim({ claim: claimText, brainFn, z3Runner: proofZ3Runner });
+        if (proof?.verdict === "proven") { supported = true; verdict = "proven"; mode = "proof"; confidence = 1; }
+        else if (proof?.verdict === "refuted") { supported = false; verdict = "refuted"; mode = "proof"; confidence = 1; }
+      }
+    } catch (e) {
+      try { logger.debug?.("reason-verify", "proof_gate_unavailable", { error: e?.message }); } catch { /* ignore */ }
+    }
+  }
+
   return {
     ok: true,
     claim: claimText || null,
@@ -116,6 +151,7 @@ export async function verifyClaim(db, { claim, citationIds = [], requesterId = n
     mode,
     verdict,
     council,
+    proof,
   };
 }
 

--- a/server/tests/proof-gate.test.js
+++ b/server/tests/proof-gate.test.js
@@ -1,0 +1,192 @@
+/**
+ * proof-gate — the sound (Z3) layer for reason.verify.
+ *
+ * Z3 and the subconscious brain are exercised live in deployment; this pins the
+ * deterministic logic offline by injecting a fake brainFn (returns canned SMT-LIB)
+ * and a fake z3Runner (returns sat/unsat/unknown), so the whole verdict mapping is
+ * CI-testable with no binary and no model — mirrors the reason-verify floor tests.
+ *
+ *   unsat-of-negation  → proven   (sound: claim is valid)
+ *   sat-of-negation    → refuted  (sound: counterexample exists)
+ *   unknown            → unknown
+ *   no z3 binary       → unavailable (and reason.verify is left untouched)
+ *   non-math claim     → not_amenable (no brain/Z3 cost)
+ *
+ * Run: node --test server/tests/proof-gate.test.js
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+
+import { classifyAmenable, extractSmt, runZ3, proveClaim } from "../lib/proof-gate.js";
+import { verifyClaim } from "../lib/reason-verify.js";
+
+// A z3Runner stub: first call is the availability probe "(check-sat)", later the
+// real script. `available:false` simulates a box with no Z3 installed.
+function z3Stub({ available = true, result = "unsat" } = {}) {
+  return async (smt) => {
+    if (!available) return { available: false, result: null, raw: "ENOENT" };
+    if (/^\s*\(check-sat\)\s*$/.test(smt)) return { available: true, result: "sat", raw: "sat" }; // probe
+    return { available: true, result, raw: result };
+  };
+}
+
+const brainStub = (smt) => async () => ({ text: "```smt\n" + smt + "\n```" });
+
+describe("proof-gate — amenability heuristic", () => {
+  it("flags math/logic claims with a formalisable anchor", () => {
+    assert.equal(classifyAmenable("for all integers n, n + 0 = n").amenable, true);
+    assert.equal(classifyAmenable("3 + 4 > 5").amenable, true);
+    assert.equal(classifyAmenable("if x is prime and x > 2 then x is odd").amenable, true);
+  });
+  it("rejects prose with no formalisable structure", () => {
+    assert.equal(classifyAmenable("Paris is the capital of France").amenable, false);
+    assert.equal(classifyAmenable("the music feels warm and nostalgic").amenable, false);
+    assert.equal(classifyAmenable("").amenable, false);
+  });
+});
+
+describe("proof-gate — SMT extraction", () => {
+  it("pulls a fenced smt block and keeps through check-sat", () => {
+    const out = extractSmt("blah\n```smt\n(declare-const x Int)\n(assert (> x 0))\n(check-sat)\n```\ntrailing");
+    assert.match(out, /\(check-sat\)/);
+    assert.match(out, /declare-const x Int/);
+    assert.doesNotMatch(out, /trailing/);
+  });
+  it("appends a check-sat when the brain forgot it but gave assertions", () => {
+    const out = extractSmt("```smt\n(assert false)\n```");
+    assert.match(out, /\(check-sat\)/);
+  });
+  it("returns null when there's nothing formalisable", () => {
+    assert.equal(extractSmt("no smt here at all"), null);
+  });
+});
+
+describe("proof-gate — proveClaim verdict mapping", () => {
+  it("unsat-of-negation → proven (sound)", async () => {
+    const r = await proveClaim({
+      claim: "for all integers n, n + 0 = n",
+      brainFn: brainStub("(declare-const n Int)\n(assert (not (= (+ n 0) n)))\n(check-sat)"),
+      z3Runner: z3Stub({ result: "unsat" }),
+    });
+    assert.equal(r.verdict, "proven");
+    assert.equal(r.attempted, true);
+    assert.equal(r.z3Available, true);
+    assert.match(r.smt, /check-sat/);
+  });
+
+  it("sat-of-negation → refuted (counterexample)", async () => {
+    const r = await proveClaim({
+      claim: "for all integers n, n > 0",
+      brainFn: brainStub("(declare-const n Int)\n(assert (not (> n 0)))\n(check-sat)"),
+      z3Runner: z3Stub({ result: "sat" }),
+    });
+    assert.equal(r.verdict, "refuted");
+  });
+
+  it("unknown → unknown", async () => {
+    const r = await proveClaim({
+      claim: "3 + 4 > 5",
+      brainFn: brainStub("(assert (not (> (+ 3 4) 5)))\n(check-sat)"),
+      z3Runner: z3Stub({ result: "unknown" }),
+    });
+    assert.equal(r.verdict, "unknown");
+  });
+
+  it("no Z3 binary → unavailable, and the brain is never called", async () => {
+    let brainCalled = false;
+    const r = await proveClaim({
+      claim: "3 + 4 > 5",
+      brainFn: async () => { brainCalled = true; return { text: "```smt\n(check-sat)\n```" }; },
+      z3Runner: z3Stub({ available: false }),
+    });
+    assert.equal(r.verdict, "unavailable");
+    assert.equal(r.z3Available, false);
+    assert.equal(brainCalled, false, "must probe Z3 before spending a brain call");
+  });
+
+  it("non-amenable claim → not_amenable, no work done", async () => {
+    let z3Called = false;
+    const r = await proveClaim({
+      claim: "Paris is lovely in spring",
+      brainFn: async () => ({ text: "" }),
+      z3Runner: async () => { z3Called = true; return { available: true, result: "sat" }; },
+    });
+    assert.equal(r.verdict, "not_amenable");
+    assert.equal(z3Called, false);
+  });
+
+  it("brain marks UNFORMALISABLE → unformalisable", async () => {
+    const r = await proveClaim({
+      claim: "for all x, beauty implies truth",
+      brainFn: async () => ({ text: "```smt\n; UNFORMALISABLE\n```" }),
+      z3Runner: z3Stub({ result: "unsat" }),
+    });
+    assert.equal(r.verdict, "unformalisable");
+  });
+});
+
+describe("runZ3 — graceful when binary absent", () => {
+  it("returns available:false instead of throwing when z3 is missing", async () => {
+    const r = await runZ3("(check-sat)", { z3Path: "/nonexistent/z3-binary-xyz", timeoutMs: 1000 });
+    assert.equal(r.available, false);
+  });
+});
+
+describe("reason.verify — proof gate integration", () => {
+  let db;
+  beforeEach(() => {
+    db = new Database(":memory:");
+    db.exec(`CREATE TABLE dtus (id TEXT PRIMARY KEY, type TEXT, title TEXT, creator_id TEXT, data TEXT);`);
+  });
+
+  it("a proven math claim upgrades the top-level verdict to 'proven'", async () => {
+    const r = await verifyClaim(db, {
+      claim: "for all integers n, n + 0 = n",
+      citationIds: [],
+      useCouncil: false,
+      proofBrainFn: brainStub("(declare-const n Int)\n(assert (not (= (+ n 0) n)))\n(check-sat)"),
+      proofZ3Runner: z3Stub({ result: "unsat" }),
+    });
+    assert.equal(r.verdict, "proven");
+    assert.equal(r.supported, true);
+    assert.equal(r.mode, "proof");
+    assert.equal(r.proof.verdict, "proven");
+  });
+
+  it("a refuted claim sets verdict 'refuted' / supported:false", async () => {
+    const r = await verifyClaim(db, {
+      claim: "for all integers n, n > 0",
+      citationIds: [],
+      useCouncil: false,
+      proofBrainFn: brainStub("(declare-const n Int)\n(assert (not (> n 0)))\n(check-sat)"),
+      proofZ3Runner: z3Stub({ result: "sat" }),
+    });
+    assert.equal(r.verdict, "refuted");
+    assert.equal(r.supported, false);
+  });
+
+  it("no Z3 ⇒ proof gate is a no-op; floor verdict untouched", async () => {
+    const r = await verifyClaim(db, {
+      claim: "3 + 4 > 5",
+      citationIds: [],
+      useCouncil: false,
+      proofZ3Runner: z3Stub({ available: false }),
+    });
+    // Nothing cited + no proof ⇒ stays at the deterministic floor.
+    assert.equal(r.verdict, "unverified");
+    assert.equal(r.proof.verdict, "unavailable");
+  });
+
+  it("non-math claim ⇒ proof stays null, no override", async () => {
+    const r = await verifyClaim(db, {
+      claim: "Paris is the capital of France",
+      citationIds: [],
+      useCouncil: false,
+      proofZ3Runner: z3Stub({ result: "unsat" }),
+    });
+    assert.equal(r.verdict, "unverified");
+    assert.equal(r.proof, null);
+  });
+});


### PR DESCRIPTION
Closes the one honest gap vs MOTO: Concord's verification stack was strong but **semantic** (citation-resolution floor + multi-brain council judge). MOTO's edge was **sound formal verification** (Lean/Z3). This adds the missing sound layer for the slice where soundness is achievable — math/logic claims — wired onto the **subconscious brain** (the autonomous formaliser) + **Z3**.

## How it works
1. `classifyAmenable(claim)` — deterministic heuristic; only math/logic claims with a formalisable anchor proceed, so non-math claims cost nothing.
2. The **subconscious brain** formalises the claim into refutation-style SMT-LIB (assert the *negation*).
3. **Z3** rules: `unsat` ⇒ **proven** (valid), `sat` ⇒ **refuted** (counterexample), `unknown` ⇒ inconclusive.

Z3 availability is probed **before** the brain call, so a box without Z3 spends nothing.

## Integration (`reason.verify`)
The gate is **additive**: a sound `proven`/`refuted` upgrades the top-level verdict (`mode:"proof"`, confidence 1); everything else leaves the citation/council verdict untouched. **No Z3 installed ⇒ `verdict:"unavailable"`, pure no-op** — same graceful-degrade shape as the council-offline path. New `reason.prove` macro for direct formal checking.

## Honesty (encoded, not aspirational)
A `proven` verdict is sound **relative to the formalisation** — the NL→SMT step is brain-dependent, so the emitted SMT is returned for human audit (MOTO's "view with scrutiny", made explicit). Sound or silent, never faked.

## Verified
- Fully offline-testable via injected `brainFn` + `z3Runner` seams (mirrors the `connectorFetch` `fetchImpl` pattern).
- `tests/proof-gate.test.js` 16/16; existing `reason-verify` floor 5/5 still green.
- `eslint` clean. Both macros `llmHint:true` (behavior-smoke harness skips them).

## Files
- `server/lib/proof-gate.js` (new) — heuristic + SMT extraction + Z3 runner + formaliser + orchestrator
- `server/lib/reason-verify.js` — additive proof layer
- `server/domains/reason.js` — `reason.prove` macro + `useProof` passthrough
- `server/tests/proof-gate.test.js` (new)

https://claude.ai/code/session_01RxwGhrNMhrCC9d2sWxmx5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxwGhrNMhrCC9d2sWxmx5W)_