### PR TITLE
feat(lattice): autonomous formal-proof pass — Z3-check HLR conclusions on the heartbeat

### DIFF
--- a/server/emergent/lattice-orchestrator.js
+++ b/server/emergent/lattice-orchestrator.js
@@ -96,16 +96,53 @@ export async function runPeriodicDriftScan({ db: _db, state: _state, tickCount: 
 
       const hlr = await import("./hlr-engine.js").catch(() => null);
       if (hlr?.runHLR) {
+        const conclusions = [];
         for (const a of alerts.slice(0, 3)) {
           try {
-            hlr.runHLR({
+            const r = hlr.runHLR({
               input: `Drift alert: ${a.kind ?? a.type ?? "unknown"}. ${a.summary ?? a.message ?? ""}`,
               mode: "constraint_check",
               tags: ["drift_resolution"],
             });
+            // Collect the chain conclusions + the synthesised conclusion so the
+            // autonomous reasoning can be FORMALLY self-checked below.
+            for (const ch of (r?.chains || [])) if (ch?.conclusion) conclusions.push(ch.conclusion);
+            const synth = r?.output?.synthesizedConclusion;
+            if (synth) conclusions.push(synth);
           } catch (err) {
             try { logger.debug("lattice-orchestrator", "hlr_route_failed", { error: err?.message }); } catch { /* ignore */ }
           }
+        }
+
+        // Autonomous formal-proof pass — the continuous analogue to MOTO's
+        // "verify the research". Proof-amenable conclusions go through the Z3 gate
+        // (subconscious brain formaliser); a sound proven/refuted is recorded +
+        // surfaced. Best-effort, bounded, near-free when Z3 isn't installed.
+        try {
+          const { verifyConclusions } = await import("../lib/proof-gate.js");
+          let brainFn = null;
+          try {
+            const { brainChat } = await import("../lib/byo-router.js");
+            const db = _STATE_REF?.db || globalThis.__concordDb || null;
+            brainFn = async (messages) => {
+              const rr = await brainChat({ db, userId: null, slot: "subconscious", messages });
+              return { text: rr?.text || "" };
+            };
+          } catch { brainFn = null; }
+          const proof = await verifyConclusions(conclusions, { brainFn, max: 3 });
+          if (scan && typeof scan === "object") scan.proof = proof;
+          if (proof.checked > 0) {
+            try {
+              const realtimeMod = await import("./realtime.js").catch(() => null);
+              const emit = realtimeMod?.realtimeEmit || globalThis.REALTIME?.io?.emit?.bind(globalThis.REALTIME.io);
+              for (const res of proof.results) {
+                emit?.("lattice:claim-verified", { verdict: res.verdict, claim: res.claim.slice(0, 200), at: Date.now() });
+              }
+              logger.info?.("lattice-orchestrator", "autonomous_proof_pass", { checked: proof.checked, proven: proof.proven, refuted: proof.refuted });
+            } catch { /* surfacing best-effort */ }
+          }
+        } catch (err) {
+          try { logger.debug("lattice-orchestrator", "proof_pass_unavailable", { error: err?.message }); } catch { /* ignore */ }
         }
       }
     }

--- a/server/lib/proof-gate.js
+++ b/server/lib/proof-gate.js
@@ -204,4 +204,39 @@ export async function proveClaim(opts = {}) {
   return out;
 }
 
-export default { classifyAmenable, extractSmt, runZ3, formaliseClaim, proveClaim };
+// ── Autonomous batch: verify a set of reasoning conclusions ──────────────────
+// The autonomous loop (lattice-orchestrator → runHLR) produces conclusions; this
+// runs the proof-amenable ones through the gate so the self-reasoning is formally
+// self-checking — Concord's continuous analogue to MOTO's "verify the research".
+// Bounded by `max` amenable checks so a heartbeat never spends unboundedly; the
+// z3-availability probe inside proveClaim keeps it near-free when Z3 is absent.
+/**
+ * @param {string[]} conclusions
+ * @param {{ brainFn?:Function, z3Runner?:Function, max?:number }} opts
+ * @returns {Promise<{ checked:number, proven:number, refuted:number, results:object[] }>}
+ */
+export async function verifyConclusions(conclusions, opts = {}) {
+  const max = Math.max(1, Math.min(10, opts.max ?? 3));
+  const list = (Array.isArray(conclusions) ? conclusions : [])
+    .map((c) => String(c || "").trim())
+    .filter(Boolean);
+  const out = { checked: 0, proven: 0, refuted: 0, results: [] };
+  for (const claim of list) {
+    if (out.checked >= max) break;
+    if (!classifyAmenable(claim).amenable) continue;
+    let r;
+    try { r = await proveClaim({ claim, brainFn: opts.brainFn, z3Runner: opts.z3Runner }); }
+    catch { continue; }
+    // "unavailable"/"not_amenable" don't count as a real check — only a checker verdict does.
+    if (r.verdict === "unavailable") break; // no Z3 ⇒ stop, the rest would be no-ops too
+    if (r.verdict === "proven" || r.verdict === "refuted" || r.verdict === "unknown") {
+      out.checked++;
+      if (r.verdict === "proven") out.proven++;
+      if (r.verdict === "refuted") out.refuted++;
+      out.results.push({ claim, verdict: r.verdict, smt: r.smt || null });
+    }
+  }
+  return out;
+}
+
+export default { classifyAmenable, extractSmt, runZ3, formaliseClaim, proveClaim, verifyConclusions };

--- a/server/tests/proof-gate.test.js
+++ b/server/tests/proof-gate.test.js
@@ -19,7 +19,7 @@ import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import Database from "better-sqlite3";
 
-import { classifyAmenable, extractSmt, runZ3, proveClaim } from "../lib/proof-gate.js";
+import { classifyAmenable, extractSmt, runZ3, proveClaim, verifyConclusions } from "../lib/proof-gate.js";
 import { verifyClaim } from "../lib/reason-verify.js";
 
 // A z3Runner stub: first call is the availability probe "(check-sat)", later the
@@ -131,6 +131,53 @@ describe("runZ3 — graceful when binary absent", () => {
   it("returns available:false instead of throwing when z3 is missing", async () => {
     const r = await runZ3("(check-sat)", { z3Path: "/nonexistent/z3-binary-xyz", timeoutMs: 1000 });
     assert.equal(r.available, false);
+  });
+});
+
+describe("verifyConclusions — autonomous batch (lattice-orchestrator path)", () => {
+  it("checks only proof-amenable conclusions and tallies proven/refuted", async () => {
+    const conclusions = [
+      "The market sentiment is broadly positive",     // not amenable → skipped
+      "for all integers n, n + 0 = n",                // proven
+      "for all integers n, n > 0",                    // refuted
+    ];
+    // Brain returns the right negation SMT per claim; z3 stub maps by content.
+    const brainFn = async (messages) => {
+      const claim = messages[1].content;
+      const smt = /> 0/.test(claim)
+        ? "(declare-const n Int)\n(assert (not (> n 0)))\n(check-sat)"
+        : "(declare-const n Int)\n(assert (not (= (+ n 0) n)))\n(check-sat)";
+      return { text: "```smt\n" + smt + "\n```" };
+    };
+    const z3Runner = async (smt) => {
+      if (/^\s*\(check-sat\)\s*$/.test(smt)) return { available: true, result: "sat" }; // probe
+      return { available: true, result: /> n 0/.test(smt) ? "sat" : "unsat" };
+    };
+    const out = await verifyConclusions(conclusions, { brainFn, z3Runner, max: 5 });
+    assert.equal(out.checked, 2);
+    assert.equal(out.proven, 1);
+    assert.equal(out.refuted, 1);
+  });
+
+  it("stops immediately when Z3 is unavailable (no wasted brain calls)", async () => {
+    let brainCalls = 0;
+    const out = await verifyConclusions(["3 + 4 > 5", "for all n, n = n"], {
+      brainFn: async () => { brainCalls++; return { text: "```smt\n(check-sat)\n```" }; },
+      z3Runner: async () => ({ available: false, result: null }),
+    });
+    assert.equal(out.checked, 0);
+    assert.equal(brainCalls, 0);
+  });
+
+  it("respects the max bound", async () => {
+    const many = Array.from({ length: 8 }, (_, i) => `${i} + 1 > ${i}`);
+    const z3Runner = async (smt) => /^\s*\(check-sat\)\s*$/.test(smt)
+      ? { available: true, result: "sat" } : { available: true, result: "unsat" };
+    const out = await verifyConclusions(many, {
+      brainFn: async () => ({ text: "```smt\n(assert false)\n(check-sat)\n```" }),
+      z3Runner, max: 2,
+    });
+    assert.equal(out.checked, 2);
   });
 });
 


### PR DESCRIPTION
Extends the proof gate from interactive `reason.verify` into Concord's **autonomous** loop — directly answering the earlier thread ("Concord is an autonomous system itself"). The continuous analogue to MOTO's "verify the research", except it runs forever on the heartbeat instead of "press start".

## What it does
The lattice-orchestrator already routes drift findings through the HLR engine (`runHLR(constraint_check)`) on a ~15min heartbeat, but the conclusions were discarded. Now:
1. Each chain conclusion + the synthesised conclusion is captured.
2. The **proof-amenable** ones go through the Z3 gate (subconscious-brain formaliser).
3. A sound `proven`/`refuted` is recorded on `scan.proof` and emitted as a real `lattice:claim-verified` socket event.

## New helper — `verifyConclusions(conclusions, { brainFn, z3Runner, max })`
Bounded batch (max 3 per pass) that tallies proven/refuted and **stops the moment Z3 reports unavailable** (the rest would be no-ops), so it's near-free when Z3 isn't installed. Best-effort, never throws — follows the existing orchestrator pattern.

## Verified live
Ran against the **real** z3 binary (stub brain, since Ollama isn't up in CI): the non-math conclusion is skipped, `n*n>=0` → **proven**, `n>0` → **refuted**.
- `proof-gate` 19 + `lattice-orchestrator` 8 = **27/27** green
- `eslint` clean
- `runHLR`'s sync signature untouched (no caller blast radius)

## Why this is the right seam
`runHLR` is synchronous with many callers; rather than make it async, this hooks the one **async autonomous** caller (the orchestrator), matching the codebase's "wire-the-unwired" lazy-import + try/catch + `{ok, reason}` convention.

https://claude.ai/code/session_01RxwGhrNMhrCC9d2sWxmx5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxwGhrNMhrCC9d2sWxmx5W)_