### PR TITLE
feat(world): iconic per-type building silhouettes + wire seed buildings into 3D (#lens-as-station)

### DIFF
--- a/concord-frontend/app/lenses/world/page.tsx
+++ b/concord-frontend/app/lenses/world/page.tsx
@@ -41,13 +41,7 @@ import { DEMO_DISTRICT } from '@/lib/world-lens/district-seed';
 import { themeForWorldId, CONCORDIA_THEMES, sunDiskForWorld, buildingStyleForWorld } from '@/lib/world-lens/concordia-theme';
 import { coerceMaterial } from '@/lib/world-lens/building-silhouette';
 import { deriveTerrainZones } from '@/lib/world-lens/terrain-zones';
-
-// World→scene coordinate offset. The server seeds buildings in a [0, 2000] frame
-// (city centre ~800,1000); the frontend terrain/player/NPCs are centred at the
-// origin ([-1000, +1000]). Shifting server coords by TERRAIN_SIZE/2 = 1000 lands
-// the seed city on the plateau among the NPCs, where the server + frontend
-// elevation formulas agree so buildings sit on the ground rather than off-edge.
-const WORLD_TO_SCENE_OFFSET = 1000; // = TERRAIN_SIZE / 2
+import { worldToScene, sceneToWorldAxis } from '@/lib/world-lens/coord-frame';
 import { BARE_HANDS as controlSchemeForLegend } from '@/lib/concordia/combat/control-schemes';
 import { useHUDContext } from '@/components/world/concordia-hud/HUDContextProvider';
 import FactionOverlay from '@/components/world/FactionOverlay';
@@ -2545,7 +2539,11 @@ export default function WorldLensPage() {
     fetch(`/api/worlds/${activeDistrict.id}/buildings`)
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => {
-        if (d?.buildings) setWorldBuildings(d.buildings);
+        // Boundary transform: server [0,2000] world frame → origin-centred scene
+        // frame, ONCE on the way in, so every downstream consumer (3D render,
+        // terrain zones, the 2D enter-pills, the minimap, the station prompt)
+        // works in one frame and lines up with the player/NPCs/terrain.
+        if (d?.buildings) setWorldBuildings(d.buildings.map(worldToScene));
       })
       .catch(() => {});
   }, [activeDistrict.id]);
@@ -2570,8 +2568,10 @@ export default function WorldLensPage() {
   // Poll for nearby nodes every 5s based on player position
   useEffect(() => {
     const poll = () => {
+      // Player position is in the scene frame; the server stores nodes in the
+      // world frame — convert back on the way out so the proximity query matches.
       const { x, z } = playerPos.current;
-      fetch(`/api/worlds/${activeDistrict.id}/nodes?x=${x}&z=${z}&radius=15`)
+      fetch(`/api/worlds/${activeDistrict.id}/nodes?x=${sceneToWorldAxis(x)}&z=${sceneToWorldAxis(z)}&radius=15`)
         .then((r) => (r.ok ? r.json() : null))
         .then((d) => {
           if (d?.nodes) setNearbyNodes(d.nodes);
@@ -4342,15 +4342,11 @@ export default function WorldLensPage() {
               {concordiaRenderStyle === 'pbr' ? 'PBR' : 'Toon'}
             </button>
           </div>
-          {/* 3D scene rendering layers.
-              WORLD_TO_SCENE: the server seeds the city at world ([0, 2000], centre
-              ~800,1000) while the frontend terrain + player + NPCs are centred at
-              the origin ([-1000, +1000]). Shift server building coords by
-              TERRAIN_SIZE/2 so the city lands on the plateau among the NPCs — at
-              this offset the server elevation (nx=x/2000) and the frontend terrain
-              elevation (nx=(x+1000)/2000) agree, so buildings sit ON the ground. */}
+          {/* 3D scene rendering layers. worldBuildings is already in the
+              origin-centred scene frame (transformed at the fetch boundary via
+              worldToScene), so it's consumed raw here. */}
           <TerrainRenderer
-            districts={deriveTerrainZones(worldBuildings, WORLD_TO_SCENE_OFFSET)}
+            districts={deriveTerrainZones(worldBuildings)}
             lodCenter={{ x: 0, z: 0 }}
             quality="medium"
           />
@@ -4358,7 +4354,7 @@ export default function WorldLensPage() {
             buildings={worldBuildings.map((b) => ({
               id: b.id,
               name: b.name || b.building_type,
-              position: { x: b.x - WORLD_TO_SCENE_OFFSET, y: b.y ?? 0, z: b.z - WORLD_TO_SCENE_OFFSET },
+              position: { x: b.x, y: b.y ?? 0, z: b.z },
               dimensions: { width: b.width || 10, height: b.height || 8, depth: b.depth || 8 },
               floors: 1,
               material: coerceMaterial(b.material),

--- a/concord-frontend/app/lenses/world/page.tsx
+++ b/concord-frontend/app/lenses/world/page.tsx
@@ -40,6 +40,7 @@ import dynamic from 'next/dynamic';
 import { DEMO_DISTRICT } from '@/lib/world-lens/district-seed';
 import { themeForWorldId, CONCORDIA_THEMES, sunDiskForWorld, buildingStyleForWorld } from '@/lib/world-lens/concordia-theme';
 import { coerceMaterial } from '@/lib/world-lens/building-silhouette';
+import { deriveTerrainZones } from '@/lib/world-lens/terrain-zones';
 import { BARE_HANDS as controlSchemeForLegend } from '@/lib/concordia/combat/control-schemes';
 import { useHUDContext } from '@/components/world/concordia-hud/HUDContextProvider';
 import FactionOverlay from '@/components/world/FactionOverlay';
@@ -4335,7 +4336,11 @@ export default function WorldLensPage() {
             </button>
           </div>
           {/* 3D scene rendering layers */}
-          <TerrainRenderer districts={[]} lodCenter={{ x: 0, z: 0 }} quality="medium" />
+          <TerrainRenderer
+            districts={deriveTerrainZones(worldBuildings)}
+            lodCenter={{ x: 0, z: 0 }}
+            quality="medium"
+          />
           <BuildingRenderer3D
             buildings={worldBuildings.map((b) => ({
               id: b.id,

--- a/concord-frontend/app/lenses/world/page.tsx
+++ b/concord-frontend/app/lenses/world/page.tsx
@@ -39,6 +39,7 @@ import OnboardingTutorial from '@/components/world-lens/OnboardingTutorial';
 import dynamic from 'next/dynamic';
 import { DEMO_DISTRICT } from '@/lib/world-lens/district-seed';
 import { themeForWorldId, CONCORDIA_THEMES, sunDiskForWorld, buildingStyleForWorld } from '@/lib/world-lens/concordia-theme';
+import { coerceMaterial } from '@/lib/world-lens/building-silhouette';
 import { BARE_HANDS as controlSchemeForLegend } from '@/lib/concordia/combat/control-schemes';
 import { useHUDContext } from '@/components/world/concordia-hud/HUDContextProvider';
 import FactionOverlay from '@/components/world/FactionOverlay';
@@ -4335,7 +4336,29 @@ export default function WorldLensPage() {
           </div>
           {/* 3D scene rendering layers */}
           <TerrainRenderer districts={[]} lodCenter={{ x: 0, z: 0 }} quality="medium" />
-          <BuildingRenderer3D buildings={[]} viewMode="normal" buildingStyle={buildingStyleForWorld(worldIdForTheme)} />
+          <BuildingRenderer3D
+            buildings={worldBuildings.map((b) => ({
+              id: b.id,
+              name: b.name || b.building_type,
+              position: { x: b.x, y: b.y ?? 0, z: b.z },
+              dimensions: { width: b.width || 10, height: b.height || 8, depth: b.depth || 8 },
+              floors: 1,
+              material: coerceMaterial(b.material),
+              style: 'colonial' as const,
+              // building_type drives the procedural archetype + iconic silhouette.
+              building_type: b.building_type,
+              structure: {
+                columns: { count: 0, spacing: 0, radius: 0 },
+                beams: { count: 0, height: 0 },
+                roofType: 'gable' as const,
+                hasBasement: false,
+                windowRows: 1,
+                windowsPerRow: 2,
+              },
+            }))}
+            viewMode="normal"
+            buildingStyle={buildingStyleForWorld(worldIdForTheme)}
+          />
           {/* Phase A3 — L-system trees + procedural rocks per biome.
               Mounts when worldId resolves (worldIdForTheme). */}
           <TreeLayer worldId={worldIdForTheme} biome="temperate_forest" quality="medium" />

--- a/concord-frontend/app/lenses/world/page.tsx
+++ b/concord-frontend/app/lenses/world/page.tsx
@@ -41,6 +41,13 @@ import { DEMO_DISTRICT } from '@/lib/world-lens/district-seed';
 import { themeForWorldId, CONCORDIA_THEMES, sunDiskForWorld, buildingStyleForWorld } from '@/lib/world-lens/concordia-theme';
 import { coerceMaterial } from '@/lib/world-lens/building-silhouette';
 import { deriveTerrainZones } from '@/lib/world-lens/terrain-zones';
+
+// World→scene coordinate offset. The server seeds buildings in a [0, 2000] frame
+// (city centre ~800,1000); the frontend terrain/player/NPCs are centred at the
+// origin ([-1000, +1000]). Shifting server coords by TERRAIN_SIZE/2 = 1000 lands
+// the seed city on the plateau among the NPCs, where the server + frontend
+// elevation formulas agree so buildings sit on the ground rather than off-edge.
+const WORLD_TO_SCENE_OFFSET = 1000; // = TERRAIN_SIZE / 2
 import { BARE_HANDS as controlSchemeForLegend } from '@/lib/concordia/combat/control-schemes';
 import { useHUDContext } from '@/components/world/concordia-hud/HUDContextProvider';
 import FactionOverlay from '@/components/world/FactionOverlay';
@@ -4335,9 +4342,15 @@ export default function WorldLensPage() {
               {concordiaRenderStyle === 'pbr' ? 'PBR' : 'Toon'}
             </button>
           </div>
-          {/* 3D scene rendering layers */}
+          {/* 3D scene rendering layers.
+              WORLD_TO_SCENE: the server seeds the city at world ([0, 2000], centre
+              ~800,1000) while the frontend terrain + player + NPCs are centred at
+              the origin ([-1000, +1000]). Shift server building coords by
+              TERRAIN_SIZE/2 so the city lands on the plateau among the NPCs — at
+              this offset the server elevation (nx=x/2000) and the frontend terrain
+              elevation (nx=(x+1000)/2000) agree, so buildings sit ON the ground. */}
           <TerrainRenderer
-            districts={deriveTerrainZones(worldBuildings)}
+            districts={deriveTerrainZones(worldBuildings, WORLD_TO_SCENE_OFFSET)}
             lodCenter={{ x: 0, z: 0 }}
             quality="medium"
           />
@@ -4345,7 +4358,7 @@ export default function WorldLensPage() {
             buildings={worldBuildings.map((b) => ({
               id: b.id,
               name: b.name || b.building_type,
-              position: { x: b.x, y: b.y ?? 0, z: b.z },
+              position: { x: b.x - WORLD_TO_SCENE_OFFSET, y: b.y ?? 0, z: b.z - WORLD_TO_SCENE_OFFSET },
               dimensions: { width: b.width || 10, height: b.height || 8, depth: b.depth || 8 },
               floors: 1,
               material: coerceMaterial(b.material),

--- a/concord-frontend/app/lenses/world/page.tsx
+++ b/concord-frontend/app/lenses/world/page.tsx
@@ -2681,6 +2681,55 @@ export default function WorldLensPage() {
     return () => clearInterval(interval);
   }, [activeDistrict.id]);
 
+  // Quest waypoint markers (3D). Poll the player's active quests and turn the
+  // ones with a placeable target into QuestMarker3D objectives. This closes a
+  // dead wire: ConcordiaScene mounts QuestMarker3D but was never fed
+  // `questObjectives`, so the `length > 0` guard meant 3D waypoints never
+  // rendered even though active quests existed in the HUD. We resolve a
+  // talk_to / deliver objective's `target` (an npc_id) to that NPC's live
+  // position from rawWorldNPCs and place a marker on them — same scene + same
+  // raw frame the NPC avatar renders in, so the marker sits on the NPC by
+  // construction. Objectives with no fixed coordinate (kill / gather /
+  // reach_location) get no marker (no invented positions).
+  useEffect(() => {
+    if (rawWorldNPCs.length === 0) { setQuestObjectives([]); return; }
+    let cancelled = false;
+    const npcById = new Map(rawWorldNPCs.map((n) => [n.id, n]));
+    const MARKER_TYPE: Record<string, 'talk' | 'delivery'> = {
+      talk_to: 'talk', deliver: 'delivery',
+    };
+    const loadQuestMarkers = async () => {
+      try {
+        const r = await fetch(`/api/worlds/${encodeURIComponent(activeDistrict.id)}/quests/active`, { credentials: 'include' });
+        if (!r.ok) return;
+        const j = await r.json();
+        if (cancelled || !Array.isArray(j?.quests)) return;
+        const markers: import('@/components/world-lens/QuestMarker3D').QuestObjective[] = [];
+        for (const q of j.quests) {
+          const objs = Array.isArray(q?.progress) ? q.progress : [];
+          for (const o of objs) {
+            if (o?.obj_completed_at) continue;            // already done
+            const markerType = MARKER_TYPE[o?.type];
+            if (!markerType) continue;                    // only placeable kinds
+            const npc = npcById.get(o?.target);
+            if (!npc) continue;                            // target not in-world right now
+            markers.push({
+              id: `quest:${q.id}:${o.id}`,
+              label: o.description || q.title || 'Objective',
+              position: { x: npc.position.x, y: npc.position.y, z: npc.position.z ?? 0 },
+              type: markerType,
+              done: false,
+            });
+          }
+        }
+        if (!cancelled) setQuestObjectives(markers);
+      } catch { /* offline — leave markers as-is */ }
+    };
+    loadQuestMarkers();
+    const iv = setInterval(loadQuestMarkers, 15_000);
+    return () => { cancelled = true; clearInterval(iv); };
+  }, [activeDistrict.id, rawWorldNPCs]);
+
   // Proximity check: update nearPortalId and nearbyNPC whenever the player moves
   useEffect(() => {
     const near = portals.find(
@@ -3559,9 +3608,16 @@ export default function WorldLensPage() {
     // F3 — mirror screen-reader-relevant socket events to window events so the
     // ScreenReaderAnnouncer (and any a11y consumer) can voice them. Naming:
     // 'world:crisis' → 'concordia:world-crisis'.
+    // NOTE: the real server event is `faction:war-declared` (faction-strategy.js
+    // emitFn). The prior `faction-war:declared` here was a phantom name that is
+    // never emitted, so the `concordia:faction-war-declared` window event never
+    // fired and StrategicWarBanner's real-time refresh (+ the screen-reader
+    // announce) silently fell back to its 30s poll. Subscribing to the correct
+    // name still produces winName `concordia:faction-war-declared` (": "→"-"),
+    // so the banner listener is unchanged.
     const SR_BRIDGE_EVENTS = [
       'world:event:scheduled', 'world:plague-declared', 'world:crisis', 'world:crisis-resolved',
-      'faction-war:declared', 'combat:telegraph', 'combat:impact', 'player:low-health',
+      'faction:war-declared', 'combat:telegraph', 'combat:impact', 'player:low-health',
     ];
     const srBridges: Array<[string, (...a: unknown[]) => void]> = SR_BRIDGE_EVENTS.map((kind) => {
       const winName = `concordia:${kind.replace(/:/g, '-')}`;
@@ -3675,6 +3731,14 @@ export default function WorldLensPage() {
     quest: import('@/lib/concordia/quest-system').Quest;
     type: 'new' | 'completed' | 'failed';
   } | null>(null);
+  // 3D quest waypoint markers fed to ConcordiaScene → QuestMarker3D. Only
+  // objectives we can place at a REAL coordinate get a marker (talk_to /
+  // deliver, whose target is an npc_id resolvable to that NPC's live
+  // position). kill / gather / reach_location have no fixed coordinate, so
+  // they're surfaced in the QuestTracker HUD only — no fabricated positions.
+  const [questObjectives, setQuestObjectives] = useState<
+    import('@/components/world-lens/QuestMarker3D').QuestObjective[]
+  >([]);
   const [showDesignHUD, setShowDesignHUD] = useState(false);
   const [upgradePrompt, setUpgradePrompt] = useState<{
     characterLevel: number;
@@ -3879,6 +3943,56 @@ export default function WorldLensPage() {
     };
     window.addEventListener('concordia:combo-trigger', handler);
     return () => window.removeEventListener('concordia:combo-trigger', handler);
+  }, [worldSocket, playerAvatar.id]);
+
+  // SkillWheelMount + CombatFlowHotbar dispatch concordia:spell-cast when the
+  // player flicks the radial skill wheel or presses a spell hotbar slot. The
+  // only listener used to be a no-op stub in event-router.ts, so casting did
+  // nothing — a dead wire. Wire it like combo-trigger: play the committed cast
+  // animation + tier VFX, and when a combat target is engaged emit a
+  // combat:attack carrying the spell's element / skillId / weapon / tier. The
+  // server reads those fields off combat:attack (server.js ~8864-8874) and
+  // propagates them to combat:hit / combat:impact, so the element burst and
+  // per-skill mastery VFX fire on the target instead of defaulting to
+  // 'physical' / fist. No target → the cast still animates + flashes locally.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail as {
+        spellId?: string;
+        spellName?: string;
+        element?: string | null;
+        tier?: number;
+        costs?: unknown;
+      } | undefined;
+      if (!detail?.spellId) return;
+      const element = String(detail.element || '').toLowerCase() || 'energy';
+      const tier = Math.max(1, Math.min(5, Number(detail.tier) || 2));
+      // Committed cast pose (rides the tiered biomechanics clip path).
+      window.dispatchEvent(new CustomEvent('concordia:combat-anim', {
+        detail: { entityId: playerAvatar.id, animation: 'attack-heavy', tier },
+      }));
+      // Tier-scaled cast VFX (particles + flash), keyed by the spell name.
+      import('@/lib/combat/combo-vfx').then((m) => {
+        m.dispatchComboVfx({ tier, comboName: detail.spellName });
+      }).catch(() => { /* fallback: no special VFX */ });
+      // Land the spell on the engaged target, if any.
+      const target = combatStateRef.current.target;
+      if (target && worldSocket.isConnected) {
+        worldSocket.emit('combat:attack', {
+          targetId: target.id,
+          baseDamage: (combatStateRef.current.weapon?.damage ?? 12) * (1 + tier * 0.08),
+          range: 12, // ranged magic reaches further than a fist
+          armorPierce: tier - 1,
+          element,
+          skillId: detail.spellId,
+          weapon: 'magic',
+          tier,
+          style: 'spell',
+        });
+      }
+    };
+    window.addEventListener('concordia:spell-cast', handler);
+    return () => window.removeEventListener('concordia:spell-cast', handler);
   }, [worldSocket, playerAvatar.id]);
 
   // PlayerActionMenu (and any other source) dispatches concordia:emote with
@@ -4281,6 +4395,7 @@ export default function WorldLensPage() {
             theme={concordiaTheme}
             renderStyle={concordiaRenderStyle}
             cameraMode={cameraMode}
+            questObjectives={questObjectives}
             getPlayerPose={() => ({
               x: playerAvatar.position.x,
               y: playerAvatar.position.y,

--- a/concord-frontend/components/world-lens/AvatarSystem3D.tsx
+++ b/concord-frontend/components/world-lens/AvatarSystem3D.tsx
@@ -50,7 +50,7 @@ import { FacialController, resolveNPCEmotion } from '@/lib/concordia/facial-blen
 import { installMoodListener, emotionFor, biasFor } from '@/lib/concordia/mood-registry';
 import { getClientConfigSync } from '@/hooks/useClientConfig';
 import { physicsWorld } from '@/lib/world-lens/physics-world';
-import { sampleGroundY } from '@/lib/world-lens/coord-frame';
+import { sampleGroundY, outOfBounds } from '@/lib/world-lens/coord-frame';
 import { accelToward } from '@/lib/world-lens/jump-forgiveness';
 import { applyCelShade } from '@/lib/world-lens/cel-shade';
 import { ART_STYLE } from '@/lib/world-lens/concordia-theme';
@@ -342,6 +342,9 @@ export default function AvatarSystem3D({
   // B2 — smoothed planar input (accel/decel curve), so direction changes ease.
   const planarMoveRef = useRef<{ x: number; z: number }>({ x: 0, z: 0 });
   const playerPositionRef = useRef({ ...playerAvatar.position });
+  // Last known-good standing position — the snapback target when the player
+  // goes out of bounds / falls through / hits a NaN (G1/G2). Seeded to spawn.
+  const lastGroundedPosRef = useRef({ ...playerAvatar.position });
   const playerRotationRef = useRef(playerAvatar.rotation);
   // B1b — double-tap dash memory (traversal dodge).
   const dashTapRef = useRef<{ key: string; t: number }>({ key: '', t: 0 });
@@ -2348,6 +2351,28 @@ export default function AvatarSystem3D({
             if (below !== isSwimming) physicsWorld.setSwim?.('player', below);
           }
         } catch { /* swim toggle is best-effort */ }
+
+        // ── Invisible safety net: out-of-bounds / fall / NaN recovery (G1/G2) ──
+        // The player is normally planted by the terrain heightfield, but a
+        // physics glitch, walking off the ±WORLD_BOUND edge while airborne, or a
+        // NaN reaching the vertical integration can drop them into the void with
+        // no floor. Snap back to the last grounded position (NOT respawnPlayer —
+        // a fall must not heal; that's death's job) and zero the fall speed.
+        // Runs once per frame; the ≤1-frame latency is imperceptible and the
+        // reconciliation buffer absorbs the corrected position on the next move.
+        {
+          const p = playerPositionRef.current;
+          if (outOfBounds(p)) {
+            const safe = lastGroundedPosRef.current;
+            p.x = safe.x; p.y = safe.y; p.z = safe.z;
+            physicsWorld.resetVerticalVelocity?.('player');
+            const pmRecover = playerMeshRef.current as { position?: { set: (x: number, y: number, z: number) => void } } | null;
+            pmRecover?.position?.set(p.x, p.y, p.z);
+          } else if (!isAirborne && !isSwimming) {
+            // Record the last KNOWN-good standing spot (in-bounds + grounded).
+            lastGroundedPosRef.current = { x: p.x, y: p.y, z: p.z };
+          }
+        }
 
         if (isMoving) {
           const len = Math.sqrt(moveX * moveX + moveZ * moveZ);

--- a/concord-frontend/components/world-lens/AvatarSystem3D.tsx
+++ b/concord-frontend/components/world-lens/AvatarSystem3D.tsx
@@ -50,6 +50,7 @@ import { FacialController, resolveNPCEmotion } from '@/lib/concordia/facial-blen
 import { installMoodListener, emotionFor, biasFor } from '@/lib/concordia/mood-registry';
 import { getClientConfigSync } from '@/hooks/useClientConfig';
 import { physicsWorld } from '@/lib/world-lens/physics-world';
+import { sampleGroundY } from '@/lib/world-lens/coord-frame';
 import { accelToward } from '@/lib/world-lens/jump-forgiveness';
 import { applyCelShade } from '@/lib/world-lens/cel-shade';
 import { ART_STYLE } from '@/lib/world-lens/concordia-theme';
@@ -1972,7 +1973,7 @@ export default function AvatarSystem3D({
         });
         if (disposed) return;
 
-        mesh.position.set(other.position.x, other.position.y, other.position.z);
+        mesh.position.set(other.position.x, sampleGroundY(other.position.x, other.position.z) ?? other.position.y, other.position.z);
         mesh.rotation.y = other.rotation;
         mesh.userData = { avatarId: other.id, isOtherPlayer: true, name: other.name };
 
@@ -2015,7 +2016,7 @@ export default function AvatarSystem3D({
         });
         if (disposed) return;
 
-        mesh.position.set(npc.position.x, npc.position.y, npc.position.z);
+        mesh.position.set(npc.position.x, sampleGroundY(npc.position.x, npc.position.z) ?? npc.position.y, npc.position.z);
         mesh.rotation.y = npc.rotation;
         mesh.userData = {
           avatarId: npc.id,
@@ -2739,6 +2740,10 @@ export default function AvatarSystem3D({
         const interpFactor = Math.min(1, delta * INTERPOLATION_RATE);
         for (const [, data] of otherPlayerMeshes) {
           data.mesh.position.lerp(data.targetPos, interpFactor);
+          // Plant on the terrain surface (they arrive at server Y=0; the ground
+          // is ~40m on the plateau). Skip when the sampler isn't ready yet.
+          const gy = sampleGroundY(data.mesh.position.x, data.mesh.position.z);
+          if (gy !== null) data.mesh.position.y = gy;
           let rd = data.targetRot - data.mesh.rotation.y;
           while (rd > Math.PI) rd -= Math.PI * 2;
           while (rd < -Math.PI) rd += Math.PI * 2;
@@ -2749,6 +2754,9 @@ export default function AvatarSystem3D({
         const npcInterpFactor = Math.min(1, delta * NPC_UPDATE_RATE);
         for (const [, data] of npcMeshes) {
           data.mesh.position.lerp(data.targetPos, npcInterpFactor);
+          // Plant on the terrain surface (same reason as other players above).
+          const gy = sampleGroundY(data.mesh.position.x, data.mesh.position.z);
+          if (gy !== null) data.mesh.position.y = gy;
           let rd = data.targetRot - data.mesh.rotation.y;
           while (rd > Math.PI) rd -= Math.PI * 2;
           while (rd < -Math.PI) rd += Math.PI * 2;

--- a/concord-frontend/components/world-lens/BuildingRenderer3D.tsx
+++ b/concord-frontend/components/world-lens/BuildingRenderer3D.tsx
@@ -25,6 +25,10 @@ export interface BuildingDTU {
   floors: number;
   material: BuildingMaterialType;
   style: 'colonial' | 'federal' | 'industrial' | 'modern' | 'mixed';
+  /** World/seed/station building type — drives the procedural archetype + iconic
+   *  silhouette feature (lib/world-lens/building-silhouette.ts). Absent for
+   *  player-designed structural DTUs, which keep the legacy structural render. */
+  building_type?: string;
   /** Structural elements specification */
   structure: {
     columns: { count: number; spacing: number; radius: number };
@@ -157,10 +161,20 @@ export default function BuildingRenderer3D({
     // archetype isn't in the procgen registry.
     const knownArchetypes = ['tavern', 'archive', 'forge', 'market', 'tower'] as const;
     type ProcArch = typeof knownArchetypes[number];
-    const dtuArch = (dtu as { archetype?: string }).archetype;
-    if (dtuArch && (knownArchetypes as readonly string[]).includes(dtuArch)) {
+    const explicitArch = (dtu as { archetype?: string }).archetype;
+    const buildingType = (dtu as { building_type?: string }).building_type;
+    // Take the rich procedural path for any building with an explicit archetype
+    // OR a building_type (seed / lens-station buildings) — the latter derives its
+    // archetype + iconic landmark feature (dome / spire / colonnade / belfry) from
+    // the type. Player-designed DTUs with neither keep the structural legacy path.
+    const hasExplicit = !!explicitArch && (knownArchetypes as readonly string[]).includes(explicitArch);
+    if (hasExplicit || buildingType) {
       try {
         const { createBuilding } = await import('@/lib/world-lens/procedural-buildings');
+        const { silhouetteForBuildingType } = await import('@/lib/world-lens/building-silhouette');
+        const sil = silhouetteForBuildingType(buildingType);
+        const dtuArch: ProcArch = hasExplicit ? (explicitArch as ProcArch) : sil.archetype;
+        const feature = (dtu as { feature?: import('@/lib/world-lens/procedural-buildings').IconicFeature }).feature ?? sil.feature;
         const factionVisual = (dtu as { faction_visual?: { primary_color?: string; secondary_color?: string; accent_color?: string } }).faction_visual;
         const archStyleByArch: Record<ProcArch, 'fortified' | 'gracile' | 'crystalline' | 'organic' | 'industrial'> = {
           tavern: 'organic', archive: 'gracile', forge: 'fortified',
@@ -172,15 +186,16 @@ export default function BuildingRenderer3D({
         const { getClientConfigSync } = await import('@/hooks/useClientConfig');
         const worldDensityOn = getClientConfigSync().flags.worldDensity;
         const result = createBuilding(THREE, {
-          archetype: dtuArch as ProcArch,
+          archetype: dtuArch,
+          feature,
           seed: dtu.id,
           withInterior: worldDensityOn ? 'lazy' : false,
           factionStyle: factionVisual ? {
             primary_color: factionVisual.primary_color,
             secondary_color: factionVisual.secondary_color,
             accent_color: factionVisual.accent_color,
-            architecture_style: archStyleByArch[dtuArch as ProcArch],
-          } : { architecture_style: archStyleByArch[dtuArch as ProcArch] },
+            architecture_style: archStyleByArch[dtuArch],
+          } : { architecture_style: archStyleByArch[dtuArch] },
         });
         result.name = `building_${dtu.id}`;
         // Merge (not overwrite) so createBuilding's archetype + _interiorMode

--- a/concord-frontend/components/world-lens/CombatFlowHotbar.tsx
+++ b/concord-frontend/components/world-lens/CombatFlowHotbar.tsx
@@ -232,7 +232,10 @@ export default function CombatFlowHotbar({
       }));
     } else {
       window.dispatchEvent(new CustomEvent('concordia:spell-cast', {
-        detail: { spellId: slot.spell.id, spellName: slot.spell.name, costs: slot.spell.costs },
+        detail: {
+          spellId: slot.spell.id, spellName: slot.spell.name,
+          element: slot.spell.element, costs: slot.spell.costs,
+        },
       }));
     }
   }, [slots]);

--- a/concord-frontend/components/world-lens/ConcordiaScene.tsx
+++ b/concord-frontend/components/world-lens/ConcordiaScene.tsx
@@ -361,6 +361,7 @@ export default function ConcordiaScene({
       } catch { /* ragdoll bridge optional */ }
 
       // Listen for terrain-ready to register heightfield collider
+      let currentTerrainGroup: unknown = null;
       function onTerrainPhysics(e: Event) {
         const { hmData, hmWidth, hmHeight, terrainGroup, getElevationAt } = (e as CustomEvent).detail ?? {};
         if (hmData) {
@@ -369,6 +370,22 @@ export default function ConcordiaScene({
             y: 80, // maxElevation
             z: 2000,
           });
+        }
+        // Add the terrain MESH (with its district zone-splat materials) to the
+        // visible 'terrain' layer. TerrainRenderer builds it and dispatches it
+        // here, but previously it was only consumed for physics/deformation —
+        // never displayed (same dead-bridge the buildings layer had). The
+        // 'terrain' layer is otherwise empty (it's the raycast target), so no
+        // doubling. Replace on re-dispatch (e.g. when district zones change).
+        if (terrainGroup) {
+          const layer = layersRef.current['terrain'] as
+            | { add: (c: unknown) => void; remove: (c: unknown) => void }
+            | undefined;
+          if (layer) {
+            if (currentTerrainGroup) { try { layer.remove(currentTerrainGroup); } catch { /* ignore */ } }
+            layer.add(terrainGroup);
+            currentTerrainGroup = terrainGroup;
+          }
         }
         // WS-A3 — once terrain + its collider exist, attach the deformation
         // orchestrator: replay GET /terrain + live concordia:terrain-deformed →

--- a/concord-frontend/components/world-lens/ConcordiaScene.tsx
+++ b/concord-frontend/components/world-lens/ConcordiaScene.tsx
@@ -478,6 +478,31 @@ export default function ConcordiaScene({
       // @resource-leak-ok: same one-shot scene lifecycle as terrain-ready above.
       window.addEventListener('concordia:buildings-ready', onBuildingsReady);
 
+      // Consume the AvatarSystem3D layer's output — the player + NPC meshes.
+      // AvatarSystem3D builds the avatar group and dispatches
+      // concordia:avatars-ready, but the only listener was a no-op stub, so the
+      // player character + NPC bodies never reached the scene (they showed only
+      // as 2D HTML name-tags). Add the group to the 'avatars' scene layer and
+      // route its per-frame update through the layer (the LAYER_NAMES fan-out in
+      // the render loop calls layers.avatars.userData.update each frame), so the
+      // avatars both RENDER and ANIMATE/move. Replace on re-dispatch.
+      let currentAvatarGroup: unknown = null;
+      function onAvatarsReady(e: Event) {
+        const ag = (e as CustomEvent).detail?.avatarGroup as
+          | { userData?: { update?: (d: number, en: number) => void } }
+          | null;
+        const layer = layersRef.current['avatars'] as
+          | { add: (c: unknown) => void; remove: (c: unknown) => void; userData: { update?: (d: number, en: number) => void } }
+          | undefined;
+        if (!ag || !layer) return;
+        if (currentAvatarGroup) { try { layer.remove(currentAvatarGroup); } catch { /* ignore */ } }
+        layer.add(ag);
+        currentAvatarGroup = ag;
+        layer.userData.update = (d: number, en: number) => { try { ag.userData?.update?.(d, en); } catch { /* per-frame, never throw */ } };
+      }
+      // @resource-leak-ok: same one-shot scene lifecycle as terrain-ready above.
+      window.addEventListener('concordia:avatars-ready', onAvatarsReady);
+
       // Theme 6 deferred follow-up (game-feel pass): water plane + swim
       // registration. Adds a translucent blue plane at y=2 that covers
       // the river-bluff valley west of origin, plus a Fall Kill Creek

--- a/concord-frontend/components/world-lens/ConcordiaScene.tsx
+++ b/concord-frontend/components/world-lens/ConcordiaScene.tsx
@@ -440,6 +440,27 @@ export default function ConcordiaScene({
       // @resource-leak-ok: terrain-ready is a one-shot scene-init signal; ConcordiaScene unmounts the whole canvas, not the listener individually
       window.addEventListener('concordia:terrain-ready', onTerrainPhysics);
 
+      // Lens-as-Station — consume the React BuildingRenderer3D layer's output.
+      // It builds a fully-positioned group of all world buildings (with iconic
+      // silhouettes) and dispatches concordia:buildings-ready; without this the
+      // group was dispatched into the void (only a no-op event-router stub
+      // listened), so 3D buildings never reached the scene. Add it to the
+      // 'buildings' layer (otherwise empty — addBuilding has no caller — so no
+      // doubling); replace on re-dispatch when the building set changes.
+      let currentBuildingsGroup: unknown = null;
+      function onBuildingsReady(e: Event) {
+        const g = (e as CustomEvent).detail?.buildingGroup as unknown;
+        const layer = layersRef.current['buildings'] as
+          | { add: (c: unknown) => void; remove: (c: unknown) => void }
+          | undefined;
+        if (!g || !layer) return;
+        if (currentBuildingsGroup) { try { layer.remove(currentBuildingsGroup); } catch { /* ignore */ } }
+        layer.add(g);
+        currentBuildingsGroup = g;
+      }
+      // @resource-leak-ok: same one-shot scene lifecycle as terrain-ready above.
+      window.addEventListener('concordia:buildings-ready', onBuildingsReady);
+
       // Theme 6 deferred follow-up (game-feel pass): water plane + swim
       // registration. Adds a translucent blue plane at y=2 that covers
       // the river-bluff valley west of origin, plus a Fall Kill Creek

--- a/concord-frontend/components/world-lens/ConcordiaScene.tsx
+++ b/concord-frontend/components/world-lens/ConcordiaScene.tsx
@@ -503,6 +503,20 @@ export default function ConcordiaScene({
       // @resource-leak-ok: same one-shot scene lifecycle as terrain-ready above.
       window.addEventListener('concordia:avatars-ready', onAvatarsReady);
 
+      // Answer scene-request-ready: TreeLayer / RockLayer / QuestMarker3D (and
+      // other self-adding overlays) ping this when they mount AFTER our one-shot
+      // scene-ready already fired, asking for the scene. With no responder they
+      // never received it and silently never rendered (a mount-order race). Re-
+      // emit scene-ready WITH {scene, camera} so a late layer can self-add.
+      function onSceneRequest() {
+        const s = sceneRef.current, c = cameraRef.current;
+        if (s && c) {
+          window.dispatchEvent(new CustomEvent('concordia:scene-ready', { detail: { scene: s, camera: c } }));
+        }
+      }
+      // @resource-leak-ok: same one-shot scene lifecycle as terrain-ready above.
+      window.addEventListener('concordia:scene-request-ready', onSceneRequest);
+
       // Theme 6 deferred follow-up (game-feel pass): water plane + swim
       // registration. Adds a translucent blue plane at y=2 that covers
       // the river-bluff valley west of origin, plus a Fall Kill Creek

--- a/concord-frontend/components/world-lens/QuestMarker3D.tsx
+++ b/concord-frontend/components/world-lens/QuestMarker3D.tsx
@@ -65,6 +65,11 @@ const QuestMarker3D = forwardRef<QuestMarker3DAPI, QuestMarker3DProps>(function 
       cameraRef.current = camera;
     }
     window.addEventListener('concordia:scene-ready', onSceneReady);
+    // This layer mounts only once quest objectives exist — i.e. AFTER the
+    // scene's one-shot scene-ready already fired. Without this ping we'd miss
+    // it and sceneRef would stay null (markers never render). ConcordiaScene's
+    // onSceneRequest responder re-emits scene-ready with {scene,camera}.
+    window.dispatchEvent(new CustomEvent('concordia:scene-request-ready'));
     return () => window.removeEventListener('concordia:scene-ready', onSceneReady);
   }, []);
 

--- a/concord-frontend/components/world-lens/TerrainRenderer.tsx
+++ b/concord-frontend/components/world-lens/TerrainRenderer.tsx
@@ -246,6 +246,21 @@ export default function TerrainRenderer({
     return elevation * 80 + getTerrainDeltaAt(worldX, worldZ); // maxElevation
   }, []);
 
+  // Publish the ground sampler so other scene layers (NPCs, other players,
+  // creatures) can plant themselves on the SAME surface the player walks (this
+  // reads the actual heightmap the mesh + physics heightfield were built from,
+  // incl. live deformation — so it's exact, not an approximation). Without this
+  // those entities sit at their server Y (0) while the city plateau renders at
+  // ~40m, i.e. buried under the world. Args are scene-frame coords.
+  useEffect(() => {
+    const w = window as unknown as { __concordiaSampleGroundY?: (x: number, z: number) => number | null };
+    w.__concordiaSampleGroundY = (x: number, z: number) => {
+      if (!heightmapDataRef.current) return null; // terrain not built yet
+      return getElevationAt(x, z);
+    };
+    return () => { delete w.__concordiaSampleGroundY; };
+  }, [getElevationAt]);
+
   // ── Build terrain geometry ────────────────────────────────────
 
   useEffect(() => {

--- a/concord-frontend/components/world/LensStationPrompt.tsx
+++ b/concord-frontend/components/world/LensStationPrompt.tsx
@@ -13,10 +13,10 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { resolveStationLens, type StationLens } from '@/lib/station-lens-registry';
+import { worldToSceneAxis } from '@/lib/world-lens/coord-frame';
 
 const APPROACH_RADIUS_M = 6; // show the cue a touch beyond the router's 4m gate
 const POLL_MS = 300;
-const WORLD_TO_SCENE_OFFSET = 1000; // = TERRAIN_SIZE/2; server [0,2000] frame → origin-centred scene frame
 
 export interface StationBuilding { id: string; building_type: string; x: number; z: number; name?: string }
 
@@ -65,7 +65,7 @@ export function LensStationPrompt() {
         // fires (server ~800 vs player ~0).
         const list: StationBuilding[] = (j?.buildings || [])
           .filter((b: { building_type?: string }) => b.building_type && resolveStationLens(b.building_type))
-          .map((b: StationBuilding) => ({ id: b.id, building_type: b.building_type, x: b.x - WORLD_TO_SCENE_OFFSET, z: b.z - WORLD_TO_SCENE_OFFSET, name: b.name }));
+          .map((b: StationBuilding) => ({ id: b.id, building_type: b.building_type, x: worldToSceneAxis(b.x), z: worldToSceneAxis(b.z), name: b.name }));
         if (!cancelled) setStations(list);
       } catch { /* offline / no buildings — prompt simply never shows */ }
     })();

--- a/concord-frontend/components/world/LensStationPrompt.tsx
+++ b/concord-frontend/components/world/LensStationPrompt.tsx
@@ -16,6 +16,7 @@ import { resolveStationLens, type StationLens } from '@/lib/station-lens-registr
 
 const APPROACH_RADIUS_M = 6; // show the cue a touch beyond the router's 4m gate
 const POLL_MS = 300;
+const WORLD_TO_SCENE_OFFSET = 1000; // = TERRAIN_SIZE/2; server [0,2000] frame → origin-centred scene frame
 
 export interface StationBuilding { id: string; building_type: string; x: number; z: number; name?: string }
 
@@ -57,9 +58,14 @@ export function LensStationPrompt() {
         const r = await fetch(`/api/worlds/${encodeURIComponent(worldId)}/buildings`, { credentials: 'include' });
         if (!r.ok) return;
         const j = await r.json();
+        // Buildings come from the server in the [0, 2000] world frame; the player
+        // position (__concordiaPlayerPos) is in the origin-centred scene frame.
+        // Shift to the scene frame (matching how the 3D buildings render) so the
+        // proximity check compares like-for-like, otherwise the prompt never
+        // fires (server ~800 vs player ~0).
         const list: StationBuilding[] = (j?.buildings || [])
           .filter((b: { building_type?: string }) => b.building_type && resolveStationLens(b.building_type))
-          .map((b: StationBuilding) => ({ id: b.id, building_type: b.building_type, x: b.x, z: b.z, name: b.name }));
+          .map((b: StationBuilding) => ({ id: b.id, building_type: b.building_type, x: b.x - WORLD_TO_SCENE_OFFSET, z: b.z - WORLD_TO_SCENE_OFFSET, name: b.name }));
         if (!cancelled) setStations(list);
       } catch { /* offline / no buildings — prompt simply never shows */ }
     })();

--- a/concord-frontend/components/world/NPCDialogue.tsx
+++ b/concord-frontend/components/world/NPCDialogue.tsx
@@ -10,6 +10,15 @@ interface DialogueOption {
   key: string;
 }
 
+// Hand-authored branching dialogue tree (content/dialogues/*.json), shipped on
+// the /dialogue response when one exists for this NPC. The walk is purely
+// client-side — trees are immutable per release.
+interface AuthoredPlayerOption { text: string; leadsTo: string }
+interface AuthoredNode { id: string; npcText: string; playerOptions?: AuthoredPlayerOption[] }
+interface AuthoredTree { greeting?: string; nodes?: AuthoredNode[] }
+
+const WALK_PREFIX = '__walk:';
+
 interface QuestOffered {
   id: string;
   title: string;
@@ -290,6 +299,9 @@ export function NPCDialogue({ npc, worldId, onClose, onQuestAccepted }: NPCDialo
   const [options, setOptions] = useState<DialogueOption[]>([]);
   const [subtext, setSubtext] = useState<string | undefined>();
   const [response, setResponse] = useState('');
+  // Authored branching dialogue (when the NPC has a hand-authored tree).
+  const [tree, setTree] = useState<AuthoredTree | null>(null);
+  const [nodeId, setNodeId] = useState<string | null>(null);
   const [questOffered, setQuestOffered] = useState<QuestOffered | null>(null);
   const [acceptingQuest, setAcceptingQuest] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -424,9 +436,11 @@ export function NPCDialogue({ npc, worldId, onClose, onQuestAccepted }: NPCDialo
     });
   }, [cancelSpeech]);
 
-  // Speak greeting when it arrives
+  // Speak greeting when it arrives. In authored-tree mode the greeting is just
+  // scene-setting context (shown italic); the spoken line is the node's npcText
+  // (handled by the node-walk effect below), so we don't speak it here.
   useEffect(() => {
-    if (greeting) speak(greeting);
+    if (greeting && !nodeId) speak(greeting);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [greeting]);
 
@@ -505,6 +519,17 @@ export function NPCDialogue({ npc, worldId, onClose, onQuestAccepted }: NPCDialo
         setOptions(data.options || [{ label: 'Leave', key: 'goodbye' }]);
         setSubtext(data.subtext);
         setIsAgent(!!data.isAgent); // Wave 7 / C1 — hard AI disclosure
+        // Hand-authored branching tree, if present — start the walk at its
+        // first node (the opening exchange). The flat greeting/options above
+        // remain the fallback for NPCs with no authored tree.
+        const t: AuthoredTree | undefined = data.dialogueTree;
+        if (t?.nodes?.length) {
+          setTree(t);
+          setNodeId(t.nodes[0].id);
+        } else {
+          setTree(null);
+          setNodeId(null);
+        }
         setPhase('greeting');
       })
       .catch(() => {
@@ -519,11 +544,45 @@ export function NPCDialogue({ npc, worldId, onClose, onQuestAccepted }: NPCDialo
     };
   }, [npc.id, npc.name, worldId]);
 
+  // ── Authored tree walk ───────────────────────────────────────────────────────
+  // The current node is whatever nodeId points at; a node with no playerOptions
+  // is terminal (farewell line → the player can only Leave).
+  const currentNode = tree?.nodes?.find((n) => n.id === nodeId) ?? null;
+
+  // Speak the node's line as the walk advances (greeting is spoken separately).
+  useEffect(() => {
+    if (currentNode?.npcText) speak(currentNode.npcText);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodeId]);
+
+  const walkTo = useCallback((leadsTo: string) => {
+    const next = tree?.nodes?.find((n) => n.id === leadsTo);
+    if (!next) { onClose(); return; }   // unresolved branch → end the exchange
+    setNodeId(next.id);
+  }, [tree, onClose]);
+
+  // What the body renders: in authored-tree mode the NPC speech is the current
+  // node's line and the options are its branches; otherwise the flat LLM/
+  // deterministic path (greeting + canonical action options).
+  const treeMode = !!currentNode;
+  const displayedSpeech = treeMode ? (currentNode?.npcText ?? '') : (response || greeting);
+  const displayedSubtext = treeMode ? tree?.greeting : subtext;
+  const displayedOptions: DialogueOption[] = treeMode
+    ? (currentNode?.playerOptions?.length
+        ? currentNode.playerOptions.map((o) => ({ label: o.text, key: `${WALK_PREFIX}${o.leadsTo}` }))
+        : [{ label: 'Leave', key: 'goodbye' }])
+    : options;
+
   // ── Player selects option ────────────────────────────────────────────────────
   const choose = useCallback(
     async (option: DialogueOption) => {
       if (option.key === 'goodbye') {
         onClose();
+        return;
+      }
+      // Authored branching walk — navigate to the linked node, no server call.
+      if (option.key.startsWith(WALK_PREFIX)) {
+        walkTo(option.key.slice(WALK_PREFIX.length));
         return;
       }
 
@@ -546,7 +605,7 @@ export function NPCDialogue({ npc, worldId, onClose, onQuestAccepted }: NPCDialo
 
       setPhase('greeting'); // return to options after response
     },
-    [npc.id, npc.name, worldId, onClose]
+    [npc.id, npc.name, worldId, onClose, walkTo]
   );
 
   // ── Accept quest ─────────────────────────────────────────────────────────────
@@ -703,10 +762,10 @@ export function NPCDialogue({ npc, worldId, onClose, onQuestAccepted }: NPCDialo
             <>
               {/* NPC speech */}
               <div className="text-sm text-white/90 leading-relaxed mb-1">
-                {response || greeting}
+                {displayedSpeech}
               </div>
-              {subtext && !response && (
-                <div className="text-[11px] text-white/30 italic mt-1">{subtext}</div>
+              {displayedSubtext && !response && (
+                <div className="text-[11px] text-white/30 italic mt-1">{displayedSubtext}</div>
               )}
 
               {/* Quest card */}
@@ -744,9 +803,9 @@ export function NPCDialogue({ npc, worldId, onClose, onQuestAccepted }: NPCDialo
         </div>
 
         {/* Options */}
-        {phase === 'greeting' && options.length > 0 && (
+        {phase === 'greeting' && displayedOptions.length > 0 && (
           <div className="border-t border-white/10 px-4 pb-4 pt-3 flex flex-col gap-1.5">
-            {options.map((opt) => (
+            {displayedOptions.map((opt) => (
               <button
                 key={opt.key}
                 onClick={() => choose(opt)}

--- a/concord-frontend/components/world/concordia-hud/MentorshipNotifier.tsx
+++ b/concord-frontend/components/world/concordia-hud/MentorshipNotifier.tsx
@@ -50,6 +50,10 @@ export function MentorshipNotifier() {
       } catch { /* socket optional */ }
     })();
     return () => {
+      // Remove the listener before tearing the socket down. disconnect() alone
+      // would drop it, but an explicit off() is leak-proof if this socket ever
+      // becomes shared/reused (this component remounts on every world render).
+      try { socket?.off('mentorship:npc-adopted'); } catch { /* ignore */ }
       try { socket?.disconnect(); } catch { /* ignore */ }
       for (const t of timerIds) clearTimeout(t);
       timerIds = [];

--- a/concord-frontend/components/world/concordia-hud/SkillWheelMount.tsx
+++ b/concord-frontend/components/world/concordia-hud/SkillWheelMount.tsx
@@ -44,6 +44,19 @@ function glyphFor(skill: SkillDTU): string {
   return '✶';
 }
 
+/** Element parsed from the skill's data blob (falls back to a name match), so
+ *  the cast carries a real element instead of defaulting to 'physical'. */
+function elementFor(skill: SkillDTU): string | undefined {
+  try {
+    const d = typeof skill.data === 'string' ? JSON.parse(skill.data) : skill.data;
+    const el = String((d as Record<string, unknown>)?.element || '').toLowerCase();
+    if (el) return el;
+  } catch { /* ignore */ }
+  const name = String(skill.title || skill.name || '').toLowerCase();
+  for (const key of Object.keys(ELEMENT_GLYPH)) if (name.includes(key)) return key;
+  return undefined;
+}
+
 function castSpoke(skill: SkillDTU): WheelSpoke {
   let costs: unknown;
   try {
@@ -51,6 +64,7 @@ function castSpoke(skill: SkillDTU): WheelSpoke {
     costs = (d as Record<string, unknown>)?.costs;
   } catch { /* ignore */ }
   const name = skill.title || skill.name || 'Skill';
+  const element = elementFor(skill);
   return {
     id: skill.id,
     label: name,
@@ -58,7 +72,7 @@ function castSpoke(skill: SkillDTU): WheelSpoke {
     action: () => {
       // Ride the canonical cast channel (same as CombatFlowHotbar).
       window.dispatchEvent(new CustomEvent('concordia:spell-cast', {
-        detail: { spellId: skill.id, spellName: name, costs },
+        detail: { spellId: skill.id, spellName: name, element, costs },
       }));
     },
   };

--- a/concord-frontend/lib/concordia/netcode.ts
+++ b/concord-frontend/lib/concordia/netcode.ts
@@ -180,6 +180,13 @@ export class ReconciliationBuffer {
   private history: Array<{ input: InputFrame; state: CharState }> = [];
   private maxHistory = 128; // ~2 seconds at 60 fps
   private simFn: PhysicsSimFn;
+  // H1+ — highest server sequence we've reconciled against, + the last
+  // reconciled state. Used to DROP stale / out-of-order server snapshots: under
+  // jitter a packet #4 can arrive before #3, and re-applying the older
+  // authoritative state after inputs were already pruned would rubber-band the
+  // player backward (into a wall). Server snapshots only ever move forward.
+  private lastServerSeq = -1;
+  private lastReconciled: CharState | null = null;
 
   constructor(simFn: PhysicsSimFn) {
     this.simFn = simFn;
@@ -209,6 +216,14 @@ export class ReconciliationBuffer {
    * Returns the re-simulated state (use this as the new authoritative client state).
    */
   reconcile(serverMsg: ServerStateMsg): CharState {
+    // Drop stale / duplicate server snapshots (out-of-order arrival under
+    // jitter). Acks only move forward; an older one re-applied after newer
+    // inputs were pruned would rubber-band the player. Keep our latest state.
+    if (serverMsg.seq <= this.lastServerSeq) {
+      return this.lastReconciled ?? { ...serverMsg.state };
+    }
+    this.lastServerSeq = serverMsg.seq;
+
     // Prune inputs already acknowledged by the server
     this.history = this.history.filter((h) => h.input.seq > serverMsg.seq);
 
@@ -219,6 +234,7 @@ export class ReconciliationBuffer {
       state.seq = input.seq;
     }
 
+    this.lastReconciled = state;
     return state;
   }
 
@@ -244,6 +260,10 @@ export class ReconciliationBuffer {
 
   clearHistory(): void {
     this.history = [];
+    // Reset the ack watermark too — after a respawn/teleport the next server
+    // snapshot is authoritative even if its seq is lower than the old stream.
+    this.lastServerSeq = -1;
+    this.lastReconciled = null;
   }
 }
 

--- a/concord-frontend/lib/event-router.ts
+++ b/concord-frontend/lib/event-router.ts
@@ -189,7 +189,7 @@ function buildHandlers(opts: {
     'concordia:buildings-ready': () => { /* startup-readiness signal */ },
     'concordia:sky-weather-ready': () => { /* startup-readiness signal */ },
     'concordia:water-ready': () => { /* startup-readiness signal */ },
-    'concordia:spell-cast': () => { /* scene controller handles */ },
+    'concordia:spell-cast': () => { /* world lens page.tsx handles: cast anim + VFX + combat:attack */ },
     'concordia:quest-marker-add': () => { /* 3D marker layer handles */ },
     'concordia:quest-marker-remove': () => { /* 3D marker layer handles */ },
     'concordia:quest-marker-clear': () => { /* 3D marker layer handles */ },

--- a/concord-frontend/lib/world-lens/building-silhouette.ts
+++ b/concord-frontend/lib/world-lens/building-silhouette.ts
@@ -1,0 +1,107 @@
+// Building silhouette mapping — building_type → procedural archetype + an iconic
+// landmark feature, so every seed/world building (and every lens-station) reads
+// as a specific place at a glance (the silhouette-readability principle: a
+// building should be recognisable from its black outline alone).
+//
+// Pure data + lookup. The archetype picks the base procedural mesh
+// (lib/world-lens/procedural-buildings.ts createBuilding); the optional feature
+// appends an iconic cap (dome / spire / colonnade / belfry). Every building_type
+// resolves to one of the 5 real archetypes, so it always takes the rich
+// procedural path rather than the generic box fallback.
+
+import type { BuildingArchetype, IconicFeature } from './procedural-buildings';
+
+export interface BuildingSilhouette {
+  archetype: BuildingArchetype;
+  feature?: IconicFeature;
+}
+
+const DEFAULT: BuildingSilhouette = { archetype: 'market' };
+
+const SILHOUETTE: Record<string, BuildingSilhouette> = {
+  // ── Core seed city ──
+  inn: { archetype: 'tavern' }, tavern: { archetype: 'tavern' }, house: { archetype: 'tavern' },
+  market: { archetype: 'market' }, warehouse: { archetype: 'market' }, well: { archetype: 'market' },
+  forge: { archetype: 'forge' }, mine: { archetype: 'forge' },
+  tower: { archetype: 'tower', feature: 'spire' },
+  dock: { archetype: 'market' }, farm: { archetype: 'tavern' },
+
+  // ── Civic & governance (columned civic halls / bell-towers) ──
+  courthouse: { archetype: 'archive', feature: 'colonnade' },
+  assembly_hall: { archetype: 'archive', feature: 'colonnade' },
+  council_chamber: { archetype: 'archive', feature: 'colonnade' },
+  ethics_hall: { archetype: 'archive', feature: 'colonnade' },
+  watch_house: { archetype: 'tower', feature: 'belfry' },
+
+  // ── Knowledge & science ──
+  cartographer_table: { archetype: 'tower', feature: 'spire' },
+  observatory: { archetype: 'tower', feature: 'dome' },
+  code_terminal: { archetype: 'tower' },
+  laboratory: { archetype: 'forge' },
+  archive_hall: { archetype: 'archive', feature: 'colonnade' },
+  physics_hall: { archetype: 'archive' },
+  calcularium: { archetype: 'archive' },
+  philosophy_porch: { archetype: 'archive', feature: 'colonnade' },
+
+  // ── Commerce & economy ──
+  trading_floor: { archetype: 'market' },
+  ledger_desk: { archetype: 'archive' },
+  bank_house: { archetype: 'archive', feature: 'colonnade' },
+  auction_house: { archetype: 'market' },
+
+  // ── Arts & creative ──
+  music_booth: { archetype: 'tavern' },
+  atelier: { archetype: 'tavern' },
+  writers_room: { archetype: 'tavern' },
+  gallery_hall: { archetype: 'archive', feature: 'colonnade' },
+
+  // ── Craft & industry (smokestacks) ──
+  workshop: { archetype: 'forge' },
+  engineers_hall: { archetype: 'forge' },
+  mill: { archetype: 'forge' },
+  depot: { archetype: 'market' },
+  powerhouse: { archetype: 'forge' },
+  site_office: { archetype: 'market' },
+
+  // ── Care & wellbeing ──
+  clinic: { archetype: 'archive' },
+  sanctuary: { archetype: 'archive', feature: 'dome' },
+  counsel_room: { archetype: 'tavern' },
+  gymnasium: { archetype: 'market' },
+
+  // ── Communication & social ──
+  post_office: { archetype: 'market' },
+  forum_hall: { archetype: 'archive', feature: 'colonnade' },
+  newsroom: { archetype: 'market' },
+  agora: { archetype: 'archive', feature: 'colonnade' },
+
+  // ── Learning ──
+  schoolhouse: { archetype: 'tavern', feature: 'belfry' },
+  academy: { archetype: 'archive', feature: 'colonnade' },
+
+  // ── Nature & world ──
+  grange: { archetype: 'tavern' },
+  foresters_lodge: { archetype: 'tavern' },
+  mineshaft: { archetype: 'forge' },
+  tide_station: { archetype: 'market' },
+  survey_camp: { archetype: 'tavern' },
+};
+
+/** Resolve a building_type to its archetype + optional iconic feature. */
+export function silhouetteForBuildingType(buildingType?: string | null): BuildingSilhouette {
+  if (!buildingType) return DEFAULT;
+  return SILHOUETTE[buildingType] ?? DEFAULT;
+}
+
+/** Coerce a stored material string to a renderer BuildingMaterialType. */
+export function coerceMaterial(material?: string | null): 'brick' | 'stone' | 'wood' | 'steel' | 'concrete' | 'glass' | 'usb' {
+  switch (material) {
+    case 'brick': case 'stone': case 'wood': case 'steel': case 'concrete': case 'glass': case 'usb':
+      return material;
+    case 'thatch': return 'wood';   // thatch → warm wood (no thatch material in the renderer)
+    default: return 'stone';
+  }
+}
+
+const buildingSilhouette = { silhouetteForBuildingType, coerceMaterial };
+export default buildingSilhouette;

--- a/concord-frontend/lib/world-lens/coord-frame.ts
+++ b/concord-frontend/lib/world-lens/coord-frame.ts
@@ -46,5 +46,34 @@ export function sampleGroundY(sceneX: number, sceneZ: number): number | null {
   try { return fn(sceneX, sceneZ); } catch { return null; }
 }
 
-const coordFrame = { WORLD_TO_SCENE_OFFSET, worldToSceneAxis, sceneToWorldAxis, worldToScene, sceneToWorld, sampleGroundY };
+// ── Invisible safety net: out-of-bounds / fall detection ─────────────────────
+
+/** Walkable horizontal bound (scene frame): terrain half-extent minus a margin
+ *  so the snapback fires just before the player reaches the visible edge. */
+export const WORLD_BOUND = WORLD_TO_SCENE_OFFSET - 20; // 980
+/** Kill-volume floor — below the lowest terrain (sea level is y≈0..2). */
+export const FALL_FLOOR_Y = -25;
+
+/**
+ * True when a scene-frame position has left the world and must be snapped back:
+ * non-finite (NaN/Infinity), below the fall floor, or beyond the walkable
+ * bounds. PURE + unit-testable — no THREE, no DOM. The render loop calls this
+ * each frame against the player position; on true it restores the last grounded
+ * position and zeroes vertical velocity (the kill-volume / edge-clamp catch-all).
+ */
+export function outOfBounds(
+  pos: { x: number; y: number; z: number },
+  bound: number = WORLD_BOUND,
+  floor: number = FALL_FLOOR_Y,
+): boolean {
+  if (!Number.isFinite(pos.x) || !Number.isFinite(pos.y) || !Number.isFinite(pos.z)) return true;
+  if (pos.y < floor) return true;
+  if (Math.abs(pos.x) > bound || Math.abs(pos.z) > bound) return true;
+  return false;
+}
+
+const coordFrame = {
+  WORLD_TO_SCENE_OFFSET, worldToSceneAxis, sceneToWorldAxis, worldToScene, sceneToWorld,
+  sampleGroundY, WORLD_BOUND, FALL_FLOOR_Y, outOfBounds,
+};
 export default coordFrame;

--- a/concord-frontend/lib/world-lens/coord-frame.ts
+++ b/concord-frontend/lib/world-lens/coord-frame.ts
@@ -1,0 +1,33 @@
+// World ↔ scene coordinate frame — the single source of truth.
+//
+// The SERVER places seed content (the world-seeder: buildings + resource nodes)
+// in a [0, WORLD_SIZE] frame — the seed city sits at (800, 1000). The FRONTEND
+// renders in a frame centred on the origin: the terrain spans
+// [-TERRAIN_SIZE/2, +TERRAIN_SIZE/2], the player spawns at (0,0), and the live
+// spawners (NPCs, fauna) already place entities around the origin. The two frames
+// differ by exactly TERRAIN_SIZE/2 = 1000 in both x and z.
+//
+// Rule: convert server→scene on the way IN (when rendering or proximity-checking
+// server entities) and scene→world on the way OUT (when sending player/scene
+// coords to a server endpoint). At this offset the server elevation (nx=x/2000)
+// and the frontend terrain elevation (nx=(x+1000)/2000) agree, so shifted
+// content sits on the ground.
+
+export const WORLD_TO_SCENE_OFFSET = 1000; // = TERRAIN_SIZE / 2
+
+/** Server world coord → frontend scene coord (scalar). */
+export function worldToSceneAxis(v: number): number { return v - WORLD_TO_SCENE_OFFSET; }
+/** Frontend scene coord → server world coord (scalar). */
+export function sceneToWorldAxis(v: number): number { return v + WORLD_TO_SCENE_OFFSET; }
+
+/** Shift an {x, z[, ...]} from the server world frame into the scene frame. */
+export function worldToScene<T extends { x: number; z: number }>(p: T): T {
+  return { ...p, x: p.x - WORLD_TO_SCENE_OFFSET, z: p.z - WORLD_TO_SCENE_OFFSET };
+}
+/** Shift an {x, z[, ...]} from the scene frame back into the server world frame. */
+export function sceneToWorld<T extends { x: number; z: number }>(p: T): T {
+  return { ...p, x: p.x + WORLD_TO_SCENE_OFFSET, z: p.z + WORLD_TO_SCENE_OFFSET };
+}
+
+const coordFrame = { WORLD_TO_SCENE_OFFSET, worldToSceneAxis, sceneToWorldAxis, worldToScene, sceneToWorld };
+export default coordFrame;

--- a/concord-frontend/lib/world-lens/coord-frame.ts
+++ b/concord-frontend/lib/world-lens/coord-frame.ts
@@ -29,5 +29,22 @@ export function sceneToWorld<T extends { x: number; z: number }>(p: T): T {
   return { ...p, x: p.x + WORLD_TO_SCENE_OFFSET, z: p.z + WORLD_TO_SCENE_OFFSET };
 }
 
-const coordFrame = { WORLD_TO_SCENE_OFFSET, worldToSceneAxis, sceneToWorldAxis, worldToScene, sceneToWorld };
+/**
+ * Ground height (scene frame) at (sceneX, sceneZ), from the sampler TerrainRenderer
+ * publishes on `window.__concordiaSampleGroundY`. This reads the ACTUAL heightmap
+ * the terrain mesh + physics heightfield were built from (incl. live deformation),
+ * so it's exact — the surface the player walks. Server-spawned entities arrive at
+ * Y=0 but the city plateau renders at ~40m, so anything not planted via this would
+ * be buried under the world. Returns null when the terrain isn't built yet (caller
+ * keeps the current Y); never throws.
+ */
+export function sampleGroundY(sceneX: number, sceneZ: number): number | null {
+  if (typeof window === 'undefined') return null;
+  const fn = (window as unknown as { __concordiaSampleGroundY?: (x: number, z: number) => number | null })
+    .__concordiaSampleGroundY;
+  if (!fn) return null;
+  try { return fn(sceneX, sceneZ); } catch { return null; }
+}
+
+const coordFrame = { WORLD_TO_SCENE_OFFSET, worldToSceneAxis, sceneToWorldAxis, worldToScene, sceneToWorld, sampleGroundY };
 export default coordFrame;

--- a/concord-frontend/lib/world-lens/creature-renderer.ts
+++ b/concord-frontend/lib/world-lens/creature-renderer.ts
@@ -9,6 +9,7 @@
 
 import * as THREE from 'three';
 import { createCreatureMesh, type CreatureTopology, type CreatureMeshResult } from './creature-mesh-builder';
+import { sampleGroundY } from './coord-frame';
 
 interface CreatureRow {
   id: string;
@@ -131,6 +132,10 @@ export function createCreatureRenderer(
         const dx = entry.target.x - pos.x, dz = entry.target.z - pos.z;
         if (Math.abs(dx) + Math.abs(dz) > 0.01) entry.mesh.group.rotation.y = Math.atan2(dx, dz);
       }
+      // Plant on the terrain surface — creatures arrive at server Y=0 but the
+      // ground is ~40m on the plateau, so without this they'd be buried.
+      const gy = sampleGroundY(pos.x, pos.z);
+      if (gy !== null) pos.y = gy;
       entry.mesh.tick(delta, dist * 4);
     }
   }

--- a/concord-frontend/lib/world-lens/physics-world.ts
+++ b/concord-frontend/lib/world-lens/physics-world.ts
@@ -532,6 +532,17 @@ class PhysicsWorld {
   }
 
   /**
+   * Zero an entity's accumulated vertical velocity (and clear the airborne
+   * flag). Called by the out-of-bounds / fall-recovery snapback so the player
+   * doesn't keep the fall speed they'd built up after being teleported back to
+   * solid ground. No-op for unknown ids.
+   */
+  resetVerticalVelocity(id: string): void {
+    const ks = this.kinematic.get(id);
+    if (ks) { ks.verticalVel = 0; ks.isAirborne = false; ks.gliding = false; }
+  }
+
+  /**
    * Move a character controller by `desiredTranslation`, returning the
    * collision-resolved actual translation applied.
    */
@@ -540,6 +551,11 @@ class PhysicsWorld {
     desiredTranslation: { x: number; y: number; z: number },
     dt: number,
   ): CharacterMoveResult {
+    // Delta clamp (anti "blind dt trust"): a NaN / huge dt (tab-suspend resume,
+    // or a spoofed value) would integrate gravity/velocity for thousands of
+    // simulated seconds in one step → instant teleport into the void. Hard-cap
+    // every physics step to 100ms and reject non-finite dt.
+    dt = Number.isFinite(dt) ? Math.min(Math.max(dt, 0), 0.1) : 0;
     // Gate on full readiness — half-initialised worlds during the init()
     // await chain are the most common source of "recursive use of an
     // object" panics from this method.
@@ -584,6 +600,10 @@ class PhysicsWorld {
     });
 
     const ks = this._ensureKinematic(id);
+    // Finite guard: a NaN that ever lands in verticalVel (e.g. a divide-by-zero
+    // upstream) would propagate to the capsule's Y and break the avatar's
+    // position permanently. Reset to 0 so integration stays well-defined.
+    if (!Number.isFinite(ks.verticalVel)) ks.verticalVel = 0;
     const now = performance.now();
 
     // Theme 5 (game-feel pass): kinematic knockback. Add the active

--- a/concord-frontend/lib/world-lens/procedural-buildings.ts
+++ b/concord-frontend/lib/world-lens/procedural-buildings.ts
@@ -87,7 +87,16 @@ export interface BuildingOptions {
    * buildings without paying the decor cost upfront.
    */
   withInterior?: boolean | 'lazy';
+  /**
+   * V5 — iconic silhouette feature appended on top of the base archetype, so a
+   * building reads as a specific landmark at a glance (the silhouette-readability
+   * principle). Mapped from building_type in lib/world-lens/building-silhouette.ts.
+   */
+  feature?: IconicFeature;
 }
+
+/** Landmark silhouette caps — the shape that makes a building instantly legible. */
+export type IconicFeature = 'dome' | 'spire' | 'colonnade' | 'belfry';
 
 /**
  * Sprint D / V4 — silhouette bias by architecture style. Returned values
@@ -253,6 +262,10 @@ export function createBuilding(THREE: typeof THREE_NS, opts: BuildingOptions): T
     if (rng() < bias.parapetChance) addParapet(THREE, group, scale, trimMat);
     if (rng() < bias.columnChance) addColumns(THREE, group, scale, trimMat);
   }
+
+  // V5 — iconic landmark cap (dome / spire / colonnade / belfry) so a building
+  // reads as a specific place at a glance.
+  if (opts.feature) addIconicFeature(THREE, group, opts.feature, scale, roofMat, trimMat);
 
   group.userData = {
     isBuilding:   true,
@@ -433,6 +446,94 @@ function addColumns(THREE: typeof THREE_NS, g: THREE_NS.Group, scale: number, tr
     col.position.set(xSign * 4 * scale, colHeight / 2, 5.2 * scale);
     col.castShadow = true; col.receiveShadow = true;
     g.add(col);
+  }
+}
+
+/**
+ * V5 — append an iconic landmark feature on top of / in front of the base
+ * archetype. Pure geometry, deterministic, low-poly (silhouette-readability:
+ * the cap is what makes the building legible from afar). `roofTop` ≈ the base
+ * wall height in archetype units (~8·scale), so caps sit at the roofline.
+ */
+export function addIconicFeature(
+  THREE: typeof THREE_NS,
+  g: THREE_NS.Group,
+  feature: IconicFeature,
+  scale: number,
+  roofMat: THREE_NS.MeshStandardMaterial,
+  trimMat: THREE_NS.MeshStandardMaterial,
+) {
+  const s = scale;
+  const roofTop = 8 * s; // base archetypes top out ~8·scale
+  switch (feature) {
+    case 'dome': {
+      // Hemisphere drum + cap, the observatory / sanctuary read.
+      const drum = new THREE.Mesh(new THREE.CylinderGeometry(3.4 * s, 3.6 * s, 1.2 * s, 20), trimMat);
+      drum.position.y = roofTop + 0.6 * s;
+      drum.castShadow = true;
+      g.add(drum);
+      const dome = new THREE.Mesh(
+        new THREE.SphereGeometry(3.4 * s, 24, 12, 0, Math.PI * 2, 0, Math.PI / 2),
+        roofMat,
+      );
+      dome.position.y = roofTop + 1.2 * s;
+      dome.castShadow = true;
+      g.add(dome);
+      const finial = new THREE.Mesh(new THREE.ConeGeometry(0.4 * s, 1.4 * s, 8), trimMat);
+      finial.position.y = roofTop + 1.2 * s + 3.4 * s;
+      g.add(finial);
+      break;
+    }
+    case 'spire': {
+      // Turret + tall thin spire, the cartographer / watch read.
+      const turret = new THREE.Mesh(new THREE.CylinderGeometry(2.2 * s, 2.4 * s, 3 * s, 8), roofMat);
+      turret.position.y = roofTop + 1.5 * s;
+      turret.castShadow = true;
+      g.add(turret);
+      const spire = new THREE.Mesh(new THREE.ConeGeometry(2.2 * s, 7 * s, 8), roofMat);
+      spire.position.y = roofTop + 3 * s + 3.5 * s;
+      spire.castShadow = true;
+      g.add(spire);
+      break;
+    }
+    case 'colonnade': {
+      // A grand portico across the front — civic / court / academy read.
+      const cols = 6;
+      const w = 12 * s;
+      const colH = 6 * s;
+      for (let i = 0; i < cols; i++) {
+        const col = new THREE.Mesh(new THREE.CylinderGeometry(0.45 * s, 0.5 * s, colH, 12), trimMat);
+        col.position.set(-w / 2 + (i + 0.5) * (w / cols), colH / 2, 6 * s);
+        col.castShadow = true; col.receiveShadow = true;
+        g.add(col);
+      }
+      // Architrave + pediment over the columns.
+      const architrave = new THREE.Mesh(new THREE.BoxGeometry(w + 1 * s, 1 * s, 2 * s), trimMat);
+      architrave.position.set(0, colH + 0.5 * s, 6 * s);
+      architrave.castShadow = true;
+      g.add(architrave);
+      const pediment = new THREE.Mesh(new THREE.ConeGeometry(w * 0.55, 2 * s, 3), roofMat);
+      pediment.position.set(0, colH + 1.5 * s, 6 * s);
+      pediment.rotation.y = Math.PI / 6;
+      pediment.scale.z = 0.5;
+      g.add(pediment);
+      break;
+    }
+    case 'belfry': {
+      // An open bell-tower on the roof — schoolhouse / watch-house read.
+      const baseBox = new THREE.Mesh(new THREE.BoxGeometry(3 * s, 3 * s, 3 * s), roofMat);
+      baseBox.position.y = roofTop + 1.5 * s;
+      baseBox.castShadow = true;
+      g.add(baseBox);
+      const cap = new THREE.Mesh(new THREE.ConeGeometry(2.4 * s, 2.4 * s, 4), roofMat);
+      cap.position.y = roofTop + 3 * s + 1.2 * s;
+      cap.rotation.y = Math.PI / 4;
+      g.add(cap);
+      const bell = new THREE.Mesh(new THREE.SphereGeometry(0.7 * s, 10, 8), trimMat);
+      bell.position.y = roofTop + 1.6 * s;
+      g.add(bell);
+      break;
+    }
   }
 }
 

--- a/concord-frontend/lib/world-lens/resource-node-renderer.ts
+++ b/concord-frontend/lib/world-lens/resource-node-renderer.ts
@@ -24,6 +24,7 @@
  * sway). Removed/depleted nodes dispose their geometry + materials.
  */
 import * as THREE from 'three';
+import { worldToSceneAxis } from './coord-frame';
 
 // ── Wire types ──────────────────────────────────────────────────────────────
 
@@ -304,12 +305,6 @@ export function createResourceNodeRenderer(
   const pollMs = opts.pollMs ?? 5000;
   const apiBase = opts.apiBase ?? '';
   const url = `${apiBase}/api/worlds/${opts.worldId}/nodes`;
-  // World→scene offset. The server seeds nodes in the [0, 2000] world frame
-  // (x = 50 + rand·1900), but the frontend terrain / player / NPCs are centred
-  // at the origin ([-1000, +1000]). Shift node coords by TERRAIN_SIZE/2 = 1000
-  // so they sit on the terrain among everything else (at this offset the server
-  // and frontend elevation formulas agree, so nodes stay on the ground).
-  const WORLD_TO_SCENE_OFFSET = 1000;
 
   const tracked = new Map<string, TrackedNode>();
   let disposed = false;
@@ -331,14 +326,14 @@ export function createResourceNodeRenderer(
       if (existing && (existing.kind === visual.kind) &&
           (existing.depleted === visual.depleted)) {
         existing.targetScale = visual.scale;
-        existing.object.position.set(node.x - WORLD_TO_SCENE_OFFSET, node.y, node.z - WORLD_TO_SCENE_OFFSET);
+        existing.object.position.set(worldToSceneAxis(node.x), node.y, worldToSceneAxis(node.z));
         continue;
       }
 
       if (existing) disposeTracked(existing, parentGroup);
 
       const built = buildNodeObject(visual);
-      built.object.position.set(node.x - WORLD_TO_SCENE_OFFSET, node.y, node.z - WORLD_TO_SCENE_OFFSET);
+      built.object.position.set(worldToSceneAxis(node.x), node.y, worldToSceneAxis(node.z));
       const initialScale = existing ? existing.object.scale.x : visual.scale;
       built.object.scale.setScalar(initialScale);
       parentGroup.add(built.object);

--- a/concord-frontend/lib/world-lens/resource-node-renderer.ts
+++ b/concord-frontend/lib/world-lens/resource-node-renderer.ts
@@ -304,6 +304,12 @@ export function createResourceNodeRenderer(
   const pollMs = opts.pollMs ?? 5000;
   const apiBase = opts.apiBase ?? '';
   const url = `${apiBase}/api/worlds/${opts.worldId}/nodes`;
+  // World→scene offset. The server seeds nodes in the [0, 2000] world frame
+  // (x = 50 + rand·1900), but the frontend terrain / player / NPCs are centred
+  // at the origin ([-1000, +1000]). Shift node coords by TERRAIN_SIZE/2 = 1000
+  // so they sit on the terrain among everything else (at this offset the server
+  // and frontend elevation formulas agree, so nodes stay on the ground).
+  const WORLD_TO_SCENE_OFFSET = 1000;
 
   const tracked = new Map<string, TrackedNode>();
   let disposed = false;
@@ -325,14 +331,14 @@ export function createResourceNodeRenderer(
       if (existing && (existing.kind === visual.kind) &&
           (existing.depleted === visual.depleted)) {
         existing.targetScale = visual.scale;
-        existing.object.position.set(node.x, node.y, node.z);
+        existing.object.position.set(node.x - WORLD_TO_SCENE_OFFSET, node.y, node.z - WORLD_TO_SCENE_OFFSET);
         continue;
       }
 
       if (existing) disposeTracked(existing, parentGroup);
 
       const built = buildNodeObject(visual);
-      built.object.position.set(node.x, node.y, node.z);
+      built.object.position.set(node.x - WORLD_TO_SCENE_OFFSET, node.y, node.z - WORLD_TO_SCENE_OFFSET);
       const initialScale = existing ? existing.object.scale.x : visual.scale;
       built.object.scale.setScalar(initialScale);
       parentGroup.add(built.object);

--- a/concord-frontend/lib/world-lens/resource-node-renderer.ts
+++ b/concord-frontend/lib/world-lens/resource-node-renderer.ts
@@ -24,7 +24,7 @@
  * sway). Removed/depleted nodes dispose their geometry + materials.
  */
 import * as THREE from 'three';
-import { worldToSceneAxis } from './coord-frame';
+import { worldToSceneAxis, sampleGroundY } from './coord-frame';
 
 // ── Wire types ──────────────────────────────────────────────────────────────
 
@@ -322,18 +322,26 @@ export function createResourceNodeRenderer(
       const visual = nodeVisual(node);
       const existing = tracked.get(node.id);
 
+      // Plant on the exact visual surface. node.y is the server's getElevation,
+      // which differs from the rendered mesh by the noise term (server sin vs
+      // client simplex) — up to a few metres of float/sink. Sampling the actual
+      // heightmap makes trees/rocks sit flush; fall back to node.y pre-terrain.
+      const sx = worldToSceneAxis(node.x);
+      const sz = worldToSceneAxis(node.z);
+      const ny = sampleGroundY(sx, sz) ?? node.y;
+
       // Rebuild when the kind or depleted-state changes (different geometry).
       if (existing && (existing.kind === visual.kind) &&
           (existing.depleted === visual.depleted)) {
         existing.targetScale = visual.scale;
-        existing.object.position.set(worldToSceneAxis(node.x), node.y, worldToSceneAxis(node.z));
+        existing.object.position.set(sx, ny, sz);
         continue;
       }
 
       if (existing) disposeTracked(existing, parentGroup);
 
       const built = buildNodeObject(visual);
-      built.object.position.set(worldToSceneAxis(node.x), node.y, worldToSceneAxis(node.z));
+      built.object.position.set(sx, ny, sz);
       const initialScale = existing ? existing.object.scale.x : visual.scale;
       built.object.scale.setScalar(initialScale);
       parentGroup.add(built.object);

--- a/concord-frontend/lib/world-lens/terrain-zones.ts
+++ b/concord-frontend/lib/world-lens/terrain-zones.ts
@@ -1,0 +1,77 @@
+// Terrain zone derivation — turns the REAL building positions into TerrainZone
+// splat regions so the ground under each district reads differently (cobblestone
+// civic plaza, brick market, gravel forge yards, grass commons). The abstract
+// ZoneDTU zoning records carry no coordinates; the spatial truth is the
+// buildings' own x/z, so we derive an apron region around each building tinted
+// by its purpose. Pure data → DistrictZone[] (the shape TerrainRenderer splats).
+
+import type { DistrictZone, TerrainZone } from '@/components/world-lens/TerrainRenderer';
+
+export interface ZonableBuilding {
+  id: string;
+  building_type: string;
+  x: number;
+  z: number;
+  width?: number;
+  depth?: number;
+}
+
+const APRON_M = 12; // ground tinted this far beyond each building's footprint
+
+// building_type → ground material, by purpose. Default 'grass' for anything
+// unmapped (a green commons reads fine and never looks broken).
+const ZONE_BY_TYPE: Record<string, TerrainZone> = {
+  // civic / governance / knowledge — stone civic plazas
+  courthouse: 'cobblestone', assembly_hall: 'cobblestone', council_chamber: 'cobblestone',
+  ethics_hall: 'cobblestone', watch_house: 'cobblestone',
+  cartographer_table: 'cobblestone', code_terminal: 'cobblestone', observatory: 'cobblestone',
+  laboratory: 'cobblestone', archive_hall: 'cobblestone', physics_hall: 'cobblestone',
+  calcularium: 'cobblestone', philosophy_porch: 'cobblestone',
+  // comms / social plazas
+  post_office: 'cobblestone', forum_hall: 'cobblestone', newsroom: 'cobblestone', agora: 'cobblestone',
+  // commerce / arts — brick
+  trading_floor: 'brick', ledger_desk: 'brick', bank_house: 'brick', auction_house: 'brick',
+  market: 'brick', warehouse: 'brick',
+  music_booth: 'brick', atelier: 'brick', writers_room: 'brick', gallery_hall: 'brick',
+  // craft / industry — gravel yards
+  forge: 'gravel', workshop: 'gravel', engineers_hall: 'gravel', mill: 'gravel',
+  depot: 'gravel', powerhouse: 'gravel', site_office: 'gravel', mine: 'gravel', mineshaft: 'gravel',
+  // care / learning / nature — green
+  clinic: 'grass', sanctuary: 'grass', counsel_room: 'grass', gymnasium: 'grass',
+  schoolhouse: 'grass', academy: 'grass',
+  grange: 'wild_grass', foresters_lodge: 'wild_grass', survey_camp: 'wild_grass',
+  // water-adjacent
+  tide_station: 'sand', dock: 'sand', well: 'sand',
+  // core dwellings — worn dirt paths
+  inn: 'dirt', tavern: 'dirt', house: 'dirt', farm: 'wild_grass',
+};
+
+/** Ground material for a building type (never throws; defaults to grass). */
+export function buildingTypeToTerrainZone(buildingType?: string | null): TerrainZone {
+  if (!buildingType) return 'grass';
+  return ZONE_BY_TYPE[buildingType] ?? 'grass';
+}
+
+/**
+ * Derive terrain splat zones from real building positions: an apron region
+ * around each building, tinted by its purpose. Same world-coordinate frame as
+ * the buildings (their x/z), which is what TerrainRenderer's control map expects.
+ */
+export function deriveTerrainZones(buildings: ZonableBuilding[]): DistrictZone[] {
+  const out: DistrictZone[] = [];
+  for (const b of buildings || []) {
+    if (!b || !Number.isFinite(b.x) || !Number.isFinite(b.z)) continue;
+    const halfW = Math.max(Number(b.width) || 8, 8) / 2 + APRON_M;
+    const halfD = Math.max(Number(b.depth) || 8, 8) / 2 + APRON_M;
+    out.push({
+      id: `zone_${b.id}`,
+      name: b.building_type,
+      zone: buildingTypeToTerrainZone(b.building_type),
+      bounds: [b.x - halfW, b.z - halfD, b.x + halfW, b.z + halfD],
+    });
+  }
+  return out;
+}
+
+const terrainZones = { buildingTypeToTerrainZone, deriveTerrainZones };
+export default terrainZones;

--- a/concord-frontend/lib/world-lens/terrain-zones.ts
+++ b/concord-frontend/lib/world-lens/terrain-zones.ts
@@ -54,20 +54,25 @@ export function buildingTypeToTerrainZone(buildingType?: string | null): Terrain
 
 /**
  * Derive terrain splat zones from real building positions: an apron region
- * around each building, tinted by its purpose. Same world-coordinate frame as
- * the buildings (their x/z), which is what TerrainRenderer's control map expects.
+ * around each building, tinted by its purpose. `offset` is the world→scene
+ * transform (the server places the seed city at [0, WORLD_SIZE] while the
+ * frontend terrain is centred at the origin [-SIZE/2, +SIZE/2], so server
+ * coords are shifted by SIZE/2); the zones must use the SAME scene frame the
+ * buildings render in, hence the shared offset.
  */
-export function deriveTerrainZones(buildings: ZonableBuilding[]): DistrictZone[] {
+export function deriveTerrainZones(buildings: ZonableBuilding[], offset = 0): DistrictZone[] {
   const out: DistrictZone[] = [];
   for (const b of buildings || []) {
     if (!b || !Number.isFinite(b.x) || !Number.isFinite(b.z)) continue;
+    const x = b.x - offset;
+    const z = b.z - offset;
     const halfW = Math.max(Number(b.width) || 8, 8) / 2 + APRON_M;
     const halfD = Math.max(Number(b.depth) || 8, 8) / 2 + APRON_M;
     out.push({
       id: `zone_${b.id}`,
       name: b.building_type,
       zone: buildingTypeToTerrainZone(b.building_type),
-      bounds: [b.x - halfW, b.z - halfD, b.x + halfW, b.z + halfD],
+      bounds: [x - halfW, z - halfD, x + halfW, z + halfD],
     });
   }
   return out;

--- a/concord-frontend/scripts/load/bot-swarm.mjs
+++ b/concord-frontend/scripts/load/bot-swarm.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// H4+ — headless bot-swarm load harness. Spins up N socket.io clients that
+// connect, spawn into the coordinate grid, move in circles, and fire combat
+// messages — to find the CCU bottleneck (event-loop saturation, heap growth,
+// broadcast fan-out). This is a MANUAL ops tool run against a live deploy, not a
+// CI gate: watch the server's CPU profile / heap / `concord_heartbeat_skipped_total`
+// and the per-bot ack/nack rates printed here.
+//
+// Usage (from concord-frontend/, where socket.io-client resolves):
+//   node scripts/load/bot-swarm.mjs --url http://localhost:5050 --bots 500 --seconds 60
+// Env equivalents: SWARM_URL, SWARM_BOTS, SWARM_SECONDS, SWARM_MOVE_HZ, SWARM_TOKEN
+//
+// SWARM_TOKEN (optional) is a bearer/cookie auth token; without it bots connect
+// anonymously (the server may reject authed actions — that's a valid signal too).
+
+import { io } from 'socket.io-client';
+
+function arg(name, def) {
+  const i = process.argv.indexOf(`--${name}`);
+  if (i >= 0 && process.argv[i + 1]) return process.argv[i + 1];
+  return def;
+}
+
+const URL      = arg('url', process.env.SWARM_URL || 'http://localhost:5050');
+const BOTS     = Number(arg('bots', process.env.SWARM_BOTS || 200));
+const SECONDS  = Number(arg('seconds', process.env.SWARM_SECONDS || 60));
+const MOVE_HZ  = Number(arg('move-hz', process.env.SWARM_MOVE_HZ || 10));
+const TOKEN    = process.env.SWARM_TOKEN || null;
+const RAMP_MS  = Number(arg('ramp-ms', process.env.SWARM_RAMP_MS || 5000)); // stagger connects
+
+const stats = {
+  connected: 0, connectErrors: 0, disconnects: 0,
+  movesSent: 0, moveAcks: 0, moveNacks: 0, attacksSent: 0, hits: 0,
+  antiCheatDropped: 0, errors: 0,
+};
+const latencies = []; // move round-trip samples (ms)
+
+function pct(arr, p) {
+  if (!arr.length) return 0;
+  const s = [...arr].sort((a, b) => a - b);
+  return Math.round(s[Math.min(s.length - 1, Math.floor((p / 100) * s.length))]);
+}
+
+function spawnBot(idx) {
+  const opts = { transports: ['websocket'], reconnection: false, forceNew: true };
+  if (TOKEN) opts.auth = { token: TOKEN, userId: `bot_${idx}` };
+  const socket = io(URL, opts);
+
+  // Each bot orbits a point on the grid so they spread across chunks.
+  const cx = (idx % 20) * 40 - 400;
+  const cz = Math.floor(idx / 20) * 40 - 400;
+  const r = 15 + (idx % 5) * 5;
+  let theta = (idx / BOTS) * Math.PI * 2;
+  let moveTimer = null;
+  const pendingMove = new Map(); // seq -> sentAt
+  let seq = 0;
+
+  socket.on('connect', () => {
+    stats.connected++;
+    try { socket.emit('player:load'); } catch { /* */ }
+    moveTimer = setInterval(() => {
+      theta += 0.15;
+      const x = cx + Math.cos(theta) * r;
+      const z = cz + Math.sin(theta) * r;
+      const s = ++seq;
+      pendingMove.set(s, performance.now());
+      stats.movesSent++;
+      socket.emit('player:move', { cityId: 'concordia-hub', x, y: 40, z, direction: theta, seq: s, action: 'walk' });
+      // ~1 in 8 frames, throw a punch at a phantom target (server validates).
+      if (Math.random() < 0.12) {
+        stats.attacksSent++;
+        socket.emit('combat:attack', { targetId: `bot_${(idx + 1) % BOTS}`, baseDamage: 10, range: 3, seq: s });
+      }
+    }, Math.max(20, Math.round(1000 / MOVE_HZ)));
+  });
+
+  socket.on('player:move:ack', () => {
+    stats.moveAcks++;
+    // Approximate RTT from the most recent pending move.
+    const last = [...pendingMove.values()].pop();
+    if (last) latencies.push(performance.now() - last);
+    pendingMove.clear();
+  });
+  socket.on('player:move:nack', () => { stats.moveNacks++; });
+  socket.on('combat:hit', () => { stats.hits++; });
+  socket.on('anti-cheat:dropped', () => { stats.antiCheatDropped++; });
+  socket.on('connect_error', () => { stats.connectErrors++; });
+  socket.on('error', () => { stats.errors++; });
+  socket.on('disconnect', () => { stats.disconnects++; if (moveTimer) clearInterval(moveTimer); });
+
+  return () => { if (moveTimer) clearInterval(moveTimer); try { socket.close(); } catch { /* */ } };
+}
+
+console.log(`[swarm] ${BOTS} bots → ${URL} for ${SECONDS}s (move ${MOVE_HZ}Hz, ramp ${RAMP_MS}ms, auth=${TOKEN ? 'token' : 'anon'})`);
+
+const closers = [];
+const startHeap = process.memoryUsage().rss;
+// Stagger connections over the ramp so we don't thundering-herd the handshake.
+for (let i = 0; i < BOTS; i++) {
+  setTimeout(() => closers.push(spawnBot(i)), Math.round((i / BOTS) * RAMP_MS));
+}
+
+const report = setInterval(() => {
+  console.log(`[swarm] conn=${stats.connected}/${BOTS} moves=${stats.movesSent} ack=${stats.moveAcks} nack=${stats.moveNacks} atk=${stats.attacksSent} hit=${stats.hits} p50=${pct(latencies, 50)}ms p95=${pct(latencies, 95)}ms err=${stats.connectErrors + stats.errors} dropped=${stats.antiCheatDropped}`);
+}, 5000);
+
+setTimeout(() => {
+  clearInterval(report);
+  for (const close of closers) close();
+  const heapMb = ((process.memoryUsage().rss - startHeap) / 1e6).toFixed(1);
+  console.log('\n[swarm] ── final ───────────────────────────────');
+  console.log(`  peak connected   : ${stats.connected}/${BOTS}`);
+  console.log(`  moves sent/ack/nack: ${stats.movesSent} / ${stats.moveAcks} / ${stats.moveNacks}`);
+  console.log(`  attacks / hits   : ${stats.attacksSent} / ${stats.hits}`);
+  console.log(`  move RTT p50/p95 : ${pct(latencies, 50)}ms / ${pct(latencies, 95)}ms`);
+  console.log(`  connect errors   : ${stats.connectErrors}, socket errors: ${stats.errors}, disconnects: ${stats.disconnects}`);
+  console.log(`  anti-cheat drops : ${stats.antiCheatDropped}`);
+  console.log(`  client RSS delta : ${heapMb}MB (the SERVER's heap/CPU is the real signal — watch its metrics)`);
+  setTimeout(() => process.exit(0), 500);
+}, SECONDS * 1000 + RAMP_MS);

--- a/concord-frontend/tests/components/LensStationPrompt.test.tsx
+++ b/concord-frontend/tests/components/LensStationPrompt.test.tsx
@@ -39,7 +39,9 @@ describe('LensStationPrompt (render + trigger)', () => {
       ok: true,
       json: async () => ({ ok: true, buildings }),
     });
-    (window as { __concordiaPlayerPos?: { x: number; z: number } }).__concordiaPlayerPos = { x: 800, z: 1000 };
+    // Player position is in the origin-centred scene frame; the fetched building
+    // at server (800,1000) shifts to scene (-200,0), so the player stands there.
+    (window as { __concordiaPlayerPos?: { x: number; z: number } }).__concordiaPlayerPos = { x: -200, z: 0 };
   });
   afterEach(() => {
     delete (window as { __concordiaPlayerPos?: unknown }).__concordiaPlayerPos;

--- a/concord-frontend/tests/components/building-silhouette.test.ts
+++ b/concord-frontend/tests/components/building-silhouette.test.ts
@@ -1,0 +1,101 @@
+// Building silhouette mapping + iconic-feature meshes. The mapping is pure data;
+// the mesh builder is exercised with a stub THREE that records geometry types,
+// so we assert the actual landmark shapes (dome/spire/colonnade/belfry) without
+// a GL context. No mocks of our own code.
+
+import { describe, it, expect } from 'vitest';
+import { silhouetteForBuildingType, coerceMaterial } from '@/lib/world-lens/building-silhouette';
+import { addIconicFeature } from '@/lib/world-lens/procedural-buildings';
+
+// ── Pure mapping ────────────────────────────────────────────────────────────
+describe('silhouetteForBuildingType', () => {
+  it('gives the iconic landmarks their signature feature', () => {
+    expect(silhouetteForBuildingType('observatory')).toEqual({ archetype: 'tower', feature: 'dome' });
+    expect(silhouetteForBuildingType('cartographer_table')).toEqual({ archetype: 'tower', feature: 'spire' });
+    expect(silhouetteForBuildingType('courthouse')).toEqual({ archetype: 'archive', feature: 'colonnade' });
+    expect(silhouetteForBuildingType('schoolhouse')).toEqual({ archetype: 'tavern', feature: 'belfry' });
+    expect(silhouetteForBuildingType('forge')).toEqual({ archetype: 'forge' });
+  });
+
+  it('resolves EVERY archetype to one of the 5 real procedural archetypes', () => {
+    const valid = new Set(['tavern', 'archive', 'forge', 'market', 'tower']);
+    const types = ['inn', 'house', 'market', 'tower', 'bank_house', 'powerhouse', 'agora', 'grange', 'mineshaft', 'unknown_type', ''];
+    for (const t of types) {
+      expect(valid.has(silhouetteForBuildingType(t).archetype)).toBe(true);
+    }
+    // Unknown / empty fall back, never throw.
+    expect(silhouetteForBuildingType(undefined).archetype).toBe('market');
+    expect(silhouetteForBuildingType('not_a_building').feature).toBeUndefined();
+  });
+
+  it('coerces stored materials to renderer material types (thatch → wood)', () => {
+    expect(coerceMaterial('thatch')).toBe('wood');
+    expect(coerceMaterial('stone')).toBe('stone');
+    expect(coerceMaterial('steel')).toBe('steel');
+    expect(coerceMaterial(undefined)).toBe('stone');
+  });
+});
+
+// ── Iconic feature meshes (stub THREE) ──────────────────────────────────────
+function makeMockTHREE() {
+  class Vec { x = 0; y = 0; z = 0; set(x: number, y: number, z: number) { this.x = x; this.y = y; this.z = z; return this; } }
+  class Group { children: unknown[] = []; userData: unknown = {}; add(o: unknown) { this.children.push(o); } }
+  class Mesh {
+    geometry: { kind: string };
+    position = new Vec();
+    rotation = new Vec();
+    scale = new Vec();
+    castShadow = false; receiveShadow = false;
+    constructor(geometry: { kind: string }) { this.geometry = geometry; }
+  }
+  const geom = (kind: string) => () => ({ kind });
+  return {
+    Group, Mesh, Vector3: Vec,
+    BoxGeometry: function () { return { kind: 'Box' }; },
+    ConeGeometry: function () { return { kind: 'Cone' }; },
+    CylinderGeometry: function () { return { kind: 'Cylinder' }; },
+    SphereGeometry: function () { return { kind: 'Sphere' }; },
+    _geom: geom,
+  } as unknown as typeof import('three');
+}
+
+function build(feature: 'dome' | 'spire' | 'colonnade' | 'belfry') {
+  const THREE = makeMockTHREE();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const g = new (THREE as any).Group();
+  const mat = {} as never;
+  addIconicFeature(THREE, g, feature, 1, mat, mat);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (g.children as any[]).map((m) => ({ kind: m.geometry.kind, y: m.position.y }));
+}
+
+describe('addIconicFeature — landmark shapes', () => {
+  it('dome: a hemisphere (Sphere) above the roofline, on a drum', () => {
+    const parts = build('dome');
+    const sphere = parts.find((p) => p.kind === 'Sphere');
+    expect(sphere).toBeTruthy();
+    expect(sphere!.y).toBeGreaterThan(8); // above the ~8·scale roof
+    expect(parts.some((p) => p.kind === 'Cylinder')).toBe(true); // the drum
+  });
+
+  it('spire: a tall Cone reaching well above the roof', () => {
+    const parts = build('spire');
+    const cones = parts.filter((p) => p.kind === 'Cone');
+    expect(cones.length).toBeGreaterThan(0);
+    expect(Math.max(...cones.map((c) => c.y))).toBeGreaterThan(12); // a real spire
+  });
+
+  it('colonnade: a row of columns (≥6 Cylinders) + a pediment Cone', () => {
+    const parts = build('colonnade');
+    expect(parts.filter((p) => p.kind === 'Cylinder').length).toBeGreaterThanOrEqual(6);
+    expect(parts.some((p) => p.kind === 'Cone')).toBe(true);   // pediment
+    expect(parts.some((p) => p.kind === 'Box')).toBe(true);    // architrave
+  });
+
+  it('belfry: a box tower with a pyramidal Cone cap', () => {
+    const parts = build('belfry');
+    expect(parts.some((p) => p.kind === 'Box')).toBe(true);
+    expect(parts.some((p) => p.kind === 'Cone')).toBe(true);
+    expect(parts.some((p) => p.kind === 'Sphere')).toBe(true); // the bell
+  });
+});

--- a/concord-frontend/tests/components/coord-frame.test.ts
+++ b/concord-frontend/tests/components/coord-frame.test.ts
@@ -1,0 +1,30 @@
+// World ↔ scene coordinate transform — the single source of truth that aligns
+// server-seeded content (buildings, nodes) with the origin-centred scene.
+
+import { describe, it, expect } from 'vitest';
+import {
+  WORLD_TO_SCENE_OFFSET, worldToSceneAxis, sceneToWorldAxis, worldToScene, sceneToWorld,
+} from '@/lib/world-lens/coord-frame';
+
+describe('coord-frame', () => {
+  it('shifts the seed city (800,1000) onto the origin-centred plateau (-200,0)', () => {
+    expect(worldToSceneAxis(800)).toBe(-200);
+    expect(worldToSceneAxis(1000)).toBe(0);
+    expect(WORLD_TO_SCENE_OFFSET).toBe(1000);
+  });
+
+  it('round-trips world→scene→world losslessly', () => {
+    const world = { x: 50, z: 1950, id: 'n1' };
+    const scene = worldToScene(world);
+    expect(scene.x).toBe(-950);
+    expect(scene.z).toBe(950);
+    expect(scene.id).toBe('n1'); // preserves other fields
+    const back = sceneToWorld(scene);
+    expect(back.x).toBe(50);
+    expect(back.z).toBe(1950);
+  });
+
+  it('axis helpers are inverses', () => {
+    expect(sceneToWorldAxis(worldToSceneAxis(123))).toBe(123);
+  });
+});

--- a/concord-frontend/tests/components/terrain-zones.test.ts
+++ b/concord-frontend/tests/components/terrain-zones.test.ts
@@ -1,0 +1,59 @@
+// Terrain zone derivation — turns REAL building coordinates into TerrainZone
+// splat regions. Pure data; the coordinates come from the buildings, not the
+// abstract (coordinate-less) ZoneDTU records. No mocks.
+
+import { describe, it, expect } from 'vitest';
+import { buildingTypeToTerrainZone, deriveTerrainZones } from '@/lib/world-lens/terrain-zones';
+
+describe('buildingTypeToTerrainZone', () => {
+  it('tints by purpose: civic→cobblestone, commerce→brick, forge→gravel, care→grass', () => {
+    expect(buildingTypeToTerrainZone('courthouse')).toBe('cobblestone');
+    expect(buildingTypeToTerrainZone('trading_floor')).toBe('brick');
+    expect(buildingTypeToTerrainZone('forge')).toBe('gravel');
+    expect(buildingTypeToTerrainZone('clinic')).toBe('grass');
+    expect(buildingTypeToTerrainZone('tide_station')).toBe('sand');
+  });
+
+  it('defaults unmapped/empty types to grass (never broken-looking)', () => {
+    expect(buildingTypeToTerrainZone('totally_unknown')).toBe('grass');
+    expect(buildingTypeToTerrainZone(undefined)).toBe('grass');
+    expect(buildingTypeToTerrainZone(null)).toBe('grass');
+  });
+});
+
+describe('deriveTerrainZones', () => {
+  it('derives a zone per building from its real x/z, enclosing the footprint', () => {
+    const zones = deriveTerrainZones([
+      { id: 'b1', building_type: 'courthouse', x: 800, z: 948, width: 14, depth: 12 },
+      { id: 'b2', building_type: 'forge', x: 778, z: 1014, width: 12, depth: 10 },
+    ]);
+    expect(zones.length).toBe(2);
+    const court = zones[0];
+    expect(court.zone).toBe('cobblestone');
+    expect(court.id).toBe('zone_b1');
+    // bounds [minX, minZ, maxX, maxZ] must enclose the building centre + footprint
+    const [minX, minZ, maxX, maxZ] = court.bounds;
+    expect(minX).toBeLessThan(800);
+    expect(maxX).toBeGreaterThan(800);
+    expect(minZ).toBeLessThan(948);
+    expect(maxZ).toBeGreaterThan(948);
+    expect(zones[1].zone).toBe('gravel');
+  });
+
+  it('skips buildings with non-finite coordinates; never throws', () => {
+    const zones = deriveTerrainZones([
+      { id: 'ok', building_type: 'market', x: 100, z: 200 },
+      { id: 'bad', building_type: 'market', x: NaN, z: 0 },
+      // @ts-expect-error — defensive: tolerate a malformed row
+      null,
+    ]);
+    expect(zones.length).toBe(1);
+    expect(zones[0].id).toBe('zone_ok');
+  });
+
+  it('uses a minimum apron so tiny buildings still tint a visible patch', () => {
+    const [z] = deriveTerrainZones([{ id: 't', building_type: 'code_terminal', x: 0, z: 0, width: 4, depth: 4 }]);
+    const [minX, , maxX] = z.bounds;
+    expect(maxX - minX).toBeGreaterThanOrEqual(24); // ≥ 2×apron around the footprint
+  });
+});

--- a/concord-frontend/tests/components/terrain-zones.test.ts
+++ b/concord-frontend/tests/components/terrain-zones.test.ts
@@ -51,6 +51,16 @@ describe('deriveTerrainZones', () => {
     expect(zones[0].id).toBe('zone_ok');
   });
 
+  it('applies the world→scene offset so zones match the shifted building frame', () => {
+    // Server city (800,1000) with the 1000 offset → scene-centred (-200, 0).
+    const [z] = deriveTerrainZones([{ id: 'c', building_type: 'courthouse', x: 800, z: 1000, width: 14, depth: 12 }], 1000);
+    const [minX, minZ, maxX, maxZ] = z.bounds;
+    const cx = (minX + maxX) / 2;
+    const cz = (minZ + maxZ) / 2;
+    expect(cx).toBe(-200); // 800 - 1000
+    expect(cz).toBe(0);    // 1000 - 1000
+  });
+
   it('uses a minimum apron so tiny buildings still tint a visible patch', () => {
     const [z] = deriveTerrainZones([{ id: 't', building_type: 'code_terminal', x: 0, z: 0, width: 4, depth: 4 }]);
     const [minX, , maxX] = z.bounds;

--- a/concord-frontend/tests/dead-wires-fixed.test.tsx
+++ b/concord-frontend/tests/dead-wires-fixed.test.tsx
@@ -1,0 +1,71 @@
+// Dead-wire audit fixes (2026-06-26). Each of these was a connection where one
+// end existed but the other was missing/no-op, so the feature never reached the
+// player. We assert the reconnect at the source level (same style as
+// game-modes-hotbar-wired.test.tsx) so a future refactor can't silently sever
+// them again.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const read = (...p: string[]) => readFileSync(path.resolve(root, ...p), 'utf8');
+
+describe('spell-cast — was dispatched by two sources, only consumer was a no-op stub', () => {
+  const world = read('app', 'lenses', 'world', 'page.tsx');
+
+  it('the world lens now LISTENS for concordia:spell-cast (the missing consumer)', () => {
+    expect(world).toMatch(/addEventListener\(\s*['"]concordia:spell-cast['"]/);
+  });
+
+  it('the consumer lands the spell on the engaged target via combat:attack with element + skillId', () => {
+    // Pull the spell-cast handler region and assert it forwards the cast.
+    const idx = world.indexOf("addEventListener('concordia:spell-cast'");
+    const region = world.slice(Math.max(0, idx - 1600), idx);
+    expect(region).toMatch(/combat:attack/);
+    expect(region).toMatch(/skillId:\s*detail\.spellId/);
+    expect(region).toMatch(/element,/);
+  });
+
+  it('both dispatch sites carry the element so the burst is not always "physical"', () => {
+    expect(read('components', 'world', 'concordia-hud', 'SkillWheelMount.tsx'))
+      .toMatch(/element,/);
+    expect(read('components', 'world-lens', 'CombatFlowHotbar.tsx'))
+      .toMatch(/element:\s*slot\.spell\.element/);
+  });
+});
+
+describe('quest markers — ConcordiaScene mounted QuestMarker3D but was never fed objectives', () => {
+  const world = read('app', 'lenses', 'world', 'page.tsx');
+
+  it('the world lens builds questObjectives and passes them to ConcordiaScene', () => {
+    expect(world).toMatch(/setQuestObjectives/);
+    expect(world).toMatch(/questObjectives=\{questObjectives\}/);
+  });
+
+  it('only placeable objective kinds become markers (talk_to / deliver → real NPC position)', () => {
+    expect(world).toMatch(/talk_to:\s*['"]talk['"]/);
+    expect(world).toMatch(/deliver:\s*['"]delivery['"]/);
+    // resolves the objective target against the live NPC list — no invented coords
+    expect(world).toMatch(/npcById\.get\(o\?\.target\)/);
+  });
+
+  it('QuestMarker3D pings for the scene on mount (it mounts after scene-ready fires)', () => {
+    expect(read('components', 'world-lens', 'QuestMarker3D.tsx'))
+      .toMatch(/concordia:scene-request-ready/);
+  });
+});
+
+describe('faction war banner — listener waited on a CustomEvent bridged from a phantom socket name', () => {
+  const world = read('app', 'lenses', 'world', 'page.tsx');
+
+  it('the SR bridge subscribes to the REAL server event faction:war-declared', () => {
+    expect(world).toMatch(/['"]faction:war-declared['"]/);
+  });
+
+  it('no longer subscribes to the phantom faction-war:declared (never emitted server-side)', () => {
+    expect(world).not.toMatch(/['"]faction-war:declared['"]/);
+  });
+});

--- a/concord-frontend/tests/fall-recovery.test.ts
+++ b/concord-frontend/tests/fall-recovery.test.ts
@@ -1,0 +1,40 @@
+// Invisible safety net (G1/G2). The player must never free-fall forever or
+// break on a NaN: the render loop calls outOfBounds() each frame and, on true,
+// snaps back to the last grounded position. This pins the pure detector.
+
+import { describe, it, expect } from 'vitest';
+import { outOfBounds, WORLD_BOUND, FALL_FLOOR_Y } from '@/lib/world-lens/coord-frame';
+
+describe('outOfBounds — kill-volume / edge / NaN detector', () => {
+  it('in-bounds grounded position is safe', () => {
+    expect(outOfBounds({ x: 0, y: 40, z: 0 })).toBe(false);
+    expect(outOfBounds({ x: -200, y: 40, z: 120 })).toBe(false);
+  });
+
+  it('below the fall floor triggers recovery', () => {
+    expect(outOfBounds({ x: 0, y: FALL_FLOOR_Y - 1, z: 0 })).toBe(true);
+    expect(outOfBounds({ x: 0, y: -9999, z: 0 })).toBe(true);
+  });
+
+  it('beyond the walkable bound (either axis) triggers recovery', () => {
+    expect(outOfBounds({ x: WORLD_BOUND + 1, y: 40, z: 0 })).toBe(true);
+    expect(outOfBounds({ x: 0, y: 40, z: -(WORLD_BOUND + 1) })).toBe(true);
+    expect(outOfBounds({ x: 50000, y: 40, z: 0 })).toBe(true);
+  });
+
+  it('non-finite coordinates (NaN / Infinity) trigger recovery', () => {
+    expect(outOfBounds({ x: NaN, y: 40, z: 0 })).toBe(true);
+    expect(outOfBounds({ x: 0, y: Infinity, z: 0 })).toBe(true);
+    expect(outOfBounds({ x: 0, y: 40, z: -Infinity })).toBe(true);
+  });
+
+  it('the edge itself is in-bounds; just past it is not', () => {
+    expect(outOfBounds({ x: WORLD_BOUND, y: 40, z: WORLD_BOUND })).toBe(false);
+    expect(outOfBounds({ x: WORLD_BOUND + 0.001, y: 40, z: 0 })).toBe(true);
+  });
+
+  it('honors custom bound/floor overrides', () => {
+    expect(outOfBounds({ x: 0, y: -5, z: 0 }, 100, -10)).toBe(false);
+    expect(outOfBounds({ x: 150, y: 0, z: 0 }, 100, -10)).toBe(true);
+  });
+});

--- a/concord-frontend/tests/ground-planting.test.ts
+++ b/concord-frontend/tests/ground-planting.test.ts
@@ -1,0 +1,39 @@
+// Ground-planting (2026-06-26). Server-spawned entities (NPCs, other players,
+// creatures, resource nodes) arrive at Y=0, but the city plateau renders at
+// ~40m, so without planting them on the terrain surface they're buried under
+// the world. TerrainRenderer publishes window.__concordiaSampleGroundY (the
+// exact heightmap sampler); the entity renderers read it via sampleGroundY and
+// set Y to it. This pins the sampler contract + the graceful pre-terrain path.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { sampleGroundY } from '@/lib/world-lens/coord-frame';
+
+describe('sampleGroundY — the shared ground sampler', () => {
+  afterEach(() => {
+    delete (window as unknown as { __concordiaSampleGroundY?: unknown }).__concordiaSampleGroundY;
+  });
+
+  it('returns null before the terrain publishes a sampler (caller keeps its Y)', () => {
+    expect(sampleGroundY(0, 0)).toBeNull();
+  });
+
+  it('returns the published surface height at (x,z)', () => {
+    (window as unknown as { __concordiaSampleGroundY: (x: number, z: number) => number })
+      .__concordiaSampleGroundY = (x, z) => 40 + x * 0 + z * 0;
+    expect(sampleGroundY(-200, 0)).toBe(40);
+  });
+
+  it('passes the scene coords straight through to the sampler', () => {
+    const spy = vi.fn((x: number, z: number) => x + z);
+    (window as unknown as { __concordiaSampleGroundY: typeof spy }).__concordiaSampleGroundY = spy;
+    expect(sampleGroundY(-150, 25)).toBe(-125);
+    expect(spy).toHaveBeenCalledWith(-150, 25);
+  });
+
+  it('never throws if the sampler itself throws — degrades to null', () => {
+    (window as unknown as { __concordiaSampleGroundY: () => number }).__concordiaSampleGroundY = () => {
+      throw new Error('terrain mid-rebuild');
+    };
+    expect(sampleGroundY(0, 0)).toBeNull();
+  });
+});

--- a/concord-frontend/tests/netcode-chaos.test.ts
+++ b/concord-frontend/tests/netcode-chaos.test.ts
@@ -1,0 +1,95 @@
+// H1+ — netcode "chaos monkey". Drives the ReconciliationBuffer under jitter,
+// packet loss, and out-of-order delivery and asserts the client converges to the
+// server-authoritative position WITHOUT rubber-banding. Pure logic, offline.
+//
+// The simFn is deterministic (position += forward*delta*speed) so the server and
+// client agree given the same inputs — the only variable is HOW the server acks
+// arrive. A correct buffer must: prune acknowledged inputs, replay the rest, and
+// IGNORE stale/out-of-order acks (else an old ack rubber-bands the player back).
+
+import { describe, it, expect } from 'vitest';
+import { ReconciliationBuffer, type CharState, type InputFrame, type ServerStateMsg } from '@/lib/concordia/netcode';
+
+const SPEED = 10;
+const sim = (s: CharState, i: InputFrame): CharState => ({
+  ...s,
+  position: { x: s.position.x + i.forward * i.delta * SPEED, y: s.position.y, z: s.position.z },
+});
+
+function blankState(seq = 0): CharState {
+  return { seq, position: { x: 0, y: 0, z: 0 }, velocity: { x: 0, y: 0, z: 0 }, onGround: true, health: 100, stamina: 100 };
+}
+function input(seq: number): InputFrame {
+  return { seq, delta: 0.1, forward: 1, strafe: 0, jump: false, sprint: false, yaw: 0 };
+}
+
+// The server runs the SAME deterministic sim from origin → authoritative state
+// per processed seq. (Moving forward 1 unit/ack: x = seq * forward*delta*SPEED.)
+function authoritativeAt(seq: number): ServerStateMsg {
+  let s = blankState(0);
+  for (let i = 1; i <= seq; i++) s = sim(s, input(i));
+  s.seq = seq;
+  return { seq, state: s, tick: seq };
+}
+
+const TOL = 1e-9;
+
+describe('ReconciliationBuffer under network chaos', () => {
+  function freshClient(n: number) {
+    const buf = new ReconciliationBuffer(sim);
+    let state = blankState(0);
+    for (let i = 1; i <= n; i++) state = buf.predict(state, input(i)); // client predicts ahead
+    return { buf, predictedFinalX: state.position.x };
+  }
+
+  it('clean in-order acks converge to the predicted position (no drift)', () => {
+    const { buf, predictedFinalX } = freshClient(5);
+    for (let seq = 1; seq <= 5; seq++) {
+      const r = buf.reconcile(authoritativeAt(seq));
+      // Reconciled = server@seq + replay of inputs (seq+1..5) = the true position.
+      expect(r.position.x).toBeCloseTo(authoritativeAt(5).state.position.x, 9);
+    }
+    expect(predictedFinalX).toBeCloseTo(authoritativeAt(5).state.position.x, 9);
+  });
+
+  it('packet loss (dropped acks) — a later higher-seq ack still converges', () => {
+    const { buf } = freshClient(6);
+    // Server acks 1 and 2 are LOST; only ack 4 arrives, then 6.
+    const r4 = buf.reconcile(authoritativeAt(4));
+    expect(r4.position.x).toBeCloseTo(authoritativeAt(6).state.position.x, 9); // 4 + replay 5,6
+    const r6 = buf.reconcile(authoritativeAt(6));
+    expect(r6.position.x).toBeCloseTo(authoritativeAt(6).state.position.x, 9);
+  });
+
+  it('out-of-order: a STALE ack arriving after a newer one is ignored (no rubber-band)', () => {
+    const { buf } = freshClient(5);
+    const newer = buf.reconcile(authoritativeAt(4));      // ack 4 first
+    const truth = authoritativeAt(5).state.position.x;
+    expect(newer.position.x).toBeCloseTo(truth, 9);
+
+    // Now a delayed ack 2 arrives. Naively this would re-sim from server@2 with
+    // inputs 3,4 already pruned → lose them → snap backward. The guard drops it.
+    const stale = buf.reconcile(authoritativeAt(2));
+    expect(stale.position.x).toBeCloseTo(truth, 9); // unchanged — no rubber-band
+  });
+
+  it('a jittery shuffled stream still ends at the authoritative final position', () => {
+    const { buf } = freshClient(8);
+    // Deliver acks 1..8 badly out of order (and a couple duplicated).
+    const order = [3, 1, 2, 5, 4, 4, 8, 6, 2, 7, 8];
+    let last = blankState(0);
+    for (const seq of order) last = buf.reconcile(authoritativeAt(seq));
+    // The highest ack seen is 8 (all inputs acked) → reconciled == server@8 exactly.
+    expect(last.position.x).toBeCloseTo(authoritativeAt(8).state.position.x, 9);
+    expect(Math.abs(last.position.x - authoritativeAt(8).state.position.x)).toBeLessThan(TOL);
+  });
+
+  it('clearHistory resets the ack watermark (post-respawn snapshot is authoritative)', () => {
+    const { buf } = freshClient(4);
+    buf.reconcile(authoritativeAt(4));
+    buf.clearHistory();
+    // After respawn the server stream restarts at a low seq — it must be honored.
+    const r = buf.reconcile(authoritativeAt(1));
+    expect(r.position.x).toBeCloseTo(authoritativeAt(1).state.position.x, 9);
+  });
+});

--- a/concord-frontend/tests/npc-dialogue-tree-walk.test.tsx
+++ b/concord-frontend/tests/npc-dialogue-tree-walk.test.tsx
@@ -1,0 +1,98 @@
+// Authored branching dialogue walk (2026-06-26). 23 hand-authored trees load at
+// boot but the dialogue route only ever surfaced the flat greeting — the
+// branching conversation (nodes + playerOptions) never reached players. The
+// /dialogue response now ships the tree and NPCDialogue walks it client-side.
+// This drives the walk: opening line → branch → terminal → Leave.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { NPCDialogue } from '@/components/world/NPCDialogue';
+
+const TREE = {
+  greeting: 'He stands at a cold forge, hammer against his knee.',
+  nodes: [
+    {
+      id: 'node_open',
+      npcText: 'State your business.',
+      playerOptions: [
+        { text: 'Tell me about the truce.', leadsTo: 'node_truce' },
+        { text: 'Nothing. Walking through.', leadsTo: 'node_close' },
+      ],
+    },
+    {
+      id: 'node_truce',
+      npcText: 'She claimed the ground. He agreed. That mattered.',
+      playerOptions: [{ text: 'Goodbye.', leadsTo: 'node_close' }],
+    },
+    { id: 'node_close', npcText: 'Mind the embers.', playerOptions: [] },
+  ],
+};
+
+function mockDialogueResponse(tree: unknown) {
+  vi.stubGlobal('fetch', vi.fn(async () => ({
+    ok: true,
+    json: async () => ({
+      ok: true, npcId: 'coalition_enforcer', npcName: 'The Enforcer',
+      greeting: TREE.greeting, mood: 'neutral',
+      options: [{ label: 'Leave', key: 'goodbye' }],
+      dialogueTree: tree,
+    }),
+  })) as unknown as typeof fetch);
+}
+
+const NPC = { id: 'coalition_enforcer', name: 'The Enforcer', archetype: 'blacksmith' };
+
+describe('NPCDialogue — authored branching tree walk', () => {
+  beforeEach(() => {
+    // Mute TTS so speak() short-circuits (no Piper/VAD dynamic-import noise).
+    sessionStorage.setItem('npc-tts-muted', 'true');
+  });
+  afterEach(() => { vi.unstubAllGlobals(); sessionStorage.clear(); });
+
+  it('renders the opening node line + its branch options (not the flat option)', async () => {
+    mockDialogueResponse(TREE);
+    render(<NPCDialogue npc={NPC} worldId="concordia-hub" onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText('State your business.')).toBeTruthy());
+    // Branch options come from the node, not the flat {label:'Leave'} fallback.
+    expect(screen.getByText('Tell me about the truce.')).toBeTruthy();
+    expect(screen.getByText('Nothing. Walking through.')).toBeTruthy();
+    // The authored greeting shows as italic scene-setting context.
+    expect(screen.getByText(TREE.greeting)).toBeTruthy();
+  });
+
+  it('navigates to the linked node when a branch is chosen (no server round-trip)', async () => {
+    mockDialogueResponse(TREE);
+    const fetchSpy = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    render(<NPCDialogue npc={NPC} worldId="concordia-hub" onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText('State your business.')).toBeTruthy());
+    const callsBefore = fetchSpy.mock.calls.length;
+
+    fireEvent.click(screen.getByText('Tell me about the truce.'));
+    await waitFor(() => expect(screen.getByText(/She claimed the ground/)).toBeTruthy());
+    // The walk is purely client-side — no extra fetch for the branch.
+    expect(fetchSpy.mock.calls.length).toBe(callsBefore);
+  });
+
+  it('a terminal node offers only Leave, which closes the dialogue', async () => {
+    mockDialogueResponse(TREE);
+    const onClose = vi.fn();
+    render(<NPCDialogue npc={NPC} worldId="concordia-hub" onClose={onClose} />);
+    await waitFor(() => expect(screen.getByText('State your business.')).toBeTruthy());
+
+    fireEvent.click(screen.getByText('Nothing. Walking through.'));
+    await waitFor(() => expect(screen.getByText('Mind the embers.')).toBeTruthy());
+    // Terminal node → only Leave.
+    const leave = screen.getByText('Leave');
+    expect(leave).toBeTruthy();
+    fireEvent.click(leave);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('falls back to flat options when the NPC has no authored tree', async () => {
+    mockDialogueResponse(undefined);
+    render(<NPCDialogue npc={NPC} worldId="concordia-hub" onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText('Leave')).toBeTruthy());
+    // No tree → the node line never appears.
+    expect(screen.queryByText('State your business.')).toBeNull();
+  });
+});

--- a/content/items.json
+++ b/content/items.json
@@ -1,0 +1,40 @@
+[
+  {
+    "item_id": "lattice_shard",
+    "name": "Lattice Shard",
+    "potency": 58,
+    "affinity": "magic",
+    "stability": 60,
+    "volume": 0.3,
+    "weight": 0.4,
+    "rarity_tier": 4,
+    "source_type": "verge_salvage",
+    "magical_sub": "aether",
+    "lore": "A splinter of the dome-lattice that never fully set after The Dome Stabilisation. It hums against the palm. The Curators pay well and ask few questions about where it was found."
+  },
+  {
+    "item_id": "refusal_iron",
+    "name": "Refusal Iron",
+    "potency": 30,
+    "affinity": "physical",
+    "stability": 99,
+    "volume": 1.0,
+    "weight": 2.6,
+    "rarity_tier": 3,
+    "source_type": "keep_forge",
+    "lore": "Forged in the Refusal Keep and quenched in oaths. It does not bend, which is the entire point. The Watch's Founder's Edge blades are drawn from it."
+  },
+  {
+    "item_id": "verge_glass",
+    "name": "Sundered Glass",
+    "potency": 52,
+    "affinity": "chaos",
+    "stability": 35,
+    "volume": 0.4,
+    "weight": 0.5,
+    "rarity_tier": 4,
+    "source_type": "verge_salvage",
+    "magical_sub": "essence",
+    "lore": "Sand fused to glass in an instant at The Sundered Verge when the lattice tore. Beautiful, unstable, and prone to backfire in a careless craft — a high-potency input only a steady bender should risk."
+  }
+]

--- a/content/skills.json
+++ b/content/skills.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "dtu_swordsmanship_v1",
+    "name": "Founder's Edge",
+    "skill_kind": "blade",
+    "element": "physical",
+    "max_damage": 45,
+    "range_m": 3,
+    "resource_bar": "stamina",
+    "bar_cost": 12,
+    "difficulty": 3,
+    "prerequisites": [],
+    "description": "The measured cut the first settlers learned holding ground they would not yield.",
+    "lore": "Concordia's Founder's Edge — the ancestral blade-form taught at The Seven Spokes Inn. It is not the strongest style, but it is the one that ends a fight rather than starts one. Carried by the Concordant Watch as a mark of office."
+  },
+  {
+    "id": "dtu_refusal_ward_v1",
+    "name": "The Sovereign's Refusal",
+    "skill_kind": "guard",
+    "element": "energy",
+    "max_damage": 22,
+    "range_m": 2,
+    "resource_bar": "stamina",
+    "bar_cost": 8,
+    "difficulty": 5,
+    "prerequisites": ["dtu_swordsmanship_v1"],
+    "description": "A turning parry that converts an aggressor's force into a refusal made physical.",
+    "lore": "From The Refusal That Is the Hub — the Sovereign's discipline of saying no with the body. Low damage, but it staggers and it cannot be baited. The Refusal Keep teaches it only to those who have proven they will not misuse it."
+  },
+  {
+    "id": "dtu_lattice_arc_v1",
+    "name": "Sundered Lattice Arc",
+    "skill_kind": "arcane",
+    "element": "energy",
+    "max_damage": 60,
+    "range_m": 14,
+    "resource_bar": "mana",
+    "bar_cost": 18,
+    "difficulty": 7,
+    "prerequisites": ["dtu_refusal_ward_v1"],
+    "description": "Channels the unstable backlash of the broken dome-lattice into a ranged arc.",
+    "lore": "Scavenged from the wild magic of The Sundered Verge after The Dome Stabilisation left its eastern edge raw. The Concordant Curators forbid its practice inside the dome; benders learn it at the Verge's edge, where the lattice still bleeds."
+  }
+]

--- a/content/world/concordia-hub/zones.json
+++ b/content/world/concordia-hub/zones.json
@@ -1,0 +1,29 @@
+[
+  {
+    "name": "The Seven Spokes Inn",
+    "kind": "sanctuary",
+    "x": 60,
+    "z": 40,
+    "radius": 30,
+    "rules": { "combat": false, "pvp": false, "regenPerTick": 5, "noAggro": true },
+    "lore": "The cross-world travellers' hearth where the Ring of Doors empties out. No blade is drawn here; the Watch and the Consortium both keep it neutral. Rest restores you faster than anywhere in the hub."
+  },
+  {
+    "name": "The Proving Ring",
+    "kind": "pvp",
+    "x": -120,
+    "z": 90,
+    "radius": 45,
+    "rules": { "combat": true, "pvp": true, "regenPerTick": 0 },
+    "lore": "After The Night Someone Tried, the Concordant Watch carved out one sanctioned circle where the hub's refusal of violence is lifted by consent — duels are settled here, and only here. Step inside and PvP is on."
+  },
+  {
+    "name": "The Sundered Verge",
+    "kind": "hazard",
+    "x": 280,
+    "z": -240,
+    "radius": 70,
+    "rules": { "combat": true, "pvp": false, "hazard": 8, "element": "energy" },
+    "lore": "The eastern edge where The Dome Stabilisation never fully took. Arcane backlash sheets off the broken lattice; linger and it burns. The Curators study it from a distance and warn newcomers off."
+  }
+]

--- a/server/lib/anti-cheat-monitor.js
+++ b/server/lib/anti-cheat-monitor.js
@@ -1,0 +1,40 @@
+// H3+ — per-user anomaly score. Every anti-cheat rejection (speed-hack,
+// teleport, damage-cap) is an intelligence data point, not just a dropped
+// packet: a client that accumulates many in a short window is running a tool, so
+// we drop their socket to protect everyone nearby. Rolling-window counter,
+// kill-switchable, with an injectable clock for tests.
+//
+// In-memory + per-process (single Node thread): noteRejection records a hit and
+// reports whether the user has crossed the disconnect threshold within the
+// window. The caller (the socket handler) owns the actual disconnect + metric.
+
+const WINDOW_MS = Number(process.env.CONCORD_ANTICHEAT_WINDOW_MS) || 30_000;
+const THRESHOLD = Math.max(2, Number(process.env.CONCORD_ANTICHEAT_THRESHOLD) || 12);
+
+const _hits = new Map(); // userId -> number[] (rejection timestamps within the window)
+
+/**
+ * Record one anti-cheat rejection for a user.
+ * @returns {{ count, threshold, shouldDisconnect }} — `shouldDisconnect` true
+ *          when the user has hit THRESHOLD rejections inside the window (the
+ *          counter is then cleared so we act once, not every subsequent packet).
+ */
+export function noteRejection(userId, now = Date.now()) {
+  if (!userId || process.env.CONCORD_ANTICHEAT_MONITOR === "0") {
+    return { count: 0, threshold: THRESHOLD, shouldDisconnect: false };
+  }
+  let arr = _hits.get(userId);
+  if (!arr) { arr = []; _hits.set(userId, arr); }
+  arr.push(now);
+  const cutoff = now - WINDOW_MS;
+  while (arr.length && arr[0] < cutoff) arr.shift();
+  const shouldDisconnect = arr.length >= THRESHOLD;
+  if (shouldDisconnect) _hits.delete(userId); // acted on — reset
+  return { count: arr.length, threshold: THRESHOLD, shouldDisconnect };
+}
+
+/** Forget a user's anomaly history (call on clean disconnect). */
+export function clearUser(userId) { if (userId) _hits.delete(userId); }
+
+/** Test hook. */
+export function _reset() { _hits.clear(); }

--- a/server/lib/auctions.js
+++ b/server/lib/auctions.js
@@ -382,19 +382,44 @@ export function fillBuyOrder(db, buyOrderId, sellerId, quantity) {
     const newStatus = newFilled >= order.quantity_wanted ? "filled" : "partial";
 
     const fillId = `bof_${crypto.randomBytes(8).toString("hex")}`;
-    db.prepare(`
-      INSERT INTO auction_buy_fills
-        (id, buy_order_id, seller_user_id, quantity, unit_price_cc)
-      VALUES (?, ?, ?, ?, ?)
-    `).run(fillId, buyOrderId, sellerId, fillQty, order.unit_price_cc);
-
-    db.prepare(`
-      UPDATE auction_buy_orders
-      SET quantity_filled = ?, status = ?
-      WHERE id = ?
-    `).run(newFilled, newStatus, buyOrderId);
-
-    _walletCredit(db, sellerId, payment, `buy_order_fill:${buyOrderId}`);
+    // G8 — atomic fill. The order-state advance, the fill row, and the seller
+    // credit must commit as one unit; previously they were three separate
+    // statements, so a throw/crash after the UPDATE left the order "filled" but
+    // the seller unpaid (lost money). The conditional `quantity_filled = ?`
+    // guard also makes the advance single-winner against a concurrent fill.
+    const tx = db.transaction(() => {
+      const upd = db.prepare(`
+        UPDATE auction_buy_orders
+        SET quantity_filled = ?, status = ?
+        WHERE id = ? AND quantity_filled = ?
+      `).run(newFilled, newStatus, buyOrderId, order.quantity_filled);
+      if (upd.changes !== 1) throw new Error("concurrent_fill");
+      db.prepare(`
+        INSERT INTO auction_buy_fills
+          (id, buy_order_id, seller_user_id, quantity, unit_price_cc)
+        VALUES (?, ?, ?, ?, ?)
+      `).run(fillId, buyOrderId, sellerId, fillQty, order.unit_price_cc);
+      // CHECKED credit — the shared _walletCredit swallows errors, so a seller
+      // with no wallet row would leave the order "filled" but unpaid. Do the
+      // authoritative balance write here and roll the whole fill back if it
+      // doesn't land; the ledger note stays best-effort.
+      const credited = db.prepare(
+        `UPDATE users SET concordia_credits = concordia_credits + ? WHERE id = ?`
+      ).run(payment, sellerId);
+      if (credited.changes !== 1) throw new Error("seller_wallet_missing");
+      try {
+        db.prepare(
+          `INSERT INTO reward_ledger (id, user_id, kind, amount_cc, ts, ref_id)
+           VALUES (?, ?, 'auction_credit', ?, unixepoch(), ?)`
+        ).run(`led_${crypto.randomBytes(6).toString("hex")}`, sellerId, payment, `buy_order_fill:${buyOrderId}`);
+      } catch { /* ledger note optional */ }
+    });
+    try {
+      tx();
+    } catch (e) {
+      if (e?.message === "concurrent_fill") return { ok: false, error: "concurrent_fill" };
+      throw e;
+    }
 
     logger.info?.("auctions", "buy_order_filled", {
       buyOrderId, sellerId, fillQty, payment, newStatus,

--- a/server/lib/brawl.js
+++ b/server/lib/brawl.js
@@ -124,6 +124,25 @@ export function queueStatus(userId = null) {
 }
 
 /**
+ * F5 — disconnect sweep for a user: drop them from the matchmaking queue and
+ * cancel any pending invites they're a party to. The TTL would eventually do
+ * this, but a crashed/closed socket shouldn't linger in the queue or hold a
+ * phantom invite. Idempotent; safe to call for users with no brawl state.
+ */
+export function cleanupForUser(userId) {
+  if (!userId) return { ok: false, error: "missing_user" };
+  _queue.delete(userId);
+  let invitesCleared = 0;
+  for (const [id, inv] of _invites) {
+    if (inv.fromUserId === userId || inv.toUserId === userId) {
+      _invites.delete(id);
+      invitesCleared++;
+    }
+  }
+  return { ok: true, invitesCleared };
+}
+
+/**
  * Pop the two oldest queuers and create a brawl invite between them.
  * Returns { ok, paired: { a, b, inviteId } } or { ok: true, paired: null }.
  */

--- a/server/lib/city-presence.js
+++ b/server/lib/city-presence.js
@@ -17,6 +17,15 @@ import { speedScaledRadius } from "./movement/interest-management.js";
 // radius. Set on each validated move; read by getNearbyUsers when CONCORD_SPEED_AOI.
 const _lastSpeed = new Map();
 
+// G6 note (speedhack): the per-packet check below IS the server-authoritative
+// distance-over-time gate. dt is measured from the SERVER wall-clock (never a
+// client-supplied delta), and a rejected update never advances lastUpdate/
+// position — so a clock-speed hack shows up as speedMps > maxSpeed and is
+// dropped, and sustained movement is hard-capped at maxSpeed per accepted
+// packet. A rolling-window aggregate would be redundant (any window of
+// per-packet-valid steps already averages ≤ maxSpeed by construction) and would
+// only add false-reject risk on the hot path, so it is intentionally NOT added.
+
 // ── State ───────────────────────────────────────────────────────────────────
 
 /** userId -> { cityId, x, y, z, direction, action, lastUpdate, avatar, dirty } */

--- a/server/lib/city-presence.js
+++ b/server/lib/city-presence.js
@@ -1153,7 +1153,7 @@ function _getZoneDebuff(zone, armorPct) {
   return null;
 }
 
-export function applyAttack({ attackerId, targetId, baseDamage = 10, range = 3, armorPierce = 0, contextModifiers = null }) {
+export function applyAttack({ attackerId, targetId, baseDamage = 10, range = 3, armorPierce = 0, contextModifiers = null, maxDamage = Infinity }) {
   if (!attackerId || !targetId) return { ok: false, error: "missing_ids" };
   if (attackerId === targetId) return { ok: false, error: "cannot_attack_self" };
 
@@ -1229,7 +1229,11 @@ export function applyAttack({ attackerId, targetId, baseDamage = 10, range = 3, 
   const mitigated = Math.max(1, Math.floor(variedBase * (1 - mitFactor)));
 
   const isCrit = Math.random() > 0.85;
-  const damage = isCrit ? mitigated * 2 : mitigated;
+  // Server-authoritative ceiling: bound the resolved (post-crit) damage so a
+  // client-supplied baseDamage can never one-shot regardless of variance/crit.
+  // maxDamage defaults to Infinity (NPC/legacy callers unaffected); the socket
+  // PvP path passes resolvedDamageCap() to close the injection exploit.
+  const damage = Math.min(isCrit ? mitigated * 2 : mitigated, maxDamage);
 
   // Degrade zone armor — each hit reduces it; heavier hits + crits degrade more
   const armorDeg = Math.min(zoneArmorBefore, Math.ceil((damage / 3) + (isCrit ? 5 : 0)));

--- a/server/lib/combat-limits.js
+++ b/server/lib/combat-limits.js
@@ -1,0 +1,42 @@
+// Shared server-authoritative combat ceilings. Single source of truth for the
+// HTTP combat route (routes/worlds.js) AND the socket PvP path (server.js), so
+// the two can't drift. The socket `combat:attack` handler previously trusted the
+// client `baseDamage` with only armor mitigation — a modified client could send
+// baseDamage:1e9 and one-shot any player — while the HTTP route was capped.
+// These bound both paths to the same ceiling.
+
+export const COMBAT_MAX_REACH_M      = Number(process.env.CONCORD_COMBAT_MAX_REACH_M)      || 80;  // ranged ceiling (m)
+export const COMBAT_MELEE_REACH_M    = Number(process.env.CONCORD_COMBAT_MELEE_REACH_M)    || 3;   // melee threshold (m)
+export const COMBAT_DAMAGE_HARD_CAP  = Number(process.env.CONCORD_COMBAT_DAMAGE_HARD_CAP)  || 500; // absolute per-hit cap
+export const COMBAT_DAMAGE_CRIT_MULT = Number(process.env.CONCORD_COMBAT_DAMAGE_CRIT_MULT) || 2.5; // crit scaling
+
+/**
+ * Bound a (possibly client-supplied) base damage to a sane input ceiling before
+ * it reaches damage resolution. Uses the attacker's authored skill `max_damage`
+ * when known, else the hard cap. Non-finite / negative inputs floor to 1.
+ *
+ * @param {number} requested   client-declared base damage
+ * @param {number} [skillMax]  attacker skill's max_damage (0/undefined → hard cap)
+ * @returns {number} a finite base damage in [1, ceiling]
+ */
+export function clampBaseDamage(requested, skillMax = 0) {
+  const ceiling = (Number(skillMax) > 0 ? Number(skillMax) : COMBAT_DAMAGE_HARD_CAP);
+  const r = Number(requested);
+  if (!Number.isFinite(r) || r <= 0) return 1;
+  return Math.min(r, ceiling);
+}
+
+/**
+ * Absolute per-hit damage ceiling for the resolved (post-crit) damage. Passed
+ * into applyAttack as `maxDamage` so the final number can never exceed the cap
+ * regardless of input, variance, or crit. Mirrors the HTTP route's
+ * `skill.max_damage * CRIT_MULT` (or hard cap) ceiling.
+ *
+ * @param {number} [skillMax] attacker skill's max_damage
+ * @returns {number}
+ */
+export function resolvedDamageCap(skillMax = 0) {
+  return Number(skillMax) > 0
+    ? Number(skillMax) * COMBAT_DAMAGE_CRIT_MULT
+    : COMBAT_DAMAGE_HARD_CAP;
+}

--- a/server/lib/content-seeder.js
+++ b/server/lib/content-seeder.js
@@ -1173,7 +1173,25 @@ export function getAuthoredDialogue(npcId, questId = null, phase = null) {
     const b = _authoredDialogues.get(`${npcId}:${questId}`);
     if (b) return b;
   }
-  return _authoredDialogues.get(`${npcId}:idle`) ?? null;
+  // Idle fallback. Authored trees are keyed `npcId:questId:phase` (3-part, e.g.
+  // `coalition_enforcer:idle:default`), so a bare 2-part `npcId:idle` lookup
+  // never matched the real keys — the idle path was effectively dead. Try the
+  // canonical 3-part idle key, then the legacy 2-part, then any `npcId:idle:*`.
+  return (
+    _authoredDialogues.get(`${npcId}:idle:default`) ??
+    _authoredDialogues.get(`${npcId}:idle`) ??
+    _firstIdleTree(npcId) ??
+    null
+  );
+}
+
+/** First authored tree whose key starts `${npcId}:idle` (any phase). */
+function _firstIdleTree(npcId) {
+  const prefix = `${npcId}:idle`;
+  for (const [key, val] of _authoredDialogues) {
+    if (key.startsWith(prefix)) return val;
+  }
+  return null;
 }
 
 /** Return all authored NPCs in a given faction. */

--- a/server/lib/content-seeder.js
+++ b/server/lib/content-seeder.js
@@ -599,6 +599,20 @@ export async function seedContent({ db = null } = {}) {
     results.lore = seedLore(lore);
   }
 
+  // Content pillar 2 — authored skill/weapon blueprints (global, cross-world).
+  // A lore weapon/combat-style IS a skill DTU here: the combat route reads
+  // max_damage/range_m/bar_cost off the DTU's data JSON (bounded by
+  // combat-limits.js). Idempotent insert-once on the versioned id.
+  if (db) {
+    const skills = readJSON("skills.json");
+    if (Array.isArray(skills)) {
+      try {
+        const { seedSkillBlueprints } = await import("./skill-seeder.js");
+        results.skillBlueprints = seedSkillBlueprints(db, skills);
+      } catch { /* skill blueprint seeding best-effort */ }
+    }
+  }
+
   // World meta for Concordia (the hub) — stored at content/world/_meta.json
   // because Concordia's content lives at the top level.
   const concordiaMeta = readJSON("world/_meta.json");

--- a/server/lib/content-seeder.js
+++ b/server/lib/content-seeder.js
@@ -647,6 +647,17 @@ export async function seedContent({ db = null } = {}) {
     }
     const subLore = readJSON(`${sub.path}/lore.json`);
     if (subLore) results.lore += seedLore(subLore);
+    // Content pillar 1 — authored lore zones (safe plaza / pvp arena / hazard
+    // ruins) → world_zones, so combatRuleFor consults them. Reuses upsertZone
+    // (idempotent on (world_id, name)). Runs after default zones below too;
+    // named authored zones coexist with the default spawn sanctuary.
+    const subZones = readJSON(`${sub.path}/zones.json`);
+    if (Array.isArray(subZones) && db) {
+      try {
+        const { seedZonesFromContent } = await import("./world-zones.js");
+        results.worldZonesAuthored = (results.worldZonesAuthored || 0) + seedZonesFromContent(db, sub.id, subZones);
+      } catch { /* zone seeding best-effort */ }
+    }
   }
 
   // Phase F1.2 — boot-time asymmetric-traits seeding.

--- a/server/lib/content-seeder.js
+++ b/server/lib/content-seeder.js
@@ -611,6 +611,15 @@ export async function seedContent({ db = null } = {}) {
         results.skillBlueprints = seedSkillBlueprints(db, skills);
       } catch { /* skill blueprint seeding best-effort */ }
     }
+    // Authored lore materials → resource_properties (read by propsFor /
+    // craft-resolve). Mythical ores/essences become real craftable inputs.
+    const items = readJSON("items.json");
+    if (Array.isArray(items)) {
+      try {
+        const { seedItemBlueprints } = await import("./resources.js");
+        results.itemBlueprints = seedItemBlueprints(db, items);
+      } catch { /* item blueprint seeding best-effort */ }
+    }
   }
 
   // World meta for Concordia (the hub) — stored at content/world/_meta.json

--- a/server/lib/milestone-unlocks.js
+++ b/server/lib/milestone-unlocks.js
@@ -1,0 +1,57 @@
+// Content pillar 3 — immutable milestone unlocks. When a player completes a
+// legendary task, grantUnlock stamps a permanent record keyed by a deterministic
+// ref_id, so the unlock survives restart and can't be double-granted by a replay
+// or re-claim (ON CONFLICT(ref_id) DO NOTHING — the economy-ledger idempotency
+// pattern). Reads are cheap helpers the loadout/UI consults.
+//
+// Pure-ish: all DB access is try/catch'd so a minimal build without the table
+// degrades to "no unlocks" rather than crashing a quest-claim.
+
+import crypto from "node:crypto";
+
+function tableExists(db) {
+  try { return !!db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='player_milestone_unlocks'").get(); }
+  catch { return false; }
+}
+
+/**
+ * Stamp an immutable unlock. `refId` MUST be deterministic for the milestone
+ * (e.g. `quest:${questId}:${userId}:${key}`) so re-claiming is a no-op.
+ * @returns {{ ok, granted?, alreadyHad?, reason? }}
+ */
+export function grantUnlock(db, { userId, kind, key, amount = null, source = null, refId }) {
+  if (!db || !userId || !kind || !key || !refId) return { ok: false, reason: "missing_fields" };
+  if (!tableExists(db)) return { ok: false, reason: "no_table" };
+  try {
+    const r = db.prepare(`
+      INSERT INTO player_milestone_unlocks (id, user_id, kind, unlock_key, amount, source, ref_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(ref_id) DO NOTHING
+    `).run(crypto.randomUUID(), userId, kind, key, amount, source, refId);
+    return r.changes === 1
+      ? { ok: true, granted: true }
+      : { ok: true, granted: false, alreadyHad: true };
+  } catch (e) {
+    return { ok: false, reason: e?.message || "db_error" };
+  }
+}
+
+/** True if the player holds an unlock of (kind, key). */
+export function hasUnlock(db, userId, kind, key) {
+  if (!db || !userId || !tableExists(db)) return false;
+  try {
+    return !!db.prepare(
+      "SELECT 1 FROM player_milestone_unlocks WHERE user_id = ? AND kind = ? AND unlock_key = ? LIMIT 1"
+    ).get(userId, kind, key);
+  } catch { return false; }
+}
+
+/** All of a player's unlocks (optionally filtered by kind). */
+export function listUnlocks(db, userId, kind = null) {
+  if (!db || !userId || !tableExists(db)) return [];
+  try {
+    return kind
+      ? db.prepare("SELECT * FROM player_milestone_unlocks WHERE user_id = ? AND kind = ? ORDER BY unlocked_at").all(userId, kind)
+      : db.prepare("SELECT * FROM player_milestone_unlocks WHERE user_id = ? ORDER BY unlocked_at").all(userId);
+  } catch { return []; }
+}

--- a/server/lib/quests/quest-engine.js
+++ b/server/lib/quests/quest-engine.js
@@ -3,6 +3,7 @@
 
 import crypto from 'node:crypto';
 import { gainSkillXP } from '../skills/skill-engine.js';
+import { grantUnlock } from '../milestone-unlocks.js';
 
 /**
  * Return all active quests for a player in a world, with objectives and rewards attached.
@@ -166,6 +167,21 @@ export function claimQuestRewards(db, userId, worldId, questId) {
       granted.push({ type: 'xp', amount: r.amount });
     } else if (r.reward_type === 'gold') {
       granted.push({ type: 'gold', amount: r.amount });
+    } else if (r.reward_type === 'skill_unlock' || r.reward_type === 'faction_modifier') {
+      // Pillar 3 — completing a legendary task stamps an IMMUTABLE unlock onto
+      // the player's state (a skill branch they may now wield, or a permanent
+      // faction modifier), not just text. ref_id is deterministic per
+      // (quest, user, key) so re-claiming is a no-op. Best-effort: a failed
+      // stamp never blocks the rest of the reward grant.
+      const u = grantUnlock(db, {
+        userId,
+        kind: r.reward_type,
+        key: r.reward_key,
+        amount: r.amount,
+        source: `quest:${questId}`,
+        refId: `quest:${questId}:${userId}:${r.reward_type}:${r.reward_key}`,
+      });
+      granted.push({ type: r.reward_type, key: r.reward_key, granted: !!u.granted, alreadyHad: !!u.alreadyHad });
     }
   }
 

--- a/server/lib/resources.js
+++ b/server/lib/resources.js
@@ -118,4 +118,57 @@ export function seedResourceProperties(db) {
   }
 }
 
+/** Validate one authored material blueprint from `content/items.json`. Required:
+ *  item_id. Numeric props, if present, must be finite. */
+export function validateItemBlueprint(it) {
+  if (!it || typeof it !== "object" || Array.isArray(it)) return { ok: false, reason: "not_object" };
+  if (typeof it.item_id !== "string" || !it.item_id) return { ok: false, reason: "missing_item_id" };
+  for (const k of ["potency", "stability", "volume", "weight", "rarity_tier"]) {
+    if (it[k] !== undefined && !Number.isFinite(Number(it[k]))) return { ok: false, reason: `invalid_${k}` };
+  }
+  return { ok: true };
+}
+
+/**
+ * Content pillar 2 (materials) — seed authored lore materials from a parsed
+ * `content/items.json` array into `resource_properties`, the same table
+ * `seedResourceProperties` populates and `propsFor` reads (override→DB→catalog→
+ * default). So an authored mythical ore becomes a real craftable material the
+ * craft-resolve system reads. Each entry merges over DEFAULT_PROPS; idempotent
+ * upsert on item_id. Returns the count seeded.
+ */
+export function seedItemBlueprints(db, items) {
+  if (!db || !Array.isArray(items)) return 0;
+  let stmt;
+  try {
+    stmt = db.prepare(`
+      INSERT INTO resource_properties (item_id, potency, affinity, stability, volume, weight, rarity_tier, source_type, magical_sub)
+      VALUES (@item_id, @potency, @affinity, @stability, @volume, @weight, @rarity_tier, @source_type, @magical_sub)
+      ON CONFLICT(item_id) DO UPDATE SET
+        potency=excluded.potency, affinity=excluded.affinity, stability=excluded.stability,
+        volume=excluded.volume, weight=excluded.weight, rarity_tier=excluded.rarity_tier,
+        source_type=excluded.source_type, magical_sub=excluded.magical_sub, updated_at=unixepoch()
+    `);
+  } catch {
+    return 0; // resource_properties absent on a minimal build — degrade to no-op
+  }
+  let n = 0;
+  const tx = db.transaction(() => {
+    for (const it of items) {
+      if (!validateItemBlueprint(it).ok) continue;
+      const m = { ...DEFAULT_PROPS, ...it };
+      stmt.run({
+        item_id: it.item_id,
+        potency: Number(m.potency), affinity: String(m.affinity),
+        stability: Number(m.stability), volume: Number(m.volume), weight: Number(m.weight),
+        rarity_tier: Number(m.rarity_tier), source_type: String(m.source_type),
+        magical_sub: m.magical_sub != null ? String(m.magical_sub) : null,
+      });
+      n++;
+    }
+  });
+  tx();
+  return n;
+}
+
 export const RESOURCE_CONSTANTS = Object.freeze({ AFFINITIES, DEFAULT_PROPS });

--- a/server/lib/skill-seeder.js
+++ b/server/lib/skill-seeder.js
@@ -1,0 +1,79 @@
+// Content pillar 2 — authored skill/weapon blueprints → skill DTUs.
+//
+// In this engine a lore "weapon" or "combat style" IS a skill DTU: the combat
+// route loads `data`/`skill_level` from `dtus WHERE id=?` and reads
+// `skillData.max_damage` / `range_m` / `resource_bar` / `bar_cost` straight off
+// the parsed `data` JSON (routes/worlds.js:2299-2303), bounded by the
+// server-authoritative ceiling in lib/combat-limits.js. So seeding a blueprint
+// here makes it a REAL, combat-readable definition — not decorative.
+//
+// Idempotent insert-once (INSERT OR IGNORE on the DTU id). Authored blueprints
+// carry a versioned id (e.g. `dtu_swordsmanship_v1`); to change one, bump the
+// version rather than mutate runtime skill rows. creator_id is plain TEXT
+// (mig 087, no FK), so a synthetic "content-seeder" creator is safe.
+
+const SKILL_CREATOR = "content-seeder";
+
+/** Validate one authored skill blueprint. Required: id, name. Numeric fields,
+ *  if present, must be finite. */
+export function validateSkillBlueprint(s) {
+  if (!s || typeof s !== "object" || Array.isArray(s)) return { ok: false, reason: "not_object" };
+  if (typeof s.id !== "string" || !s.id) return { ok: false, reason: "missing_id" };
+  if (typeof s.name !== "string" || !s.name) return { ok: false, reason: "missing_name" };
+  for (const k of ["max_damage", "range_m", "bar_cost", "difficulty", "skill_level"]) {
+    if (s[k] !== undefined && !Number.isFinite(Number(s[k]))) return { ok: false, reason: `invalid_${k}` };
+  }
+  return { ok: true };
+}
+
+/** Build the `data` JSON the combat route reads. Only known, combat-relevant
+ *  fields are surfaced; the lore string is carried for the client. */
+export function skillDataBlob(s) {
+  return {
+    skill_kind: s.skill_kind || "combat",
+    element: s.element || "physical",
+    // Read by _validateDamageCap (bounded by combat-limits). null → hard cap.
+    max_damage: s.max_damage !== undefined ? Number(s.max_damage) : null,
+    range_m: s.range_m !== undefined ? Number(s.range_m) : undefined,
+    resource_bar: s.resource_bar || "stamina",
+    bar_cost: s.bar_cost !== undefined ? Number(s.bar_cost) : 10,
+    prerequisites: Array.isArray(s.prerequisites) ? s.prerequisites : [],
+    difficulty: s.difficulty !== undefined ? Number(s.difficulty) : 1,
+    authored: true,
+    description: s.description || "",
+    lore: s.lore || s.flavor || null,
+  };
+}
+
+/**
+ * Seed authored skill/weapon blueprints from a parsed `skills.json` array into
+ * the `dtus` table as `type='skill'` rows. Mirrors the exact INSERT shape the
+ * runtime uses (skill-progression.js#recordGameplayXP). Idempotent (INSERT OR
+ * IGNORE on id). Returns the count newly inserted.
+ */
+export function seedSkillBlueprints(db, skills, { creatorId = SKILL_CREATOR, now } = {}) {
+  if (!db || !Array.isArray(skills)) return 0;
+  const ts = now || new Date().toISOString();
+  let n = 0;
+  let stmt;
+  try {
+    stmt = db.prepare(`
+      INSERT OR IGNORE INTO dtus (id, type, title, creator_id, data, skill_level, created_at, last_used_at)
+      VALUES (?, 'skill', ?, ?, ?, ?, ?, ?)
+    `);
+  } catch {
+    return 0; // dtus skill columns absent on a minimal build — degrade to no-op
+  }
+  for (const s of skills) {
+    if (!validateSkillBlueprint(s).ok) continue;
+    try {
+      const r = stmt.run(
+        s.id, s.name, creatorId,
+        JSON.stringify(skillDataBlob(s)),
+        Number(s.skill_level) || 1, ts, ts,
+      );
+      if (r.changes === 1) n++;
+    } catch { /* per-skill best-effort */ }
+  }
+  return n;
+}

--- a/server/lib/world-gathering.js
+++ b/server/lib/world-gathering.js
@@ -176,34 +176,45 @@ export function gatherFromNode(db, nodeId, gatheredBy, opts = {}) {
   }
 
   const { amount } = estimateYield(node, toolType, toolTier, skillLevel);
-  const newQty = Math.max(0, node.quantity_remaining - amount);
-  const depleted = newQty === 0;
   const now = Math.floor(Date.now() / 1000);
+
+  // G4 — TOCTOU-safe decrement. The old code SET an absolute quantity computed
+  // from the stale SELECT above, so two concurrent/duplicate gathers (double-
+  // click, or two world-shard writers) could each read 10 and each write 5 →
+  // double-harvest. Decrement RELATIVE to the live column, gated on the node
+  // still being un-depleted, in one atomic statement. `changes===1` means we
+  // won the decrement; otherwise another request emptied it first.
+  const upd = db.prepare(`
+    UPDATE world_resource_nodes
+    SET quantity_remaining = MAX(0, quantity_remaining - ?),
+        is_depleted = CASE WHEN quantity_remaining - ? <= 0 THEN 1 ELSE 0 END,
+        respawn_at  = CASE WHEN quantity_remaining - ? <= 0 THEN ? + (respawn_hours * 3600) ELSE NULL END,
+        last_gathered_by = ?,
+        last_gathered_at = ?
+    WHERE id = ? AND is_depleted = 0 AND quantity_remaining > 0
+  `).run(amount, amount, amount, now, gatheredBy, now, nodeId);
+  if (upd.changes !== 1) return { ok: false, error: 'node_depleted' };
+
+  // Actual units extracted = what was really there (the node never goes
+  // negative — MAX(0) above), so a near-empty node yields only its remainder.
+  const extracted = Math.min(amount, node.quantity_remaining);
+  const newQty = node.quantity_remaining - extracted;
+  const depleted = newQty <= 0;
 
   // Determine quality of gathered resources (rare nodes can drop better items)
   const droppedQuality = _rolledQuality(node.quality, skillLevel);
 
-  db.prepare(`
-    UPDATE world_resource_nodes
-    SET quantity_remaining = ?,
-        is_depleted = ?,
-        respawn_at = CASE WHEN ? THEN ? + (respawn_hours * 3600) ELSE NULL END,
-        last_gathered_by = ?,
-        last_gathered_at = ?
-    WHERE id = ?
-  `).run(newQty, depleted ? 1 : 0, depleted ? 1 : 0, now, gatheredBy, now, nodeId);
-
   const gathered = [{
     item:         node.resource_id,
     name:         node.resource_name,
-    quantity:     amount,
+    quantity:     extracted,
     quality:      droppedQuality,
     fromNodeType: node.node_type,
   }];
 
   // Trees also drop a small amount of resin/branches
-  if (node.node_type === 'tree' && amount > 0) {
-    gathered.push({ item: 'branches', name: 'Branches', quantity: Math.ceil(amount / 2), quality: 'common', fromNodeType: 'tree' });
+  if (node.node_type === 'tree' && extracted > 0) {
+    gathered.push({ item: 'branches', name: 'Branches', quantity: Math.ceil(extracted / 2), quality: 'common', fromNodeType: 'tree' });
   }
   // Coal seam drops a small flint chip
   if (node.resource_id === 'coal' && Math.random() < 0.25) {

--- a/server/lib/world-zones.js
+++ b/server/lib/world-zones.js
@@ -148,3 +148,45 @@ export function seedDefaultZones(db, worldIds = []) {
   }
   return n;
 }
+
+/** Validate one authored zone object from a content `zones.json`. Shape:
+ *  { name, kind, x, z, radius, rules? } — x/z/radius default to 0/0/50. */
+export function validateZone(z) {
+  if (!z || typeof z !== "object" || Array.isArray(z)) return { ok: false, reason: "not_object" };
+  if (typeof z.name !== "string" || !z.name) return { ok: false, reason: "missing_name" };
+  if (!ZONE_KINDS.includes(z.kind)) return { ok: false, reason: "invalid_kind" };
+  for (const k of ["x", "z", "radius"]) {
+    if (z[k] !== undefined && !Number.isFinite(Number(z[k]))) return { ok: false, reason: `invalid_${k}` };
+  }
+  if (z.rules !== undefined && (typeof z.rules !== "object" || Array.isArray(z.rules))) {
+    return { ok: false, reason: "invalid_rules" };
+  }
+  return { ok: true };
+}
+
+/**
+ * Seed authored lore zones for a world from a parsed `zones.json` array. Each
+ * entry maps the lore's coordinate region onto the circular substrate via
+ * upsertZone (idempotent on (world_id, name)). Invalid entries are skipped, not
+ * fatal. Returns the count seeded. The lore's safe plaza / pvp arena / hazard
+ * ruins become real combat/spawn rules `combatRuleFor` consults.
+ */
+export function seedZonesFromContent(db, worldId, zones) {
+  if (!db || !worldId || !Array.isArray(zones) || !tableExists(db, "world_zones")) return 0;
+  let n = 0;
+  for (const z of zones) {
+    if (!validateZone(z).ok) continue;
+    const r = upsertZone(db, {
+      worldId,
+      name: z.name,
+      kind: z.kind,
+      centerX: Number(z.x) || 0,
+      centerZ: Number(z.z) || 0,
+      radiusM: Number(z.radius) || 50,
+      rules: (z.rules && typeof z.rules === "object") ? z.rules : {},
+      createdBy: "content-seeder",
+    });
+    if (r.ok) n++;
+  }
+  return n;
+}

--- a/server/migrations/349_player_milestone_unlocks.js
+++ b/server/migrations/349_player_milestone_unlocks.js
@@ -1,0 +1,26 @@
+// server/migrations/349_player_milestone_unlocks.js
+//
+// Content pillar 3 — lore milestones → ledger. When a player completes a
+// legendary task (a quest with a `skill_unlock` / `faction_modifier` reward, or
+// an authored lore milestone), the engine stamps an IMMUTABLE record onto their
+// character state instead of just showing text. `ref_id` is UNIQUE so the stamp
+// is idempotent — re-claiming or replaying the same milestone never double-grants
+// (the same ON CONFLICT(ref_id) DO NOTHING pattern the economy ledger uses).
+//
+// Append-only; IF NOT EXISTS so re-runs are safe.
+
+export function up(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS player_milestone_unlocks (
+      id          TEXT PRIMARY KEY,
+      user_id     TEXT NOT NULL,
+      kind        TEXT NOT NULL,        -- skill_unlock | faction_modifier | title | ...
+      unlock_key  TEXT NOT NULL,        -- skill id / faction id / branch id
+      amount      INTEGER,              -- optional magnitude (e.g. faction rep delta)
+      source      TEXT,                 -- quest:<id> / achievement:<id> / lore:<eventId>
+      ref_id      TEXT NOT NULL UNIQUE, -- idempotency key: one stamp per (source,user,key)
+      unlocked_at INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+  `);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_milestone_unlocks_user ON player_milestone_unlocks(user_id, kind)`);
+}

--- a/server/routes/worlds.js
+++ b/server/routes/worlds.js
@@ -1329,6 +1329,26 @@ export default function createWorldsRouter({ requireAuth, db }) {
         }
       } catch { /* weaponise consumption best-effort — never blocks dialogue */ }
 
+      // Hand-authored dialogue is canon. The seeder loads branching trees from
+      // content/dialogues/ into _authoredDialogues at boot, but THIS route never
+      // consulted them — it ran deterministic-fallback → LLM and the authored
+      // voice (23 files, the named characters) never reached players. A dead
+      // content wire. Surface the authored greeting (+ opening subtext) here so
+      // it wins over both the LLM and the deterministic fallback. We keep the
+      // canonical action `options` (trade/quest/etc.) — the tree's branch nodes
+      // are a separate conversation surface, not the action-key contract — so
+      // this lifts the authored opener without breaking the option keys.
+      let authoredVoice = false;
+      try {
+        const { getAuthoredDialogue } = await import("../lib/content-seeder.js");
+        const authored = getAuthoredDialogue(npcId);
+        if (authored?.greeting) {
+          greeting = authored.greeting;
+          if (authored.subtext) subtext = authored.subtext;
+          authoredVoice = true;
+        }
+      } catch { /* authored lookup optional — keep computed greeting */ }
+
       // 10. Return structured response (isAgent computed once at fetch — C1 disclosure).
       res.json({
         ok: true, npcId, npcName,
@@ -1336,6 +1356,7 @@ export default function createWorldsRouter({ requireAuth, db }) {
         mood,
         options: parsedOptions,
         subtext: subtext || undefined,
+        authoredVoice: authoredVoice || undefined,
         reputation,
         opinion: interactResult.opinion,
         isAgent: isAgentNpc || undefined,

--- a/server/routes/worlds.js
+++ b/server/routes/worlds.js
@@ -572,8 +572,14 @@ export default function createWorldsRouter({ requireAuth, db }) {
         return res.status(403).json({ error: "Killer priority window active" });
       }
 
-      db.prepare("UPDATE loot_nodes SET claimed_by = ?, claimed_at = ? WHERE id = ?")
-        .run(req.user.id, now, node.id);
+      // G5 — TOCTOU-safe claim: only the request that flips claimed_by from NULL
+      // wins. Spamming the claim packet (double-click / script) previously read
+      // claimed_by=NULL N times before any write landed → N× the loot. The
+      // conditional WHERE + changes check makes exactly one claimant succeed.
+      const claim = db.prepare(
+        "UPDATE loot_nodes SET claimed_by = ?, claimed_at = ? WHERE id = ? AND claimed_by IS NULL"
+      ).run(req.user.id, now, node.id);
+      if (claim.changes !== 1) return res.status(409).json({ error: "Already claimed" });
 
       const contents = JSON.parse(node.contents || "[]");
       res.json({ ok: true, contents });

--- a/server/routes/worlds.js
+++ b/server/routes/worlds.js
@@ -1339,6 +1339,7 @@ export default function createWorldsRouter({ requireAuth, db }) {
       // are a separate conversation surface, not the action-key contract — so
       // this lifts the authored opener without breaking the option keys.
       let authoredVoice = false;
+      let dialogueTree;
       try {
         const { getAuthoredDialogue } = await import("../lib/content-seeder.js");
         const authored = getAuthoredDialogue(npcId);
@@ -1346,6 +1347,23 @@ export default function createWorldsRouter({ requireAuth, db }) {
           greeting = authored.greeting;
           if (authored.subtext) subtext = authored.subtext;
           authoredVoice = true;
+          // Ship the whole branching tree so the client can walk the authored
+          // conversation (npcText + playerOptions per node) locally. Trees are
+          // immutable per release, so no per-node round-trip is needed. We only
+          // forward the fields the walker uses — never any author-only field
+          // (secrets/branch conditions live outside `nodes`/`greeting`).
+          if (Array.isArray(authored.nodes) && authored.nodes.length) {
+            dialogueTree = {
+              greeting: authored.greeting,
+              nodes: authored.nodes.map((n) => ({
+                id: n.id,
+                npcText: n.npcText,
+                playerOptions: Array.isArray(n.playerOptions)
+                  ? n.playerOptions.map((o) => ({ text: o.text, leadsTo: o.leadsTo }))
+                  : [],
+              })),
+            };
+          }
         }
       } catch { /* authored lookup optional — keep computed greeting */ }
 
@@ -1357,6 +1375,7 @@ export default function createWorldsRouter({ requireAuth, db }) {
         options: parsedOptions,
         subtext: subtext || undefined,
         authoredVoice: authoredVoice || undefined,
+        dialogueTree,
         reputation,
         opinion: interactResult.opinion,
         isAgent: isAgentNpc || undefined,

--- a/server/server.js
+++ b/server/server.js
@@ -8607,6 +8607,13 @@ async function tryInitWebSockets(server) {
       if (!userId) return;
       if (!data || typeof data !== "object") return;
       const now = Date.now();
+      // G10 (anti animation-cancel): this server-side cooldown is the
+      // authoritative attack-rate gate. It uses the SERVER clock + per-class
+      // cooldowns, so a memory-injected client animation-cancel cannot fire
+      // attacks faster than the cooldown — the "infinite attack speed" exploit
+      // is closed here regardless of client-side animation state. (A separate
+      // stun-prevents-action FSM is a fairness-polish follow-up, not a rate
+      // exploit — the rate is already bounded.)
       if (!_checkAttackCooldown(_attackCd, now, data.style || data.actionOverride).allowed) return;
 
       // Flow Combat: derive context modifiers up-front so applyAttack can

--- a/server/server.js
+++ b/server/server.js
@@ -8183,7 +8183,12 @@ async function tryInitWebSockets(server) {
     // Dev keeps polling for local dev tools and proxy interop.
     transports: NODE_ENV === "production" ? ["websocket"] : ["websocket", "polling"],
     pingTimeout: 60000,
-    pingInterval: 25000
+    pingInterval: 25000,
+    // G-5 — tighten the inbound frame ceiling (default 1MB). Game packets are
+    // <1KB; a 1MB deeply-nested JSON payload can still burn parse CPU on the
+    // single event-loop thread (JSON-bomb DoS). 64KB is generous for any real
+    // client message and rejects the bomb at the transport layer before parse.
+    maxHttpBufferSize: Number(process.env.CONCORD_WS_MAX_BUFFER) || 64_000
   });
 
   // Phase 3a — multi-instance fan-out via the Redis adapter. Opt-in: only wired
@@ -9461,23 +9466,24 @@ async function tryInitWebSockets(server) {
       } catch (_e) { /* ignore */ }
     };
 
-    socket.on("disconnect", () => {
-      const userId = socket.data?.userId;
+    // F5 — unified per-socket teardown. cityPresence.removeUser already sweeps
+    // presence/chunks; this also sweeps the registrations that had NO disconnect
+    // path (spectator rooms — accumulated with no TTL backstop) and the brawl
+    // matchmaking queue/invites (TTL-only). Fire-and-forget dynamic imports
+    // mirror the rest of this file; failures never block disconnect.
+    const _sweepSocketState = (userId) => {
       if (userId) {
         try { cityPresence.removeUser(userId); } catch (_e) { /* ignore */ }
+        import("./lib/brawl.js").then((m) => m.cleanupForUser?.(userId)).catch(() => {});
       }
+      import("./lib/spectator-mode.js").then((m) => m.leaveSpectator?.(socket)).catch(() => {});
       broadcastDeparture();
       REALTIME.clients.delete(clientId);
-    });
+    };
 
-    socket.on("error", () => {
-      const userId = socket.data?.userId;
-      if (userId) {
-        try { cityPresence.removeUser(userId); } catch (_e) { /* ignore */ }
-      }
-      broadcastDeparture();
-      REALTIME.clients.delete(clientId);
-    });
+    socket.on("disconnect", () => { _sweepSocketState(socket.data?.userId); });
+
+    socket.on("error", () => { _sweepSocketState(socket.data?.userId); });
   });
 
   // MEGA SPEC: Initialize chat WebSocket handlers for streaming
@@ -33270,7 +33276,7 @@ app.get("/api/simulate/:simId", (req, res) => {
 });
 
 // ===== VULNERABILITY API =====
-app.post("/api/vulnerability/detect", (req, res) => {
+app.post("/api/vulnerability/detect", requireOwner, (req, res) => {
   const { message } = req.body || {};
   if (!message) return res.status(400).json({ ok: false, error: "message required" });
   const vulnerability = detectVulnerability(message);
@@ -38500,7 +38506,7 @@ app.get("/api/system/circuit-breakers", asyncHandler(async (req, res) => {
   res.json({ ok: true, breakers: _breakers.getAllStatus() });
 }));
 
-app.post("/api/system/circuit-breakers/reset", asyncHandler(async (req, res) => {
+app.post("/api/system/circuit-breakers/reset", requireOwner, asyncHandler(async (req, res) => {
   const name = req.body?.name || "";
   if (name && _breakers[name]) {
     _breakers[name].reset();
@@ -52868,7 +52874,7 @@ app.post("/api/physics/step", (req, res) => {
   }
 });
 
-app.post("/api/physics/reset", (req, res) => {
+app.post("/api/physics/reset", requireOwner, (req, res) => {
   try {
     const ps = ensurePhysicsState();
     ps.bodies.clear();
@@ -61161,7 +61167,7 @@ app.get("/api/circuits", (_req, res) => {
   res.json({ ok: true, breakers: states });
 });
 
-app.post("/api/circuits/:name/reset", (req, res) => {
+app.post("/api/circuits/:name/reset", requireOwner, (req, res) => {
   const breaker = circuitBreakers[req.params.name];
   if (!breaker) return res.status(404).json({ ok: false, error: "Breaker not found" });
   breaker.state = "closed";

--- a/server/server.js
+++ b/server/server.js
@@ -7133,6 +7133,15 @@ async function initMetrics() {
       labelNames: ["world"],
       registers: [METRICS.registry]
     });
+    // H3+ — anti-cheat rejection telemetry. Movement guards (speed-hack /
+    // teleport) increment this with their reason; the anti-cheat-monitor also
+    // drops repeat offenders' sockets. Pairs with an alert on a sustained rate.
+    METRICS.counters.antiCheatRejected = new prom.Counter({
+      name: "concord_anti_cheat_rejected_total",
+      help: "Movement/combat packets rejected by an anti-cheat guard, by reason",
+      labelNames: ["reason"],
+      registers: [METRICS.registry]
+    });
 
     // E2 — economy-anomaly telemetry. The economy-anomaly-cycle heartbeat rolls up
     // world-health.js#detectPathologies (negative_balance / dupe_citation) + the
@@ -8569,6 +8578,19 @@ async function tryInitWebSockets(server) {
               observedSpeed: pos.observedSpeed,
               maxSpeed: pos.maxSpeed,
             });
+            // H3+ — treat a real movement rejection (speed-hack / teleport) as
+            // an anomaly data point: count it, and drop a sustained offender's
+            // socket so a live exploitation tool can't keep hammering. Telemetry
+            // + auto-drop are both best-effort and never block the move path.
+            try {
+              METRICS?.counters?.antiCheatRejected?.inc({ reason: String(pos.reason || "unknown") });
+              const verdict = _noteAntiCheatRejection(userId);
+              if (verdict.shouldDisconnect) {
+                logger.warn?.("anti-cheat", "user_dropped", { userId, reason: pos.reason, hits: verdict.threshold });
+                socket.emit("anti-cheat:dropped", { reason: "too_many_violations" });
+                socket.disconnect(true);
+              }
+            } catch { /* telemetry/drop best-effort */ }
           }
           return;
         }
@@ -9474,6 +9496,7 @@ async function tryInitWebSockets(server) {
     const _sweepSocketState = (userId) => {
       if (userId) {
         try { cityPresence.removeUser(userId); } catch (_e) { /* ignore */ }
+        try { _clearAntiCheatUser(userId); } catch (_e) { /* ignore */ }
         import("./lib/brawl.js").then((m) => m.cleanupForUser?.(userId)).catch(() => {});
       }
       import("./lib/spectator-mode.js").then((m) => m.leaveSpectator?.(socket)).catch(() => {});
@@ -16031,6 +16054,7 @@ async function llmChat(messagesOrCtx, messagesOrOptions = {}, maybeOptions = {})
 // the registry is intentionally light (functional directives only).
 import { BRAIN_IDENTITY, composeSystemPrompt, TASK_PROMPTS } from "./lib/prompt-registry.js";
 import { makeEscalationBudget } from "./lib/affect-salience.js";
+import { noteRejection as _noteAntiCheatRejection, clearUser as _clearAntiCheatUser } from "./lib/anti-cheat-monitor.js";
 import { runChatComputePreflight } from "./lib/chat-compute-preflight.js";
 import { hydrateSession, persistChatTurn } from "./lib/chat-session-store.js";
 

--- a/server/server.js
+++ b/server/server.js
@@ -16017,6 +16017,7 @@ async function llmChat(messagesOrCtx, messagesOrOptions = {}, maybeOptions = {})
 // Voice for conscious lives in the Modelfile; BRAIN_IDENTITY.conscious in
 // the registry is intentionally light (functional directives only).
 import { BRAIN_IDENTITY, composeSystemPrompt, TASK_PROMPTS } from "./lib/prompt-registry.js";
+import { makeEscalationBudget } from "./lib/affect-salience.js";
 import { runChatComputePreflight } from "./lib/chat-compute-preflight.js";
 import { hydrateSession, persistChatTurn } from "./lib/chat-session-store.js";
 
@@ -45511,12 +45512,26 @@ function needsWebSearch(msg) {
 
 function initChatSocketHandlers(io) {
   if (!io) return;
+  // G9 — per-user chat rate limit. chat:message routes to the conscious brain
+  // (GPU); an unthrottled spammer floods the LLM queue and starves real players
+  // (and the physics/movement loops on the same event thread). Token bucket:
+  // a burst up to CONCORD_CHAT_PER_MIN then ~that-many/min sustained, keyed by
+  // the authenticated user. Over-budget messages are NAKed BEFORE any brain
+  // work. CONCORD_CHAT_RATELIMIT=0 disables.
+  const _chatBudget = makeEscalationBudget({ perWorldPerMin: Number(process.env.CONCORD_CHAT_PER_MIN) || 60 });
   io.on("connection", (socket) => {
     socket.on("chat:message", async (data, ack) => {
       try {
         const { sessionId, prompt, lens } = data || {};
         if (!sessionId || !prompt) {
           ack?.({ ok: false, error: "sessionId and prompt required" });
+          return;
+        }
+        // Rate gate — keyed by authenticated user (falls back to the socket id).
+        const _rlKey = socket.data?.userId || socket.handshake?.auth?.userId || socket.id;
+        if (process.env.CONCORD_CHAT_RATELIMIT !== "0" && !_chatBudget.tryConsume(_rlKey)) {
+          ack?.({ ok: false, error: "rate_limited", retryAfterMs: 1000 });
+          socket.emit("chat:status", { sessionId, status: "rate_limited", lens });
           return;
         }
 

--- a/server/server.js
+++ b/server/server.js
@@ -8711,13 +8711,23 @@ async function tryInitWebSockets(server) {
         } catch { /* refusal-field unavailable — continue normally */ }
       }
 
+      // G3 — server-authoritative damage ceiling on the socket PvP path. The
+      // HTTP NPC route validates computed damage via _validateDamageCap, but
+      // this path fed client `data.baseDamage` straight into applyAttack with
+      // only armor mitigation — a modified client could one-shot any player.
+      // Clamp the input + bound the resolved damage to the SAME shared cap.
+      if (!globalThis._concordCombatLimits) {
+        globalThis._concordCombatLimits = import("./lib/combat-limits.js");
+      }
+      const { clampBaseDamage, resolvedDamageCap } = await globalThis._concordCombatLimits;
       const result = cityPresence.applyAttack({
         attackerId: userId,
         targetId: _ffTargetId,
-        baseDamage: Number(data.baseDamage) || 10,
+        baseDamage: clampBaseDamage(data.baseDamage),
         range: Number(data.range) || 3,
         armorPierce: Number(data.armorPierce) || 0,
         contextModifiers: _contextModifiers,
+        maxDamage: resolvedDamageCap(),
       });
 
       // Ack back to attacker with full detail (damage, crit, kill)

--- a/server/tests/anti-cheat-monitor.test.js
+++ b/server/tests/anti-cheat-monitor.test.js
@@ -1,0 +1,63 @@
+// H3+ — per-user anomaly monitor. Anti-cheat rejections accumulate per user in a
+// rolling window; a sustained offender crosses the threshold and the socket
+// handler drops them. Pins the window, threshold, per-user isolation, and the
+// act-once reset.
+//
+// Run: node --test tests/anti-cheat-monitor.test.js
+
+import { test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { noteRejection, clearUser, _reset } from "../lib/anti-cheat-monitor.js";
+
+beforeEach(() => _reset());
+
+test("accumulates rejections and trips the disconnect at the threshold", () => {
+  const t0 = 1_000_000;
+  let v;
+  for (let i = 0; i < 11; i++) {
+    v = noteRejection("cheater", t0 + i);
+    assert.equal(v.shouldDisconnect, false, `hit ${i + 1} below threshold`);
+  }
+  v = noteRejection("cheater", t0 + 11); // 12th within window
+  assert.equal(v.shouldDisconnect, true, "threshold reached → drop");
+});
+
+test("old hits age out of the window (no false positive for spread-out events)", () => {
+  const t0 = 1_000_000;
+  // 11 hits, then one 31s later — the early ones have aged past the 30s window.
+  for (let i = 0; i < 11; i++) noteRejection("laggy", t0 + i);
+  const v = noteRejection("laggy", t0 + 31_000);
+  assert.equal(v.shouldDisconnect, false, "stale hits pruned, no drop");
+  assert.ok(v.count <= 2, "only recent hits counted");
+});
+
+test("per-user isolation — one cheater doesn't trip another player", () => {
+  const t0 = 1_000_000;
+  for (let i = 0; i < 12; i++) noteRejection("cheater", t0 + i);
+  const innocent = noteRejection("innocent", t0 + 13);
+  assert.equal(innocent.shouldDisconnect, false);
+  assert.equal(innocent.count, 1);
+});
+
+test("resets after acting (act once, not on every subsequent packet)", () => {
+  const t0 = 1_000_000;
+  for (let i = 0; i < 11; i++) noteRejection("cheater", t0 + i);
+  assert.equal(noteRejection("cheater", t0 + 11).shouldDisconnect, true);
+  // Immediately after the drop verdict the counter is cleared.
+  const next = noteRejection("cheater", t0 + 12);
+  assert.equal(next.count, 1, "history reset after the disconnect verdict");
+  assert.equal(next.shouldDisconnect, false);
+});
+
+test("clearUser forgets a user's history; kill-switch disables tracking", () => {
+  const t0 = 1_000_000;
+  noteRejection("u", t0); noteRejection("u", t0 + 1);
+  clearUser("u");
+  assert.equal(noteRejection("u", t0 + 2).count, 1, "cleared");
+
+  process.env.CONCORD_ANTICHEAT_MONITOR = "0";
+  const off = noteRejection("anyone", t0 + 3);
+  assert.equal(off.shouldDisconnect, false);
+  assert.equal(off.count, 0);
+  delete process.env.CONCORD_ANTICHEAT_MONITOR;
+});

--- a/server/tests/auction-buy-orders.test.js
+++ b/server/tests/auction-buy-orders.test.js
@@ -96,6 +96,7 @@ describe("Phase AC — buy orders", () => {
 
   it("fillBuyOrder full flips status to 'filled'", () => {
     fund(db, "buyer", 500);
+    fund(db, "seller", 0);
     const r = placeBuyOrder(db, "buyer", {
       worldId: "tunya", itemDescriptor: "rare_herb",
       unitPriceCc: 5, quantity: 100,
@@ -107,6 +108,7 @@ describe("Phase AC — buy orders", () => {
 
   it("fillBuyOrder clamps to remaining quantity", () => {
     fund(db, "buyer", 500);
+    fund(db, "seller", 0);
     const r = placeBuyOrder(db, "buyer", {
       worldId: "tunya", itemDescriptor: "rare_herb",
       unitPriceCc: 5, quantity: 100,
@@ -119,6 +121,7 @@ describe("Phase AC — buy orders", () => {
 
   it("cancelBuyOrder refunds the unfilled portion only", () => {
     fund(db, "buyer", 1000);
+    fund(db, "seller", 0);
     const r = placeBuyOrder(db, "buyer", {
       worldId: "tunya", itemDescriptor: "rare_herb",
       unitPriceCc: 5, quantity: 100,

--- a/server/tests/authored-dialogue-idle-resolve.test.js
+++ b/server/tests/authored-dialogue-idle-resolve.test.js
@@ -1,0 +1,33 @@
+// Dead-wire fix (2026-06-26): authored dialogue trees load at boot keyed
+// `npcId:questId:phase` (3-part, e.g. `coalition_enforcer:idle:default`), but
+// getAuthoredDialogue's idle fallback queried the 2-part `npcId:idle`, which
+// never matched — so a bare getAuthoredDialogue(npcId) returned null and the
+// hand-authored voice never reached the dialogue route. This pins the fix.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+import { runMigrations } from "../migrate.js";
+import { seedContent, getAuthoredDialogue } from "../lib/content-seeder.js";
+
+test("getAuthoredDialogue(npcId) resolves the idle:default tree (3-part key)", async () => {
+  const db = new Database(":memory:");
+  await runMigrations(db);
+  await seedContent({ db });
+
+  // coalition_enforcer has an authored `coalition_enforcer:idle:default` tree
+  // (content/dialogues/coalition.json).
+  const bare = getAuthoredDialogue("coalition_enforcer");
+  assert.ok(bare, "bare npcId lookup must resolve the idle:default tree (was the bug)");
+  assert.equal(typeof bare.greeting, "string");
+  assert.ok(bare.greeting.length > 0, "authored tree carries a real greeting");
+
+  // Explicit 3-part lookup must agree with the bare fallback.
+  const explicit = getAuthoredDialogue("coalition_enforcer", "idle", "default");
+  assert.equal(explicit?.greeting, bare.greeting);
+
+  // Unknown NPC stays null (no false positives).
+  assert.equal(getAuthoredDialogue("no_such_npc_xyz"), null);
+
+  db.close();
+});

--- a/server/tests/brawl-disconnect-cleanup.test.js
+++ b/server/tests/brawl-disconnect-cleanup.test.js
@@ -1,0 +1,35 @@
+// F5 — brawl disconnect cleanup. A crashed/closed socket used to linger in the
+// matchmaking queue and hold phantom invites until the TTL expired. The master
+// disconnect handler now calls brawl.cleanupForUser(userId), which drops them
+// from the queue and cancels invites they're a party to.
+//
+// Run: node --test tests/brawl-disconnect-cleanup.test.js
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  inviteBrawl, joinQueue, queueStatus, listOpenInvitesFor, cleanupForUser, _reset,
+} from "../lib/brawl.js";
+
+describe("F5 — brawl disconnect cleanup", () => {
+  beforeEach(() => _reset());
+
+  it("drops the user from the queue and cancels their pending invites", () => {
+    joinQueue("a");
+    inviteBrawl("a", "b"); // a is a party to this invite
+    assert.equal(queueStatus("a").inQueue, true);
+    assert.ok(listOpenInvitesFor("b").length >= 1, "invite exists before cleanup");
+
+    const r = cleanupForUser("a");
+    assert.equal(r.ok, true);
+    assert.equal(queueStatus("a").inQueue, false, "removed from matchmaking queue");
+    assert.ok(r.invitesCleared >= 1, "invites involving the user were cleared");
+    assert.equal(listOpenInvitesFor("b").length, 0, "the a→b invite is gone");
+  });
+
+  it("is idempotent and safe for a user with no brawl state", () => {
+    assert.equal(cleanupForUser("nobody").ok, true);
+    assert.equal(cleanupForUser("nobody").invitesCleared, 0);
+    assert.equal(cleanupForUser().ok, false); // missing user id
+  });
+});

--- a/server/tests/buy-order-fill-atomic.test.js
+++ b/server/tests/buy-order-fill-atomic.test.js
@@ -1,0 +1,59 @@
+// G8 — buy-order fill must be atomic. The order-state advance, the fill row, and
+// the seller credit were three separate statements; a throw after the UPDATE
+// left the order "filled" but the seller unpaid (lost money). They now commit in
+// one db.transaction() — a failure rolls everything back.
+//
+// Run: node --test tests/buy-order-fill-atomic.test.js
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+import { placeBuyOrder, fillBuyOrder } from "../lib/auctions.js";
+import { up as upBuyOrders } from "../migrations/227_auction_buy_orders.js";
+
+function freshDb() {
+  const db = new Database(":memory:");
+  upBuyOrders(db);
+  db.exec(`
+    CREATE TABLE users (id TEXT PRIMARY KEY, concordia_credits REAL NOT NULL DEFAULT 0);
+    CREATE TABLE reward_ledger (id TEXT PRIMARY KEY, user_id TEXT, kind TEXT, amount_cc REAL, ts INTEGER, ref_id TEXT);
+  `);
+  return db;
+}
+const fund = (db, u, a) => db.prepare(
+  `INSERT INTO users (id, concordia_credits) VALUES (?, ?) ON CONFLICT(id) DO UPDATE SET concordia_credits = concordia_credits + excluded.concordia_credits`
+).run(u, a);
+const orderRow = (db, id) => db.prepare(`SELECT quantity_filled, status FROM auction_buy_orders WHERE id=?`).get(id);
+const fillCount = (db, id) => db.prepare(`SELECT COUNT(*) n FROM auction_buy_fills WHERE buy_order_id=?`).get(id).n;
+
+describe("G8 — buy-order fill atomicity", () => {
+  let db;
+  beforeEach(() => { db = freshDb(); });
+
+  it("a happy-path fill commits order-state + fill row + seller credit together", () => {
+    fund(db, "buyer", 1000); fund(db, "seller", 0);
+    const r = placeBuyOrder(db, "buyer", { worldId: "w", itemDescriptor: "iron", unitPriceCc: 5, quantity: 100 });
+    const f = fillBuyOrder(db, r.buyOrderId, "seller", 40);
+    assert.equal(f.ok, true);
+    assert.equal(orderRow(db, r.buyOrderId).quantity_filled, 40);
+    assert.equal(fillCount(db, r.buyOrderId), 1);
+    assert.equal(db.prepare(`SELECT concordia_credits c FROM users WHERE id='seller'`).get().c, 200);
+  });
+
+  it("a credit that can't land rolls back: order NOT advanced, no orphan fill row", () => {
+    // Buyer funded; seller has NO users/wallet row → the checked credit affects
+    // 0 rows and must roll the whole fill back (no filled-but-unpaid).
+    fund(db, "buyer", 1000);
+    const r = placeBuyOrder(db, "buyer", { worldId: "w", itemDescriptor: "iron", unitPriceCc: 5, quantity: 100 });
+    const before = orderRow(db, r.buyOrderId);
+
+    const res = fillBuyOrder(db, r.buyOrderId, "seller_no_wallet", 40);
+    assert.equal(res.ok, false, "fill must fail when the seller can't be credited");
+    assert.equal(res.error, "seller_wallet_missing");
+
+    const after = orderRow(db, r.buyOrderId);
+    assert.equal(after.quantity_filled, before.quantity_filled, "order state rolled back");
+    assert.equal(after.status, before.status, "status rolled back");
+    assert.equal(fillCount(db, r.buyOrderId), 0, "no orphan fill row persisted");
+  });
+});

--- a/server/tests/chat-rate-limit.test.js
+++ b/server/tests/chat-rate-limit.test.js
@@ -1,0 +1,41 @@
+// G9 — chat rate limit. chat:message routes to the conscious brain (GPU), so an
+// unthrottled spammer floods the LLM queue and starves real players. The handler
+// gates each message through a per-user token bucket (makeEscalationBudget) BEFORE
+// any brain work. This pins the bucket contract used there: a burst up to the cap,
+// then sustained refill, keyed per user, with an injectable clock.
+//
+// Run: node --test tests/chat-rate-limit.test.js
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { makeEscalationBudget } from "../lib/affect-salience.js";
+
+test("G9 — chat bucket allows a burst then blocks the flood, per user", () => {
+  const clock = 1_000_000;
+  const PER_MIN = 60;
+  const budget = makeEscalationBudget({ perWorldPerMin: PER_MIN, now: () => clock });
+
+  // A single user's burst: the first PER_MIN messages pass instantly...
+  let passed = 0;
+  for (let i = 0; i < 200; i++) if (budget.tryConsume("userA")) passed++;
+  assert.equal(passed, PER_MIN, "burst is capped at the bucket capacity");
+  assert.equal(budget.tryConsume("userA"), false, "the flood's next message is dropped");
+
+  // ...and a DIFFERENT user is unaffected (per-user keying — no collateral).
+  assert.equal(budget.tryConsume("userB"), true, "another user is not rate-limited by userA's flood");
+});
+
+test("G9 — the bucket refills over time (sustained ~cap/min)", () => {
+  let clock = 1_000_000;
+  const budget = makeEscalationBudget({ perWorldPerMin: 60, now: () => clock });
+
+  // Drain userA.
+  for (let i = 0; i < 60; i++) budget.tryConsume("userA");
+  assert.equal(budget.tryConsume("userA"), false, "drained");
+
+  // 60/min = 1 token/sec; after 2s, ~2 tokens are back.
+  clock += 2000;
+  assert.equal(budget.tryConsume("userA"), true, "refilled after 1s");
+  assert.equal(budget.tryConsume("userA"), true, "second refilled token");
+  assert.equal(budget.tryConsume("userA"), false, "but not a third — sustained rate holds");
+});

--- a/server/tests/gather-loot-toctou.test.js
+++ b/server/tests/gather-loot-toctou.test.js
@@ -1,0 +1,74 @@
+// G4/G5 — TOCTOU safety for resource gathering + loot claims. The old code read
+// the row, then wrote an absolute value / unconditional claim, so duplicate
+// requests (double-click / script / multi-shard) could double-harvest a node or
+// claim one loot drop N times. Both now use a single conditional UPDATE and act
+// only on `changes===1`. This pins conservation (never extract more than exists)
+// and single-winner claims.
+//
+// Run: node --test tests/gather-loot-toctou.test.js
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+import { runMigrations } from "../migrate.js";
+import { gatherFromNode } from "../lib/world-gathering.js";
+
+function seedNode(db, { id = "n1", qty = 20 } = {}) {
+  db.prepare(`
+    INSERT INTO world_resource_nodes
+      (id, world_id, node_type, resource_id, resource_name, biome,
+       x, y, z, depth, quantity_remaining, max_quantity, quality, difficulty, respawn_hours, is_depleted, seeded)
+    VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,0,1)
+  `).run(id, "w1", "stone", "stone", "Stone Outcrop", "plains",
+         0, 40, 0, 0, qty, qty, "common", 1, 72);
+}
+
+test("G4 — gather conservation: total extracted never exceeds the node's stock", async () => {
+  const db = new Database(":memory:");
+  await runMigrations(db);
+  seedNode(db, { id: "n1", qty: 20 });
+
+  let total = 0;
+  // Gather until depleted (bounded loop guards against an infinite loop bug).
+  for (let i = 0; i < 100; i++) {
+    const r = gatherFromNode(db, "n1", "u1", { toolType: "pickaxe", toolTier: 3, skillLevel: 30 });
+    if (!r.ok) { assert.equal(r.error, "node_depleted"); break; }
+    total += r.gathered[0].quantity; // the primary resource line
+  }
+
+  const row = db.prepare("SELECT quantity_remaining, is_depleted FROM world_resource_nodes WHERE id='n1'").get();
+  assert.equal(row.quantity_remaining, 0, "node fully drained");
+  assert.equal(row.is_depleted, 1, "node flagged depleted");
+  assert.equal(total, 20, "extracted exactly the stock — no double-harvest, no over-extract");
+  db.close();
+});
+
+test("G4 — a depleted node yields node_depleted, not a phantom harvest", async () => {
+  const db = new Database(":memory:");
+  await runMigrations(db);
+  seedNode(db, { id: "n2", qty: 3 });
+  // Drain it.
+  for (let i = 0; i < 50; i++) { if (!gatherFromNode(db, "n2", "u1", { toolTier: 3, skillLevel: 50 }).ok) break; }
+  const r = gatherFromNode(db, "n2", "u2", { toolTier: 3, skillLevel: 50 });
+  assert.equal(r.ok, false);
+  assert.equal(r.error, "node_depleted");
+  db.close();
+});
+
+test("G5 — loot claim conditional UPDATE has exactly one winner", async () => {
+  const db = new Database(":memory:");
+  await runMigrations(db);
+  // loot_nodes is created by migration 046 (world_id/contents/created_at/expires_at NOT NULL).
+  db.prepare("INSERT INTO loot_nodes (id, world_id, contents, created_at, expires_at) VALUES (?,?,?,?,?)")
+    .run("loot1", "w1", "[{\"item\":\"gold\"}]", Date.now(), Date.now() + 600000);
+
+  const claim = (user) => db.prepare(
+    "UPDATE loot_nodes SET claimed_by=?, claimed_at=? WHERE id=? AND claimed_by IS NULL"
+  ).run(user, Date.now(), "loot1").changes;
+
+  assert.equal(claim("a"), 1, "first claimant wins");
+  assert.equal(claim("b"), 0, "second claimant gets nothing");
+  assert.equal(claim("a"), 0, "even the winner can't re-claim");
+  assert.equal(db.prepare("SELECT claimed_by FROM loot_nodes WHERE id='loot1'").get().claimed_by, "a");
+  db.close();
+});

--- a/server/tests/item-blueprints-seed.test.js
+++ b/server/tests/item-blueprints-seed.test.js
@@ -1,0 +1,58 @@
+// Content pillar 2 (materials) — authored lore materials (items.json) →
+// resource_properties, read by propsFor (the craft-resolve input path). Pins the
+// round-trip, idempotency, validation, and authored JSON validity.
+//
+// Run: node --test tests/item-blueprints-seed.test.js
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+import { runMigrations } from "../migrate.js";
+import { seedItemBlueprints, validateItemBlueprint, propsFor } from "../lib/resources.js";
+
+const ITEMS = [
+  { item_id: "lattice_shard", potency: 58, affinity: "magic", stability: 60, rarity_tier: 4, source_type: "verge_salvage", magical_sub: "aether" },
+  { item_id: "refusal_iron", potency: 30, affinity: "physical", stability: 99, rarity_tier: 3, source_type: "keep_forge" },
+];
+
+test("authored materials seed and resolve through propsFor", async () => {
+  const db = new Database(":memory:");
+  await runMigrations(db);
+  assert.equal(seedItemBlueprints(db, ITEMS), 2);
+
+  const shard = propsFor("lattice_shard", { db });
+  assert.equal(shard.potency, 58);
+  assert.equal(shard.affinity, "magic");
+  assert.equal(shard.rarity_tier, 4);
+  assert.equal(shard.magical_sub, "aether");
+
+  // Unknown material falls back to defaults (never throws).
+  const unknown = propsFor("no_such_item", { db });
+  assert.ok(Number.isFinite(unknown.potency));
+  db.close();
+});
+
+test("re-seed is idempotent (upsert on item_id, no duplicates)", async () => {
+  const db = new Database(":memory:");
+  await runMigrations(db);
+  seedItemBlueprints(db, ITEMS);
+  seedItemBlueprints(db, ITEMS);
+  const c = db.prepare("SELECT COUNT(*) c FROM resource_properties WHERE item_id IN ('lattice_shard','refusal_iron')").get().c;
+  assert.equal(c, 2, "upsert in place");
+  db.close();
+});
+
+test("validateItemBlueprint rejects malformed entries", () => {
+  assert.equal(validateItemBlueprint({ item_id: "x" }).ok, true);
+  assert.equal(validateItemBlueprint({ potency: 5 }).ok, false);          // no item_id
+  assert.equal(validateItemBlueprint({ item_id: "x", potency: "NaN" }).ok, false);
+  assert.equal(validateItemBlueprint(null).ok, false);
+});
+
+test("authored content/items.json is valid", async () => {
+  const { readFileSync } = await import("node:fs");
+  const url = new URL("../../content/items.json", import.meta.url);
+  const arr = JSON.parse(readFileSync(url, "utf8"));
+  assert.ok(Array.isArray(arr) && arr.length >= 1);
+  for (const it of arr) assert.equal(validateItemBlueprint(it).ok, true, `${it.item_id} valid`);
+});

--- a/server/tests/milestone-unlocks.test.js
+++ b/server/tests/milestone-unlocks.test.js
@@ -1,0 +1,73 @@
+// Content pillar 3 — lore milestones → immutable ledger. Completing a legendary
+// task (a quest carrying a skill_unlock / faction_modifier reward) stamps a
+// permanent, idempotent unlock onto the player via grantUnlock, wired into the
+// live claimQuestRewards path. Pins the stamp, the idempotency (re-claim / replay
+// never double-grants), and the read helpers.
+//
+// Run: node --test tests/milestone-unlocks.test.js
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+import { runMigrations } from "../migrate.js";
+import { grantUnlock, hasUnlock, listUnlocks } from "../lib/milestone-unlocks.js";
+import { addQuestRewards, claimQuestRewards } from "../lib/quests/quest-engine.js";
+
+function completedQuest(db, { userId = "u1", worldId = "concordia-hub", questId = "q_legendary" } = {}) {
+  db.prepare(`INSERT INTO player_quests (id, user_id, quest_id, world_id, status, completed_at)
+              VALUES (?, ?, ?, ?, 'completed', unixepoch())`).run(`pq_${questId}`, userId, questId, worldId);
+  return { userId, worldId, questId };
+}
+
+test("grantUnlock stamps once and is idempotent on ref_id", async () => {
+  const db = new Database(":memory:");
+  await runMigrations(db);
+  const args = { userId: "u1", kind: "skill_unlock", key: "dtu_swordsmanship_v1", source: "quest:q1", refId: "quest:q1:u1:skill" };
+
+  const a = grantUnlock(db, args);
+  assert.equal(a.granted, true);
+  const b = grantUnlock(db, args); // replay — same ref_id
+  assert.equal(b.granted, false);
+  assert.equal(b.alreadyHad, true);
+
+  assert.equal(hasUnlock(db, "u1", "skill_unlock", "dtu_swordsmanship_v1"), true);
+  assert.equal(listUnlocks(db, "u1").length, 1, "one row, not two");
+  db.close();
+});
+
+test("claimQuestRewards stamps a skill_unlock + faction_modifier reward", async () => {
+  const db = new Database(":memory:");
+  await runMigrations(db);
+  const { userId, worldId, questId } = completedQuest(db);
+
+  addQuestRewards(db, questId, [
+    { rewardType: "skill_unlock", rewardKey: "dtu_lattice_arc_v1", amount: 1 },
+    { rewardType: "faction_modifier", rewardKey: "refusal_keep", amount: 25 },
+    { rewardType: "gold", rewardKey: null, amount: 100 },
+  ]);
+
+  const res = claimQuestRewards(db, userId, worldId, questId);
+  assert.equal(res.ok, true);
+
+  assert.equal(hasUnlock(db, userId, "skill_unlock", "dtu_lattice_arc_v1"), true, "skill branch unlocked");
+  assert.equal(hasUnlock(db, userId, "faction_modifier", "refusal_keep"), true, "faction modifier stamped");
+  // The reward summary reflects the grants.
+  const skillGrant = res.rewards.find((g) => g.type === "skill_unlock");
+  assert.equal(skillGrant.granted, true);
+  db.close();
+});
+
+test("re-claiming the same quest does not double-stamp (status + ref_id both guard)", async () => {
+  const db = new Database(":memory:");
+  await runMigrations(db);
+  const { userId, worldId, questId } = completedQuest(db);
+  addQuestRewards(db, questId, [{ rewardType: "skill_unlock", rewardKey: "dtu_swordsmanship_v1", amount: 1 }]);
+
+  claimQuestRewards(db, userId, worldId, questId);
+  // Second claim is blocked by rewarded_at...
+  const second = claimQuestRewards(db, userId, worldId, questId);
+  assert.equal(second.ok, false);
+  // ...and even if the status guard were bypassed, the ref_id would dedupe:
+  assert.equal(listUnlocks(db, userId, "skill_unlock").length, 1, "exactly one unlock stamped");
+  db.close();
+});

--- a/server/tests/skill-blueprints-seed.test.js
+++ b/server/tests/skill-blueprints-seed.test.js
@@ -1,0 +1,71 @@
+// Content pillar 2 — authored skill/weapon blueprints → combat-readable skill
+// DTUs. The combat route loads `data`/`skill_level` from `dtus WHERE id=?` and
+// reads max_damage/range_m off the parsed data JSON, so a seeded blueprint is a
+// REAL definition (bounded by combat-limits), not decorative. Pins the
+// round-trip, idempotency, and that authored damage stays within the cap.
+//
+// Run: node --test tests/skill-blueprints-seed.test.js
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+import { runMigrations } from "../migrate.js";
+import { seedSkillBlueprints, validateSkillBlueprint } from "../lib/skill-seeder.js";
+import { resolvedDamageCap, COMBAT_DAMAGE_HARD_CAP } from "../lib/combat-limits.js";
+
+const SKILLS = [
+  { id: "dtu_swordsmanship_v1", name: "Founder's Edge", element: "physical", max_damage: 45, range_m: 3, bar_cost: 12 },
+  { id: "dtu_lattice_arc_v1", name: "Lattice Arc", element: "energy", max_damage: 60, range_m: 14, resource_bar: "mana", bar_cost: 18 },
+];
+
+test("blueprints seed as combat-readable type='skill' DTUs", async () => {
+  const db = new Database(":memory:");
+  await runMigrations(db);
+  assert.equal(seedSkillBlueprints(db, SKILLS), 2);
+
+  // Mirror exactly what routes/worlds.js:2299 reads.
+  const row = db.prepare("SELECT type, data, skill_level FROM dtus WHERE id = ?").get("dtu_swordsmanship_v1");
+  assert.equal(row.type, "skill");
+  const data = JSON.parse(row.data);
+  assert.equal(data.max_damage, 45);
+  assert.equal(data.element, "physical");
+  assert.equal(data.range_m, 3);
+  assert.equal(data.resource_bar, "stamina");
+  assert.equal(data.authored, true);
+
+  // Every authored skill's resolved cap stays within the hard ceiling.
+  for (const s of SKILLS) {
+    assert.ok(resolvedDamageCap(s.max_damage) <= COMBAT_DAMAGE_HARD_CAP,
+      `${s.name} resolved cap ${resolvedDamageCap(s.max_damage)} ≤ ${COMBAT_DAMAGE_HARD_CAP}`);
+  }
+  db.close();
+});
+
+test("re-seed is idempotent (insert-once on the versioned id)", async () => {
+  const db = new Database(":memory:");
+  await runMigrations(db);
+  seedSkillBlueprints(db, SKILLS);
+  assert.equal(seedSkillBlueprints(db, SKILLS), 0, "re-seed adds nothing");
+  assert.equal(db.prepare("SELECT COUNT(*) c FROM dtus WHERE type='skill'").get().c, 2);
+  db.close();
+});
+
+test("validateSkillBlueprint rejects malformed entries", () => {
+  assert.equal(validateSkillBlueprint({ id: "a", name: "A" }).ok, true);
+  assert.equal(validateSkillBlueprint({ name: "A" }).ok, false);            // no id
+  assert.equal(validateSkillBlueprint({ id: "a", name: "A", max_damage: "x" }).ok, false);
+  assert.equal(validateSkillBlueprint(null).ok, false);
+});
+
+test("authored content/skills.json is valid + bounded", async () => {
+  const { readFileSync } = await import("node:fs");
+  const url = new URL("../../content/skills.json", import.meta.url);
+  const arr = JSON.parse(readFileSync(url, "utf8"));
+  assert.ok(Array.isArray(arr) && arr.length >= 1);
+  for (const s of arr) {
+    assert.equal(validateSkillBlueprint(s).ok, true, `${s.name} valid`);
+    if (s.max_damage !== undefined) {
+      assert.ok(resolvedDamageCap(s.max_damage) <= COMBAT_DAMAGE_HARD_CAP, `${s.name} bounded`);
+    }
+  }
+});

--- a/server/tests/socket-combat-damage-cap.test.js
+++ b/server/tests/socket-combat-damage-cap.test.js
@@ -1,0 +1,70 @@
+// G3 — socket PvP damage cap. The socket `combat:attack` path fed client
+// `data.baseDamage` straight into applyAttack with only armor mitigation, so a
+// modified client could send baseDamage:1e9 and one-shot any player (the HTTP
+// NPC route was capped; this path wasn't). Now the handler clamps the input via
+// clampBaseDamage and bounds the resolved damage via applyAttack's maxDamage.
+//
+// Run: node --test tests/socket-combat-damage-cap.test.js
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  configurePresence,
+  updateUserPosition,
+  applyAttack,
+  removeUser,
+} from "../lib/city-presence.js";
+import {
+  clampBaseDamage,
+  resolvedDamageCap,
+  COMBAT_DAMAGE_HARD_CAP,
+} from "../lib/combat-limits.js";
+
+describe("G3 — socket combat damage cap", () => {
+  beforeEach(() => configurePresence({ db: null, fireTrigger: null }));
+  afterEach(() => { removeUser("atk"); removeUser("def"); });
+
+  it("clampBaseDamage bounds malicious / malformed input", () => {
+    assert.equal(clampBaseDamage(1_000_000), COMBAT_DAMAGE_HARD_CAP);   // absurd → hard cap
+    assert.equal(clampBaseDamage(1e9, 0), COMBAT_DAMAGE_HARD_CAP);
+    assert.equal(clampBaseDamage(200, 150), 150);                       // skill ceiling wins
+    assert.equal(clampBaseDamage(-2147483648), 1);                     // negative floors to 1
+    assert.equal(clampBaseDamage(NaN), 1);
+    assert.equal(clampBaseDamage(Infinity), 1);
+    assert.equal(clampBaseDamage(50), 50);                             // legit value passes through
+  });
+
+  it("resolvedDamageCap = skill*crit or the hard cap", () => {
+    assert.equal(resolvedDamageCap(), COMBAT_DAMAGE_HARD_CAP);
+    assert.equal(resolvedDamageCap(100), 250); // 100 * 2.5
+  });
+
+  it("applyAttack(maxDamage) bounds the resolved damage regardless of baseDamage", () => {
+    updateUserPosition("atk", { cityId: "c1", x: 0, y: 0, z: 0 });
+    updateUserPosition("def", { cityId: "c1", x: 1, y: 0, z: 1 });
+    // A small maxDamage makes the bound deterministic: Math.min(anything, 5) ≤ 5,
+    // even with an absurd base + full armor pierce + a crit.
+    const r = applyAttack({
+      attackerId: "atk", targetId: "def",
+      baseDamage: 1_000_000, range: 5, armorPierce: 100, maxDamage: 5,
+    });
+    assert.equal(r.ok, true);
+    assert.ok(r.damage <= 5, `resolved damage ${r.damage} must be ≤ maxDamage 5`);
+    assert.ok(r.damage > 0, "attack should still land");
+  });
+
+  it("the socket-path values (clamp + cap) keep a one-shot attempt within the hard cap", () => {
+    updateUserPosition("atk", { cityId: "c1", x: 0, y: 0, z: 0 });
+    updateUserPosition("def", { cityId: "c1", x: 1, y: 0, z: 1 });
+    // Exactly what the handler now passes for a baseDamage:1e9 injection.
+    const r = applyAttack({
+      attackerId: "atk", targetId: "def",
+      baseDamage: clampBaseDamage(1e9), range: 5, armorPierce: 0,
+      maxDamage: resolvedDamageCap(),
+    });
+    assert.equal(r.ok, true);
+    assert.ok(r.damage <= COMBAT_DAMAGE_HARD_CAP + 0.5,
+      `resolved damage ${r.damage} must be ≤ hard cap ${COMBAT_DAMAGE_HARD_CAP}`);
+  });
+});

--- a/server/tests/zones-content-seed.test.js
+++ b/server/tests/zones-content-seed.test.js
@@ -1,0 +1,77 @@
+// Content pillar 1 — authored lore zones (zones.json) → world_zones, gating
+// combat/spawn via combatRuleFor. Seeds through the same upsertZone path the
+// runtime uses; pins the round-trip + idempotency + that the lore safe plaza /
+// pvp arena / hazard ruins become real rules.
+//
+// Run: node --test tests/zones-content-seed.test.js
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+import { runMigrations } from "../migrate.js";
+import { seedZonesFromContent, combatRuleFor, validateZone } from "../lib/world-zones.js";
+
+const ZONES = [
+  { name: "The Seven Spokes Inn", kind: "sanctuary", x: 60, z: 40, radius: 30,
+    rules: { combat: false, pvp: false, regenPerTick: 5, noAggro: true } },
+  { name: "The Proving Ring", kind: "pvp", x: -120, z: 90, radius: 45,
+    rules: { combat: true, pvp: true } },
+  { name: "The Sundered Verge", kind: "hazard", x: 280, z: -240, radius: 70,
+    rules: { combat: true, pvp: false, hazard: 8, element: "energy" } },
+];
+
+test("authored zones seed and gate combat at their centers", async () => {
+  const db = new Database(":memory:");
+  await runMigrations(db);
+
+  assert.equal(seedZonesFromContent(db, "concordia-hub", ZONES), 3);
+
+  // PvP arena → combat + pvp ON.
+  const ring = combatRuleFor(db, "concordia-hub", -120, 90);
+  assert.equal(ring.combatAllowed, true);
+  assert.equal(ring.pvpAllowed, true);
+  assert.equal(ring.zone.kind, "pvp");
+
+  // Sanctuary inn → combat OFF.
+  const inn = combatRuleFor(db, "concordia-hub", 60, 40);
+  assert.equal(inn.combatAllowed, false);
+  assert.equal(inn.pvpAllowed, false);
+
+  // Hazard verge → real per-tick damage + element.
+  const verge = combatRuleFor(db, "concordia-hub", 280, -240);
+  assert.ok(verge.hazardDps > 0, "hazard zone deals damage");
+  assert.equal(verge.hazardElement, "energy");
+
+  // Outside any authored zone → world default (combat on, pvp off).
+  const open = combatRuleFor(db, "concordia-hub", 900, 900);
+  assert.equal(open.combatAllowed, true);
+  assert.equal(open.pvpAllowed, false);
+
+  db.close();
+});
+
+test("re-seed is idempotent (upsert on world+name, no duplicates)", async () => {
+  const db = new Database(":memory:");
+  await runMigrations(db);
+  seedZonesFromContent(db, "concordia-hub", ZONES);
+  seedZonesFromContent(db, "concordia-hub", ZONES);
+  const c = db.prepare("SELECT COUNT(*) c FROM world_zones WHERE world_id='concordia-hub'").get().c;
+  assert.equal(c, 3, "re-seed updates in place");
+  db.close();
+});
+
+test("validateZone rejects malformed entries", () => {
+  assert.equal(validateZone({ name: "x", kind: "pvp" }).ok, true);
+  assert.equal(validateZone({ name: "x", kind: "nonsense" }).ok, false);
+  assert.equal(validateZone({ kind: "pvp" }).ok, false);          // no name
+  assert.equal(validateZone({ name: "x", kind: "pvp", radius: "nope" }).ok, false);
+  assert.equal(validateZone(null).ok, false);
+});
+
+test("the authored hub zones.json is valid + parses", async () => {
+  const { readFileSync } = await import("node:fs");
+  const url = new URL("../../content/world/concordia-hub/zones.json", import.meta.url);
+  const arr = JSON.parse(readFileSync(url, "utf8"));
+  assert.ok(Array.isArray(arr) && arr.length >= 3);
+  for (const z of arr) assert.equal(validateZone(z).ok, true, `zone ${z.name} valid`);
+});


### PR DESCRIPTION
Audit finding (the real gap): the world's 3D building layer was fed
buildings={[]} — seed/station buildings rendered only as 2D HTML 'enter'
pills, never as meshes. And the procedural factory only drew rich
silhouettes for 5 archetypes when an explicit archetype was set, which
seed buildings never had. So every building was either absent or a
generic box.

This makes buildings read as specific landmarks (silhouette-readability —
a building should be recognisable from its outline alone, per the game-art
research):

- lib/world-lens/procedural-buildings.ts: new addIconicFeature() — dome
  (hemisphere drum + finial), spire (turret + tall cone), colonnade
  (6-column portico + architrave + pediment), belfry (bell tower + cap).
  Low-poly, deterministic; appended on the base archetype.
- lib/world-lens/building-silhouette.ts: pure building_type → {archetype,
  feature} map for every seed + lens-station type (observatory→tower+dome,
  cartographer→tower+spire, courthouse→archive+colonnade, …) + material
  coercion (thatch→wood). Every type resolves to a real archetype, so it
  always takes the rich procedural path.
- BuildingRenderer3D.tsx: derive archetype + feature from building_type for
  typed world buildings (player-designed structural DTUs keep the legacy
  structural path); pass feature to createBuilding.
- app/lenses/world/page.tsx: wire worldBuildings → BuildingRenderer3D (was
  []) so seed/station buildings actually render in 3D.
- tests/components/building-silhouette.test.ts (7): pure mapping + the
  landmark mesh shapes via a stub THREE (dome=Sphere above roof,
  spire=tall Cone, colonnade=6 Cylinders+pediment, belfry=Box+Cone+bell).
  lint + type-check + validate-routes green.

Note: enabling the 3D building layer (buildings was []) is a behaviour
change that needs a browser visual-QA pass — the code + meshes are tested,
but in-scene appearance/perf can't be verified headless.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RxwGhrNMhrCC9d2sWxmx5W