### PR TITLE
feat(proof): proven_claim DTUs + ConKay "Proven ✓" badge + Lean 4 fallback

### DIFF
--- a/concord-frontend/components/conkay/ConKayOverlay.tsx
+++ b/concord-frontend/components/conkay/ConKayOverlay.tsx
@@ -35,6 +35,17 @@ function newRunId(): string {
   return `ck-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+// Cheap client-side mirror of the backend proof-amenability anchors
+// (server/lib/proof-gate.js). Math/logic claims should be sent to reason.verify
+// EVEN WITHOUT citations so the Z3 proof gate can fire and earn the "Proven ✓"
+// badge. This only gates whether we *ask* the backend — the backend re-decides
+// authoritatively and returns "unverified" if it isn't really formalisable.
+const PROVABLE_RE = /[<>]=?|≤|≥|≠|\bfor all\b|\bfor every\b|\bthere exists\b|\bdivisible\b|\bprime\b|\bif and only if\b|\bimplies\b|\b\d+\s*[+\-*/^]\s*\d+\b/i;
+function looksProvable(claim: string): boolean {
+  const t = String(claim || '');
+  return t.length >= 3 && t.length <= 2000 && PROVABLE_RE.test(t);
+}
+
 // The world-tree field is WebGL — load client-only so SSR never touches it.
 const ConKayBackdrop = dynamic(
   () => import('./ConKayBackdrop').then((m) => m.ConKayBackdrop),
@@ -245,7 +256,9 @@ export function ConKayOverlay() {
   // event spine (a runId) like any other macro call; degrades silently to the
   // heuristic badge if the macro is unavailable.
   const verifyMessage = useCallback(async (msgId: string, claim: string, citationIds: string[]) => {
-    if (!citationIds.length) return;
+    // Run when there are citations to check OR when the claim is proof-amenable
+    // (so the Z3 gate can fire and earn "Proven ✓" even for an uncited theorem).
+    if (!citationIds.length && !looksProvable(claim)) return;
     setMessages((prev) => prev.map((m) => (m.id === msgId ? { ...m, verifyVerdict: 'pending' } : m)));
     try {
       const rid = newRunId();
@@ -351,7 +364,7 @@ export function ConKayOverlay() {
       setStep('render', 'done', 'Done');
       // Phase 1: verify the cited DTUs through the real reason.verify macro.
       const citeIds = (result.dtuRefs || []).map((d) => d.id).filter(Boolean);
-      if (citeIds.length) verifyMessage(aid, result.spoken, citeIds);
+      if (citeIds.length || looksProvable(result.spoken)) verifyMessage(aid, result.spoken, citeIds);
       persistArtifact(`Skill: ${match.skill.label}`, { task: text, skill: match.skill.id, spoken: result.spoken, viz: result.viz ?? null });
       if (result.navigate) { const dest = result.navigate; setTimeout(() => { window.location.href = dest; }, 900); }
     } catch {

--- a/concord-frontend/components/conkay/ConKayViz.tsx
+++ b/concord-frontend/components/conkay/ConKayViz.tsx
@@ -12,7 +12,7 @@
 // mapping: structured-output-shape → meaningful visualization, reusing ChartKit.
 
 import { useMemo } from 'react';
-import { BarChart3, Database, Globe, Wrench, Network, Cpu, ShieldCheck, AlertTriangle } from 'lucide-react';
+import { BarChart3, Database, Globe, Wrench, Network, Cpu, ShieldCheck, AlertTriangle, BadgeCheck, XOctagon } from 'lucide-react';
 import { ChartKit } from '@/components/viz/ChartKit';
 
 export interface ConKayReplyFields {
@@ -216,6 +216,24 @@ function ToolCalls({ toolCalls }: { toolCalls: unknown }) {
 // output — the badge IS the verification result, never a guess.
 function VerdictBadge({ verdict }: { verdict: string }) {
   switch (verdict) {
+    case "proven":
+      // The STRONGEST badge: a math/logic claim machine-checked valid by Z3 (the
+      // subconscious brain formalised it; the SMT solver — not the model — ruled).
+      // This is SOUND, not semantic — the only badge that certifies, and only for
+      // the formalisable slice.
+      return (
+        <span className="inline-flex items-center gap-1 text-[10px] text-emerald-300 font-medium" title="Machine-checked: the subconscious brain formalised this claim into SMT-LIB and Z3 proved it valid. Sound — not a model's opinion. (Sound relative to the formalisation; the SMT is auditable.)">
+          <BadgeCheck className="h-3 w-3" /> Proven ✓
+        </span>
+      );
+    case "refuted":
+      // Z3 found a counterexample — the claim is provably FALSE. Also sound, and
+      // more useful than a soft "unsupported": don't rely on it, it's wrong.
+      return (
+        <span className="inline-flex items-center gap-1 text-[10px] text-rose-400" title="Machine-checked: Z3 found a counterexample — this claim is provably false. Do not rely on it.">
+          <XOctagon className="h-3 w-3" /> Refuted
+        </span>
+      );
     case "pending":
       return (
         <span className="inline-flex items-center gap-1 text-[10px] text-cyan-300/70 ck-shimmer" title="Checking the cited sources against your archive…">

--- a/server/emergent/lattice-orchestrator.js
+++ b/server/emergent/lattice-orchestrator.js
@@ -119,11 +119,11 @@ export async function runPeriodicDriftScan({ db: _db, state: _state, tickCount: 
         // (subconscious brain formaliser); a sound proven/refuted is recorded +
         // surfaced. Best-effort, bounded, near-free when Z3 isn't installed.
         try {
-          const { verifyConclusions } = await import("../lib/proof-gate.js");
+          const { verifyConclusions, persistProvenClaim } = await import("../lib/proof-gate.js");
+          const db = _STATE_REF?.db || globalThis.__concordDb || null;
           let brainFn = null;
           try {
             const { brainChat } = await import("../lib/byo-router.js");
-            const db = _STATE_REF?.db || globalThis.__concordDb || null;
             brainFn = async (messages) => {
               const rr = await brainChat({ db, userId: null, slot: "subconscious", messages });
               return { text: rr?.text || "" };
@@ -136,7 +136,10 @@ export async function runPeriodicDriftScan({ db: _db, state: _state, tickCount: 
               const realtimeMod = await import("./realtime.js").catch(() => null);
               const emit = realtimeMod?.realtimeEmit || globalThis.REALTIME?.io?.emit?.bind(globalThis.REALTIME.io);
               for (const res of proof.results) {
-                emit?.("lattice:claim-verified", { verdict: res.verdict, claim: res.claim.slice(0, 200), at: Date.now() });
+                // Mint each sound verdict into the archive (idempotent, system-authored).
+                let dtuId = null;
+                try { dtuId = persistProvenClaim(db, { claim: res.claim, verdict: res.verdict, smt: res.smt, creatorId: "concord-lattice" })?.dtuId || null; } catch { /* best-effort */ }
+                emit?.("lattice:claim-verified", { verdict: res.verdict, claim: res.claim.slice(0, 200), dtuId, at: Date.now() });
               }
               logger.info?.("lattice-orchestrator", "autonomous_proof_pass", { checked: proof.checked, proven: proof.proven, refuted: proof.refuted });
             } catch { /* surfacing best-effort */ }

--- a/server/lib/proof-gate.js
+++ b/server/lib/proof-gate.js
@@ -34,6 +34,10 @@
 //     deterministically testable offline — mirrors the connectorFetch fetchImpl seam.
 
 import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { writeFile, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import logger from "../logger.js";
 
 const DEFAULT_TIMEOUT_MS = 8000;
@@ -198,10 +202,152 @@ export async function proveClaim(opts = {}) {
   const z = await runZ3(f.smt, { runner: opts.z3Runner, z3Path: opts.z3Path, timeoutMs: opts.timeoutMs });
   out.result = z.result;
   out.z3Raw = z.raw;
-  if (z.result === "unsat") out.verdict = "proven";       // negation impossible ⇒ claim valid
-  else if (z.result === "sat") out.verdict = "refuted";   // negation has a model ⇒ counterexample
-  else out.verdict = "unknown";                            // unknown / timeout
+  if (z.result === "unsat") { out.verdict = "proven"; out.verifier = "z3"; return out; }   // negation impossible ⇒ claim valid
+  if (z.result === "sat") { out.verdict = "refuted"; out.verifier = "z3"; return out; }     // negation has a model ⇒ counterexample
+
+  // Z3 said UNKNOWN — first-order SMT can't settle it (induction, higher-order,
+  // nonlinear). Escalate to Lean 4, which CAN express those, as a deeper fallback.
+  // Lean only ever upgrades unknown→proven (a failed Lean proof attempt is NOT a
+  // disproof, so it never produces "refuted"). No-op when Lean isn't installed.
+  out.verdict = "unknown"; out.verifier = "z3";
+  if (opts.useLean !== false) {
+    const lean = await tryLean(claim, opts);
+    if (lean) {
+      out.lean = { attempted: true, available: lean.available, source: lean.source || null };
+      if (lean.verdict === "proven") { out.verdict = "proven"; out.verifier = "lean"; }
+    }
+  }
   return out;
+}
+
+// ── Lean 4 path (deeper checker for what SMT can't express) ──────────────────
+// Lean's model differs from Z3's: the brain must produce a theorem STATEMENT *and*
+// a PROOF; if `lean` type-checks the file, the theorem is proven. A non-compiling
+// file is inconclusive (a bad proof attempt), never a disproof.
+const LEAN_SYSTEM =
+  "You are a Lean 4 theorem prover. Write a SELF-CONTAINED Lean 4 file that states " +
+  "the user's claim as a `theorem` and PROVES it (prefer core/Init + tactics like " +
+  "simp, omega, decide, induction; avoid Mathlib imports unless unavoidable). Output " +
+  "ONLY a single ```lean code block — no prose. If you cannot prove it, output " +
+  "exactly ```lean\\n-- UNPROVABLE\\n```.";
+
+export function extractLean(text) {
+  const raw = String(text || "");
+  const fence = raw.match(/```(?:lean4?|lean)?\s*([\s\S]*?)```/i);
+  let body = (fence ? fence[1] : raw).trim();
+  if (!body || body.length > SMT_MAX_BYTES) return null;
+  if (/--\s*UNPROVABLE/i.test(body)) return null;
+  if (!/\btheorem\b|\bexample\b|\blemma\b/.test(body)) return null;
+  return body;
+}
+
+function locateLean() {
+  return process.env.CONCORD_LEAN_PATH || process.env.LEAN_PATH || "lean";
+}
+
+/**
+ * Type-check a Lean 4 source. Returns { available, ok, raw }. available:false ⇒
+ * no `lean` binary. ok:true ⇒ the file (theorem + proof) type-checks. Injectable
+ * via opts.runner(source) → { available, ok, raw }.
+ */
+export async function runLean(source, opts = {}) {
+  if (typeof opts.runner === "function") {
+    try { return await opts.runner(source); }
+    catch (e) { return { available: false, ok: false, raw: String(e?.message || e) }; }
+  }
+  const lean = opts.leanPath || locateLean();
+  const timeoutMs = opts.timeoutMs || 20000; // Lean elaboration is slower than SMT
+  let dir;
+  try {
+    dir = await mkdtemp(join(tmpdir(), "concord-lean-"));
+    const file = join(dir, "Claim.lean");
+    await writeFile(file, String(source || ""), "utf8");
+    return await new Promise((resolve) => {
+      execFile(lean, [file], { timeout: timeoutMs, maxBuffer: 1_000_000 }, (err, stdout, stderr) => {
+        const raw = `${stdout || ""}${stderr || ""}`.trim();
+        if (err && (err.code === "ENOENT" || /ENOENT|not found/i.test(String(err.message)))) {
+          resolve({ available: false, ok: false, raw });
+          return;
+        }
+        // lean exits 0 with no "error:" diagnostics when the proof type-checks.
+        const ok = !err && !/error:/i.test(raw) && !/sorry|admit/i.test(raw);
+        resolve({ available: true, ok, raw });
+      });
+    });
+  } catch (e) {
+    return { available: false, ok: false, raw: String(e?.message || e) };
+  } finally {
+    if (dir) { try { await rm(dir, { recursive: true, force: true }); } catch { /* ignore */ } }
+  }
+}
+
+async function tryLean(claim, opts = {}) {
+  // Formalise to Lean via the (subconscious) brain.
+  let source = null;
+  try {
+    if (typeof opts.brainFn === "function") {
+      const r = await opts.brainFn([
+        { role: "system", content: LEAN_SYSTEM },
+        { role: "user", content: `Claim: "${String(claim || "").trim()}"` },
+      ]);
+      source = extractLean(String(r?.text ?? r ?? ""));
+    }
+  } catch { source = null; }
+  if (!source) return { attempted: false, available: null, verdict: "unknown" };
+  const res = await runLean(source, { runner: opts.leanRunner, leanPath: opts.leanPath, timeoutMs: opts.leanTimeoutMs });
+  return {
+    attempted: true,
+    available: res.available,
+    source,
+    verdict: res.available && res.ok ? "proven" : "unknown",
+  };
+}
+
+// ── Persist a sound verdict into the DTU substrate ───────────────────────────
+// A machine-checked proof is a durable piece of knowledge — minting it as a
+// `proven_claim` DTU lets it enter the archive + citation/royalty graph like any
+// other DTU. Idempotent: the id is a hash of the claim, so re-proving the same
+// claim is a no-op (a claim's formal status doesn't change). Public-scoped so it
+// is citable. Best-effort + fully guarded — proof-gate must never throw on a DB
+// quirk, and persistence failing must not change the verdict.
+/**
+ * @param {object} db better-sqlite3 handle
+ * @param {{ claim:string, verdict:"proven"|"refuted", smt?:string|null, creatorId?:string|null }} o
+ * @returns {{ ok:boolean, dtuId?:string, created?:boolean, reason?:string }}
+ */
+export function persistProvenClaim(db, { claim, verdict, smt = null, creatorId = null } = {}) {
+  if (!db) return { ok: false, reason: "no_db" };
+  const text = String(claim || "").trim();
+  if (!text || (verdict !== "proven" && verdict !== "refuted")) return { ok: false, reason: "not_sound_verdict" };
+  const dtuId = "dtu_proof_" + createHash("sha256").update(text).digest("hex").slice(0, 24);
+  const author = creatorId || "concord-lattice";
+  const now = new Date().toISOString();
+  const data = JSON.stringify({
+    human: `${verdict === "proven" ? "Proven" : "Refuted"} (Z3): ${text}`,
+    core: { claims: [text], verdict, verifier: "z3" },
+    // The SMT the subconscious brain produced is kept for human audit — the
+    // verdict is sound RELATIVE TO this formalisation (MOTO's "view with scrutiny").
+    machine: { verifier: "z3", verdict, smt: smt || null, checked_at: now },
+    scope: "public",
+  });
+  try {
+    const info = db.prepare(
+      `INSERT INTO dtus (id, creator_id, type, title, data, created_at)
+       VALUES (?, ?, 'proven_claim', ?, ?, ?)
+       ON CONFLICT(id) DO NOTHING`,
+    ).run(dtuId, author, text.slice(0, 160), data, now);
+    return { ok: true, dtuId, created: info.changes > 0 };
+  } catch (e) {
+    // Minimal fallback for a leaner dtus schema (id, creator_id, type, data).
+    try {
+      db.prepare(`INSERT OR IGNORE INTO dtus (id, creator_id, type, data) VALUES (?, ?, 'proven_claim', ?)`)
+        .run(dtuId, author, data);
+      return { ok: true, dtuId, created: true };
+    } catch (e2) {
+      try { logger.debug?.("proof-gate", "persist_failed", { error: e2?.message || e?.message }); } catch { /* ignore */ }
+      return { ok: false, reason: "insert_failed" };
+    }
+  }
 }
 
 // ── Autonomous batch: verify a set of reasoning conclusions ──────────────────
@@ -239,4 +385,4 @@ export async function verifyConclusions(conclusions, opts = {}) {
   return out;
 }
 
-export default { classifyAmenable, extractSmt, runZ3, formaliseClaim, proveClaim, verifyConclusions };
+export default { classifyAmenable, extractSmt, runZ3, formaliseClaim, proveClaim, verifyConclusions, persistProvenClaim, runLean, extractLean };

--- a/server/lib/reason-verify.js
+++ b/server/lib/reason-verify.js
@@ -133,6 +133,15 @@ export async function verifyClaim(db, { claim, citationIds = [], requesterId = n
         proof = await proveClaim({ claim: claimText, brainFn, z3Runner: proofZ3Runner });
         if (proof?.verdict === "proven") { supported = true; verdict = "proven"; mode = "proof"; confidence = 1; }
         else if (proof?.verdict === "refuted") { supported = false; verdict = "refuted"; mode = "proof"; confidence = 1; }
+        // A sound verdict is durable knowledge — mint it as a citable proven_claim
+        // DTU (idempotent on the claim). Best-effort; never affects the verdict.
+        if (proof?.verdict === "proven" || proof?.verdict === "refuted") {
+          try {
+            const { persistProvenClaim } = await import("./proof-gate.js");
+            const p = persistProvenClaim(db, { claim: claimText, verdict: proof.verdict, smt: proof.smt, creatorId: requesterId });
+            if (p?.ok) proof.dtuId = p.dtuId;
+          } catch { /* persistence best-effort */ }
+        }
       }
     } catch (e) {
       try { logger.debug?.("reason-verify", "proof_gate_unavailable", { error: e?.message }); } catch { /* ignore */ }

--- a/server/tests/proof-gate.test.js
+++ b/server/tests/proof-gate.test.js
@@ -19,7 +19,7 @@ import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import Database from "better-sqlite3";
 
-import { classifyAmenable, extractSmt, runZ3, proveClaim, verifyConclusions } from "../lib/proof-gate.js";
+import { classifyAmenable, extractSmt, runZ3, proveClaim, verifyConclusions, persistProvenClaim, runLean, extractLean } from "../lib/proof-gate.js";
 import { verifyClaim } from "../lib/reason-verify.js";
 
 // A z3Runner stub: first call is the availability probe "(check-sat)", later the
@@ -178,6 +178,109 @@ describe("verifyConclusions — autonomous batch (lattice-orchestrator path)", (
       z3Runner, max: 2,
     });
     assert.equal(out.checked, 2);
+  });
+});
+
+describe("Lean 4 path — deeper fallback when Z3 says unknown", () => {
+  // A Z3 stub that returns unknown for the real script (probe stays sat).
+  const z3Unknown = async (smt) => /^\s*\(check-sat\)\s*$/.test(smt)
+    ? { available: true, result: "sat" } : { available: true, result: "unknown" };
+  // Brain returns SMT for the SMT prompt and Lean for the Lean prompt.
+  const dualBrain = async (messages) => {
+    const isLean = /Lean 4/.test(messages[0].content);
+    return { text: isLean
+      ? "```lean\ntheorem t (n : Nat) : n + 0 = n := by simp\n```"
+      : "```smt\n(declare-const n Int)\n(assert (not (= (+ n 0) n)))\n(check-sat)\n```" };
+  };
+
+  it("extractLean pulls a theorem block and rejects UNPROVABLE / sorry-free check", () => {
+    assert.match(extractLean("```lean\ntheorem t : True := trivial\n```"), /theorem/);
+    assert.equal(extractLean("```lean\n-- UNPROVABLE\n```"), null);
+    assert.equal(extractLean("just prose"), null);
+  });
+
+  it("Z3-unknown + Lean type-checks → proven (verifier:lean)", async () => {
+    const r = await proveClaim({
+      claim: "for all natural numbers n, n + 0 = n",
+      brainFn: dualBrain,
+      z3Runner: z3Unknown,
+      leanRunner: async () => ({ available: true, ok: true, raw: "" }),
+    });
+    assert.equal(r.verdict, "proven");
+    assert.equal(r.verifier, "lean");
+    assert.equal(r.lean.attempted, true);
+  });
+
+  it("Z3-unknown + Lean fails to compile → stays unknown", async () => {
+    const r = await proveClaim({
+      claim: "for all natural numbers n, n + 0 = n",
+      brainFn: dualBrain,
+      z3Runner: z3Unknown,
+      leanRunner: async () => ({ available: true, ok: false, raw: "error: unsolved goals" }),
+    });
+    assert.equal(r.verdict, "unknown");
+  });
+
+  it("Z3-unknown + no Lean binary → stays unknown (graceful)", async () => {
+    const r = await proveClaim({
+      claim: "for all natural numbers n, n + 0 = n",
+      brainFn: dualBrain,
+      z3Runner: z3Unknown,
+      leanRunner: async () => ({ available: false, ok: false, raw: "ENOENT" }),
+    });
+    assert.equal(r.verdict, "unknown");
+    assert.equal(r.lean.available, false);
+  });
+
+  it("a proof using `sorry` does NOT count as proven", async () => {
+    const r = await runLean("theorem t : False := sorry", {
+      runner: async () => ({ available: true, ok: false, raw: "warning: declaration uses 'sorry'" }),
+    });
+    assert.equal(r.ok, false);
+  });
+
+  it("runLean returns available:false when the binary is missing", async () => {
+    const r = await runLean("theorem t : True := trivial", { leanPath: "/nonexistent/lean-xyz", timeoutMs: 1000 });
+    assert.equal(r.available, false);
+  });
+});
+
+describe("persistProvenClaim — mint a citable proven_claim DTU", () => {
+  function dtuDb() {
+    const db = new Database(":memory:");
+    db.exec(`CREATE TABLE dtus (id TEXT PRIMARY KEY, creator_id TEXT, type TEXT, title TEXT, data TEXT, created_at TEXT);`);
+    return db;
+  }
+  it("mints a proven_claim DTU with the SMT kept for audit", () => {
+    const db = dtuDb();
+    const r = persistProvenClaim(db, { claim: "for all integers n, n + 0 = n", verdict: "proven", smt: "(check-sat)", creatorId: "u1" });
+    assert.equal(r.ok, true);
+    assert.equal(r.created, true);
+    const row = db.prepare("SELECT type, title, data, creator_id FROM dtus WHERE id = ?").get(r.dtuId);
+    assert.equal(row.type, "proven_claim");
+    assert.equal(row.creator_id, "u1");
+    const data = JSON.parse(row.data);
+    assert.equal(data.core.verdict, "proven");
+    assert.equal(data.machine.verifier, "z3");
+    assert.equal(data.machine.smt, "(check-sat)");
+    assert.equal(data.scope, "public");
+  });
+  it("is idempotent on the claim (re-proving doesn't duplicate)", () => {
+    const db = dtuDb();
+    const a = persistProvenClaim(db, { claim: "3 > 2", verdict: "proven" });
+    const b = persistProvenClaim(db, { claim: "3 > 2", verdict: "proven" });
+    assert.equal(a.dtuId, b.dtuId);
+    assert.equal(b.created, false);
+    assert.equal(db.prepare("SELECT COUNT(*) c FROM dtus").get().c, 1);
+  });
+  it("defaults the autonomous author to concord-lattice", () => {
+    const db = dtuDb();
+    const r = persistProvenClaim(db, { claim: "for all n, n*n >= 0", verdict: "proven" });
+    assert.equal(db.prepare("SELECT creator_id FROM dtus WHERE id = ?").get(r.dtuId).creator_id, "concord-lattice");
+  });
+  it("rejects non-sound verdicts / missing db", () => {
+    assert.equal(persistProvenClaim(dtuDb(), { claim: "x", verdict: "unknown" }).ok, false);
+    assert.equal(persistProvenClaim(null, { claim: "x", verdict: "proven" }).ok, false);
   });
 });
 

--- a/setup.sh
+++ b/setup.sh
@@ -79,6 +79,27 @@ else
   fi
 fi
 
+# ── 3c. Lean 4 (OPT-IN — the deeper proof checker, gigabytes) ────────────
+# Lean handles theorems Z3's first-order SMT returns "unknown" on (induction,
+# higher-order). It's a multi-GB toolchain (elan + Mathlib), so it is NEVER
+# auto-installed — opt in with CONCORD_INSTALL_LEAN=1. Without it, the proof gate
+# simply never escalates past Z3 (verdict stays "unknown"), which is fine.
+if [ "${CONCORD_INSTALL_LEAN:-0}" = "1" ]; then
+  if command -v lean &>/dev/null; then
+    ok "Lean found at $(command -v lean)."
+  else
+    info "CONCORD_INSTALL_LEAN=1 — installing the Lean 4 toolchain via elan (this is large)..."
+    if command -v elan &>/dev/null || curl -fsSL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y 2>/dev/null; then
+      export PATH="$HOME/.elan/bin:$PATH"
+      elan default stable 2>/dev/null || true
+    fi
+    command -v lean &>/dev/null && ok "Lean installed at $(command -v lean)." \
+      || warn "Lean install did not complete — proof gate will stay at the Z3 tier. Set CONCORD_LEAN_PATH if you install it elsewhere."
+  fi
+else
+  info "Skipping Lean 4 (opt in with CONCORD_INSTALL_LEAN=1 for the deeper proof tier)."
+fi
+
 # ── 4. Install server dependencies ───────────────────────────────────────
 info "Installing server dependencies..."
 (cd server && npm install)


### PR DESCRIPTION
All three follow-ons to the Z3 proof gate, behind the same graceful-degrade + honesty discipline.

## 1. Persist proven claims as DTUs
`proof-gate.js#persistProvenClaim` — a machine-checked verdict is durable knowledge, so a `proven`/`refuted` claim is minted as a **public, citable `kind:"proven_claim"` DTU** with the SMT kept for audit. Idempotent on the claim (`id = sha256(claim)`). Wired into both paths:
- **Interactive:** `reason.verify` stamps `proof.dtuId`.
- **Autonomous:** the lattice pass mints each verdict and includes `dtuId` in the `lattice:claim-verified` event.

Best-effort; never affects the verdict.

## 2. ConKay "Proven ✓" badge
`ConKayViz.tsx` — two new tiers in the TrustBadge: **"Proven ✓"** (`BadgeCheck` — the only *sound*/certifying badge) and **"Refuted"** (`XOctagon`). They ride the existing 1:1 verdict→badge mapping, so the new backend verdicts light automatically. `ConKayOverlay` now also sends proof-amenable claims to `reason.verify` **even without citations** (a cheap `looksProvable` regex mirroring the backend anchors), so an uncited theorem can still earn "Proven ✓".

## 3. Lean 4 path
`proof-gate.js#runLean`/`extractLean` — a deeper fallback for theorems Z3 returns `unknown` on (induction, higher-order). On Z3-unknown the gate asks the brain for a Lean theorem+proof and type-checks it with `lean`; a compiling proof upgrades `unknown`→`proven` (`verifier:"lean"`). A `sorry`/`admit` proof is **rejected**. No-op without the toolchain — Lean only ever upgrades `unknown`→`proven` (a failed Lean attempt is never a disproof). `setup.sh` installs it **only** when `CONCORD_INSTALL_LEAN=1` (it's multi-GB); never baked into the Docker image.

## Verified
- Live against the **real** z3 binary: verify → proven → minted `proven_claim` DTU.
- Lean path via injected runner/brain stubs (toolchain not installed here).
- `proof-gate` 29 + `reason-verify` 5 + `lattice-orchestrator` 8 = **42/42** green.
- Frontend `tsc` 0 / `lint` 0 / prod build **"Compiled successfully"** (Prophet 0 warnings); `eslint` clean.

https://claude.ai/code/session_01RxwGhrNMhrCC9d2sWxmx5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxwGhrNMhrCC9d2sWxmx5W)_