### PR TITLE
refactor(lenses): remove rival/competitor app names from the lens surfaces

### DIFF
--- a/concord-frontend/app/lenses/accounting/page.tsx
+++ b/concord-frontend/app/lenses/accounting/page.tsx
@@ -40,7 +40,7 @@ import {
   PiggyBank as MTabPig, Building2 as MTabBldg, Calculator as MTabCalc,
 } from 'lucide-react';
 import AccountingWorkbench from '@/components/accounting/AccountingWorkbench';
-import { QBSection } from '@/components/accounting/QBSection';
+import { BooksSection } from '@/components/accounting/BooksSection';
 import { AccountingActionPanel } from '@/components/accounting/AccountingActionPanel';
 import { CategoryRulesPanel } from '@/components/accounting/CategoryRulesPanel';
 import { PipingProvider } from '@/components/panel-polish';
@@ -173,7 +173,7 @@ export default function AccountingLensPage() {
   const [ledgerSubType, setLedgerSubType] = useState<'Account' | 'Transaction'>('Account');
   const [showFeatures, setShowFeatures] = useState(true);
 
-  // Lens-scoped keyboard commands. QuickBooks-style mode switching;
+  // Lens-scoped keyboard commands. mode switching;
   // n opens the editor; / focuses the search box.
   const searchInputRef = useRef<HTMLInputElement>(null);
   useLensCommand(
@@ -2006,7 +2006,7 @@ export default function AccountingLensPage() {
 
   const renderDashboard = () => (
     <div className="space-y-6">
-      {/* QuickBooks-shape KPI strip — horizontal numeric tile rail with
+      {/* KPI strip — horizontal numeric tile rail with
           delta arrows. Reads as financial software in 200ms. */}
       <KPIStrip
         periodLabel={periodType === 'monthly' ? 'This month' : periodType === 'quarterly' ? 'This quarter' : periodType === 'annual' ? 'YTD' : 'Period'}
@@ -2683,7 +2683,7 @@ export default function AccountingLensPage() {
       <FirstRunTour lensId="accounting" />
       <DepthBadge lensId="accounting" size="sm" className="ml-2" />
       <div className="px-4 mt-3">
-        <QBSection />
+        <BooksSection />
       </div>
     <div data-lens-theme="accounting" className={ds.pageContainer}>
       {/* Header */}
@@ -2711,7 +2711,7 @@ export default function AccountingLensPage() {
             type="button"
             onClick={() => setWorkbenchOpen(true)}
             className={cn(ds.btnSecondary, 'border-emerald-500/30 text-emerald-200 hover:brightness-110')}
-            title="Live accounting workbench — QuickBooks/Xero/FreshBooks parity"
+            title="Live accounting workbench"
           >
             <Calculator className="w-4 h-4" /> Workbench
           </button>
@@ -2720,7 +2720,7 @@ export default function AccountingLensPage() {
 
 
       {/* HERO: Wallet position + Action Queue. Per canonical accounting
-          UI research (QuickBooks, Xero, Bench, Wave, FreshBooks): the
+          UI research: the
           lens entry-point is "your money + what's waiting on you",
           NOT a chart wall. Charts are macro context below. */}
       {(() => {

--- a/concord-frontend/app/lenses/agriculture/page.tsx
+++ b/concord-frontend/app/lenses/agriculture/page.tsx
@@ -72,7 +72,7 @@ import GrainBinsPanel from '@/components/agriculture/GrainBinsPanel';
 import ZonesPanel from '@/components/agriculture/ZonesPanel';
 import TankMixesPanel from '@/components/agriculture/TankMixesPanel';
 import PrecisionAgPanel from '@/components/agriculture/PrecisionAgPanel';
-import { RivalShapePreview } from '@/components/lens/RivalShapePreview';
+import { ShellPreview } from '@/components/lens/ShellPreview';
 import { PipingProvider } from '@/components/panel-polish';
 
 // ---------------------------------------------------------------------------
@@ -1468,7 +1468,7 @@ export default function AgricultureLensPage() {
       <FirstRunTour lensId="agriculture" />
       <DepthBadge lensId="agriculture" size="sm" className="ml-2" />
     <div data-lens-theme="agriculture" className={ds.pageContainer}>
-      <RivalShapePreview lensId="agriculture" defaultOpen={true} />
+      <ShellPreview lensId="agriculture" defaultOpen={true} />
       <DeereWorkbenchSection />
       <PrecisionAgPanel />
       <header className={ds.sectionHeader}>

--- a/concord-frontend/app/lenses/answers/page.tsx
+++ b/concord-frontend/app/lenses/answers/page.tsx
@@ -457,7 +457,7 @@ export default function AnswersLensPage() {
   const [query, setQuery] = useState('');
   const searchInputRef = useRef<HTMLInputElement>(null);
 
-  // Section nav (1-8) — Wolfram / Quora idiom adapted for the answers grid.
+  // Section nav (1-8) — keyboard idiom adapted for the answers grid.
   useLensCommand(
     [
       { id: 'sec-physics',       keys: '1', description: 'Physics',       category: 'navigation', action: () => setActiveSection('physics') },

--- a/concord-frontend/app/lenses/art/page.tsx
+++ b/concord-frontend/app/lenses/art/page.tsx
@@ -145,8 +145,7 @@ export default function ArtLensPage() {
 
   const searchInputRef = useRef<HTMLInputElement>(null);
 
-  // Lens-scoped keyboard commands. Procreate / Photoshop / Midjourney
-  // idiom: g (gallery), c (canvas), m (marketplace), u upload, l list,
+  // Lens-scoped keyboard commands: g (gallery), c (canvas), m (marketplace), u upload, l list,
   // / focus search.
   useLensCommand(
     [

--- a/concord-frontend/app/lenses/aviation/page.tsx
+++ b/concord-frontend/app/lenses/aviation/page.tsx
@@ -19,7 +19,7 @@ import RouteAdvisor from '@/components/aviation/RouteAdvisor';
 import TrackLogsPanel from '@/components/aviation/TrackLogsPanel';
 import FuelStopsCalc from '@/components/aviation/FuelStopsCalc';
 import LiveFlightsPanel from '@/components/aviation/LiveFlightsPanel';
-import { RivalShapePreview } from '@/components/lens/RivalShapePreview';
+import { ShellPreview } from '@/components/lens/ShellPreview';
 import { PipingProvider } from '@/components/panel-polish';
 import { useLensNav } from '@/hooks/useLensNav';
 import { useLensCommand } from '@/hooks/useLensCommand';
@@ -1677,7 +1677,7 @@ export default function AviationLensPage() {
       <FirstRunTour lensId="aviation" />
       <DepthBadge lensId="aviation" size="sm" className="ml-2" />
     <div className={ds.pageContainer}>
-      <RivalShapePreview lensId="aviation" defaultOpen={true} />
+      <ShellPreview lensId="aviation" defaultOpen={true} />
       <ForeFlightWorkbenchSection />
       {/* Header */}
       <header className={ds.sectionHeader}>

--- a/concord-frontend/app/lenses/code/page.tsx
+++ b/concord-frontend/app/lenses/code/page.tsx
@@ -11,7 +11,7 @@ import { CrossLensRecentsPanel } from '@/components/lens/CrossLensRecentsPanel';
 import { FirstRunTour } from '@/components/lens/FirstRunTour';
 import { DepthBadge } from '@/components/lens/DepthBadge';
 import LensAgentFab from '@/components/lens/LensAgentFab';
-import { RivalShapePreview } from '@/components/lens/RivalShapePreview';
+import { ShellPreview } from '@/components/lens/ShellPreview';
 import { ManifestActionBar } from '@/components/lens/ManifestActionBar';
 import { CodeWorkbenchSection } from '@/components/code/CodeWorkbenchSection';
 import { CodeAdvancedPanel } from '@/components/code/CodeAdvancedPanel';
@@ -612,7 +612,7 @@ export default function CodeLensPage() {
   const paletteInputRef = useRef<HTMLInputElement>(null);
 
   // ── Find in files (⌘⇧F) ────────────────────────────────────────
-  // VSCode-shape grep across every open tab AND every saved script.
+  // Grep across every open tab AND every saved script.
   // Keeps a 60-line context window, highlights matches, click jumps
   // to the matching tab and scrolls Monaco to the match line.
   const [findOpen, setFindOpen] = useState(false);
@@ -1338,7 +1338,7 @@ export default function CodeLensPage() {
       <FirstRunTour lensId="code" />
       <ManifestActionBar />
       <DepthBadge lensId="code" size="sm" className="ml-2" />
-      <RivalShapePreview lensId="code" defaultOpen={true} />
+      <ShellPreview lensId="code" defaultOpen={true} />
       <div className="px-4 mt-3">
         <CodeWorkbenchSection />
       </div>
@@ -1684,7 +1684,7 @@ export default function CodeLensPage() {
       </div>
 
       <div className="flex-1 flex overflow-hidden">
-        {/* VSCode-style activity bar — selects which sidebar panel renders */}
+        {/* Activity bar — selects which sidebar panel renders */}
         <ActivityBar
           active={activity}
           onChange={(a) => {
@@ -2613,7 +2613,7 @@ export default function CodeLensPage() {
       <GithubTrending />
     </section>
 
-    {/* VS Code-shape code review workbench: complexity / deps / coverage / snippet + actions */}
+    {/* Code review workbench: complexity / deps / coverage / snippet + actions */}
     <PipingProvider>
       <section className="mt-6 mx-4">
         <CodeActionPanel />
@@ -2624,7 +2624,7 @@ export default function CodeLensPage() {
           <AutoActionStrip domain="code" hideWhenEmpty className="mt-3" title="More actions" />
           <CrossLensRecentsPanel lensId="code" sinceDays={7} limit={6} hideWhenEmpty className="mt-3" />
           {/* Phase 12 (Item 5) — mobile thumb-reachable activity bar.
-              Surfaces the most-used VS Code-style activities on touch. */}
+              Surfaces the most-used activities on touch. */}
           <MobileTabBar
             tabs={[
               { id: 'files',         label: 'Files',   icon: MTabFiles },

--- a/concord-frontend/app/lenses/crypto/page.tsx
+++ b/concord-frontend/app/lenses/crypto/page.tsx
@@ -13,8 +13,8 @@ import { CryptoActionPanel } from '@/components/crypto/CryptoActionPanel';
 import { AddressBookPanel } from '@/components/crypto/AddressBookPanel';
 import { PipingProvider } from '@/components/panel-polish';
 import { SwapRoutePanel } from '@/components/crypto-explorer/SwapRoutePanel';
-import { RivalShapePreview } from '@/components/lens/RivalShapePreview';
-import { CoinbaseSection } from '@/components/crypto/CoinbaseSection';
+import { ShellPreview } from '@/components/lens/ShellPreview';
+import { ExchangeSection } from '@/components/crypto/ExchangeSection';
 import { ManifestActionBar } from '@/components/lens/ManifestActionBar';
 import { useLensCommand } from '@/hooks/useLensCommand';
 import { useTilePush } from '@/hooks/useTilePush';
@@ -220,7 +220,7 @@ export default function CryptoLensPage() {
     return () => { cancelled = true; };
   }, [activeTab, chartTokenId, chartDays]);
 
-  // Lens-scoped keyboard commands. Coinbase / Binance idiom: single-
+  // Lens-scoped keyboard commands. keyboard idiom: single-
   // letter tab jumps and a balance-blur toggle (privacy hotkey).
   useLensCommand(
     [
@@ -605,9 +605,9 @@ export default function CryptoLensPage() {
       <FirstRunTour lensId="crypto" />
       <ManifestActionBar />
       <DepthBadge lensId="crypto" size="sm" className="ml-2" />
-      <RivalShapePreview lensId="crypto" defaultOpen={true} />
+      <ShellPreview lensId="crypto" defaultOpen={true} />
       <div className="px-4 mt-3">
-        <CoinbaseSection />
+        <ExchangeSection />
       </div>
     <div data-lens-theme="crypto" className="p-6 space-y-6">
       <header className="flex items-center justify-between">

--- a/concord-frontend/app/lenses/education/page.tsx
+++ b/concord-frontend/app/lenses/education/page.tsx
@@ -22,7 +22,7 @@ import CertificatesPanel from '@/components/education/CertificatesPanel';
 import AssignmentsBoard from '@/components/education/AssignmentsBoard';
 import LessonNotes from '@/components/education/LessonNotes';
 import CourseDiscussions from '@/components/education/CourseDiscussions';
-import { RivalShapePreview } from '@/components/lens/RivalShapePreview';
+import { ShellPreview } from '@/components/lens/ShellPreview';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useLensNav } from '@/hooks/useLensNav';
@@ -1340,7 +1340,7 @@ export default function EducationLensPage() {
       <FirstRunTour lensId="education" />
       <DepthBadge lensId="education" size="sm" className="ml-2" />
     <div data-lens-theme="education" className="p-6 space-y-6 bg-gradient-to-b from-amber-950/10 to-transparent">
-      <RivalShapePreview lensId="education" defaultOpen={true} />
+      <ShellPreview lensId="education" defaultOpen={true} />
       <KhanCourseraWorkbenchSection />
       {/* Header */}
       <header className={ds.sectionHeader}>

--- a/concord-frontend/app/lenses/environment/page.tsx
+++ b/concord-frontend/app/lenses/environment/page.tsx
@@ -22,7 +22,7 @@ import InventoryReportBuilder from '@/components/environment/InventoryReportBuil
 import ActivityImportPanel from '@/components/environment/ActivityImportPanel';
 import ScenarioModeler from '@/components/environment/ScenarioModeler';
 import AuditTrailPanel from '@/components/environment/AuditTrailPanel';
-import { RivalShapePreview } from '@/components/lens/RivalShapePreview';
+import { ShellPreview } from '@/components/lens/ShellPreview';
 import { GbifPanel } from '@/components/environment/GbifPanel';
 import { AirQualityPanel } from '@/components/environment/AirQualityPanel';
 import { MobileTabBar } from '@/components/mobile/MobileTabBar';
@@ -3351,7 +3351,7 @@ export default function EnvironmentLensPage() {
       <FirstRunTour lensId="environment" />
       <DepthBadge lensId="environment" size="sm" className="ml-2" />
       <div className="px-4 mt-2">
-        <RivalShapePreview lensId="environment" defaultOpen={true} />
+        <ShellPreview lensId="environment" defaultOpen={true} />
         <CarbonWorkbenchSection />
       </div>
     <LensPageShell

--- a/concord-frontend/app/lenses/finance/page.tsx
+++ b/concord-frontend/app/lenses/finance/page.tsx
@@ -37,7 +37,7 @@ import CreditScoreMonitor from '@/components/finance/CreditScoreMonitor';
 import CashFlowSankey from '@/components/finance/CashFlowSankey';
 import BillReminders from '@/components/finance/BillReminders';
 import RolloverRules from '@/components/finance/RolloverRules';
-import { RivalShapePreview } from '@/components/lens/RivalShapePreview';
+import { ShellPreview } from '@/components/lens/ShellPreview';
 import { useLensNav } from '@/hooks/useLensNav';
 import { useLensCommand } from "@/hooks/useLensCommand";
 import { useTilePush } from '@/hooks/useTilePush';
@@ -1832,7 +1832,7 @@ export default function FinanceLensPage() {
       <FirstRunTour lensId="finance" />
       <DepthBadge lensId="finance" size="sm" className="ml-2" />
     <div data-lens-theme="finance" className="p-6 space-y-6 bg-[#0c0f14] font-mono">
-      <RivalShapePreview lensId="finance" defaultOpen={true} />
+      <ShellPreview lensId="finance" defaultOpen={true} />
       {/* Phase 4 (sixth wave) — REAL World Bank country indicators. */}
       <WorldBankPanel domain="finance" />
       {/* REAL FRED economic time series (FRED_API_KEY-gated; honest empty/no-key states). */}
@@ -2490,7 +2490,7 @@ export default function FinanceLensPage() {
         <MarketsPulse />
       </section>
 
-      {/* Robinhood + YNAB-shape money workbench: net-worth / envelopes / tax / retirement-MC + actions */}
+      {/* Money workbench: net-worth / envelopes / tax / retirement-MC + actions */}
       <PipingProvider>
         <section className="mt-6">
           <FinanceActionPanel />

--- a/concord-frontend/app/lenses/fitness/page.tsx
+++ b/concord-frontend/app/lenses/fitness/page.tsx
@@ -177,7 +177,7 @@ const MODE_TABS: { id: ModeTab; icon: React.ComponentType<{ className?: string; 
   { id: 'Classes', icon: CalendarDays, defaultType: 'Class' },
   { id: 'Teams', icon: Shield, defaultType: 'Team' },
   { id: 'Recruiting', icon: Medal, defaultType: 'Athlete' },
-  // Parity-sprint personal-fitness surfaces (Strava / Whoop / Apple Fitness+ / Hevy)
+  // Personal-fitness surfaces
   { id: 'Log', icon: Dumbbell, defaultType: 'Workout' },
   { id: 'HRZones', icon: Activity, defaultType: 'Workout' },
   { id: 'Recovery', icon: Activity, defaultType: 'Workout' },
@@ -2231,7 +2231,7 @@ export default function FitnessLensPage() {
           </div>
         )}
       </div>
-      {/* Hevy + Strong-shape workout finisher: progression / HR zones / save / mint / DM / PR publish / next workout */}
+      {/* workout finisher: progression / HR zones / save / mint / DM / PR publish / next workout */}
       <section className="mt-6">
         <WorkoutFinishPanel />
       </section>

--- a/concord-frontend/app/lenses/government/page.tsx
+++ b/concord-frontend/app/lenses/government/page.tsx
@@ -20,7 +20,7 @@ import ServiceRequestReporter from '@/components/government/ServiceRequestReport
 import AdvocacyPanel from '@/components/government/AdvocacyPanel';
 import DocumentLibraryPanel from '@/components/government/DocumentLibraryPanel';
 import NotificationsPanel from '@/components/government/NotificationsPanel';
-import { RivalShapePreview } from '@/components/lens/RivalShapePreview';
+import { ShellPreview } from '@/components/lens/ShellPreview';
 import { PipingProvider } from '@/components/panel-polish';
 import RepresentativeFinder from '@/components/government/RepresentativeFinder';
 import BillTracker from '@/components/government/BillTracker';
@@ -3203,7 +3203,7 @@ export default function GovernmentLensPage() {
       <FirstRunTour lensId="government" />
       <DepthBadge lensId="government" size="sm" className="ml-2" />
     <div data-lens-theme="government" className={ds.pageContainer}>
-      <RivalShapePreview lensId="government" defaultOpen={true} />
+      <ShellPreview lensId="government" defaultOpen={true} />
       <CivicWorkbenchSection />
       {/* Header */}
       <header className={ds.sectionHeader}>

--- a/concord-frontend/app/lenses/healthcare/page.tsx
+++ b/concord-frontend/app/lenses/healthcare/page.tsx
@@ -17,7 +17,7 @@ import { ProviderDirectory } from '@/components/healthcare/ProviderDirectory';
 import { HealthcareActionPanel } from '@/components/healthcare/HealthcareActionPanel';
 import { ImmunizationsPanel } from '@/components/healthcare/ImmunizationsPanel';
 import { PipingProvider } from '@/components/panel-polish';
-import { RivalShapePreview } from '@/components/lens/RivalShapePreview';
+import { ShellPreview } from '@/components/lens/ShellPreview';
 import { useState, useMemo, useCallback, useRef } from 'react';
 import { useLensNav } from '@/hooks/useLensNav';
 import { useLensCommand } from '@/hooks/useLensCommand';
@@ -1499,7 +1499,7 @@ export default function HealthcareLensPage() {
     <LensShell lensId="healthcare" asMain={false}>
       <FirstRunTour lensId="healthcare" />
       <DepthBadge lensId="healthcare" size="sm" className="ml-2" />
-      <RivalShapePreview lensId="healthcare" defaultOpen={true} />
+      <ShellPreview lensId="healthcare" defaultOpen={true} />
       <div className="px-4 mt-3">
         <EpicSection />
       </div>

--- a/concord-frontend/app/lenses/hr/page.tsx
+++ b/concord-frontend/app/lenses/hr/page.tsx
@@ -8,7 +8,7 @@ import { AutoActionStrip } from '@/components/lens/AutoActionStrip';
 import { CrossLensRecentsPanel } from '@/components/lens/CrossLensRecentsPanel';
 import { FirstRunTour } from '@/components/lens/FirstRunTour';
 import { DepthBadge } from '@/components/lens/DepthBadge';
-import { HrWorkdaySection } from '@/components/hr/HrWorkdaySection';
+import { HrHrisSection } from '@/components/hr/HrHrisSection';
 import { ManifestActionBar } from '@/components/lens/ManifestActionBar';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useLensNav } from '@/hooks/useLensNav';
@@ -345,7 +345,7 @@ export default function HRLensPage() {
       <ManifestActionBar />
       <DepthBadge lensId="hr" size="sm" className="ml-2" />
       <div className="px-4 mt-3">
-        <HrWorkdaySection />
+        <HrHrisSection />
       </div>
     <div data-lens-theme="hr" className="space-y-6 p-6">
       <motion.header initial={{ opacity: 0, y: -20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4 }} className="flex items-center justify-between">
@@ -430,7 +430,7 @@ export default function HRLensPage() {
         <BlsSeriesExplorer />
       </section>
 
-      {/* BambooHR + Gusto-shape people-ops workbench: comp / turnover / interview / pto + actions */}
+      {/* people-ops workbench: comp / turnover / interview / pto + actions */}
       <PipingProvider>
         <section className="mt-6">
           <HrActionPanel />

--- a/concord-frontend/app/lenses/legal/page.tsx
+++ b/concord-frontend/app/lenses/legal/page.tsx
@@ -20,7 +20,7 @@ import { LegalCaseSearch } from '@/components/legal/LegalCaseSearch';
 import { IntakeFormsPanel } from '@/components/legal/IntakeFormsPanel';
 import { ReportsPanel } from '@/components/legal/ReportsPanel';
 import LensAgentFab from '@/components/lens/LensAgentFab';
-import { RivalShapePreview } from '@/components/lens/RivalShapePreview';
+import { ShellPreview } from '@/components/lens/ShellPreview';
 import { useState, useMemo, useCallback, useRef } from 'react';
 import { useLensNav } from '@/hooks/useLensNav';
 import { useLensCommand } from '@/hooks/useLensCommand';
@@ -3078,7 +3078,7 @@ export default function LegalLensPage() {
     <LensShell lensId="legal" asMain={false} disableAgentFab={true}>
       <FirstRunTour lensId="legal" />
       <DepthBadge lensId="legal" size="sm" className="ml-2" />
-      <RivalShapePreview lensId="legal" defaultOpen={true} />
+      <ShellPreview lensId="legal" defaultOpen={true} />
       <div className="px-4 mt-3">
         <ClioSection />
       </div>
@@ -3387,7 +3387,7 @@ export default function LegalLensPage() {
         )}
       </div>
 
-      {/* Westlaw + CourtListener-shape legal workbench: deadlines / renewals / conflicts / audit + actions */}
+      {/* legal workbench: deadlines / renewals / conflicts / audit + actions */}
       <PipingProvider>
         <section className="mt-6">
           <LegalActionPanel />

--- a/concord-frontend/app/lenses/logistics/page.tsx
+++ b/concord-frontend/app/lenses/logistics/page.tsx
@@ -22,7 +22,7 @@ import LoadBoardPanel from '@/components/logistics/LoadBoardPanel';
 import DeliveryProofPanel from '@/components/logistics/DeliveryProofPanel';
 import ShipmentEventsTimeline from '@/components/logistics/ShipmentEventsTimeline';
 import { VisibilityTower } from '@/components/logistics/VisibilityTower';
-import { RivalShapePreview } from '@/components/lens/RivalShapePreview';
+import { ShellPreview } from '@/components/lens/ShellPreview';
 import { MobileTabBar } from '@/components/mobile/MobileTabBar';
 import {
   Truck as MTabTruck, Users as MTabDriver, Package as MTabShip,
@@ -2114,7 +2114,7 @@ export default function LogisticsLensPage() {
       <FirstRunTour lensId="logistics" />
       <DepthBadge lensId="logistics" size="sm" className="ml-2" />
       <div className="px-4 mt-2">
-        <RivalShapePreview lensId="logistics" defaultOpen={true} />
+        <ShellPreview lensId="logistics" defaultOpen={true} />
         <TmsWorkbenchSection />
         <VisibilityTower />
       </div>

--- a/concord-frontend/app/lenses/marketplace/page.tsx
+++ b/concord-frontend/app/lenses/marketplace/page.tsx
@@ -12,7 +12,7 @@ import { TrendingListings } from '@/components/marketplace/TrendingListings';
 import { MarketplaceActionPanel } from '@/components/marketplace/MarketplaceActionPanel';
 import { PipingProvider } from '@/components/panel-polish';
 import LensAgentFab from '@/components/lens/LensAgentFab';
-import { EtsySection } from '@/components/marketplace/EtsySection';
+import { ShopfrontSection } from '@/components/marketplace/ShopfrontSection';
 import { useLensCommand } from '@/hooks/useLensCommand';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useLensData } from '@/lib/hooks/use-lens-data';
@@ -710,7 +710,7 @@ export default function MarketplaceLensPage() {
 
   // Watchlist — listings the user starred for later.  Persisted in
   // localStorage keyed by dtuId so it survives reloads without a
-  // backend round-trip.  Bandcamp / OpenSea / Etsy all expect this.
+  // backend round-trip — the standard marketplace pattern.
   const WATCHLIST_KEY = 'concord_marketplace_watchlist';
   const [watchlist, setWatchlist] = useState<Set<string>>(() => {
     if (typeof window === 'undefined') return new Set();
@@ -731,7 +731,7 @@ export default function MarketplaceLensPage() {
     });
   }, [persistWatchlist]);
 
-  // Lens-scoped keyboard commands. Etsy / Bandcamp idiom: single-letter
+  // Lens-scoped keyboard commands: single-letter
   // tab jumps; v swaps grid/list; n opens the new-listing composer.
   useLensCommand(
     [
@@ -747,7 +747,7 @@ export default function MarketplaceLensPage() {
     { lensId: 'marketplace' }
   );
 
-  // ── ⌘K palette state — Bandcamp-shape search across every listing ──
+  // ── ⌘K palette state — search across every listing ──────────────
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [paletteQuery, setPaletteQuery] = useState('');
   const [paletteIdx, setPaletteIdx] = useState(0);
@@ -1311,7 +1311,7 @@ export default function MarketplaceLensPage() {
       <FirstRunTour lensId="marketplace" />
       <DepthBadge lensId="marketplace" size="sm" className="ml-2" />
       <div className="px-4 mt-3">
-        <EtsySection />
+        <ShopfrontSection />
       </div>
     <div className="lens-marketplace space-y-6 pb-24" data-lens-theme="marketplace">
       {/* ---- Header ---- */}
@@ -2779,7 +2779,7 @@ export default function MarketplaceLensPage() {
     </div>
 
     {/* ── ⌘K palette: search every listing across templates / components /
-        datasets / art / music. Bandcamp-style discovery shortcut. ── */}
+        datasets / art / music. Discovery shortcut. ── */}
     {paletteOpen && (() => {
       const q = paletteQuery.trim().toLowerCase();
       const creatorName = (c: CreatorInfo | string | undefined): string => {
@@ -2885,7 +2885,7 @@ export default function MarketplaceLensPage() {
       <TrendingListings />
     </section>
 
-    {/* Bandcamp + Gumroad-shape listing workbench: score / price / metrics + actions */}
+    {/* Listing workbench: score / price / metrics + actions */}
     <PipingProvider>
       <section className="mt-6 mx-auto max-w-7xl">
         <MarketplaceActionPanel />

--- a/concord-frontend/app/lenses/math/page.tsx
+++ b/concord-frontend/app/lenses/math/page.tsx
@@ -1170,7 +1170,7 @@ export default function MathLensPage() {
         <MathStackFeed />
       </section>
 
-      {/* Wolfram + Desmos-shape math workbench: stats / matrix / polynomial / regression + actions */}
+      {/* math workbench: stats / matrix / polynomial / regression + actions */}
       <PipingProvider>
         <section className="mt-6">
           <MathActionPanel />

--- a/concord-frontend/app/lenses/productivity/page.tsx
+++ b/concord-frontend/app/lenses/productivity/page.tsx
@@ -257,7 +257,7 @@ export default function ProductivityLensPage() {
         <ProductivityRepos />
       </section>
 
-      {/* Todoist + Things-shape task workbench: create / filter / focus / summary + actions */}
+      {/* task workbench: create / filter / focus / summary + actions */}
       <PipingProvider>
         <section className="mt-6 mx-4">
           <ProductivityActionPanel />

--- a/concord-frontend/app/lenses/realestate/page.tsx
+++ b/concord-frontend/app/lenses/realestate/page.tsx
@@ -95,7 +95,7 @@ import PreApprovalFlow from '@/components/realestate/PreApprovalFlow';
 import SavedSearchAlerts from '@/components/realestate/SavedSearchAlerts';
 import PropertyDetailPanel from '@/components/realestate/PropertyDetailPanel';
 import ContactAgentForm from '@/components/realestate/ContactAgentForm';
-import { RivalShapePreview } from '@/components/lens/RivalShapePreview';
+import { ShellPreview } from '@/components/lens/ShellPreview';
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -940,7 +940,7 @@ export default function RealEstateLensPage() {
       <FirstRunTour lensId="realestate" />
       <DepthBadge lensId="realestate" size="sm" className="ml-2" />
     <div className={ds.pageContainer}>
-      <RivalShapePreview lensId="realestate" defaultOpen={true} />
+      <ShellPreview lensId="realestate" defaultOpen={true} />
       <RealtorWorkbenchSection />
       {/* Header */}
       <header className={ds.sectionHeader}>

--- a/concord-frontend/app/lenses/reasoning/page.tsx
+++ b/concord-frontend/app/lenses/reasoning/page.tsx
@@ -2540,7 +2540,7 @@ export default function ReasoningLensPage() {
           </div>
         )}
       </div>
-      {/* Wolfram-shape argument workbench: validate / map / fallacy / premise + actions */}
+      {/* argument workbench: validate / map / fallacy / premise + actions */}
       <section className="mt-6">
         <ArgumentWorkbench />
       </section>

--- a/concord-frontend/app/lenses/retail/page.tsx
+++ b/concord-frontend/app/lenses/retail/page.tsx
@@ -94,7 +94,7 @@ import CollectionsPanel from '@/components/retail/CollectionsPanel';
 import InventoryTransfers from '@/components/retail/InventoryTransfers';
 import SalesAnalytics from '@/components/retail/SalesAnalytics';
 import CommerceSuite from '@/components/retail/CommerceSuite';
-import { RivalShapePreview } from '@/components/lens/RivalShapePreview';
+import { ShellPreview } from '@/components/lens/ShellPreview';
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -1884,8 +1884,8 @@ export default function RetailLensPage() {
       <FirstRunTour lensId="retail" />
       <DepthBadge lensId="retail" size="sm" className="ml-2" />
     <div data-lens-theme="retail" className={ds.pageContainer}>
-      <RivalShapePreview lensId="retail" defaultOpen={true} />
-      <ShopifyWorkbenchSection />
+      <ShellPreview lensId="retail" defaultOpen={true} />
+      <RetailWorkbenchSection />
       <CommerceSuite />
       {/* Header */}
       <header className={ds.sectionHeader}>
@@ -2060,10 +2060,10 @@ export default function RetailLensPage() {
 }
 
 /* ------------------------------------------------------------------ */
-/*  Shopify-parity workbench section                                    */
+/*  Retail workbench section                                    */
 /* ------------------------------------------------------------------ */
 
-function ShopifyWorkbenchSection() {
+function RetailWorkbenchSection() {
   const [active, setActive] = useState<'analytics' | 'customers' | 'discounts' | 'abandoned' | 'shipping' | 'gift' | 'refunds' | 'collections' | 'transfers'>('analytics');
   const TABS = [
     { id: 'analytics', label: 'Analytics' },
@@ -2078,7 +2078,7 @@ function ShopifyWorkbenchSection() {
   ] as const;
   return (
     <section className="mt-6 space-y-3">
-      <h2 className="text-sm font-semibold text-emerald-300 uppercase tracking-wider">Shopify-parity workbench</h2>
+      <h2 className="text-sm font-semibold text-emerald-300 uppercase tracking-wider">Retail workbench</h2>
       <nav className="flex items-center gap-1 border-b border-emerald-900/30 pb-2 overflow-x-auto">
         {TABS.map(t => (
           <button

--- a/concord-frontend/app/lenses/self/page.tsx
+++ b/concord-frontend/app/lenses/self/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 /**
- * Unified Self Lens — quantified-self surface shadowing Apple Health /
- * Gyroscope. A real metric ledger (server/domains/self.js) powers
+ * Unified Self Lens — a quantified-self surface. A real metric ledger
+ * (server/domains/self.js) powers
  * customizable overview tiles, trend charts, cross-metric correlation,
  * goals + progress rings, daily/weekly digest, streaks, and wearable
  * import. The legacy aggregator tabs (fitness/sleep/mood/journal/

--- a/concord-frontend/app/lenses/studio/page.tsx
+++ b/concord-frontend/app/lenses/studio/page.tsx
@@ -28,7 +28,7 @@ import QuantizePanel from '@/components/studio/QuantizePanel';
 import RecordingPanel from '@/components/studio/RecordingPanel';
 import ProjectIOPanel from '@/components/studio/ProjectIOPanel';
 import CollabPanel from '@/components/studio/CollabPanel';
-import { RivalShapePreview } from '@/components/lens/RivalShapePreview';
+import { ShellPreview } from '@/components/lens/ShellPreview';
 import { MobileTabBar } from '@/components/mobile/MobileTabBar';
 import {
   Grid3x3 as MTabSess, LineChart as MTabArr, SlidersHorizontal as MTabMix,
@@ -377,9 +377,8 @@ export default function StudioLensPage() {
   const queryClient = useQueryClient();
 
   // ---- State ----
-  // Default to Ableton-style Session view per canonical DAW research
-  // (Ableton Session View / GarageBand Live Loops are the iconic
-  // distinctive surface). Other views are still reachable via the
+  // Default to the Session view (clip-launching grid) — the iconic DAW
+  // surface. Other views are still reachable via the
   // toolbar — they're the per-clip / per-track editors. localStorage-
   // sticky so power users who pin a different default keep it.
   const [studioView, setStudioView] = useState<StudioViewType>(() => {
@@ -799,7 +798,7 @@ export default function StudioLensPage() {
     }
   }, [recordedUrl]);
 
-  // ── DAW transport shortcuts (Logic / Ableton idiom) ──────────────
+  // ── DAW transport shortcuts ──────────────────────────────────────
   // Space toggles play/pause, R records, . stops, Enter rewinds.
   useLensCommand(
     [
@@ -1614,7 +1613,7 @@ export default function StudioLensPage() {
       <FirstRunTour lensId="studio" />
       <DepthBadge lensId="studio" size="sm" className="ml-2" />
       <div className="px-4 mt-2">
-        <RivalShapePreview lensId="studio" defaultOpen={true} />
+        <ShellPreview lensId="studio" defaultOpen={true} />
         <DawWorkbenchSection />
       </div>
     <div
@@ -1801,7 +1800,7 @@ export default function StudioLensPage() {
         {/* Primary view */}
         <div className="flex-1 flex flex-col overflow-hidden">
           {studioView === 'session' && (
-            // Ableton-style hero — clip grid + browser left + inspector
+            // Session hero — clip grid + browser left + inspector
             // right + mixer peek strip below. Composed in
             // components/studio/SessionWorkspace.tsx per the canonical
             // DAW research blueprint.
@@ -2707,7 +2706,7 @@ export default function StudioLensPage() {
         <StudioRepos />
       </section>
 
-      {/* Ableton Live-shape session workbench: project / track / effect / render + actions */}
+      {/* Session workbench: project / track / effect / render + actions */}
       <PipingProvider>
         <section className="mt-6 mx-auto max-w-7xl">
           <StudioActionPanel />
@@ -2735,7 +2734,7 @@ export default function StudioLensPage() {
 }
 
 /* ------------------------------------------------------------------ */
-/*  Logic / Ableton-parity workbench section                            */
+/*  Session workbench section                                          */
 /* ------------------------------------------------------------------ */
 
 type WorkbenchTab =
@@ -2768,7 +2767,7 @@ function DawWorkbenchSection() {
   ];
   return (
     <section className="mt-6 space-y-3">
-      <h2 className="text-sm font-semibold text-violet-300 uppercase tracking-wider">Logic/Ableton-parity workbench</h2>
+      <h2 className="text-sm font-semibold text-violet-300 uppercase tracking-wider">Session workbench</h2>
       <div className="grid grid-cols-3 gap-2 text-xs">
         <input value={projectId} onChange={e => setProjId(e.target.value)} placeholder="Project ID (paste from project list)" className="px-2 py-1 bg-lattice-deep border border-lattice-border rounded text-white font-mono" />
         <input value={trackId} onChange={e => setTrackId(e.target.value)} placeholder="Track ID" className="px-2 py-1 bg-lattice-deep border border-lattice-border rounded text-white font-mono" />

--- a/concord-frontend/app/lenses/trades/page.tsx
+++ b/concord-frontend/app/lenses/trades/page.tsx
@@ -92,7 +92,7 @@ import FieldTrackingPanel from '@/components/trades/FieldTrackingPanel';
 import NotificationsPanel from '@/components/trades/NotificationsPanel';
 import PricebookPanel from '@/components/trades/PricebookPanel';
 import ReportingPanel from '@/components/trades/ReportingPanel';
-import { RivalShapePreview } from '@/components/lens/RivalShapePreview';
+import { ShellPreview } from '@/components/lens/ShellPreview';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -2270,7 +2270,7 @@ export default function TradesLensPage() {
       <FirstRunTour lensId="trades" />
       <DepthBadge lensId="trades" size="sm" className="ml-2" />
     <div className={cn(ds.pageContainer, 'lens-trades')} data-lens-theme="trades">
-      <RivalShapePreview lensId="trades" defaultOpen={true} />
+      <ShellPreview lensId="trades" defaultOpen={true} />
       <ServiceTitanWorkbenchSection />
       {/* Header */}
       <header className={ds.sectionHeader}>

--- a/concord-frontend/app/lenses/wallet/page.tsx
+++ b/concord-frontend/app/lenses/wallet/page.tsx
@@ -149,7 +149,7 @@ function WalletPageInner() {
   const [showTransfer, setShowTransfer] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  // ── Main wallet keyboard shortcuts (Coinbase / Phantom-style) ──────
+  // ── Main wallet keyboard shortcuts ────────────────────────────────
   // Single-letter actions for the three core flows + tab navigation.
   // Note: a separate useLensCommand inside TransferFlow handles its
   // own internal step navigation; that one is scoped to the modal.
@@ -1175,7 +1175,7 @@ export default function WalletPage() {
       <WalletMarkets />
     </section>
 
-    {/* Coinbase + Mint-shape wallet workbench: balance / categorize / budget / trend + actions */}
+    {/* wallet workbench: balance / categorize / budget / trend + actions */}
     <PipingProvider>
       <section className="mt-6 mx-auto max-w-7xl">
         <WalletActionPanel />

--- a/concord-frontend/app/lenses/whiteboard/page.tsx
+++ b/concord-frontend/app/lenses/whiteboard/page.tsx
@@ -11,8 +11,8 @@ import { DepthBadge } from '@/components/lens/DepthBadge';
 import { WhiteboardRepos } from '@/components/whiteboard/WhiteboardRepos';
 import { WhiteboardActionPanel } from '@/components/whiteboard/WhiteboardActionPanel';
 import { PipingProvider } from '@/components/panel-polish';
-import { RivalShapePreview } from '@/components/lens/RivalShapePreview';
-import { MiroSection } from '@/components/whiteboard/MiroSection';
+import { ShellPreview } from '@/components/lens/ShellPreview';
+import { CollabBoardSection } from '@/components/whiteboard/CollabBoardSection';
 import { UniversalActions } from '@/components/lens/UniversalActions';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiHelpers } from '@/lib/api/client';
@@ -539,7 +539,7 @@ export default function WhiteboardLensPage() {
   // Vector export — produces an SVG of the current board.  Vector form
   // scales without aliasing, opens in Figma / Illustrator / Inkscape, and
   // is the gold-standard "I want my drawing again later" format that
-  // Miro / FigJam ship.  Rasters (PNG) lose information; SVG keeps the
+  // vector editors. Rasters (PNG) lose information; SVG keeps the
   // primitives addressable.  Renders rectangles, ellipses, lines,
   // arrows, freehand strokes, text, and labelled cards/sections; image
   // pins reference their source URL via `<image href>` so the SVG
@@ -835,7 +835,7 @@ export default function WhiteboardLensPage() {
     setSelectedElement(copy);
   }, [selectedElement, pushUndo]);
 
-  /* ---------- keyboard shortcuts (Figma / Excalidraw idiom) ---------- */
+  /* ---------- keyboard shortcuts (canvas idiom) ---------- */
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
@@ -951,9 +951,9 @@ export default function WhiteboardLensPage() {
     <LensShell lensId="whiteboard" asMain={false}>
       <FirstRunTour lensId="whiteboard" />
       <DepthBadge lensId="whiteboard" size="sm" className="ml-2" />
-      <RivalShapePreview lensId="whiteboard" defaultOpen={true} />
+      <ShellPreview lensId="whiteboard" defaultOpen={true} />
       <div className="px-4 mt-3">
-        <MiroSection />
+        <CollabBoardSection />
       </div>
     <div className="h-full flex bg-lattice-bg">
       {/* ===== Sidebar ===== */}
@@ -1693,7 +1693,7 @@ export default function WhiteboardLensPage() {
       <WhiteboardRepos />
     </section>
 
-    {/* Excalidraw + Miro-shape session workbench: template / save / vote / share + actions */}
+    {/* session workbench: template / save / vote / share + actions */}
     <PipingProvider>
       <section className="mt-6 mx-auto max-w-7xl">
         <WhiteboardActionPanel />

--- a/concord-frontend/app/lenses/worldmodel/page.tsx
+++ b/concord-frontend/app/lenses/worldmodel/page.tsx
@@ -3,9 +3,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 /**
- * Worldmodel Lens — digital-twin / counterfactual-simulation surface.
- * Category leader: Palantir Foundry — entity-graph world model with
- * counterfactual simulation over a modeled system.
+ * Worldmodel Lens — digital-twin / counterfactual-simulation surface:
+ * an entity-graph world model with counterfactual simulation over a
+ * modeled system.
  *
  * Every panel here is wired to a real `worldmodel.*` domain macro. There
  * is no mock / seed / demo data: each rendered value comes from a macro

--- a/concord-frontend/components/accounting/AdvancedAccountingPanel.tsx
+++ b/concord-frontend/components/accounting/AdvancedAccountingPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * AdvancedAccountingPanel — 2026 QuickBooks-parity features:
+ * AdvancedAccountingPanel — advanced accounting features:
  * live bank feeds, multi-currency FX, dimensional tagging, payroll
  * tax e-filing + ACH, recurring bills, receipt OCR, edit audit log,
  * and 1099/W-2 IRS FIRE export. All data is real user input or

--- a/concord-frontend/components/accounting/BankFeedsInbox.tsx
+++ b/concord-frontend/components/accounting/BankFeedsInbox.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * BankFeedsInbox — QBO 2026-style transaction inbox with AI bulk-suggest.
+ * BankFeedsInbox — BooksO 2026-style transaction inbox with AI bulk-suggest.
  *
  * Hero workflow:
  *   1. Click "Suggest all" → calls bank-feeds-bulk-suggest → server returns

--- a/concord-frontend/components/accounting/BooksSection.tsx
+++ b/concord-frontend/components/accounting/BooksSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * QBSection — top-level QuickBooks-shape workbench for the accounting lens.
+ * BooksSection — top-level workbench for the accounting lens.
  *
  * Owns the nav-state and mounts the right panel per nav. Wires the
  * dashboard's "jump-to" shortcuts and the JAX-style ask bar to the
@@ -10,7 +10,7 @@
 
 import { useEffect, useState } from 'react';
 import { lensRun } from '@/lib/api/client';
-import { QBShell, QBNav } from './QBShell';
+import { BooksShell, BooksNav } from './BooksShell';
 import { AccountingAskBar } from './AccountingAskBar';
 import { AccountingDashboard } from './AccountingDashboard';
 import { BankFeedsInbox } from './BankFeedsInbox';
@@ -32,9 +32,9 @@ import { AcSalesTaxPanel } from './AcSalesTaxPanel';
 import { AcPurchaseOrdersPanel } from './AcPurchaseOrdersPanel';
 import { AcRatiosPanel } from './AcRatiosPanel';
 
-export function QBSection() {
-  const [nav, setNav] = useState<QBNav>('dashboard');
-  const [badges, setBadges] = useState<Partial<Record<QBNav, number>>>({});
+export function BooksSection() {
+  const [nav, setNav] = useState<BooksNav>('dashboard');
+  const [badges, setBadges] = useState<Partial<Record<BooksNav, number>>>({});
 
   useEffect(() => { refreshBadges(); }, [nav]);
 
@@ -53,13 +53,13 @@ export function QBSection() {
   }
 
   return (
-    <QBShell
+    <BooksShell
       activeNav={nav}
       onNavChange={setNav}
       badges={badges}
       askBar={<AccountingAskBar />}
     >
-      {nav === 'dashboard' && <AccountingDashboard onJumpTo={(n) => setNav(n as QBNav)} />}
+      {nav === 'dashboard' && <AccountingDashboard onJumpTo={(n) => setNav(n as BooksNav)} />}
       {nav === 'banking'   && <BankFeedsInbox />}
       {nav === 'invoices'  && <InvoicesPlaceholder />}
       {nav === 'estimates' && <EstimatesPanel />}
@@ -82,7 +82,7 @@ export function QBSection() {
       {nav === 'salestax'  && <AcSalesTaxPanel />}
       {nav === 'purchaseorders' && <AcPurchaseOrdersPanel />}
       {nav === 'ratios'    && <AcRatiosPanel />}
-    </QBShell>
+    </BooksShell>
   );
 }
 
@@ -118,4 +118,4 @@ function CoaHint() {
   );
 }
 
-export default QBSection;
+export default BooksSection;

--- a/concord-frontend/components/accounting/BooksShell.tsx
+++ b/concord-frontend/components/accounting/BooksShell.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 /**
- * QBShell — QuickBooks Online-shape sidebar + top-tab chrome.
+ * BooksShell — a books-chrome sidebar + top-tab chrome.
  *
- * The QBO interface anyone who has done SMB books recognises: dark sidebar
+ * The BooksO interface anyone who has done SMB books recognises: dark sidebar
  * on the left with the major nav buckets (Dashboard / Banking / Sales /
  * Expenses / Reports), each with its own sub-tabs. Keeps Concord branding
  * but the shape says "this is your books".
@@ -16,7 +16,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
-export type QBNav =
+export type BooksNav =
   | 'dashboard'
   | 'banking'
   | 'invoices'
@@ -43,18 +43,18 @@ export type QBNav =
   | 'ratios';
 
 interface NavItem {
-  id: QBNav;
+  id: BooksNav;
   label: string;
   icon: typeof Home;
   group: 'core' | 'sales' | 'expenses' | 'reports';
   badge?: number | string;
 }
 
-export interface QBShellProps {
-  activeNav: QBNav;
-  onNavChange: (next: QBNav) => void;
+export interface BooksShellProps {
+  activeNav: BooksNav;
+  onNavChange: (next: BooksNav) => void;
   /** Counts driven by dashboard-summary backend data. Show in nav as red pills. */
-  badges?: Partial<Record<QBNav, number | string>>;
+  badges?: Partial<Record<BooksNav, number | string>>;
   children: React.ReactNode;
   /** Slot for the JAX-style "Ask anything" bar mounted in the header. */
   askBar?: React.ReactNode;
@@ -93,7 +93,7 @@ const GROUP_LABELS: Record<NavItem['group'], string> = {
   reports: 'Reports',
 };
 
-export function QBShell({ activeNav, onNavChange, badges = {}, children, askBar }: QBShellProps) {
+export function BooksShell({ activeNav, onNavChange, badges = {}, children, askBar }: BooksShellProps) {
   const groups: NavItem['group'][] = ['core', 'sales', 'expenses', 'reports'];
   return (
     <div className="flex h-[calc(100vh-180px)] min-h-[640px] bg-[#0d1117] border border-emerald-500/15 rounded-lg overflow-hidden">
@@ -151,4 +151,4 @@ export function QBShell({ activeNav, onNavChange, badges = {}, children, askBar 
   );
 }
 
-export default QBShell;
+export default BooksShell;

--- a/concord-frontend/components/accounting/CategoryRulesPanel.tsx
+++ b/concord-frontend/components/accounting/CategoryRulesPanel.tsx
@@ -4,7 +4,7 @@
  * CategoryRulesPanel — surfaces accounting's transaction auto-categorization rules
  * (the accounting.category-rules-* macros existed backend-side but had no UI). A
  * rule maps a description pattern → a chart-of-accounts account, so bank-feed
- * transactions get categorized automatically (a QuickBooks-core feature).
+ * transactions get categorized automatically (a core accounting feature).
  */
 
 import { useCallback, useEffect, useState } from 'react';

--- a/concord-frontend/components/accounting/KPIStrip.tsx
+++ b/concord-frontend/components/accounting/KPIStrip.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * KPIStrip — QuickBooks-shape financial dashboard at a glance.
+ * KPIStrip — financial dashboard at a glance.
  *
  * The horizontal strip of high-density numeric tiles every accounting
  * tool ships above the ledger. Numbers go big, deltas go small with

--- a/concord-frontend/components/accounting/StripeInvoicePanel.tsx
+++ b/concord-frontend/components/accounting/StripeInvoicePanel.tsx
@@ -10,11 +10,9 @@
  *   accounting.invoice-mark-paid            — manual mark-paid for non-
  *                                             Stripe payments
  *
- * Per category-leader UX research against QuickBooks, Xero, FreshBooks,
- * Wave, and Stripe Dashboard:
- *   • Status badge system (Draft / Open / Paid / Overdue) with Stripe-
- *     style sub-badges (Past due if dueAt < today)
- *   • Wave-style three-tab grouping (Draft / Unpaid / All)
+ * An invoicing surface.
+ *   • Status badge system (Draft / Open / Paid / Overdue) with sub-badges (Past due if dueAt < today)
+ *   • Three-tab grouping (Draft / Unpaid / All)
  *   • Single-page invoice composer with customer + total + Send-via-
  *     Stripe split-button
  *   • Save-as-DTU on the Stripe hosted invoice URL so a sent invoice

--- a/concord-frontend/components/code/CodeActionPanel.tsx
+++ b/concord-frontend/components/code/CodeActionPanel.tsx
@@ -229,7 +229,6 @@ export function CodeActionPanel() {
       <header className="flex items-center gap-2 border-b border-cyan-500/10 pb-2">
         <Code className="h-4 w-4 text-cyan-400" />
         <h3 className="text-sm font-semibold text-white">Code review workbench</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">vs code</span>
       </header>
 
       <div className="grid grid-cols-1 md:grid-cols-4 gap-2">

--- a/concord-frontend/components/code/CodeEditorShell.tsx
+++ b/concord-frontend/components/code/CodeEditorShell.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 /**
- * VSCodeShell — IDE silhouette: activity bar + file tree + tab strip +
+ * CodeEditorShell — IDE silhouette: activity bar + file tree + tab strip +
  * editor pane + status bar.
  *
  * Drop-in for /lenses/code (and any code-like lens — repos, debug,
  * scripts). Ships the visual structure every IDE shares so the lens
- * reads as VS Code in 200ms; the actual editor / file-tree contents
+ * reads as a familiar IDE in 200ms; the actual editor / file-tree contents
  * are passed as children so callers stay in control of behaviour.
  */
 
@@ -33,7 +33,7 @@ export interface OpenTab {
 
 export type ActivityIcon = 'files' | 'search' | 'git' | 'debug' | 'settings';
 
-export interface VSCodeShellProps {
+export interface CodeEditorShellProps {
   files: FileTreeNode[];
   openTabs: OpenTab[];
   activeTabId?: string;
@@ -63,7 +63,7 @@ const ACTIVITY_ICONS: Array<{ id: ActivityIcon; icon: typeof FileText; label: st
   { id: 'settings', icon: Settings,  label: 'Settings' },
 ];
 
-export function VSCodeShell({
+export function CodeEditorShell({
   files,
   openTabs,
   activeTabId,
@@ -75,7 +75,7 @@ export function VSCodeShell({
   onActivityChange,
   statusBar,
   className,
-}: VSCodeShellProps) {
+}: CodeEditorShellProps) {
   return (
     <div className={cn('flex h-full bg-[#1e1e1e] text-[#d4d4d4] font-mono text-sm', className)}>
       {/* Activity bar */}
@@ -235,4 +235,4 @@ function FileNode({ node, depth, onSelectFile }: FileNodeProps) {
   );
 }
 
-export default VSCodeShell;
+export default CodeEditorShell;

--- a/concord-frontend/components/crypto/CryptoPanels.tsx
+++ b/concord-frontend/components/crypto/CryptoPanels.tsx
@@ -248,7 +248,7 @@ export function StakingPanel() {
           <button onClick={() => setRewardFor(null)} className="col-span-2 px-2 py-1.5 text-xs rounded text-gray-300 hover:bg-white/[0.05]">Cancel</button>
         </div>
       )}
-      {loading ? <Loading /> : list.length === 0 ? <Empty label="No staking positions. SOL ~5-7% APR, ETH ~3-4% APR via Phantom 2026." /> : (
+      {loading ? <Loading /> : list.length === 0 ? <Empty label="No staking positions. SOL ~5-7% APR, ETH ~3-4% APR." /> : (
         <ul className="divide-y divide-white/5">
           {list.map(p => (
             <li key={p.id} className="px-4 py-2.5 hover:bg-white/[0.02] flex items-center gap-3">

--- a/concord-frontend/components/crypto/ExchangeSection.tsx
+++ b/concord-frontend/components/crypto/ExchangeSection.tsx
@@ -2,12 +2,12 @@
 
 import { useEffect, useState } from 'react';
 import { lensRun } from '@/lib/api/client';
-import { CoinbaseShell, CryptoNav } from './CoinbaseShell';
+import { ExchangeShell, CryptoNav } from './ExchangeShell';
 import { PortfolioPanel } from './PortfolioPanel';
 import { WatchlistPanel, RecurringBuysPanel, StakingPanel, NFTsPanel, ActivityPanel, TaxPanel, InsightsPanel } from './CryptoPanels';
 import { TradePanel, MarketPanel, WalletsPanel, PerformanceCard } from './CryptoTradePanels';
 
-export function CoinbaseSection() {
+export function ExchangeSection() {
   const [nav, setNav] = useState<CryptoNav>('portfolio');
   const [summary, setSummary] = useState<{ totalValueUsd: number; unrealizedPnlPct: number; activeRecurringBuys: number; activeStakingPositions: number; watchlistSize: number; nftCount: number; priceAlertCount: number } | null>(null);
 
@@ -26,7 +26,7 @@ export function CoinbaseSection() {
   } : {};
 
   return (
-    <CoinbaseShell
+    <ExchangeShell
       activeNav={nav}
       onNavChange={setNav}
       badges={badges}
@@ -54,8 +54,8 @@ export function CoinbaseSection() {
         </div>
       )}
       {nav === 'wallet'    && <WalletsPanel />}
-    </CoinbaseShell>
+    </ExchangeShell>
   );
 }
 
-export default CoinbaseSection;
+export default ExchangeSection;

--- a/concord-frontend/components/crypto/ExchangeShell.tsx
+++ b/concord-frontend/components/crypto/ExchangeShell.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * CoinbaseShell — Coinbase + Phantom 2026-shape sidebar chrome.
+ * ExchangeShell — a wallet-chrome sidebar chrome.
  *
  * Left rail: Portfolio / Watchlist / Recurring / Staking / NFTs /
  * Activity / Tax / Insights / Wallet (existing approvals + addressbook
@@ -43,7 +43,7 @@ const NAV: NavItem[] = [
   { id: 'wallet',    label: 'Wallets & Send', icon: Send },
 ];
 
-export interface CoinbaseShellProps {
+export interface ExchangeShellProps {
   activeNav: CryptoNav;
   onNavChange: (n: CryptoNav) => void;
   badges?: Partial<Record<CryptoNav, number | string>>;
@@ -52,7 +52,7 @@ export interface CoinbaseShellProps {
   children: React.ReactNode;
 }
 
-export function CoinbaseShell({ activeNav, onNavChange, badges = {}, totalValueUsd, unrealizedPnlPct, children }: CoinbaseShellProps) {
+export function ExchangeShell({ activeNav, onNavChange, badges = {}, totalValueUsd, unrealizedPnlPct, children }: ExchangeShellProps) {
   return (
     <div className="flex h-[calc(100vh-180px)] min-h-[640px] bg-[#0d1117] border border-blue-500/15 rounded-lg overflow-hidden">
       <aside className="w-48 bg-[#0a0c10] border-r border-white/5 flex flex-col flex-shrink-0">
@@ -105,4 +105,4 @@ export function CoinbaseShell({ activeNav, onNavChange, badges = {}, totalValueU
   );
 }
 
-export default CoinbaseShell;
+export default ExchangeShell;

--- a/concord-frontend/components/crypto/WalletShell.tsx
+++ b/concord-frontend/components/crypto/WalletShell.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * WalletShell — Coinbase / Phantom-shape wallet silhouette.
+ * WalletShell — a wallet surface.
  *
  * Big balance up top with hide/show, send/receive/swap action triple,
  * portfolio breakdown by asset, transaction history rail. Drop-in for

--- a/concord-frontend/components/finance/EnvelopeBudget.tsx
+++ b/concord-frontend/components/finance/EnvelopeBudget.tsx
@@ -83,7 +83,7 @@ export function EnvelopeBudget({ monthlyIncome = 0 }: EnvelopeBudgetProps) {
       <header className="px-4 py-2 border-b border-white/10 flex items-center gap-2">
         <Wallet className="w-4 h-4 text-cyan-400" />
         <span className="text-xs uppercase font-semibold text-gray-300 tracking-wider">Envelope budgets</span>
-        <span className="ml-auto text-[10px] text-gray-400">YNAB-style zero-based</span>
+        <span className="ml-auto text-[10px] text-gray-400">zero-based</span>
         <button onClick={() => setCreating(v => !v)} className="p-1 text-gray-400 hover:text-white" title="New envelope">
           <Plus className="w-4 h-4" />
         </button>

--- a/concord-frontend/components/finance/FinanceActionPanel.tsx
+++ b/concord-frontend/components/finance/FinanceActionPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * FinanceActionPanel — Robinhood + YNAB-shape money workbench.
+ * FinanceActionPanel — a money workbench.
  * Surfaces budget / envelopes / net-worth / investment / tax /
  * retirement-monte-carlo macros plus mint/DM/publish/agent.
  */
@@ -236,7 +236,6 @@ export function FinanceActionPanel() {
       <header className="flex items-center gap-2 border-b border-emerald-500/10 pb-2">
         <DollarSign className="h-4 w-4 text-emerald-400" />
         <h3 className="text-sm font-semibold text-white">Money workbench</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">robinhood · ynab</span>
       </header>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">

--- a/concord-frontend/components/finance/FinanceShell.tsx
+++ b/concord-frontend/components/finance/FinanceShell.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * FinanceShell — Robinhood / Monarch Money-shape silhouette.
+ * FinanceShell — a portfolio surface.
  *
  * Dominant net-worth header with hide toggle and time-range chips,
  * portfolio sparkline, Trade / Transfer / Budget action triple,
@@ -244,7 +244,7 @@ export function FinanceShell({
 
       {/* Two-column: holdings + watchlist */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-        {/* Holdings (Robinhood-shape rows with mini-sparklines) */}
+        {/* Holdings (rows with mini-sparklines) */}
         <section className="lg:col-span-2">
           <header className="flex items-center justify-between mb-2">
             <h2 className="text-xs uppercase tracking-wider text-gray-400">Holdings</h2>

--- a/concord-frontend/components/fitness/WorkoutFinishPanel.tsx
+++ b/concord-frontend/components/fitness/WorkoutFinishPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * WorkoutFinishPanel — Hevy / Strong-shape end-of-workout action surface
+ * WorkoutFinishPanel — an end-of-workout action surface
  * for the fitness lens. Sits below the existing WorkoutLogger; once you
  * finish a workout, this panel turns it into shareable + analysable
  * artifacts.
@@ -268,9 +268,6 @@ export function WorkoutFinishPanel() {
       <header className="flex items-center gap-2 border-b border-orange-500/10 pb-2">
         <Dumbbell className="h-4 w-4 text-orange-400" />
         <h3 className="text-sm font-semibold text-white">Workout finisher</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">
-          hevy · strong
-        </span>
         <span className="ml-auto text-[10px] text-zinc-400 font-mono">
           {totalSets} sets · {Math.round(totalVolume)} kg
         </span>

--- a/concord-frontend/components/food/FoodActionPanel.tsx
+++ b/concord-frontend/components/food/FoodActionPanel.tsx
@@ -168,7 +168,6 @@ export function FoodActionPanel() {
       <header className="flex items-center gap-2 border-b border-orange-500/10 pb-2">
         <ChefHat className="h-4 w-4 text-orange-400" />
         <h3 className="text-sm font-semibold text-white">Kitchen workbench</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">yummly · POS</span>
       </header>
 
       <div className="grid grid-cols-1 md:grid-cols-5 gap-2">

--- a/concord-frontend/components/foundry/FoundryActionPanel.tsx
+++ b/concord-frontend/components/foundry/FoundryActionPanel.tsx
@@ -229,7 +229,6 @@ export function FoundryActionPanel() {
       <header className="flex items-center gap-2 border-b border-orange-500/10 pb-2">
         <Box className="h-4 w-4 text-orange-400" />
         <h3 className="text-sm font-semibold text-white">Foundry workbench</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">unity · roblox studio</span>
       </header>
 
       <div className="grid grid-cols-1 md:grid-cols-5 gap-2">

--- a/concord-frontend/components/household/HouseholdActionPanel.tsx
+++ b/concord-frontend/components/household/HouseholdActionPanel.tsx
@@ -156,7 +156,6 @@ export function HouseholdActionPanel() {
       <header className="flex items-center gap-2 border-b border-teal-500/10 pb-2">
         <Home className="h-4 w-4 text-teal-400" />
         <h3 className="text-sm font-semibold text-white">Household workbench</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">tody · sweepy</span>
       </header>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-2">

--- a/concord-frontend/components/hr/HrActionPanel.tsx
+++ b/concord-frontend/components/hr/HrActionPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * HrActionPanel — BambooHR + Gusto-shape people-ops workbench.
+ * HrActionPanel — people-ops workbench.
  * Surfaces compensationBenchmark / turnoverAnalysis / interviewScorecard /
  * ptoBalance + mint/DM/publish/agent.
  */
@@ -174,7 +174,6 @@ export function HrActionPanel() {
       <header className="flex items-center gap-2 border-b border-blue-500/10 pb-2">
         <Users className="h-4 w-4 text-blue-400" />
         <h3 className="text-sm font-semibold text-white">People ops workbench</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">bamboohr · gusto</span>
       </header>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-2">

--- a/concord-frontend/components/hr/HrHrisSection.tsx
+++ b/concord-frontend/components/hr/HrHrisSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * HrWorkdaySection — Workday + BambooHR 2026-shape HRIS workbench.
+ * HrHrisSection — an HRIS workbench.
  * Tab chrome owns nav state; panels hydrate via lensRun().
  */
 
@@ -44,7 +44,7 @@ const TABS: { id: TabId; label: string; icon: typeof Users }[] = [
   { id: 'self', label: 'Self-Service', icon: UserCog },
 ];
 
-export function HrWorkdaySection() {
+export function HrHrisSection() {
   const [tab, setTab] = useState<TabId>('people');
   const [dash, setDash] = useState<Dash | null>(null);
   const [loading, setLoading] = useState(true);
@@ -62,7 +62,7 @@ export function HrWorkdaySection() {
       <header className="flex items-center gap-2 px-4 py-3 border-b border-zinc-800 bg-gradient-to-r from-emerald-600/15 to-transparent">
         <Users className="w-5 h-5 text-emerald-400" />
         <h2 className="text-sm font-bold text-zinc-100">People Hub</h2>
-        <span className="text-[11px] text-zinc-400">Workday + BambooHR shape — HRIS</span>
+        <span className="text-[11px] text-zinc-400">HRIS</span>
       </header>
 
       {loading ? (

--- a/concord-frontend/components/legal/LegalActionPanel.tsx
+++ b/concord-frontend/components/legal/LegalActionPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * LegalActionPanel — Westlaw + CourtListener + contract-mgmt shape.
+ * LegalActionPanel — a legal-practice workbench.
  * Surfaces contractRenewal / conflictCheck / complianceAudit /
  * deadlineCheck + mint/DM/publish/agent.
  */
@@ -163,7 +163,6 @@ export function LegalActionPanel() {
       <header className="flex items-center gap-2 border-b border-amber-500/10 pb-2">
         <Scale className="h-4 w-4 text-amber-400" />
         <h3 className="text-sm font-semibold text-white">Legal workbench</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">westlaw · courtlistener</span>
       </header>
 
       <div className="grid grid-cols-1 md:grid-cols-5 gap-2">

--- a/concord-frontend/components/legal/LegalCaseSearch.tsx
+++ b/concord-frontend/components/legal/LegalCaseSearch.tsx
@@ -6,8 +6,7 @@
  * (CourtListener REST API v4, federal + state opinions, free with
  * optional COURTLISTENER_API_TOKEN env for higher rate limits).
  *
- * Designed per category-leader UX research against Westlaw, LexisNexis,
- * Bloomberg Law, CourtListener, Casetext / CoCounsel, and Justia:
+ * A legal case-search surface.
  *
  *   • Search box with filter chips (court / date-after / date-before
  *     / natural-language vs terms-and-connectors mode hint)

--- a/concord-frontend/components/lens/ShellPreview.tsx
+++ b/concord-frontend/components/lens/ShellPreview.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 /**
- * RivalShapePreview — collapsible accordion that renders the lens's
- * rival-shape shell hydrated with the signed-in user's REAL data
+ * ShellPreview — collapsible accordion that renders the lens's
+ * full-shell view hydrated with the signed-in user's REAL data
  * (per the "everything must be real" directive — no seed/fake data).
  *
- *   <RivalShapePreview lensId="finance" />
+ *   <ShellPreview lensId="finance" />
  *
  * Each *Preview fetches via `/api/lens/run` on mount. When the user
  * has no data yet, the shell renders in its empty state. There is no
@@ -21,7 +21,7 @@ import { WalletShell } from '@/components/crypto/WalletShell';
 import { WhiteboardCanvas } from '@/components/whiteboard/WhiteboardCanvas';
 import { FinanceShell } from '@/components/finance/FinanceShell';
 import { RealtorShell } from '@/components/realestate/RealtorShell';
-import { ShopifyShell } from '@/components/retail/ShopifyShell';
+import { StorefrontShell } from '@/components/retail/StorefrontShell';
 import { ClassroomShell } from '@/components/education/ClassroomShell';
 import { DispatchShell } from '@/components/trades/DispatchShell';
 import { TmsShell } from '@/components/logistics/TmsShell';
@@ -55,13 +55,13 @@ const SHELL_TITLES: Record<SupportedLens, string> = {
   environment: 'Emissions',
 };
 
-export interface RivalShapePreviewProps {
+export interface ShellPreviewProps {
   lensId: string;
   defaultOpen?: boolean;
   className?: string;
 }
 
-export function RivalShapePreview({ lensId, defaultOpen = true, className }: RivalShapePreviewProps) {
+export function ShellPreview({ lensId, defaultOpen = true, className }: ShellPreviewProps) {
   const [open, setOpen] = useState(defaultOpen);
   const supported = (['code', 'crypto', 'legal', 'message', 'whiteboard', 'healthcare', 'finance', 'realestate', 'retail', 'education', 'trades', 'logistics', 'agriculture', 'studio', 'aviation', 'government', 'environment'] as const).includes(lensId as SupportedLens);
   if (!supported) return null;
@@ -94,7 +94,7 @@ export function RivalShapePreview({ lensId, defaultOpen = true, className }: Riv
 
 function PreviewBody({ lensId }: { lensId: SupportedLens }) {
   switch (lensId) {
-    case 'code': return <EmptyShellPlaceholder label="VS Code — open the workbench below to load your repository." />;
+    case 'code': return <EmptyShellPlaceholder label="Open the workbench below to load your repository." />;
     case 'crypto': return <CryptoPreview />;
     case 'legal': return <EmptyShellPlaceholder label="Docs — author or open a contract from the workbench below." />;
     case 'message': return <EmptyShellPlaceholder label="Inbox — incoming messages and royalty notifications will appear here." />;
@@ -290,7 +290,7 @@ function RetailPreview() {
   }, []);
   if (loading) return <PreviewLoading />;
   return (
-    <ShopifyShell
+    <StorefrontShell
       activeNav={nav}
       onNavChange={(n) => n && setNav(n)}
       storeName="My Concord Store"
@@ -733,4 +733,4 @@ function EnvironmentPreview() {
   );
 }
 
-export default RivalShapePreview;
+export default ShellPreview;

--- a/concord-frontend/components/marketplace/CreatorGrid.tsx
+++ b/concord-frontend/components/marketplace/CreatorGrid.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 /**
- * BandcampGrid — Bandcamp-shape cover-grid feed.
+ * CreatorGrid — a cover-grid feed that puts creator art up front.
  *
  * The visual signature of a creator-economy storefront where the
  * artist gets paid: chunky cover-art grid, audio preview on hover /
  * tap, "name your price" minimum + suggested, "support the creator"
  * CTA in the artist's own colour. Concord's marketplace is already
  * 95/5 to creators, so this grid is the *honest* version of what
- * Bandcamp implies but Spotify hides.
+ * a creator-first marketplace surfaces.
  *
  * Drop-in for the marketplace lens browse tab. Each tile carries
  * audio preview, royalty-aware pricing, and the creator chip.
@@ -18,7 +18,7 @@ import React, { useRef, useState } from 'react';
 import { Play, Pause, Coins, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
-export interface BandcampItem {
+export interface CreatorGridItem {
   id: string;
   title: string;
   creator: string;
@@ -38,10 +38,10 @@ export interface BandcampItem {
   tags?: string[];
 }
 
-export interface BandcampGridProps {
-  items: BandcampItem[];
-  onSupport?: (item: BandcampItem, priceCc: number) => void;
-  onOpen?: (item: BandcampItem) => void;
+export interface CreatorGridProps {
+  items: CreatorGridItem[];
+  onSupport?: (item: CreatorGridItem, priceCc: number) => void;
+  onOpen?: (item: CreatorGridItem) => void;
   /** Optional grid density override. */
   columns?: 2 | 3 | 4 | 5;
   className?: string;
@@ -55,7 +55,7 @@ function gradientFor(seed: string): string {
   return `linear-gradient(135deg, hsl(${h1} 70% 28%), hsl(${h2} 70% 18%))`;
 }
 
-export function BandcampGrid({ items, onSupport, onOpen, columns = 3, className }: BandcampGridProps) {
+export function CreatorGrid({ items, onSupport, onOpen, columns = 3, className }: CreatorGridProps) {
   if (items.length === 0) return null;
   const gridCols =
     columns === 5 ? 'grid-cols-2 sm:grid-cols-3 lg:grid-cols-5'
@@ -65,19 +65,19 @@ export function BandcampGrid({ items, onSupport, onOpen, columns = 3, className 
   return (
     <div className={cn('grid gap-4', gridCols, className)}>
       {items.map((item) => (
-        <BandcampTile key={item.id} item={item} onSupport={onSupport} onOpen={onOpen} />
+        <CreatorTile key={item.id} item={item} onSupport={onSupport} onOpen={onOpen} />
       ))}
     </div>
   );
 }
 
-interface BandcampTileProps {
-  item: BandcampItem;
-  onSupport?: (item: BandcampItem, priceCc: number) => void;
-  onOpen?: (item: BandcampItem) => void;
+interface CreatorTileProps {
+  item: CreatorGridItem;
+  onSupport?: (item: CreatorGridItem, priceCc: number) => void;
+  onOpen?: (item: CreatorGridItem) => void;
 }
 
-function BandcampTile({ item, onSupport, onOpen }: BandcampTileProps) {
+function CreatorTile({ item, onSupport, onOpen }: CreatorTileProps) {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [playing, setPlaying] = useState(false);
   const [price, setPrice] = useState(item.suggestedPriceCc ?? item.minPriceCc);
@@ -101,7 +101,7 @@ function BandcampTile({ item, onSupport, onOpen }: BandcampTileProps) {
   return (
     <article
       className="group rounded-lg overflow-hidden border border-white/10 bg-black/40 hover:border-amber-500/40 transition-colors"
-      data-bandcamp-tile
+      data-creator-tile
     >
       <button
         type="button"
@@ -164,7 +164,7 @@ function BandcampTile({ item, onSupport, onOpen }: BandcampTileProps) {
           </ul>
         )}
 
-        {/* Name-your-price row — Bandcamp's signature interaction. */}
+        {/* Name-your-price row. */}
         <div className="flex items-center gap-2">
           <span className="text-[10px] text-gray-400 uppercase tracking-wider">name your price</span>
           {item.suggestedPriceCc !== undefined && (
@@ -206,4 +206,4 @@ function BandcampTile({ item, onSupport, onOpen }: BandcampTileProps) {
   );
 }
 
-export default BandcampGrid;
+export default CreatorGrid;

--- a/concord-frontend/components/marketplace/MarketplaceActionPanel.tsx
+++ b/concord-frontend/components/marketplace/MarketplaceActionPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * MarketplaceActionPanel — Bandcamp + Gumroad-shape listing workbench.
+ * MarketplaceActionPanel — a creator-listing workbench.
  * Surfaces listingScore / priceOptimize / sellerMetrics macros plus
  * mint/DM/publish/agent.
  */
@@ -182,7 +182,7 @@ export function MarketplaceActionPanel() {
         scoreResult ? `Score ${scoreResult.score} (${scoreResult.band}).` : '',
         priceResult ? `Price optimization suggests $${priceResult.suggestedPrice}.` : '',
         '',
-        'Rewrite the listing title + first sentence of description for maximum conversion in the Bandcamp + Gumroad style.',
+        'Rewrite the listing title + first sentence of description for maximum conversion for a creator marketplace.',
         'Return: new title, new opening sentence, why it converts better. Plain text.',
       ].filter(Boolean).join(' ');
       const r = await lensRun({ domain: 'chat_agent', name: 'do', input: { task, maxTurns: 4 } });
@@ -208,7 +208,6 @@ export function MarketplaceActionPanel() {
       <header className="flex items-center gap-2 border-b border-green-500/10 pb-2">
         <ShoppingBag className="h-4 w-4 text-green-400" />
         <h3 className="text-sm font-semibold text-white">Listing workbench</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">bandcamp · gumroad</span>
       </header>
 
       <div className="grid grid-cols-1 md:grid-cols-4 gap-2">

--- a/concord-frontend/components/marketplace/ShopDashboard.tsx
+++ b/concord-frontend/components/marketplace/ShopDashboard.tsx
@@ -5,7 +5,7 @@ import { Eye, Package, DollarSign, Tag, TrendingUp, Loader2, Megaphone } from 'l
 import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
 import { lensRun } from '@/lib/api/client';
 import { cn } from '@/lib/utils';
-import type { ShopNav } from './EtsyShell';
+import type { ShopNav } from './ShopfrontShell';
 
 interface Summary {
   days: number;

--- a/concord-frontend/components/marketplace/ShopfrontSection.tsx
+++ b/concord-frontend/components/marketplace/ShopfrontSection.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { lensRun } from '@/lib/api/client';
-import { EtsyShell, ShopNav } from './EtsyShell';
+import { ShopfrontShell, ShopNav } from './ShopfrontShell';
 import { ShopDashboard } from './ShopDashboard';
 import { ListingsPanel } from './ListingsPanel';
 import { OrdersPanel } from './OrdersPanel';
@@ -20,7 +20,7 @@ import { InventoryAlertsPanel } from './InventoryAlertsPanel';
 
 interface Shop { id: string; name: string; currency: string }
 
-export function EtsySection() {
+export function ShopfrontSection() {
   const [nav, setNav] = useState<ShopNav>('home');
   const [shop, setShop] = useState<Shop | null>(null);
   const [badges, setBadges] = useState<Partial<Record<ShopNav, number>>>({});
@@ -58,7 +58,7 @@ export function EtsySection() {
   }
 
   return (
-    <EtsyShell
+    <ShopfrontShell
       activeNav={nav}
       onNavChange={setNav}
       badges={badges}
@@ -85,8 +85,8 @@ export function EtsySection() {
         </div>
       )}
       {nav === 'shop'       && <ShopSettingsPanel onUpdated={setShop} />}
-    </EtsyShell>
+    </ShopfrontShell>
   );
 }
 
-export default EtsySection;
+export default ShopfrontSection;

--- a/concord-frontend/components/marketplace/ShopfrontShell.tsx
+++ b/concord-frontend/components/marketplace/ShopfrontShell.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 /**
- * EtsyShell — Etsy Shop Manager-shape sidebar chrome.
+ * ShopfrontShell — the storefront Shop Manager-shape sidebar chrome.
  *
- * Top nav (Etsy's): Home / Listings / Orders / Stats / Marketing /
+ * Top nav (the storefront's): Home / Listings / Orders / Stats / Marketing /
  * Finances / Tools. Includes a header strip with the user's shop name
  * + currency for quick context.
  */
@@ -38,7 +38,7 @@ const NAV: NavItem[] = [
   { id: 'shop',       label: 'Shop settings', icon: Store },
 ];
 
-export interface EtsyShellProps {
+export interface ShopfrontShellProps {
   activeNav: ShopNav;
   onNavChange: (n: ShopNav) => void;
   badges?: Partial<Record<ShopNav, number | string>>;
@@ -47,7 +47,7 @@ export interface EtsyShellProps {
   children: React.ReactNode;
 }
 
-export function EtsyShell({ activeNav, onNavChange, badges = {}, shopName, currency, children }: EtsyShellProps) {
+export function ShopfrontShell({ activeNav, onNavChange, badges = {}, shopName, currency, children }: ShopfrontShellProps) {
   return (
     <div className="flex h-[calc(100vh-180px)] min-h-[640px] bg-[#0d1117] border border-orange-500/15 rounded-lg overflow-hidden">
       <aside className="w-48 bg-[#0a0c10] border-r border-white/5 flex flex-col flex-shrink-0">
@@ -93,4 +93,4 @@ export function EtsyShell({ activeNav, onNavChange, badges = {}, shopName, curre
   );
 }
 
-export default EtsyShell;
+export default ShopfrontShell;

--- a/concord-frontend/components/markets/MarketsQuoteDetail.tsx
+++ b/concord-frontend/components/markets/MarketsQuoteDetail.tsx
@@ -4,7 +4,7 @@
  * MarketsQuoteDetail — bespoke quote-research surface for the markets lens.
  *
  * Designed per category-leader UX research (TradingView, Yahoo Finance,
- * Bloomberg, Robinhood, Webull, Google Finance):
+ * a quote-detail surface):
  *
  *   • Single hero panel: [Symbol] [Last] [Δ abs] [Δ%] above a
  *     lightweight-charts line series, faded pre/after-hours second row

--- a/concord-frontend/components/math/MathActionPanel.tsx
+++ b/concord-frontend/components/math/MathActionPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * MathActionPanel — Wolfram + Desmos-shape math workbench. Surfaces
+ * MathActionPanel — math workbench. Surfaces
  * statisticalAnalysis / matrixOperations / polynomialAnalysis /
  * regressionFit + mint/DM/publish/agent.
  */
@@ -169,7 +169,6 @@ export function MathActionPanel() {
       <header className="flex items-center gap-2 border-b border-indigo-500/10 pb-2">
         <Sigma className="h-4 w-4 text-indigo-400" />
         <h3 className="text-sm font-semibold text-white">Math workbench</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">wolfram · desmos</span>
       </header>
 
       <input type="text" value={problem} onChange={(e) => setProblem(e.target.value)} className="w-full bg-zinc-900 border border-zinc-800 rounded px-3 py-1.5 text-[12px] text-white" placeholder="Problem statement (for mint / agent)" />

--- a/concord-frontend/components/math/SymbolicWorkbench.tsx
+++ b/concord-frontend/components/math/SymbolicWorkbench.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 /**
- * SymbolicWorkbench — Wolfram-Alpha-shape CAS surface for the math lens.
+ * SymbolicWorkbench — a CAS surface for the math lens.
  * Six purpose-built panels, each wired to a real backend macro in
  * server/domains/math.js: symbolicCompute, stepSolve, naturalQuery,
  * plotFunction, unitConvert, numberTheory. No mock data — every number
@@ -50,7 +50,7 @@ export function SymbolicWorkbench() {
         <FunctionSquare className="h-4 w-4 text-indigo-400" />
         <h3 className="text-sm font-semibold text-white">Computational Math Engine</h3>
         <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">
-          CAS · wolfram-shape
+          CAS
         </span>
       </header>
 

--- a/concord-frontend/components/music/MusicActionPanel.tsx
+++ b/concord-frontend/components/music/MusicActionPanel.tsx
@@ -163,7 +163,6 @@ export function MusicActionPanel() {
       <header className="flex items-center gap-2 border-b border-purple-500/10 pb-2">
         <Music className="h-4 w-4 text-purple-400" />
         <h3 className="text-sm font-semibold text-white">Music workbench</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">spotify · ableton</span>
       </header>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-2">

--- a/concord-frontend/components/music/MusicArtistExplorer.tsx
+++ b/concord-frontend/components/music/MusicArtistExplorer.tsx
@@ -8,7 +8,7 @@
  *   music.mb-lookup-by-isrc — ISRC → recording metadata
  *
  * Per category-leader UX research against Spotify, MusicBrainz, AllMusic,
- * Apple Music, Discogs, Bandcamp:
+ * an artist-explorer surface:
  *   • Spotify-style hero (name, life-span, country, top tags)
  *   • MusicBrainz disambiguation popover when >1 candidate
  *   • Discogs-style discography grouped by release-group type

--- a/concord-frontend/components/nonprofit/NonprofitActionPanel.tsx
+++ b/concord-frontend/components/nonprofit/NonprofitActionPanel.tsx
@@ -153,7 +153,6 @@ export function NonprofitActionPanel() {
       <header className="flex items-center gap-2 border-b border-rose-500/10 pb-2">
         <Heart className="h-4 w-4 text-rose-400" />
         <h3 className="text-sm font-semibold text-white">Nonprofit workbench</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">candid · givewell</span>
       </header>
 
       <div className="grid grid-cols-2 md:grid-cols-5 gap-2">

--- a/concord-frontend/components/nonprofit/NonprofitWorkbench.tsx
+++ b/concord-frontend/components/nonprofit/NonprofitWorkbench.tsx
@@ -102,7 +102,6 @@ export function NonprofitWorkbench() {
       <div className="flex items-center gap-2 mb-3">
         <Users className="w-4 h-4 text-rose-400" />
         <h3 className="text-sm font-bold text-zinc-100">Fundraising Workbench</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">bloomerang · givebutter</span>
       </div>
 
       <nav className="flex items-center gap-1 flex-wrap border-b border-zinc-800 pb-2 mb-3">

--- a/concord-frontend/components/observe/ObserveActionPanel.tsx
+++ b/concord-frontend/components/observe/ObserveActionPanel.tsx
@@ -247,7 +247,6 @@ export function ObserveActionPanel() {
       <header className="flex items-center gap-2 border-b border-cyan-500/10 pb-2">
         <Activity className="h-4 w-4 text-cyan-400" />
         <h3 className="text-sm font-semibold text-white">Observability workbench</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">datadog</span>
       </header>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">

--- a/concord-frontend/components/ops/IncidentConsole.tsx
+++ b/concord-frontend/components/ops/IncidentConsole.tsx
@@ -237,7 +237,6 @@ export function IncidentConsole() {
       <header className="flex flex-wrap items-center gap-3 border-b border-rose-500/10 pb-3">
         <Radio className="h-5 w-5 text-rose-400" />
         <h2 className="text-base font-semibold text-white">Incident Management</h2>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">pagerduty parity</span>
         <div className="ml-auto flex items-center gap-3 text-xs">
           <span className="rounded bg-rose-500/15 px-2 py-1 text-rose-300">{open.length} open</span>
           <span className="rounded bg-zinc-800 px-2 py-1 text-zinc-300">

--- a/concord-frontend/components/ops/OpsActionPanel.tsx
+++ b/concord-frontend/components/ops/OpsActionPanel.tsx
@@ -247,7 +247,6 @@ export function OpsActionPanel() {
       <header className="flex items-center gap-2 border-b border-rose-500/10 pb-2">
         <Phone className="h-4 w-4 text-rose-400" />
         <h3 className="text-sm font-semibold text-white">On-call ops workbench</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">pagerduty</span>
       </header>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">

--- a/concord-frontend/components/productivity/ProductivityActionPanel.tsx
+++ b/concord-frontend/components/productivity/ProductivityActionPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * ProductivityActionPanel — Todoist + Things-shape task workbench.
+ * ProductivityActionPanel — task workbench.
  * Self-contained; runs the 4 new productivity.* macros plus mint/DM/
  * publish/agent.
  */
@@ -283,7 +283,6 @@ export function ProductivityActionPanel() {
       <header className="flex items-center gap-2 border-b border-cyan-500/10 pb-2">
         <CheckSquare className="h-4 w-4 text-cyan-400" />
         <h3 className="text-sm font-semibold text-white">Task workbench</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">todoist · things</span>
         <span className="ml-auto text-[10px] text-zinc-400 font-mono">{tasks.filter(t => !t.completed).length}/{tasks.length} open</span>
       </header>
 

--- a/concord-frontend/components/productivity/ProductivityFocusPanel.tsx
+++ b/concord-frontend/components/productivity/ProductivityFocusPanel.tsx
@@ -2,7 +2,7 @@
 
 /**
  * ProductivityFocusPanel — Pomodoro focus logging, the Eisenhower
- * matrix and a Todoist-style karma score.
+ * matrix and a karma score.
  */
 
 import { useCallback, useEffect, useState } from 'react';

--- a/concord-frontend/components/productivity/ProductivityTaskSection.tsx
+++ b/concord-frontend/components/productivity/ProductivityTaskSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * ProductivityTaskSection — Todoist + TickTick 2026-shape task manager.
+ * ProductivityTaskSection — task manager.
  * Tab chrome owns nav state; panels hydrate via lensRun().
  */
 
@@ -54,7 +54,7 @@ export function ProductivityTaskSection() {
       <header className="flex items-center gap-2 px-4 py-3 border-b border-zinc-800 bg-gradient-to-r from-red-600/15 to-transparent">
         <CheckSquare className="w-5 h-5 text-red-400" />
         <h2 className="text-sm font-bold text-zinc-100">Task Manager</h2>
-        <span className="text-[11px] text-zinc-400">Todoist + TickTick shape</span>
+        
       </header>
 
       {loading ? (

--- a/concord-frontend/components/realestate/RealEstateActionPanel.tsx
+++ b/concord-frontend/components/realestate/RealEstateActionPanel.tsx
@@ -163,7 +163,6 @@ export function RealEstateActionPanel() {
       <header className="flex items-center gap-2 border-b border-blue-500/10 pb-2">
         <Home className="h-4 w-4 text-blue-400" />
         <h3 className="text-sm font-semibold text-white">Property workbench</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">zillow · redfin · stessa</span>
       </header>
 
       <div className="grid grid-cols-2 md:grid-cols-5 gap-2">

--- a/concord-frontend/components/reasoning/ArgumentWorkbench.tsx
+++ b/concord-frontend/components/reasoning/ArgumentWorkbench.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * ArgumentWorkbench — Wolfram / step-by-step-calc-shape action surface
+ * ArgumentWorkbench — a step-by-step argument-analysis surface
  * for the reasoning lens. Takes a free-text argument or statement,
  * runs the 4 reasoning macros that previously had no UI, and exposes
  * the standard mint/DM/publish/agent quartet on top.
@@ -253,7 +253,7 @@ export function ArgumentWorkbench() {
         <Brain className="h-4 w-4 text-purple-400" />
         <h3 className="text-sm font-semibold text-white">Argument workbench</h3>
         <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">
-          wolfram-style · step-by-step
+          step-by-step
         </span>
       </header>
 

--- a/concord-frontend/components/retail/CommerceSuite.tsx
+++ b/concord-frontend/components/retail/CommerceSuite.tsx
@@ -25,7 +25,7 @@ const TABS: { id: SuiteTab; label: string }[] = [
 ];
 
 /**
- * CommerceSuite — the Shopify-parity backlog surface. Bundles the
+ * CommerceSuite — the commerce-suite surface. Bundles the
  * buyer-facing storefront, order fulfillment, carrier labels, marketing
  * campaigns, multi-channel listing, product reviews and staff accounts
  * into one tabbed workbench. Each panel is real CRUD over the retail

--- a/concord-frontend/components/retail/StorefrontShell.tsx
+++ b/concord-frontend/components/retail/StorefrontShell.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 /**
- * ShopifyShell — Shopify-admin-shape silhouette.
+ * StorefrontShell — a storefront-admin surface.
  *
  * Left-rail nav (Home/Orders/Products/Customers/Analytics) + top metric
  * tiles row + chart placeholder + recent-orders rail. Drop into the
  * retail lens above the existing workbench and the page reads as a
- * Shopify admin inside 200ms.
+ * a familiar storefront admin inside 200ms.
  */
 
 import React from 'react';
@@ -16,7 +16,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
-export interface ShopifyOrder {
+export interface StorefrontOrder {
   id: string;
   number: string;
   customer?: string;
@@ -26,16 +26,16 @@ export interface ShopifyOrder {
   timestamp: string;
 }
 
-export interface ShopifyShellProps {
+export interface StorefrontShellProps {
   activeNav?: 'home' | 'orders' | 'products' | 'customers' | 'analytics' | 'discounts' | 'shipping' | 'settings';
-  onNavChange?: (nav: ShopifyShellProps['activeNav']) => void;
+  onNavChange?: (nav: StorefrontShellProps['activeNav']) => void;
   storeName?: string;
   revenueToday: number;
   ordersToday: number;
   conversionRate?: number;
   visitors?: number;
   revenue7dSeries: number[];
-  recentOrders: ShopifyOrder[];
+  recentOrders: StorefrontOrder[];
   className?: string;
 }
 
@@ -56,16 +56,16 @@ function fmtMoney(n: number): string {
   return `$${n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 }
 
-export function ShopifyShell({
+export function StorefrontShell({
   activeNav = 'home', onNavChange,
   storeName = 'My Concord Store',
   revenueToday, ordersToday, conversionRate, visitors,
   revenue7dSeries, recentOrders,
   className,
-}: ShopifyShellProps) {
+}: StorefrontShellProps) {
   return (
     <div className={cn('flex bg-[#f6f6f7] text-gray-800 rounded-lg overflow-hidden border border-gray-200', className)} style={{ minHeight: 480 }}>
-      {/* Left rail (Shopify admin nav) */}
+      {/* Left rail (storefront admin nav) */}
       <aside className="w-48 bg-[#1a1a1a] text-gray-200 flex-shrink-0 flex flex-col">
         <div className="px-4 py-3 border-b border-white/10">
           <div className="text-[10px] uppercase tracking-wider text-gray-400">Store</div>
@@ -182,4 +182,4 @@ function RevenueChart({ series }: { series: number[] }) {
   );
 }
 
-export default ShopifyShell;
+export default StorefrontShell;

--- a/concord-frontend/components/retail/TaxRatesPanel.tsx
+++ b/concord-frontend/components/retail/TaxRatesPanel.tsx
@@ -3,7 +3,7 @@
 /**
  * TaxRatesPanel — surfaces the retail lens's tax-rate table (the retail.tax-rates-*
  * macros existed backend-side but had no UI). Set a sales-tax rate per region,
- * list, delete. A Shopify-core feature. tax-rates-set returns the full updated list.
+ * list, delete. A core commerce feature. tax-rates-set returns the full updated list.
  */
 
 import { useCallback, useEffect, useState } from 'react';

--- a/concord-frontend/components/studio/StudioActionPanel.tsx
+++ b/concord-frontend/components/studio/StudioActionPanel.tsx
@@ -239,7 +239,6 @@ export function StudioActionPanel() {
       <header className="flex items-center gap-2 border-b border-purple-500/10 pb-2">
         <Music className="h-4 w-4 text-purple-400" />
         <h3 className="text-sm font-semibold text-white">Studio session</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">ableton live</span>
         {currentProjectId && <span className="ml-auto text-[10px] text-purple-300 font-mono">▶ {currentProjectId.slice(0, 8)}</span>}
       </header>
 

--- a/concord-frontend/components/travel/TravelActionPanel.tsx
+++ b/concord-frontend/components/travel/TravelActionPanel.tsx
@@ -162,7 +162,6 @@ export function TravelActionPanel() {
       <header className="flex items-center gap-2 border-b border-sky-500/10 pb-2">
         <Plane className="h-4 w-4 text-sky-400" />
         <h3 className="text-sm font-semibold text-white">Travel workbench</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">tripit · google travel</span>
       </header>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-2">

--- a/concord-frontend/components/wallet/WalletActionPanel.tsx
+++ b/concord-frontend/components/wallet/WalletActionPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * WalletActionPanel — Coinbase + Mint-shape wallet workbench.
+ * WalletActionPanel — a wallet workbench.
  * Surfaces portfolioBalance / transactionCategorize / budgetCheck /
  * spendingTrend + mint/DM/publish/agent.
  */
@@ -171,7 +171,6 @@ export function WalletActionPanel() {
       <header className="flex items-center gap-2 border-b border-emerald-500/10 pb-2">
         <Wallet className="h-4 w-4 text-emerald-400" />
         <h3 className="text-sm font-semibold text-white">Wallet workbench</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">coinbase · mint</span>
       </header>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-2">

--- a/concord-frontend/components/whiteboard/CollabBoardSection.tsx
+++ b/concord-frontend/components/whiteboard/CollabBoardSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * MiroSection — full Miro / FigJam 2026 workbench.
+ * CollabBoardSection — full collaborative whiteboard workbench.
  *
  * Boards rail (left) + interactive WhiteboardCanvas (center) +
  * AI sidebar (right, collapsible). Persists every shape change through
@@ -31,7 +31,7 @@ const TEMPLATE_KINDS = [
   { id: 'swot',         label: 'SWOT' },
 ] as const;
 
-export function MiroSection() {
+export function CollabBoardSection() {
   const [boards, setBoards] = useState<BoardMeta[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [activeShapes, setActiveShapes] = useState<Shape[]>([]);
@@ -65,7 +65,7 @@ export function MiroSection() {
       if (Array.isArray(els)) {
         setSyncShapes(els);
         setSyncSignal((s) => s + 1); // tells the canvas to replace its scene
-        setActiveShapes(els);        // keep MiroSection's copy in sync (no dirty → no save echo)
+        setActiveShapes(els);        // keep CollabBoardSection's copy in sync (no dirty → no save echo)
       }
     }
   }, [collab.remoteSceneUpdateCount, collab.remoteScene]);
@@ -94,7 +94,7 @@ export function MiroSection() {
       const list = (r.data?.result?.boards || []) as BoardMeta[];
       setBoards(list);
       if (!activeId && list.length > 0) openBoard(list[0].id);
-    } catch (e) { console.error('[Miro] boards', e); }
+    } catch (e) { console.error('[Board] boards', e); }
     finally { setLoading(false); }
   }
 
@@ -110,7 +110,7 @@ export function MiroSection() {
       setClusters(null);
       setSummary(null);
       await refreshComments(id);
-    } catch (e) { console.error('[Miro] load', e); }
+    } catch (e) { console.error('[Board] load', e); }
   }
 
   async function createBoard() {
@@ -121,7 +121,7 @@ export function MiroSection() {
       } });
       const id = r.data?.result?.board?.id;
       if (id) { await refreshBoards(); openBoard(id); }
-    } catch (e) { console.error('[Miro] create', e); }
+    } catch (e) { console.error('[Board] create', e); }
   }
 
   async function deleteBoard(id: string) {
@@ -130,7 +130,7 @@ export function MiroSection() {
       await lensRun({ domain: 'whiteboard', action: 'board-delete', input: { id } });
       if (activeId === id) { setActiveId(null); setActiveShapes([]); setActiveTitle(''); }
       await refreshBoards();
-    } catch (e) { console.error('[Miro] delete', e); }
+    } catch (e) { console.error('[Board] delete', e); }
   }
 
   async function duplicateBoard() {
@@ -140,7 +140,7 @@ export function MiroSection() {
       const r = await lensRun({ domain: 'whiteboard', action: 'board-duplicate', input: { id: activeId } });
       const newId = r.data?.result?.board?.id;
       if (newId) { await refreshBoards(); openBoard(newId); }
-    } catch (e) { console.error('[Miro] duplicate', e); }
+    } catch (e) { console.error('[Board] duplicate', e); }
   }
 
   async function save() {
@@ -153,7 +153,7 @@ export function MiroSection() {
         scene: { elements: activeShapes, appState: {} },
       } });
       setDirty(false);
-    } catch (e) { console.error('[Miro] save', e); }
+    } catch (e) { console.error('[Board] save', e); }
     finally { setSaving(false); }
   }
 
@@ -179,7 +179,7 @@ export function MiroSection() {
     try {
       const r = await lensRun({ domain: 'whiteboard', action: 'ai-cluster-stickies', input: { boardId: activeId } });
       setClusters((r.data?.result?.clusters || []) as Cluster[]);
-    } catch (e) { console.error('[Miro] cluster', e); }
+    } catch (e) { console.error('[Board] cluster', e); }
     finally { setClustering(false); }
   }
 
@@ -191,7 +191,7 @@ export function MiroSection() {
     try {
       const r = await lensRun({ domain: 'whiteboard', action: 'ai-summarize-board', input: { boardId: activeId } });
       setSummary(r.data?.result as SummaryResult);
-    } catch (e) { console.error('[Miro] summarize', e); }
+    } catch (e) { console.error('[Board] summarize', e); }
     finally { setSummarizing(false); }
   }
 
@@ -212,7 +212,7 @@ export function MiroSection() {
       setGenPrompt('');
       await refreshBoards();
       if (newId) openBoard(newId);
-    } catch (e) { console.error('[Miro] generate', e); }
+    } catch (e) { console.error('[Board] generate', e); }
     finally { setGenerating(false); }
   }
 
@@ -226,7 +226,7 @@ export function MiroSection() {
       a.href = URL.createObjectURL(blob);
       a.download = `${(activeTitle || 'board').replace(/\s+/g, '-')}.concord-whiteboard.json`;
       a.click();
-    } catch (e) { console.error('[Miro] export', e); }
+    } catch (e) { console.error('[Board] export', e); }
   }
 
   // ── Comments ──────────────────────────────────────────────────
@@ -235,7 +235,7 @@ export function MiroSection() {
     try {
       const r = await lensRun({ domain: 'whiteboard', action: 'comments-list', input: { boardId: id } });
       setComments((r.data?.result?.comments as Record<string, Comment[]>) || {});
-    } catch (e) { console.error('[Miro] comments', e); }
+    } catch (e) { console.error('[Board] comments', e); }
   }
 
   async function addComment(elementId: string, body: string) {
@@ -243,7 +243,7 @@ export function MiroSection() {
     try {
       await lensRun({ domain: 'whiteboard', action: 'comments-add', input: { boardId: activeId, elementId, body: body.trim() } });
       await refreshComments(activeId);
-    } catch (e) { console.error('[Miro] add comment', e); }
+    } catch (e) { console.error('[Board] add comment', e); }
   }
 
   async function resolveComment(id: string) {
@@ -251,7 +251,7 @@ export function MiroSection() {
     try {
       await lensRun({ domain: 'whiteboard', action: 'comments-resolve', input: { boardId: activeId, id } });
       await refreshComments(activeId);
-    } catch (e) { console.error('[Miro] resolve', e); }
+    } catch (e) { console.error('[Board] resolve', e); }
   }
 
   const totalOpenComments = useMemo(() => Object.values(comments).reduce((s, arr) => s + arr.filter(c => !c.resolved).length, 0), [comments]);
@@ -584,4 +584,4 @@ function CommentsTab({ activeId, shapes, comments, onAdd, onResolve }: { activeI
   );
 }
 
-export default MiroSection;
+export default CollabBoardSection;

--- a/concord-frontend/components/whiteboard/WhiteboardActionPanel.tsx
+++ b/concord-frontend/components/whiteboard/WhiteboardActionPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * WhiteboardActionPanel — Excalidraw + Miro-shape session workbench.
+ * WhiteboardActionPanel — session workbench.
  * Surfaces the board / vote / template / share macros plus mint/DM/
  * publish/agent. Designed to sit below the existing whiteboard canvas
  * as a session controls strip.
@@ -256,7 +256,6 @@ export function WhiteboardActionPanel() {
       <header className="flex items-center gap-2 border-b border-violet-500/10 pb-2">
         <Palette className="h-4 w-4 text-violet-400" />
         <h3 className="text-sm font-semibold text-white">Whiteboard session</h3>
-        <span className="rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-zinc-400">excalidraw · miro</span>
         {templates.length > 0 && <span className="ml-auto text-[10px] text-zinc-400">{templates.length} templates · {boards.length} boards</span>}
       </header>
 

--- a/concord-frontend/components/whiteboard/WhiteboardCanvas.tsx
+++ b/concord-frontend/components/whiteboard/WhiteboardCanvas.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * WhiteboardCanvas — tldraw / Miro / Excalidraw shape: infinite-feeling
+ * WhiteboardCanvas — an infinite-feeling
  * canvas + floating tool palette + zoom controls + zoomable presence
  * grid background.
  *

--- a/concord-frontend/components/whiteboard/WhiteboardCollabPanel.tsx
+++ b/concord-frontend/components/whiteboard/WhiteboardCollabPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * WhiteboardCollabPanel — surfaces the 2026 Miro/FigJam parity backlog:
+ * WhiteboardCollabPanel — surfaces the collaboration backlog:
  * frames + presentation mode, connectors with auto-routing, embeds,
  * raster (PNG/SVG/PDF) export planning, and reactions / live cursors.
  *

--- a/concord-frontend/lib/daw/types.ts
+++ b/concord-frontend/lib/daw/types.ts
@@ -502,7 +502,7 @@ export interface TempoAutomation {
 // ============================================================================
 
 export type StudioViewType =
-  | 'session'      // Default Ableton-style clip-grid hero (browser left + inspector right + mixer peek)
+  | 'session'      // Default clip-grid hero (browser left + inspector right + mixer peek)
   | 'arrange'
   | 'mixer'
   | 'pianoRoll'

--- a/concord-frontend/lib/lenses/manifest.ts
+++ b/concord-frontend/lib/lenses/manifest.ts
@@ -217,7 +217,7 @@ export const LENS_MANIFESTS: LensManifest[] = [
     },
     firstRunGuide: {
       steps: [
-        { caption: 'Drop code into the editor — the VS Code-shape silhouette gives you file tree, tabs, and a status bar so it reads as your IDE.' },
+        { caption: 'Drop code into the editor — a full workbench shell with file tree, tabs, and a status bar.' },
         { caption: 'Use the action bar to lint, format, or run a review pass. Results stream back as DTUs you can cite from chat.' },
         { caption: 'Repos you connect via GitHub appear in the side panel — code-substrate-refresh keeps them current every 5 ticks.' },
       ],
@@ -723,7 +723,7 @@ export const LENS_MANIFESTS: LensManifest[] = [
     },
     firstRunGuide: {
       steps: [
-        { caption: 'The Bandcamp-shape grid puts creator art up front. Click any tile for provenance + price + license terms.' },
+        { caption: 'The creator grid puts artwork up front. Click any tile for provenance + price + license terms.' },
         { caption: 'Buying mints a license + cascades royalties up the lineage chain (95% to creators, 30% cap to ancestors, seller keeps ≥64.54%).' },
         { caption: 'Selling: hit the "Mint" action on any DTU you own and set a tier price. Citations from your DTU pay you forever.' },
       ],
@@ -931,7 +931,7 @@ export const LENS_MANIFESTS: LensManifest[] = [
     dataTier: 'REAL_LIVE',
     emptyState: {
       headline: 'Blank canvas.',
-      caption: 'Drag shapes, connect them, comment. The tldraw-shape silhouette opens by default. extract_decisions distills any board into a DTU.',
+      caption: 'Drag shapes, connect them, comment. The canvas opens by default. extract_decisions distills any board into a DTU.',
       firstActionLabel: 'Drop a shape',
     },
     firstRunGuide: {
@@ -1491,7 +1491,7 @@ export const LENS_MANIFESTS: LensManifest[] = [
     },
     firstRunGuide: {
       steps: [
-        { caption: 'Notion-shape doc surface — the DocsShell silhouette opens by default. Bespoke legal workflow lives below.' },
+        { caption: 'A document surface — the DocsShell opens by default. Bespoke legal workflow lives below.' },
         { caption: 'deadlineCheck + conflictCheck + complianceScore run scheduled passes against your active matters.' },
         { caption: 'Honest tier: this lens is DEMO until we wire a paid case-law feed. The structure works; the data is yours to author.' },
       ],
@@ -2611,12 +2611,12 @@ export const LENS_MANIFESTS: LensManifest[] = [
     realtimeEvents: ['crypto:ticker'],
     emptyState: {
       headline: 'No tracked tokens.',
-      caption: 'Add a token to track price + balance via CoinGecko. The Coinbase-shape wallet silhouette opens by default so you read the lens immediately.',
+      caption: 'Add a token to track price + balance via CoinGecko. The wallet view opens by default so you read the lens immediately.',
       firstActionLabel: 'Track a token',
     },
     firstRunGuide: {
       steps: [
-        { caption: 'The wallet silhouette at the top is the rival shape — Coinbase / Phantom feel without leaving the substrate.' },
+        { caption: 'The wallet view at the top gives you balances and transfers without leaving the substrate.' },
         { caption: 'Live prices via CoinGecko (no key). Tokens you track are persisted server-side; the list survives reload.' },
         { caption: 'Send / receive / swap actions remain stubs unless you wire an actual chain integration — the panel is honest about its DEMO status for those flows.' },
       ],
@@ -2743,7 +2743,7 @@ export const LENS_MANIFESTS: LensManifest[] = [
     dataTier: 'REAL_LIVE',
     emptyState: {
       headline: 'No docs yet.',
-      caption: 'Author a document — Notion-shape sidebar tree + page editor. Every save is a DTU; versions are immutable.',
+      caption: 'Author a document — sidebar tree + page editor. Every save is a DTU; versions are immutable.',
       firstActionLabel: 'Create a doc',
     },
     firstRunGuide: {
@@ -4612,7 +4612,7 @@ export const LENS_MANIFESTS: LensManifest[] = [
     },
     firstRunGuide: {
       steps: [
-        { caption: 'Threads list in the left rail; the right pane shows the active conversation in the Gmail-shape silhouette.' },
+        { caption: 'Threads list in the left rail; the right pane shows the active conversation in the inbox view.' },
         { caption: 'Mark as read, archive, or search — all mutations write to the substrate; offline edits queue and replay.' },
         { caption: 'Channels routed through Concord-Mesh fall back to BLE / WiFi-Direct when offline.' },
       ],

--- a/concord-frontend/lib/music/types.ts
+++ b/concord-frontend/lib/music/types.ts
@@ -397,7 +397,7 @@ export type MusicLensView =
   | 'queue'
   | 'revenue'
   | 'marketplace'
-  | 'session';   // Ableton-shape session view: clip-launching grid
+  | 'session';   // Session view: clip-launching grid
 
 // ---------- Marketplace types ----------
 

--- a/concord-frontend/tests/components/CreatorGrid.test.tsx
+++ b/concord-frontend/tests/components/CreatorGrid.test.tsx
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-import { BandcampGrid, type BandcampItem } from '@/components/marketplace/BandcampGrid';
+import { CreatorGrid, type CreatorGridItem } from '@/components/marketplace/CreatorGrid';
 
-const items: BandcampItem[] = [
+const items: CreatorGridItem[] = [
   {
     id: 'i1', title: 'Stance Against the Cold', creator: 'Aria',
     minPriceCc: 5, suggestedPriceCc: 12, royaltyRate: 0.21,
@@ -15,9 +15,9 @@ const items: BandcampItem[] = [
   },
 ];
 
-describe('BandcampGrid', () => {
+describe('CreatorGrid', () => {
   it('renders each item title + creator', () => {
-    render(<BandcampGrid items={items} />);
+    render(<CreatorGrid items={items} />);
     expect(screen.getByText('Stance Against the Cold')).toBeInTheDocument();
     expect(screen.getByText('Aria')).toBeInTheDocument();
     expect(screen.getByText('Twilight Commune')).toBeInTheDocument();
@@ -26,7 +26,7 @@ describe('BandcampGrid', () => {
 
   it('calls onOpen when an item tile is clicked', () => {
     const onOpen = vi.fn();
-    render(<BandcampGrid items={items} onOpen={onOpen} />);
+    render(<CreatorGrid items={items} onOpen={onOpen} />);
     const titleEl = screen.getByText('Stance Against the Cold');
     const opener = titleEl.closest('button') ?? titleEl.closest('article')?.querySelector('button[aria-label^="Open"]');
     if (opener) fireEvent.click(opener);

--- a/concord-frontend/tests/components/ShellComponents.test.tsx
+++ b/concord-frontend/tests/components/ShellComponents.test.tsx
@@ -18,13 +18,13 @@ vi.mock('lucide-react', async (importOriginal) => {
   return { ...actual, ...o };
 });
 
-import { VSCodeShell, type FileTreeNode, type OpenTab } from '@/components/code/VSCodeShell';
+import { CodeEditorShell, type FileTreeNode, type OpenTab } from '@/components/code/CodeEditorShell';
 import { WalletShell, type WalletAsset, type WalletTx } from '@/components/crypto/WalletShell';
 import { DocsShell, type DocNode } from '@/components/legal/DocsShell';
 import { WhiteboardCanvas } from '@/components/whiteboard/WhiteboardCanvas';
 import { EHRShell, type EHRPatient, type VitalSet } from '@/components/healthcare/EHRShell';
 
-describe('VSCodeShell', () => {
+describe('CodeEditorShell', () => {
   const files: FileTreeNode[] = [
     { id: 'a', name: 'app.tsx', kind: 'file' },
     { id: 'b', name: 'lib', kind: 'folder', children: [
@@ -38,9 +38,9 @@ describe('VSCodeShell', () => {
 
   it('renders open tabs and editor children', () => {
     render(
-      <VSCodeShell files={files} openTabs={openTabs} activeTabId="a">
+      <CodeEditorShell files={files} openTabs={openTabs} activeTabId="a">
         <div data-testid="editor">code goes here</div>
-      </VSCodeShell>
+      </CodeEditorShell>
     );
     expect(screen.getAllByText('app.tsx').length).toBeGreaterThan(0);
     expect(screen.getAllByText('util.ts').length).toBeGreaterThan(0);
@@ -50,9 +50,9 @@ describe('VSCodeShell', () => {
   it('calls onSelectTab when a tab strip entry is clicked', () => {
     const onSelectTab = vi.fn();
     render(
-      <VSCodeShell files={files} openTabs={openTabs} activeTabId="a" onSelectTab={onSelectTab}>
+      <CodeEditorShell files={files} openTabs={openTabs} activeTabId="a" onSelectTab={onSelectTab}>
         <div />
-      </VSCodeShell>
+      </CodeEditorShell>
     );
     // Tab strip entry is a clickable div (not a button) — find it via the close-button aria.
     const closeBtn = screen.getByLabelText('Close util.ts');


### PR DESCRIPTION
The lenses positioned themselves as "the [famous app] of X" — in user-visible captions/badges/titles, in code comments, and in component identifiers. Concord stands on its own; it shouldn't name a rival to describe itself.

## User-visible scrub
- **8 firstRunGuide captions** ("VS Code-shape silhouette", "Bandcamp-shape grid", "Notion-shape", "Coinbase/Phantom feel", "Gmail-shape", "tldraw-shape") → plain product language.
- **~20 action-panel "shape badge" chips** naming rivals (`robinhood · ynab`, `wolfram · desmos`, `excalidraw · miro`, `bandcamp · gumroad`, `todoist · things`, `hevy · strong`…) **removed**. The **~150 legitimate data-source badges** (arxiv, coingecko, github, NASA APOD, usgs, open-meteo…) are **kept** — those name real integrations, not rivals.
- visible titles/labels ("QuickBooks/Xero/FreshBooks parity", "via Phantom 2026", "Workday + BambooHR shape") neutralized.

## Comments
~30 lens-page + component header comments ("Category leader: Palantir", "shadowing Apple Health", "Robinhood + YNAB-shape workbench", "Ableton-style"…) rewritten to describe what the thing *is*.

## Identifiers renamed (rival brand → role)
`VSCodeShell→CodeEditorShell`, `BandcampGrid→CreatorGrid`, `ShopifyShell→StorefrontShell`, `EtsyShell→ShopfrontShell`, `CoinbaseShell/Section→ExchangeShell/Section`, `QBShell/Section→BooksShell/Section`, `MiroSection→CollabBoardSection`, `HrWorkdaySection→HrHrisSection`, `RivalShapePreview→ShellPreview` (+ its 16 lens mounts) + the `RivalShells` test.

## Kept (genuine integrations / libraries / data sources)
Naming the service you *connect to* is factual, not derivative: Gmail/Google Calendar connectors, Stripe, Strava, CourtListener, CoinGecko + every data-source API badge, the shipped **VS Code extension** (dx-platform), and the `@excalidraw/excalidraw` library.

## Verified
`tsc` 0 · `eslint` 0 (changed files) · prod build **"Compiled successfully"** (Prophet 0 warnings) · renamed component tests 9/9. **88 files.**

https://claude.ai/code/session_01RxwGhrNMhrCC9d2sWxmx5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxwGhrNMhrCC9d2sWxmx5W)_