### PR TITLE
build: install Z3 (setup.sh + Dockerfile) so the proof gate is live by default

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,13 +6,17 @@
 # Then replace the FROM line with: FROM node:20-bookworm-slim@sha256:<digest> AS base
 FROM node:20-bookworm-slim AS base
 
-# Install build tools for native modules (better-sqlite3) and runtime deps
+# Install build tools for native modules (better-sqlite3) and runtime deps.
+# z3 is the SMT checker for reason.verify's formal-proof gate (lib/proof-gate.js);
+# it's optional at runtime (the gate degrades to verdict:"unavailable" without it)
+# but baking it into the image makes the proof gate live out of the box.
 RUN apt-get update && apt-get install -y \
     curl \
     ca-certificates \
     python3 \
     make \
     g++ \
+    z3 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/setup.sh
+++ b/setup.sh
@@ -53,6 +53,32 @@ if ! command -v ollama &>/dev/null; then
 fi
 ok "Ollama found at $(command -v ollama)"
 
+# ── 3b. Check / install Z3 (OPTIONAL — the reason.verify proof gate) ─────
+# Z3 is the SMT checker behind the formal-proof gate (server/lib/proof-gate.js).
+# It's OPTIONAL: when absent, reason.verify/reason.prove return verdict:"unavailable"
+# and the rest of verification (citation floor + council) is unaffected. We try a
+# best-effort install but never fail the setup over it.
+info "Checking for Z3 (optional — formal-proof gate)..."
+if command -v z3 &>/dev/null; then
+  ok "Z3 found at $(command -v z3) ($(z3 --version 2>/dev/null | head -1))"
+else
+  warn "Z3 not found — attempting a best-effort install (proof gate is optional)."
+  if command -v apt-get &>/dev/null; then
+    (sudo apt-get update -y && sudo apt-get install -y z3) 2>/dev/null || true
+  elif command -v brew &>/dev/null; then
+    brew install z3 2>/dev/null || true
+  elif command -v pip3 &>/dev/null; then
+    pip3 install --quiet z3-solver 2>/dev/null || true   # provides a `z3` console script
+  fi
+  if command -v z3 &>/dev/null; then
+    ok "Z3 installed at $(command -v z3)."
+  else
+    warn "Z3 still unavailable — reason.verify's formal-proof gate will report"
+    warn "verdict:\"unavailable\". Install later with: apt-get install z3  (or  pip3 install z3-solver)"
+    warn "and optionally set CONCORD_Z3_PATH to the binary."
+  fi
+fi
+
 # ── 4. Install server dependencies ───────────────────────────────────────
 info "Installing server dependencies..."
 (cd server && npm install)


### PR DESCRIPTION
Makes the `reason.verify` formal-proof gate (PR #828) **live out of the box** by installing Z3 — the SMT checker `lib/proof-gate.js` shells out to.

## Changes
- **`server/Dockerfile`** — add `z3` to the apt-get install layer. The production image and the docker-compose `backend` + `backend-read` services (both build from `server/Dockerfile`) now ship with `z3` on PATH. Verified installable on `bookworm` (Z3 4.8.12).
- **`setup.sh`** — a soft, optional check/install for bare-metal: if `z3` is missing, best-effort install via apt-get / brew / pip3 (`z3-solver` provides a `z3` console script), and **WARN, never fail** if it still isn't there — matching the gate's graceful-degrade contract. Points at `CONCORD_Z3_PATH` for custom installs.

## Why optional-but-installed
The gate already returns `verdict:"unavailable"` and leaves citation/council verdicts untouched when Z3 is absent, so Z3 is never a hard requirement. Baking it in just means the sound proof path is active by default.

## Verified live
Installed Z3 4.8.12 and ran the gate end-to-end against the **real** binary (faking only the brain, since Ollama isn't up in CI):
- `n+0=n` → unsat → **proven**
- `n*n>=0` → **proven**
- `n>0` → **refuted** (counterexample found)

`proof-gate` 16/16 + `reason-verify` floor 5/5 still green with the binary present (stubs keep tests deterministic regardless of install state). `setup.sh` passes `bash -n`.

https://claude.ai/code/session_01RxwGhrNMhrCC9d2sWxmx5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxwGhrNMhrCC9d2sWxmx5W)_