### PR TITLE
MMO/RPG completeness + Orchestrated Invariant Engine + per-lens flawless loop

### DIFF
--- a/concord-frontend/app/lenses/affect/page.tsx
+++ b/concord-frontend/app/lenses/affect/page.tsx
@@ -549,7 +549,12 @@ export default function AffectLensPage() {
 
   if (stateLoading) {
     return (
-      <div className="flex items-center justify-center h-full p-8">
+      <div
+        role="status"
+        aria-busy="true"
+        aria-live="polite"
+        className="flex items-center justify-center h-full p-8"
+      >
         <div className="text-center space-y-3">
           <div className="w-8 h-8 border-2 border-neon-pink border-t-transparent rounded-full animate-spin mx-auto" />
           <p className="text-sm text-gray-400">Loading affect state...</p>
@@ -560,7 +565,7 @@ export default function AffectLensPage() {
 
   if (isError || isError2 || isError3 || isError4) {
     return (
-      <div className="flex items-center justify-center h-full p-8">
+      <div role="alert" className="flex items-center justify-center h-full p-8">
         <ErrorState
           error={error?.message || error2?.message || error3?.message || error4?.message}
           onRetry={() => {
@@ -2079,17 +2084,17 @@ export default function AffectLensPage() {
                                   : 'text-purple-400'
                             }`} />
                             <div className="flex-1 min-w-0">
-                              <p className="text-sm font-medium text-gray-300">
-                                {String(pattern.name || pattern.label || pattern.type || `Pattern ${i + 1}`)}
+                              <p className="text-sm font-medium text-gray-300 capitalize">
+                                {String(pattern.theme || pattern.name || pattern.label || pattern.type || `Pattern ${i + 1}`)}
                               </p>
                               {!!(pattern.description || pattern.detail) && (
                                 <p className="text-xs text-gray-400 mt-0.5">
                                   {String(pattern.description || pattern.detail)}
                                 </p>
                               )}
-                              {!!pattern.frequency && (
+                              {!!(pattern.count ?? pattern.frequency) && (
                                 <span className="text-[10px] text-gray-400 mt-1 block">
-                                  Frequency: {String(pattern.frequency)}
+                                  Occurrences: {String(pattern.count ?? pattern.frequency)}
                                 </span>
                               )}
                             </div>
@@ -2114,8 +2119,11 @@ export default function AffectLensPage() {
                       <p className="text-xs text-gray-400 font-medium mb-2">Emotional Triggers</p>
                       <div className="flex flex-wrap gap-1.5">
                         {(patternResult.triggers as Array<Record<string, unknown>>).map((trigger, i) => (
-                          <span key={i} className="text-xs bg-red-500/10 text-red-400 px-2 py-0.5 rounded-full">
-                            {String(trigger.name || trigger.label || trigger)}
+                          <span key={i} className="text-xs bg-red-500/10 text-red-400 px-2 py-0.5 rounded-full capitalize">
+                            {String(trigger.trigger || trigger.name || trigger.label || trigger)}
+                            {trigger.count != null && (
+                              <span className="ml-1 opacity-70">({String(trigger.count)})</span>
+                            )}
                           </span>
                         ))}
                       </div>
@@ -2130,9 +2138,9 @@ export default function AffectLensPage() {
                         {(patternResult.cycles as Array<Record<string, unknown>>).map((cycle, i) => (
                           <div key={i} className="flex items-center gap-2 text-xs p-2 bg-purple-500/5 rounded border border-purple-500/10">
                             <RefreshCw className="w-3 h-3 text-purple-400 shrink-0" />
-                            <span className="text-gray-400">{String(cycle.description || cycle.name || `Cycle ${i + 1}`)}</span>
-                            {!!cycle.period && (
-                              <span className="ml-auto text-gray-600 font-mono">{String(cycle.period)}</span>
+                            <span className="text-gray-400">{String(cycle.label || cycle.description || cycle.name || `Cycle ${i + 1}`)}</span>
+                            {!!(cycle.count ?? cycle.period) && (
+                              <span className="ml-auto text-gray-600 font-mono">{String(cycle.count ?? cycle.period)}</span>
                             )}
                           </div>
                         ))}
@@ -2145,19 +2153,32 @@ export default function AffectLensPage() {
                     <div>
                       <p className="text-xs text-gray-400 font-medium mb-2">Correlations</p>
                       <div className="space-y-1">
-                        {(patternResult.correlations as Array<Record<string, unknown>>).map((corr, i) => (
-                          <div key={i} className="flex items-center gap-2 text-xs">
-                            <Activity className="w-3 h-3 text-cyan-400" />
-                            <span className="text-gray-400">
-                              {String(corr.description || corr.name || `${corr.from || ''} -> ${corr.to || ''}`)}
-                            </span>
-                            {typeof corr.strength === 'number' && (
-                              <span className="ml-auto font-mono text-cyan-400">
-                                r={corr.strength.toFixed(2)}
-                              </span>
-                            )}
-                          </div>
-                        ))}
+                        {(patternResult.correlations as Array<Record<string, unknown>>).map((corr, i) => {
+                          // Canonical handler shape: { between: [a, b], strength: 'strong'|'moderate' }.
+                          // Fall back to the alternate shapes the panel historically tolerated.
+                          const between = Array.isArray(corr.between)
+                            ? (corr.between as unknown[]).map((x) => String(x)).join(' ↔ ')
+                            : null;
+                          const label =
+                            String(corr.description || corr.name || '') ||
+                            between ||
+                            `${corr.from || ''} -> ${corr.to || ''}`;
+                          return (
+                            <div key={i} className="flex items-center gap-2 text-xs">
+                              <Activity className="w-3 h-3 text-cyan-400" />
+                              <span className="text-gray-400">{label}</span>
+                              {typeof corr.strength === 'number' ? (
+                                <span className="ml-auto font-mono text-cyan-400">
+                                  r={(corr.strength as number).toFixed(2)}
+                                </span>
+                              ) : typeof corr.strength === 'string' ? (
+                                <span className="ml-auto font-mono text-cyan-400 capitalize">
+                                  {String(corr.strength)}
+                                </span>
+                              ) : null}
+                            </div>
+                          );
+                        })}
                       </div>
                     </div>
                   )}

--- a/concord-frontend/app/lenses/art/page.tsx
+++ b/concord-frontend/app/lenses/art/page.tsx
@@ -374,14 +374,17 @@ export default function ArtLensPage() {
 
   const { data: artAssets, isLoading: assetsLoading, isError: isError, error: error, refetch: refetch,} = useQuery({
     queryKey: ['art-assets', selectedStyle, searchQuery],
+    // Don't swallow the error: a thrown queryFn surfaces isError so the
+    // ErrorState + working Retry actually render (previously a `.catch(()=>[])`
+    // made isError permanently false and the error UI dead-code).
     queryFn: () => apiHelpers.artistry.assets.list({ type: 'artwork', search: searchQuery || undefined })
-    .then(r => r.data?.assets || []).catch((err) => { console.error('Failed to fetch art assets:', err instanceof Error ? err.message : err); return []; }),
+    .then(r => r.data?.assets || []),
     initialData: [],
   });
 
   const { data: artListings, isError: isError2, error: error2, refetch: refetch2,} = useQuery({
     queryKey: ['art-marketplace'],
-    queryFn: () => apiHelpers.artistry.marketplace.art.list().then(r => r.data?.artworks || []).catch((err) => { console.error('Failed to fetch art listings:', err instanceof Error ? err.message : err); return []; }),
+    queryFn: () => apiHelpers.artistry.marketplace.art.list().then(r => r.data?.artworks || []),
     initialData: [],
   });
 

--- a/concord-frontend/app/lenses/artistry/page.tsx
+++ b/concord-frontend/app/lenses/artistry/page.tsx
@@ -120,10 +120,15 @@ export default function ArtistryLensPage() {
   const [uploadType, setUploadType] = useState('illustration');
   const [uploadTags, setUploadTags] = useState('');
 
-  // Assets from API
+  // Assets from API — the primary list channel wired to ErrorState/refetch.
+  // Do NOT swallow the failure into an empty resolve: catching → `return []`
+  // makes the promise resolve, so `isError` stays permanently false and the
+  // ErrorState (and its working Retry) below is dead — a load failure would
+  // read as an honest-but-wrong "No assets found." Re-throw so React Query
+  // surfaces `isError`, while `initialData` keeps the first render populated-safe.
   const { data: assets, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['artistry', 'assets', searchQuery],
-    queryFn: () => apiHelpers.artistry.assets.list({ search: searchQuery || undefined }).then(r => r.data?.assets || []).catch((e) => { console.warn('[Artistry] Query failed:', e?.message); return []; }),
+    queryFn: () => apiHelpers.artistry.assets.list({ search: searchQuery || undefined }).then(r => r.data?.assets || []),
     initialData: [],
   });
 

--- a/concord-frontend/app/lenses/atlas/page.tsx
+++ b/concord-frontend/app/lenses/atlas/page.tsx
@@ -94,7 +94,7 @@ export default function AtlasLensPage() {
 
   // ── Data fetching ──────────────────────────────────────────────────────
 
-  const { data: coverageData, isLoading: coverageLoading, isError: coverageError } = useQuery({
+  const { data: coverageData, isLoading: coverageLoading, isError: coverageError, refetch: refetchCoverage } = useQuery({
     queryKey: ['atlas-coverage'],
     queryFn: () => apiHelpers.atlasTomography.coverage().then(r => r.data),
     refetchInterval: 30000,
@@ -106,7 +106,7 @@ export default function AtlasLensPage() {
     refetchInterval: 20000,
   });
 
-  const { data: anomalyData, isLoading: anomalyLoading, isError: anomalyError } = useQuery({
+  const { data: anomalyData, isLoading: anomalyLoading, isError: anomalyError, refetch: refetchAnomalies } = useQuery({
     queryKey: ['atlas-anomalies'],
     queryFn: () => apiHelpers.atlasTomography.signalsAnomalies(50).then(r => r.data),
     refetchInterval: 15000,
@@ -167,11 +167,34 @@ export default function AtlasLensPage() {
     <div data-lens-theme="atlas" className="min-h-screen bg-zinc-950 text-zinc-100 p-6 space-y-6">
       {/* Phase 4 — REAL OpenStreetMap Nominatim search. Tier-1 honest live geocode. */}
       <OsmGeocodePanel />
-      {/* Error banner */}
+      {/* ── Four UX states for the tomography channel ── */}
+      {/* LOADING */}
+      {(coverageLoading || anomalyLoading) && !coverageError && !anomalyError && (
+        <div role="status" aria-live="polite" className="bg-zinc-900 border border-zinc-800 rounded-lg p-3 flex items-center gap-2">
+          <Loader2 className="w-4 h-4 text-emerald-400 animate-spin" />
+          <p className="text-sm text-zinc-400">Scanning signal tomography…</p>
+        </div>
+      )}
+      {/* ERROR — role=alert + a working Retry that RE-FETCHES (not a full reload) */}
       {(coverageError || anomalyError) && (
-        <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-3 flex items-center justify-between">
+        <div role="alert" className="bg-red-500/10 border border-red-500/20 rounded-lg p-3 flex items-center justify-between">
           <p className="text-red-400 text-sm">Some data sources failed to load. Showing available data.</p>
-          <button onClick={() => window.location.reload()} className="text-xs text-red-300 hover:text-white">Retry</button>
+          <button
+            onClick={() => { refetchCoverage(); refetchAnomalies(); }}
+            className="text-xs text-red-300 hover:text-white border border-red-500/30 rounded px-2 py-1"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+      {/* EMPTY — honest CTA when every tomography source resolved with no rows */}
+      {!coverageLoading && !anomalyLoading && !coverageError && !anomalyError &&
+        markers.length === 0 &&
+        ((taxonomyData as { signals?: unknown[]; total?: number })?.signals?.length || (taxonomyData as { total?: number })?.total || 0) === 0 &&
+        ((anomalyData as { anomalies?: unknown[]; total?: number })?.anomalies?.length || (anomalyData as { total?: number })?.total || 0) === 0 && (
+        <div className="bg-zinc-900 border border-dashed border-zinc-700 rounded-lg p-4 text-center">
+          <p className="text-sm text-zinc-300 font-medium">No signal coverage yet</p>
+          <p className="text-xs text-zinc-500 mt-1">Query a tile by latitude/longitude below, or save a place to seed your atlas.</p>
         </div>
       )}
       {/* Header */}

--- a/concord-frontend/app/lenses/board/page.tsx
+++ b/concord-frontend/app/lenses/board/page.tsx
@@ -277,6 +277,75 @@ function avatarColor(name: string): string {
   return colors[Math.abs(hash) % colors.length];
 }
 
+// Map the live kanban tasks onto the {cards,columns,sprints,remainingPoints}
+// shapes the board.* calculator macros read. Every value is derived from real
+// task state — no fabricated rows. `done` tasks are treated as completed (their
+// dueDate stands in for completion), priority maps to WSJF business value, and
+// the column ordering matches the on-screen columns.
+const PRIORITY_VALUE: Record<Priority, number> = { urgent: 10, high: 8, medium: 5, low: 3 };
+
+function buildBoardActionParams(
+  action: string,
+  tasks: Task[]
+): Record<string, unknown> {
+  if (action === 'workflowAnalysis') {
+    return {
+      columns: columns.map((c) => ({ name: c.name })),
+      cards: tasks.map((t) => {
+        const col = columns.find((c) => c.id === t.status);
+        const created =
+          t.activity[t.activity.length - 1]?.timestamp || t.dueDate || new Date().toISOString();
+        return {
+          id: t.id,
+          title: t.title,
+          column: col?.name ?? t.status,
+          createdAt: created,
+          completedAt: t.status === 'done' ? t.dueDate || created : undefined,
+        };
+      }),
+    };
+  }
+  if (action === 'cardPrioritization') {
+    return {
+      cards: tasks.map((t) => ({
+        id: t.id,
+        title: t.title,
+        businessValue: PRIORITY_VALUE[t.priority],
+        // Less-complete work carries more remaining criticality.
+        timeCriticality: Math.max(1, Math.round((100 - t.progress) / 10)),
+        riskReduction: t.type === 'bug' ? 8 : 5,
+        effort: t.estimate && /^\d/.test(t.estimate) ? Math.max(1, parseInt(t.estimate, 10)) : 5,
+        deadline: t.dueDate || undefined,
+      })),
+    };
+  }
+  if (action === 'burndownForecast') {
+    // Group done tasks into weekly "sprints" by completion week; remaining points
+    // = open tasks weighted by how much work is left (1 pt per 100−progress%).
+    const doneByWeek = new Map<string, number>();
+    for (const t of tasks) {
+      if (t.status !== 'done' || !t.dueDate) continue;
+      const d = new Date(t.dueDate);
+      if (Number.isNaN(d.getTime())) continue;
+      const wk = `${d.getUTCFullYear()}-${Math.floor(d.getTime() / (7 * 86400000))}`;
+      doneByWeek.set(wk, (doneByWeek.get(wk) || 0) + PRIORITY_VALUE[t.priority]);
+    }
+    const sprints = Array.from(doneByWeek.entries()).map(([id, completedPoints], i) => ({
+      id,
+      completedPoints,
+      plannedPoints: completedPoints,
+      startDate: '',
+      endDate: '',
+      index: i,
+    }));
+    const remainingPoints = tasks
+      .filter((t) => t.status !== 'done')
+      .reduce((s, t) => s + Math.max(1, Math.round(((100 - t.progress) / 100) * PRIORITY_VALUE[t.priority])), 0);
+    return { sprints, remainingPoints };
+  }
+  return {};
+}
+
 // ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
@@ -350,7 +419,12 @@ export default function BoardLensPage() {
     if (!targetId) return;
     setIsRunning(action);
     try {
-      const res = await runAction.mutateAsync({ id: targetId, action });
+      // The persisted task artifact's .data carries a single task, not the
+      // board-wide {cards,columns,sprints} the calculators read. Derive those
+      // from the live tasks and pass them as params so the handler computes over
+      // the real board instead of silently returning "No cards provided".
+      const params = buildBoardActionParams(action, tasks);
+      const res = await runAction.mutateAsync({ id: targetId, action, params });
       if (res.ok === false) {
         setActionResult({
           message: `Action failed: ${(res as Record<string, unknown>).error || 'Unknown error'}`,

--- a/concord-frontend/app/lenses/classroom/page.tsx
+++ b/concord-frontend/app/lenses/classroom/page.tsx
@@ -53,12 +53,24 @@ export default function ClassroomPage() {
   const [submitForm, setSubmitForm] = useState({ cohortId: '', dtuId: '' });
   const [status, setStatus] = useState<string | null>(null);
   const [activeCohort, setActiveCohort] = useState<number | null>(null);
+  // Honest load lifecycle: distinguish "still loading" and "load failed" from
+  // a genuinely-empty cohort list. Without this, a swallowed fetch (macro()
+  // returns null on any network/parse error) renders identically to "no
+  // cohorts" — a silent-empty that hides backend outages from the user.
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   const refresh = async () => {
+    setLoading(true);
     const r = await macro('classroom', 'list_cohorts');
+    setLoading(false);
     if (r?.ok) {
       setTeaching(r.teaching || []);
       setStudying(r.studying || []);
+      setLoadError(null);
+    } else {
+      // null (swallowed fetch failure) or { ok:false } → surface, don't silently blank.
+      setLoadError(r?.error || r?.reason || 'Could not reach the classroom service.');
     }
   };
 
@@ -106,6 +118,19 @@ export default function ClassroomPage() {
 
         {status && (
           <div className="mb-4 bg-cyan-950/50 border border-cyan-700/50 text-cyan-200 px-3 py-2 rounded-lg text-sm">{status}</div>
+        )}
+
+        {loadError && (
+          <div role="alert" className="mb-4 bg-rose-950/50 border border-rose-700/50 text-rose-200 px-3 py-2 rounded-lg text-sm flex items-center justify-between gap-3">
+            <span>{loadError}</span>
+            <button
+              type="button"
+              onClick={() => void refresh()}
+              className="shrink-0 rounded bg-rose-800/60 hover:bg-rose-700/60 px-2 py-1 text-xs text-rose-100 focus:outline-none focus:ring-2 focus:ring-amber-500"
+            >
+              Try again
+            </button>
+          </div>
         )}
 
         <div className="grid md:grid-cols-3 gap-3 mb-6">
@@ -159,8 +184,12 @@ export default function ClassroomPage() {
           </section>
         </div>
 
+        {loading && (
+          <div role="status" aria-busy="true" className="mb-4 text-zinc-400 italic text-sm">Loading classroom cohorts…</div>
+        )}
+
         <h2 className="text-sm font-bold text-zinc-300 uppercase tracking-wider mb-2">Teaching</h2>
-        {teaching.length === 0 ? <p className="text-zinc-400 italic mb-4">No cohorts you teach.</p> : (
+        {loading || loadError ? null : teaching.length === 0 ? <p className="text-zinc-400 italic mb-4">No cohorts you teach.</p> : (
           <ul className="space-y-1 mb-6">
             {teaching.map(c => (
               <li key={c.id}>
@@ -181,7 +210,7 @@ export default function ClassroomPage() {
         )}
 
         <h2 className="text-sm font-bold text-zinc-300 uppercase tracking-wider mb-2">Studying</h2>
-        {studying.length === 0 ? <p className="text-zinc-400 italic">No cohorts you're enrolled in.</p> : (
+        {loading || loadError ? null : studying.length === 0 ? <p className="text-zinc-400 italic">No cohorts you're enrolled in.</p> : (
           <ul className="space-y-1">
             {studying.map(c => (
               <li key={c.id}>

--- a/concord-frontend/app/lenses/consulting/page.tsx
+++ b/concord-frontend/app/lenses/consulting/page.tsx
@@ -517,6 +517,38 @@ export default function ConsultingLensPage() {
     </div>
   );
 
+  // Loading state — a11y role=status with aria-busy so assistive tech announces
+  // the in-flight fetch instead of a silent blank surface.
+  if (isLoading) {
+    return (
+      <LensShell lensId="consulting" asMain={false}>
+        <div className="flex items-center justify-center h-full p-8" role="status" aria-busy="true">
+          <div className="flex flex-col items-center gap-3">
+            <div className="w-8 h-8 border-2 border-amber-500 border-t-transparent rounded-full animate-spin" />
+            <p className="text-sm text-gray-400">Loading consulting data…</p>
+          </div>
+        </div>
+      </LensShell>
+    );
+  }
+
+  // Error state — a11y role=alert with a WORKING Retry that re-fetches the list
+  // (refetch), not a dead button. A swallowed fetch must surface here, not as a
+  // silent empty surface.
+  if (isError) {
+    return (
+      <LensShell lensId="consulting" asMain={false}>
+        <div className="flex items-center justify-center h-full p-8" role="alert">
+          <div className="flex flex-col items-center gap-3 text-center">
+            <p className="text-sm font-medium text-white">Could not load consulting data</p>
+            <p className="text-xs text-gray-400 max-w-sm">{error?.message || 'An unexpected error occurred.'}</p>
+            <button onClick={() => refetch()} className={ds.btnPrimary}>Try again</button>
+          </div>
+        </div>
+      </LensShell>
+    );
+  }
+
   return (
     <LensShell lensId="consulting" asMain={false}>
       <FirstRunTour lensId="consulting" />

--- a/concord-frontend/app/lenses/eco/page.tsx
+++ b/concord-frontend/app/lenses/eco/page.tsx
@@ -247,7 +247,11 @@ export default function EcoLensPage() {
   const totalSpecies = POPULATIONS.length;
   const criticalCount = POPULATIONS.filter(p => p.conservationStatus === 'critical' || p.conservationStatus === 'endangered').length;
   const growingCount = POPULATIONS.filter(p => p.conservationStatus === 'growing').length;
-  const avgBiodiversity = BIODIVERSITY.reduce((sum, b) => sum + b.shannonIndex, 0) / BIODIVERSITY.length;
+  // Fail-CLOSED: guard the divide so an empty BIODIVERSITY array renders 0, not
+  // NaN (the page prints avgBiodiversity.toFixed(2) directly).
+  const avgBiodiversity = BIODIVERSITY.length > 0
+    ? BIODIVERSITY.reduce((sum, b) => sum + b.shannonIndex, 0) / BIODIVERSITY.length
+    : 0;
   const totalImpactArea = IMPACTS.reduce((sum, i) => sum + i.affectedArea, 0);
   const criticalImpacts = IMPACTS.filter(i => i.severity === 'critical' || i.severity === 'high').length;
 
@@ -1262,7 +1266,7 @@ export default function EcoLensPage() {
           <div className="lens-card text-xs text-gray-400 space-y-2">
             <h3 className="text-sm font-bold text-white">Why this matters</h3>
             <p>Each action below cites real lifecycle research. The kgCO₂e saved is a per-instance estimate; the more you log, the more accurate your annual delta.</p>
-            <p>Pair with the offsets marketplace (coming) to neutralise the residual emissions you can&apos;t cut.</p>
+            <p>Log the actions you take below; the Footprint trend tab turns your running total into a tracked delta over time.</p>
           </div>
         </div>
       )}

--- a/concord-frontend/app/lenses/fishing/page.tsx
+++ b/concord-frontend/app/lenses/fishing/page.tsx
@@ -71,10 +71,15 @@ export default function FishingLensPage() {
       ]);
       if (!cRes.ok) throw new Error(`catalog ${cRes.status}`);
       const c = await cRes.json();
-      // catches is auth-gated; tolerate a 401 by showing an empty log rather
-      // than failing the whole lens.
+      // The catalog is the PRIMARY read. A handler rejection ({ ok:false })
+      // must surface as a real ERROR, never collapse into the empty-state CTA
+      // (the silent-empty defect class): an empty catalog and a failed catalog
+      // load are different truths and must read differently to the player.
+      if (c?.ok === false) throw new Error(c.error || c.reason || 'catalog unavailable');
+      // catches is auth-gated + secondary; tolerate a 401 / { ok:false } by
+      // showing an empty log rather than failing the whole lens.
       const m = mRes.ok ? await mRes.json() : { ok: true, catches: [] };
-      setCatalog(c?.ok ? (c.fish || []) : []);
+      setCatalog(Array.isArray(c?.fish) ? c.fish : []);
       setCatches(m?.ok ? (m.catches || []) : []);
       setState('ready');
     } catch (e) {

--- a/concord-frontend/app/lenses/forum/page.tsx
+++ b/concord-frontend/app/lenses/forum/page.tsx
@@ -258,16 +258,52 @@ export default function ForumLensPage() {
   const [forumActionResult, setForumActionResult] = useState<Record<string, unknown> | null>(null);
   const [forumRunning, setForumRunning] = useState<string | null>(null);
 
+  // Derive the forum-WIDE inputs each analytical macro reads from the REAL
+  // live posts/communities the page already holds. The persisted post artifact
+  // is a single post (no posts/reports/threads arrays), so without these
+  // derived params the handlers see empty input and render the "Add thread
+  // posts…" guidance — a dead surface. Every value below comes from genuine
+  // on-page state (no fabricated rows): handler reads `params.X ?? data.X`.
+  const deriveForumParams = useCallback((action: string): Record<string, unknown> => {
+    const live = posts.filter(p => !p.removed);
+    if (action === 'threadAnalysis') {
+      // One row per post + per comment (recursively), as {author, content}.
+      const rows: { author: string; content: string }[] = [];
+      const walk = (cs: Comment[]) => { for (const c of cs) { rows.push({ author: c.author.username, content: c.content }); walk(c.replies); } };
+      for (const p of live) { rows.push({ author: p.author.username, content: `${p.title} ${p.content}` }); walk(p.comments); }
+      return { posts: rows };
+    }
+    if (action === 'moderationQueue') {
+      // Real reports: locked posts = pending review, removed posts = resolved.
+      const reports = [
+        ...posts.filter(p => p.locked).map(p => ({ status: 'pending', reason: 'off_topic', date: p.createdAt })),
+        ...posts.filter(p => p.removed).map(p => ({ status: 'resolved', reason: 'inappropriate', date: p.createdAt })),
+      ];
+      return { reports };
+    }
+    if (action === 'communityHealth') {
+      const authors = new Set(live.map(p => p.author.username));
+      const weekAgo = Date.now() - 7 * 86400000;
+      const postsThisWeek = live.filter(p => new Date(p.createdAt).getTime() >= weekAgo).length;
+      const postsLastWeek = live.filter(p => { const t = new Date(p.createdAt).getTime(); return t < weekAgo && t >= weekAgo - 7 * 86400000; }).length;
+      return { activeUsers: authors.size, totalUsers: Math.max(authors.size, communities.reduce((s, c) => s + c.memberCount, 0)), postsThisWeek, postsLastWeek };
+    }
+    if (action === 'topicClustering') {
+      return { threads: live.map(p => ({ tags: p.tags })) };
+    }
+    return {};
+  }, [posts, communities]);
+
   const handleForumAction = useCallback(async (action: string) => {
     const targetId = postItems[0]?.id;
     if (!targetId) return;
     setForumRunning(action);
     try {
-      const res = await runForumAction.mutateAsync({ id: targetId, action });
+      const res = await runForumAction.mutateAsync({ id: targetId, action, params: deriveForumParams(action) });
       if (res.ok === false) { setForumActionResult({ _action: action, message: `Action failed: ${(res as Record<string, unknown>).error || 'Unknown error'}` }); } else { setForumActionResult({ _action: action, ...(res.result as Record<string, unknown>) }); }
-    } catch (e) { console.error(`Forum action ${action} failed:`, e); setForumActionResult({ message: `Action failed: ${e instanceof Error ? e.message : 'Unknown error'}` }); }
+    } catch (e) { console.error(`Forum action ${action} failed:`, e); setForumActionResult({ _action: action, message: `Action failed: ${e instanceof Error ? e.message : 'Unknown error'}` }); }
     setForumRunning(null);
-  }, [postItems, runForumAction]);
+  }, [postItems, runForumAction, deriveForumParams]);
 
   // Sync backend data into local state when available
   // IMPORTANT: Use the lens artifact ID (i.id) as the Post id so that

--- a/concord-frontend/app/lenses/household/page.tsx
+++ b/concord-frontend/app/lenses/household/page.tsx
@@ -366,13 +366,58 @@ export default function HouseholdLensPage() {
 
   const handleDelete = async (id: string) => { await remove(id); };
 
+  // Derive the board-wide arrays each calculator reads from the LIVE artifacts.
+  // The persisted artifact's .data is a single record (family member / chore /
+  // meal) and never carries mealPlan / chores / maintenanceItems — so without
+  // these params the handlers always saw undefined and returned empty (the
+  // board-style dead surface). The handlers read params.X ?? artifact.data.X.
+  const deriveActionParams = useCallback((action: string): Record<string, unknown> => {
+    if (action === 'generateGroceryList') {
+      return {
+        mealPlan: mealItems.map(i => {
+          const d = i.data as unknown as MealPlan;
+          return {
+            day: d.day, meal: d.mealType, recipe: d.recipe,
+            ingredients: (d.ingredients || []).map(name => ({ name, quantity: 1, unit: '' })),
+          };
+        }),
+      };
+    }
+    if (action === 'rotateChores' || action === 'choreRotation') {
+      return {
+        chores: choreItems.map(i => ({ name: i.title, currentAssignee: (i.data as unknown as Chore).assignee, frequency: (i.data as unknown as Chore).frequency })),
+        members: familyItems.map(i => (i.data as unknown as FamilyMember).name).filter(Boolean),
+      };
+    }
+    if (action === 'maintenanceCheck' || action === 'maintenanceDue') {
+      return {
+        maintenanceItems: maintenanceItems.map(i => {
+          const d = i.data as unknown as MaintenanceItem;
+          // dueDate is the page's field; the handler computes from lastCompleted
+          // + intervalDays, so pass dueDate as an explicit nextDue anchor via a
+          // synthetic lastCompleted is wrong — instead surface name + dueDate so
+          // the handler flags never-completed items as overdue honestly.
+          return { name: i.title, category: d.area, priority: d.priority };
+        }),
+      };
+    }
+    if (action === 'weeklySummary') {
+      return {
+        chores: choreItems.map(i => ({ name: i.title, completedDate: i.meta.status === 'completed' ? (i.data as unknown as Chore).lastCompleted : undefined })),
+        mealPlan: mealItems.map(i => ({ recipe: (i.data as unknown as MealPlan).recipe })),
+      };
+    }
+    return {};
+  }, [mealItems, choreItems, familyItems, maintenanceItems]);
+
   const handleAction = async (action: string, artifactId?: string) => {
-    const targetId = artifactId || editingId || filtered[0]?.id;
-    if (!targetId) return;
+    const targetId = artifactId || editingId || familyItems[0]?.id || filtered[0]?.id;
+    if (!targetId) { setActionResult({ message: 'Add a family member first so actions have somewhere to attach.' }); return; }
     try {
-      const result = await runAction.mutateAsync({ id: targetId, action });
+      const params = deriveActionParams(action);
+      const result = await runAction.mutateAsync({ id: targetId, action, params });
       if (result.ok === false) { setActionResult({ message: `Action failed: ${(result as Record<string, unknown>).error || 'Unknown error'}` }); } else { setActionResult(result.result as Record<string, unknown>); }
-    } catch (err) { console.error('Action failed:', err); }
+    } catch (err) { console.error('Action failed:', err); setActionResult({ message: `Action failed: ${err instanceof Error ? err.message : 'unknown error'}` }); }
   };
 
   const toggleChoreComplete = async (item: LensItem<ArtifactData>) => {

--- a/concord-frontend/app/lenses/insurance/page.tsx
+++ b/concord-frontend/app/lenses/insurance/page.tsx
@@ -960,9 +960,9 @@ export default function InsuranceLensPage() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-full p-8">
-        <div className="text-center space-y-3">
+        <div className="text-center space-y-3" role="status" aria-busy="true">
           <div className="w-8 h-8 border-2 border-neon-cyan border-t-transparent rounded-full animate-spin mx-auto" />
-          <p className="text-sm text-gray-400">Loading...</p>
+          <p className="text-sm text-gray-400">Loading insurance data...</p>
         </div>
       </div>
     );
@@ -970,7 +970,7 @@ export default function InsuranceLensPage() {
 
   if (isError) {
     return (
-      <div className="flex items-center justify-center h-full p-8">
+      <div className="flex items-center justify-center h-full p-8" role="alert">
         <ErrorState error={error?.message} onRetry={refetch} />
       </div>
     );

--- a/concord-frontend/app/lenses/legal/page.tsx
+++ b/concord-frontend/app/lenses/legal/page.tsx
@@ -1011,7 +1011,7 @@ export default function LegalLensPage() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-full p-8">
+      <div className="flex items-center justify-center h-full p-8" role="status" aria-busy="true">
         <div className="text-center space-y-3">
           <div className="w-8 h-8 border-2 border-amber-400 border-t-transparent rounded-full animate-spin mx-auto" />
           <p className="text-sm text-gray-400">Loading case files...</p>
@@ -1024,7 +1024,7 @@ export default function LegalLensPage() {
 
   if (isError) {
     return (
-      <div className="flex items-center justify-center h-full p-8">
+      <div className="flex items-center justify-center h-full p-8" role="alert">
         <ErrorState error={error?.message} onRetry={refetch} />
       </div>
     );

--- a/concord-frontend/components/art/ArtActionPanel.tsx
+++ b/concord-frontend/components/art/ArtActionPanel.tsx
@@ -35,17 +35,32 @@ function pickMessage(e: unknown): string {
   return ax?.response?.data?.error ?? ax?.message ?? 'request failed';
 }
 
-interface HarmonyResult { harmony?: string; mood?: string; balanceScore?: number }
-interface CompositionResult { score?: number; ruleOfThirds?: number; symmetry?: number; tips?: string[] }
-interface PaletteResult { palette?: Array<{ hex: string; name?: string }>; mood?: string }
-interface StyleResult { style?: string; period?: string; confidence?: number }
+// ── Result shapes — these mirror the REAL server/domains/art.js handler
+// returns (NOT invented names). colorHarmony → { harmonies[], temperature,
+// harmonyScore, paletteSize, dominantHue }; compositionScore → { overall,
+// rating, scores{} }; generatePalette → { palette[{hex,role}], harmony,
+// baseColor, count }; styleClassify → { topMatch{style,similarity}, allMatches,
+// confidence }. ────────────────────────────────────────────────────────────
+interface HarmonyMatch { type: string; colors: string[]; hueDistance: number }
+interface HarmonyResult { harmonies?: HarmonyMatch[]; temperature?: string; harmonyScore?: number; paletteSize?: number; dominantHue?: number }
+interface CompositionResult { overall?: number; rating?: string; scores?: Record<string, number>; canvasCoverage?: number; elementCount?: number }
+interface PaletteResult { palette?: Array<{ hex: string; role?: string }>; harmony?: string; baseColor?: string; count?: number }
+interface StyleMatch { style: string; similarity: number }
+interface StyleResult { topMatch?: StyleMatch; allMatches?: StyleMatch[]; confidence?: string }
+
+// A composition element the workbench sends to compositionScore.
+interface CompElement { x: number; y: number; width: number; height: number; weight?: number }
 
 export function ArtActionPanel() {
   const [pieceTitle, setPieceTitle] = useState('');
   const [colors, setColors] = useState('');
   const [seedColor, setSeedColor] = useState('');
+  const [paletteHarmony, setPaletteHarmony] = useState('analogous');
   const [paletteCount, setPaletteCount] = useState('');
-  const [imageDataUrl] = useState('');
+  // Composition + style attributes are authored as a compact comma list the
+  // panel parses into the handler's real input shapes.
+  const [compElements, setCompElements] = useState('');
+  const [styleAttrs, setStyleAttrs] = useState('');
   const [recipient, setRecipient] = useState('');
 
   const [busy, setBusy] = useState<ActionId | null>(null);
@@ -65,45 +80,63 @@ export function ArtActionPanel() {
   const dmRecall = useRecallableAction({ label: 'DM', windowMs: 60_000, onUndo: async (id) => { await api.delete(`/api/social/dm/${encodeURIComponent(id)}`); } });
   const publishRecall = useRecallableAction({ label: 'publish', windowMs: 30_000, onUndo: async (id) => { await api.delete(`/api/dtus/${encodeURIComponent(id)}/publish`); setPublishedDtuId(null); } });
 
+  // colorHarmony reads artifact.data.palette = ["#hex", ...]. Send { palette }.
   async function actHarmony() {
     const colorList = colors.split('\n').map(c => c.trim()).filter(c => /^#[0-9a-f]{6}$/i.test(c));
     if (colorList.length < 2) { err('Need at least 2 hex colors (one per line, #RRGGBB).'); return; }
     setBusy('harmony'); setFeedback(null);
     try {
-      const r = await callMacro<HarmonyResult>('colorHarmony', { colors: colorList });
-      if (r.ok && r.result) { setHarmonyResult(r.result); pipe.publish('art.harmony', r.result, { label: `Harmony ${r.result.harmony}` }); ok(`Harmony: ${r.result.harmony}.`); } else err(r.error ?? 'harmony failed');
+      const r = await callMacro<HarmonyResult>('colorHarmony', { palette: colorList });
+      if (r.ok && r.result) { setHarmonyResult(r.result); pipe.publish('art.harmony', r.result, { label: `Harmony ${r.result.harmonyScore ?? 0}` }); ok(`Harmony score ${r.result.harmonyScore ?? 0}, ${r.result.temperature ?? '—'}.`); } else err(r.error ?? 'harmony failed');
     } catch (e) { err(pickMessage(e)); } finally { setBusy(null); }
   }
+  // compositionScore reads artifact.data.elements = [{x,y,width,height,weight?}]
+  // + artifact.data.canvas = {width,height}. Parse the compact "x,y,w,h[,wt]"
+  // lines the panel authors into that exact shape.
   async function actComposition() {
-    if (!imageDataUrl) { err('Provide image data URL first.'); return; }
+    const elements: CompElement[] = compElements.split('\n').map(line => {
+      const parts = line.split(',').map(p => Number(p.trim()));
+      if (parts.length < 4 || parts.slice(0, 4).some(n => !Number.isFinite(n))) return null;
+      const [x, y, width, height, weight] = parts;
+      return { x, y, width, height, ...(Number.isFinite(weight) ? { weight } : {}) };
+    }).filter((e): e is CompElement => e !== null);
+    if (elements.length === 0) { err('Add ≥1 element line: x,y,width,height[,weight].'); return; }
     setBusy('composition'); setFeedback(null);
     try {
-      const r = await callMacro<CompositionResult>('compositionScore', { imageDataUrl });
-      if (r.ok && r.result) { setCompositionResult(r.result); pipe.publish('art.composition', r.result, { label: `Composition ${r.result.score}` }); ok(`Composition: ${r.result.score}.`); } else err(r.error ?? 'composition failed');
+      const r = await callMacro<CompositionResult>('compositionScore', { elements, canvas: { width: 1920, height: 1080 } });
+      if (r.ok && r.result) { setCompositionResult(r.result); pipe.publish('art.composition', r.result, { label: `Composition ${r.result.overall}` }); ok(`Composition: ${r.result.overall}/100 (${r.result.rating ?? '—'}).`); } else err(r.error ?? 'composition failed');
     } catch (e) { err(pickMessage(e)); } finally { setBusy(null); }
   }
+  // generatePalette reads params.baseColor / params.harmony / params.count.
   async function actPalette() {
     if (!/^#[0-9a-f]{6}$/i.test(seedColor)) { err('Valid seed hex required (#RRGGBB).'); return; }
     const n = parseInt(paletteCount, 10);
     if (!Number.isFinite(n) || n < 2) { err('Palette count must be ≥ 2.'); return; }
     setBusy('palette'); setFeedback(null);
     try {
-      const r = await callMacro<PaletteResult>('generatePalette', { seedColor, count: n });
+      const r = await callMacro<PaletteResult>('generatePalette', { baseColor: seedColor, harmony: paletteHarmony, count: n });
       if (r.ok && r.result) { setPaletteResult(r.result); pipe.publish('art.palette', r.result, { label: `${r.result.palette?.length ?? 0} colors` }); ok(`${r.result.palette?.length ?? 0} colors.`); } else err(r.error ?? 'palette failed');
     } catch (e) { err(pickMessage(e)); } finally { setBusy(null); }
   }
+  // styleClassify reads artifact.data.attributes = { brushwork, colorSaturation,
+  // contrast, perspective, detail, abstraction, lineWeight, texture } (0-100).
   async function actStyle() {
-    if (!imageDataUrl && !pieceTitle.trim()) { err('Image data URL or piece title required.'); return; }
+    const AXES = ['brushwork', 'colorSaturation', 'contrast', 'perspective', 'detail', 'abstraction', 'lineWeight', 'texture'] as const;
+    const nums = styleAttrs.split(',').map(p => Number(p.trim()));
+    const provided = nums.filter(n => Number.isFinite(n));
+    if (provided.length === 0) { err('Enter 1-8 axis values 0-100 (brushwork,colorSaturation,contrast,perspective,detail,abstraction,lineWeight,texture).'); return; }
+    const attributes: Record<string, number> = {};
+    AXES.forEach((k, i) => { if (Number.isFinite(nums[i])) attributes[k] = nums[i]; });
     setBusy('style'); setFeedback(null);
     try {
-      const r = await callMacro<StyleResult>('styleClassify', { imageDataUrl: imageDataUrl || null, title: pieceTitle });
-      if (r.ok && r.result) { setStyleResult(r.result); pipe.publish('art.style', r.result, { label: `${r.result.style} (${r.result.period})` }); ok(`${r.result.style} (${r.result.period}).`); } else err(r.error ?? 'style failed');
+      const r = await callMacro<StyleResult>('styleClassify', { attributes });
+      if (r.ok && r.result?.topMatch) { setStyleResult(r.result); pipe.publish('art.style', r.result, { label: `${r.result.topMatch.style} (${r.result.confidence})` }); ok(`${r.result.topMatch.style} · ${r.result.confidence}.`); } else err(r.error ?? 'style failed');
     } catch (e) { err(pickMessage(e)); } finally { setBusy(null); }
   }
   async function actMint() {
     setBusy('mint'); setFeedback(null);
     try {
-      const r = await api.post('/api/lens/run', { domain: 'dtu', name: 'create', input: { title: `Art — ${pieceTitle.trim() || 'piece'}`, tags: ['art', styleResult?.style ?? 'unknown', harmonyResult?.mood ?? ''].filter(Boolean), source: 'art:piece:mint', meta: { visibility: 'private', consent: { allowCitations: false }, art: { title: pieceTitle, colors: colors.split('\n').filter(Boolean), harmony: harmonyResult, composition: compositionResult, palette: paletteResult, style: styleResult } } } });
+      const r = await api.post('/api/lens/run', { domain: 'dtu', name: 'create', input: { title: `Art — ${pieceTitle.trim() || 'piece'}`, tags: ['art', styleResult?.topMatch?.style ?? 'unknown', harmonyResult?.temperature ?? ''].filter(Boolean), source: 'art:piece:mint', meta: { visibility: 'private', consent: { allowCitations: false }, art: { title: pieceTitle, colors: colors.split('\n').filter(Boolean), harmony: harmonyResult, composition: compositionResult, palette: paletteResult, style: styleResult } } } });
       const id = r.data?.result?.dtu?.id ?? r.data?.dtu?.id ?? r.data?.result?.id;
       if (id) { setMintedDtuId(id); pipe.publish('art.mintedDtuId', id, { label: `Piece DTU ${id.slice(0, 8)}…` }); ok(`Piece DTU ${id.slice(0, 8)}…`); } else err('No DTU id.');
     } catch (e) { err(pickMessage(e)); } finally { setBusy(null); }
@@ -112,10 +145,10 @@ export function ArtActionPanel() {
     if (!recipient.trim()) { err('Recipient required.'); return; }
     setBusy('dm'); setFeedback(null);
     const body = [`🎨 Art piece: ${pieceTitle || 'untitled'}`, '',
-      harmonyResult ? `Harmony: ${harmonyResult.harmony} (${harmonyResult.mood})` : '',
-      compositionResult ? `Composition: ${compositionResult.score}/100` : '',
+      harmonyResult ? `Harmony: score ${harmonyResult.harmonyScore ?? 0}, ${harmonyResult.temperature ?? '—'}` : '',
+      compositionResult ? `Composition: ${compositionResult.overall}/100 (${compositionResult.rating ?? '—'})` : '',
       paletteResult?.palette ? `Palette: ${paletteResult.palette.map(p => p.hex).join(' ')}` : '',
-      styleResult ? `Style: ${styleResult.style} (${styleResult.period})` : '',
+      styleResult?.topMatch ? `Style: ${styleResult.topMatch.style} (${styleResult.confidence})` : '',
       mintedDtuId ? `\n[DTU ${mintedDtuId}]` : '',
     ].filter(Boolean).join('\n');
     try {
@@ -131,7 +164,7 @@ export function ArtActionPanel() {
     setBusy('publish'); setFeedback(null);
     try {
       const id = await publishRecall.run(async () => {
-        const r = await api.post('/api/lens/run', { domain: 'dtu', name: 'create', input: { title: `Public piece — ${pieceTitle.trim() || 'untitled'}`, tags: ['art', 'public', styleResult?.style ?? 'unknown'], source: 'art:piece:publish', meta: { visibility: 'public', consent: { allowCitations: true }, piece: { title: pieceTitle, palette: paletteResult?.palette?.map(p => p.hex), style: styleResult?.style, harmony: harmonyResult?.harmony } } } });
+        const r = await api.post('/api/lens/run', { domain: 'dtu', name: 'create', input: { title: `Public piece — ${pieceTitle.trim() || 'untitled'}`, tags: ['art', 'public', styleResult?.topMatch?.style ?? 'unknown'], source: 'art:piece:publish', meta: { visibility: 'public', consent: { allowCitations: true }, piece: { title: pieceTitle, palette: paletteResult?.palette?.map(p => p.hex), style: styleResult?.topMatch?.style, harmony: harmonyResult?.harmonyScore } } } });
         const newId = r.data?.result?.dtu?.id ?? r.data?.dtu?.id ?? r.data?.result?.id;
         if (!newId) throw new Error('No DTU id.');
         const pub = await api.post(`/api/dtus/${encodeURIComponent(newId)}/publish`);
@@ -144,7 +177,7 @@ export function ArtActionPanel() {
   async function actAgent() {
     setBusy('agent'); setFeedback(null); setAgentReply(null);
     try {
-      const task = `Art piece: "${pieceTitle || 'untitled'}". ${styleResult ? `Style: ${styleResult.style} ${styleResult.period}.` : ''} ${harmonyResult ? `Harmony: ${harmonyResult.harmony}, mood ${harmonyResult.mood}.` : ''} ${compositionResult ? `Composition score ${compositionResult.score}/100.` : ''} Suggest 3 concrete moves to strengthen the next iteration (composition, palette, technique). Plain text, one per line.`;
+      const task = `Art piece: "${pieceTitle || 'untitled'}". ${styleResult?.topMatch ? `Style: ${styleResult.topMatch.style} (${styleResult.confidence} confidence).` : ''} ${harmonyResult ? `Harmony score ${harmonyResult.harmonyScore}, ${harmonyResult.temperature} palette.` : ''} ${compositionResult ? `Composition score ${compositionResult.overall}/100.` : ''} Suggest 3 concrete moves to strengthen the next iteration (composition, palette, technique). Plain text, one per line.`;
       const r = await api.post('/api/lens/run', { domain: 'chat_agent', name: 'do', input: { task, maxTurns: 3 } });
       const reply = r.data?.result?.reply ?? r.data?.result?.summary ?? r.data?.result?.output ?? r.data?.reply;
       if (reply) { setAgentReply(typeof reply === 'string' ? reply : JSON.stringify(reply, null, 2)); ok('Critique ready.'); } else err('Agent returned empty.');
@@ -152,10 +185,10 @@ export function ArtActionPanel() {
   }
 
   const actions = [
-    { id: 'harmony' as ActionId, label: 'Harmony', desc: 'colorHarmony + mood', icon: Palette, accent: '#06b6d4', handler: actHarmony },
-    { id: 'composition' as ActionId, label: 'Composition', desc: 'compositionScore + tips', icon: Grid3x3, accent: '#8b5cf6', handler: actComposition },
+    { id: 'harmony' as ActionId, label: 'Harmony', desc: 'colorHarmony score + temp', icon: Palette, accent: '#06b6d4', handler: actHarmony },
+    { id: 'composition' as ActionId, label: 'Composition', desc: 'compositionScore + rating', icon: Grid3x3, accent: '#8b5cf6', handler: actComposition },
     { id: 'palette' as ActionId, label: 'Palette', desc: 'generatePalette from seed', icon: Brush, accent: '#22c55e', handler: actPalette },
-    { id: 'style' as ActionId, label: 'Style', desc: 'styleClassify period + confidence', icon: Eye, accent: '#f97316', handler: actStyle },
+    { id: 'style' as ActionId, label: 'Style', desc: 'styleClassify + confidence', icon: Eye, accent: '#f97316', handler: actStyle },
     { id: 'mint' as ActionId, label: mintedDtuId ? 'Saved' : 'Mint', desc: mintedDtuId ? `${mintedDtuId.slice(0, 8)}…` : 'Private piece DTU', icon: Sparkles, accent: '#3b82f6', handler: actMint },
     { id: 'dm' as ActionId, label: 'DM', desc: 'Send critique brief', icon: Send, accent: '#ec4899', handler: actDm },
     { id: 'publish' as ActionId, label: publishedDtuId ? 'Published' : 'Publish', desc: publishedDtuId ? `${publishedDtuId.slice(0, 8)}…` : 'Public piece DTU + federation', icon: Globe, accent: '#15803d', handler: actPublish },
@@ -175,10 +208,26 @@ export function ArtActionPanel() {
         <input type="text" value={seedColor} onChange={(e) => setSeedColor(e.target.value)} className="bg-zinc-900 border border-zinc-800 rounded px-3 py-1.5 text-[12px] text-white font-mono" placeholder="#seed hex" />
         <input type="text" value={paletteCount} onChange={(e) => setPaletteCount(e.target.value.replace(/\D/g, ''))} className="bg-zinc-900 border border-zinc-800 rounded px-3 py-1.5 text-[12px] text-white font-mono" placeholder="palette N" />
       </div>
+      <div>
+        <label className="text-[10px] uppercase tracking-wider text-zinc-400 font-semibold mb-1 block">Palette harmony</label>
+        <select aria-label="Palette harmony" value={paletteHarmony} onChange={(e) => setPaletteHarmony(e.target.value)} className="w-full bg-zinc-900 border border-zinc-800 rounded px-2 py-1.5 text-[12px] text-white">
+          {['analogous', 'complementary', 'triadic', 'split-complementary', 'monochromatic'].map(h => <option key={h} value={h}>{h}</option>)}
+        </select>
+      </div>
 
       <div>
         <label className="text-[10px] uppercase tracking-wider text-zinc-400 font-semibold mb-1 block">Color list (one hex per line)</label>
         <textarea value={colors} onChange={(e) => setColors(e.target.value)} rows={4} className="w-full bg-zinc-900 border border-zinc-800 rounded px-2 py-1 text-[11px] text-pink-200 font-mono focus:outline-none focus:ring-2 focus:ring-pink-400/40 resize-none" />
+      </div>
+
+      <div>
+        <label className="text-[10px] uppercase tracking-wider text-zinc-400 font-semibold mb-1 block">Composition elements — one per line: x,y,width,height[,weight]</label>
+        <textarea value={compElements} onChange={(e) => setCompElements(e.target.value)} rows={3} placeholder={'640,360,200,200\n1280,720,150,150'} className="w-full bg-zinc-900 border border-zinc-800 rounded px-2 py-1 text-[11px] text-purple-200 font-mono focus:outline-none focus:ring-2 focus:ring-purple-400/40 resize-none" />
+      </div>
+
+      <div>
+        <label className="text-[10px] uppercase tracking-wider text-zinc-400 font-semibold mb-1 block">Style axes 0-100 (brushwork,colorSaturation,contrast,perspective,detail,abstraction,lineWeight,texture)</label>
+        <input type="text" value={styleAttrs} onChange={(e) => setStyleAttrs(e.target.value)} placeholder="80,70,40,40,30,40,20,70" className="w-full bg-zinc-900 border border-zinc-800 rounded px-2 py-1.5 text-[11px] text-orange-200 font-mono focus:outline-none focus:ring-2 focus:ring-orange-400/40" />
       </div>
 
       <div className="flex items-center gap-2 flex-wrap">
@@ -207,34 +256,54 @@ export function ArtActionPanel() {
         {harmonyResult && (
           <div className="rounded-md border border-cyan-500/30 bg-cyan-500/5 p-2.5">
             <div className="text-[10px] uppercase tracking-wider text-cyan-300 font-semibold">Harmony</div>
-            <div className="text-sm font-semibold text-zinc-100 capitalize">{harmonyResult.harmony} · {harmonyResult.mood}</div>
-            {harmonyResult.balanceScore != null && <div className="text-[10px] text-zinc-400">balance {harmonyResult.balanceScore}</div>}
+            <div className="text-sm font-semibold text-zinc-100 capitalize">score {harmonyResult.harmonyScore ?? 0} · {harmonyResult.temperature ?? '—'}</div>
+            {harmonyResult.paletteSize != null && <div className="text-[10px] text-zinc-400">{harmonyResult.paletteSize} colors · dominant hue {harmonyResult.dominantHue}°</div>}
+            {harmonyResult.harmonies && harmonyResult.harmonies.length > 0 && (
+              <div className="mt-1.5 flex flex-wrap gap-1">
+                {harmonyResult.harmonies.slice(0, 4).map((h, i) => (
+                  <span key={i} className="rounded bg-cyan-500/20 px-1.5 py-0.5 font-mono text-[10px] text-cyan-200">{h.type}</span>
+                ))}
+              </div>
+            )}
           </div>
         )}
         {compositionResult && (
           <div className="rounded-md border border-purple-500/30 bg-purple-500/5 p-2.5">
-            <div className="text-[10px] uppercase tracking-wider text-purple-300 font-semibold">Composition</div>
-            <div className="text-2xl font-bold text-zinc-100">{compositionResult.score}<span className="text-xs text-zinc-400">/100</span></div>
-            {compositionResult.tips?.length ? <ul className="text-[11px] text-zinc-300 list-disc list-inside mt-1">{compositionResult.tips.slice(0, 3).map((t, i) => <li key={i}>{t}</li>)}</ul> : null}
+            <div className="text-[10px] uppercase tracking-wider text-purple-300 font-semibold">Composition {compositionResult.rating && `· ${compositionResult.rating}`}</div>
+            <div className="text-2xl font-bold text-zinc-100">{compositionResult.overall}<span className="text-xs text-zinc-400">/100</span></div>
+            {compositionResult.scores && (
+              <div className="grid grid-cols-2 gap-1 mt-1">
+                {Object.entries(compositionResult.scores).map(([k, v]) => (
+                  <div key={k} className="text-[10px] text-zinc-300"><span className="text-zinc-500 capitalize">{k.replace(/([A-Z])/g, ' $1')}</span> {v}</div>
+                ))}
+              </div>
+            )}
           </div>
         )}
         {paletteResult?.palette && (
           <div className="rounded-md border border-emerald-500/30 bg-emerald-500/5 p-2.5">
-            <div className="text-[10px] uppercase tracking-wider text-emerald-300 font-semibold">Palette {paletteResult.mood && `· ${paletteResult.mood}`}</div>
+            <div className="text-[10px] uppercase tracking-wider text-emerald-300 font-semibold">Palette {paletteResult.harmony && `· ${paletteResult.harmony}`}</div>
             <div className="flex gap-1 mt-2">
               {paletteResult.palette.map((c, i) => (
-                <div key={i} className="flex-1 h-12 rounded border border-zinc-700" style={{ backgroundColor: c.hex }} title={c.hex}>
+                <div key={i} className="flex-1 h-12 rounded border border-zinc-700" style={{ backgroundColor: c.hex }} title={`${c.hex}${c.role ? ` (${c.role})` : ''}`}>
                   <div className="text-[9px] text-white/80 text-center pt-9 font-mono drop-shadow">{c.hex}</div>
                 </div>
               ))}
             </div>
           </div>
         )}
-        {styleResult && (
+        {styleResult?.topMatch && (
           <div className="rounded-md border border-orange-500/30 bg-orange-500/5 p-2.5">
             <div className="text-[10px] uppercase tracking-wider text-orange-300 font-semibold">Style</div>
-            <div className="text-sm font-semibold text-zinc-100 capitalize">{styleResult.style} · {styleResult.period}</div>
-            {styleResult.confidence != null && <div className="text-[10px] text-zinc-400">confidence {Math.round(styleResult.confidence * 100)}%</div>}
+            <div className="text-sm font-semibold text-zinc-100 capitalize">{styleResult.topMatch.style} · {styleResult.topMatch.similarity}%</div>
+            {styleResult.confidence != null && <div className="text-[10px] text-zinc-400">confidence {styleResult.confidence}</div>}
+            {styleResult.allMatches && styleResult.allMatches.length > 1 && (
+              <div className="mt-1 space-y-0.5">
+                {styleResult.allMatches.slice(1, 4).map((m, i) => (
+                  <div key={i} className="flex items-center justify-between text-[10px] text-zinc-400"><span className="capitalize">{m.style}</span><span>{m.similarity}%</span></div>
+                ))}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/concord-frontend/components/atlas/AtlasActionPanel.tsx
+++ b/concord-frontend/components/atlas/AtlasActionPanel.tsx
@@ -43,8 +43,8 @@ interface GeoResult { query: string; places: Place[]; count: number }
 interface RevResult { latitude: number; longitude: number; displayName: string; address?: Record<string, string> }
 interface PoiElement { id: number; latitude: number; longitude: number; name?: string; amenity?: string; tags?: Record<string, string> }
 interface PoiResult { elements?: PoiElement[]; count?: number }
-interface DistMatrix { from: string; to: string; distanceKm: number; estTimeMinutes: number }
-interface DistResult { matrix: DistMatrix[]; nearest?: { from: string; to: string; distanceKm: number } }
+interface DistPair { from: string; to: string; distanceKm: number; estTimeMinutes: number }
+interface DistResult { pairs: DistPair[]; nearest?: { from: string; to: string; distanceKm: number } }
 
 interface PointRow { name: string; lat: number; lng: number }
 const POINT_COLS: ColumnSpec<PointRow>[] = [
@@ -137,8 +137,8 @@ export function AtlasActionPanel() {
       const r = await callMacro<DistResult>('distanceMatrix', { artifact: { data: { points } } });
       if (r.ok && r.result) {
         setDistResult(r.result);
-        pipe.publish('atlas.dist', r.result, { label: `${r.result.matrix.length} pairs` });
-        ok(`${r.result.matrix.length} pairs.`);
+        pipe.publish('atlas.dist', r.result, { label: `${r.result.pairs.length} pairs` });
+        ok(`${r.result.pairs.length} pairs.`);
       } else err(r.error ?? 'dist failed');
     } catch (e) { err(pickMessage(e)); } finally { setBusy(null); }
   }
@@ -186,7 +186,7 @@ export function AtlasActionPanel() {
   async function actAgent() {
     setBusy('agent'); setFeedback(null); setAgentReply(null);
     try {
-      const task = `Atlas/geo brief. ${geoResult?.places[0] ? `Location: ${geoResult.places[0].displayName}.` : ''} ${poiResult ? `Found ${poiResult.elements?.length} ${amenity} in bbox.` : ''} ${distResult ? `${distResult.matrix.length} distance pairs.` : ''} Suggest one geospatial insight + one related query worth running. Plain text, 3 sentences max.`;
+      const task = `Atlas/geo brief. ${geoResult?.places[0] ? `Location: ${geoResult.places[0].displayName}.` : ''} ${poiResult ? `Found ${poiResult.elements?.length} ${amenity} in bbox.` : ''} ${distResult ? `${distResult.pairs.length} distance pairs.` : ''} Suggest one geospatial insight + one related query worth running. Plain text, 3 sentences max.`;
       const r = await lensRun({ domain: 'chat_agent', name: 'do', input: { task, maxTurns: 3 } });
       const reply = r.data?.result?.reply ?? r.data?.result?.summary ?? r.data?.result?.output;
       if (reply) {
@@ -306,9 +306,9 @@ export function AtlasActionPanel() {
         )}
         {distResult && (
           <div className="rounded-md border border-purple-500/30 bg-purple-500/5 p-2.5 max-h-60 overflow-y-auto md:col-span-2">
-            <div className="text-[10px] uppercase tracking-wider text-purple-300 font-semibold">Distance matrix · {distResult.matrix.length} pairs</div>
+            <div className="text-[10px] uppercase tracking-wider text-purple-300 font-semibold">Distance matrix · {distResult.pairs.length} pairs</div>
             {distResult.nearest && <div className="text-[11px] text-emerald-300">nearest: {distResult.nearest.from} ↔ {distResult.nearest.to} ({distResult.nearest.distanceKm}km)</div>}
-            {distResult.matrix.slice(0, 8).map((m, i) => <div key={i} className="text-[10px] text-zinc-300 mt-0.5 flex justify-between"><span><span className="font-mono text-purple-200">{m.from}</span> → <span className="font-mono text-purple-200">{m.to}</span></span><span className="font-mono">{m.distanceKm}km · {m.estTimeMinutes}min</span></div>)}
+            {distResult.pairs.slice(0, 8).map((m, i) => <div key={i} className="text-[10px] text-zinc-300 mt-0.5 flex justify-between"><span><span className="font-mono text-purple-200">{m.from}</span> → <span className="font-mono text-purple-200">{m.to}</span></span><span className="font-mono">{m.distanceKm}km · {m.estTimeMinutes}min</span></div>)}
           </div>
         )}
       </div>

--- a/concord-frontend/components/bio/BioActionPanel.tsx
+++ b/concord-frontend/components/bio/BioActionPanel.tsx
@@ -30,7 +30,12 @@ interface SeqResult { length: number; kind: string; gcPercent?: number; tm?: num
 interface PrimerInfo { sequence: string; length: number; tm: number; gcPercent: number }
 interface PrimerResult { forward: PrimerInfo; reverse: PrimerInfo; productSize: number; notes?: string }
 interface AlignResult { score: number; alignA: string; alignB: string; alignBars: string; matches: number; identity: number; alignmentLength: number }
-interface RestrictResult { enzyme?: string; sites?: number[]; fragments?: { start: number; end: number; length: number }[] }
+// bio.restriction-map returns sites as objects {enzyme, position, cutAt, site}
+// plus a count + the list of enzymes scanned — NOT a number[] of positions and
+// NOT a fragments array (those were never emitted by the handler, so the old
+// shape rendered "[object Object]" cut positions and never showed fragments).
+interface RestrictSite { enzyme: string; position: number; cutAt: number; site: string }
+interface RestrictResult { sites?: RestrictSite[]; count?: number; enzymesScanned?: string[] }
 
 // No seed sequences — paste real DNA / RNA / protein strings.
 export function BioActionPanel() {
@@ -86,7 +91,10 @@ export function BioActionPanel() {
     if (!enzyme.trim()) { err('Enzyme required (e.g. EcoRI, BamHI, HindIII).'); return; }
     setBusy('restrict'); setFeedback(null);
     try {
-      const r = await callMacro<RestrictResult>('restriction-map', { sequence: sequence.trim(), enzyme: enzyme.trim() });
+      // Handler reads params.enzymes (an array); pass the single enzyme as a
+      // one-element array so the filter actually applies (a singular `enzyme`
+      // field is ignored by the handler and silently scans ALL 10 enzymes).
+      const r = await callMacro<RestrictResult>('restriction-map', { sequence: sequence.trim(), enzymes: [enzyme.trim()] });
       if (r.ok && r.result) { setRestrictResult(r.result); pipe.publish('bio.restrict', r.result, { label: `${enzyme}: ${r.result.sites?.length ?? 0} sites` }); ok(`${r.result.sites?.length ?? 0} cut sites.`); } else err(r.error ?? 'restrict failed');
     } catch (e) { err(pickMessage(e)); } finally { setBusy(null); }
   }
@@ -232,8 +240,8 @@ export function BioActionPanel() {
         {restrictResult && (
           <div className="rounded-md border border-amber-500/30 bg-amber-500/5 p-2.5">
             <div className="text-[10px] uppercase tracking-wider text-amber-300 font-semibold">{enzyme} · {restrictResult.sites?.length ?? 0} sites</div>
-            <div className="text-[10px] text-zinc-400 mt-1">cuts at: {(restrictResult.sites ?? []).slice(0, 10).join(', ') || 'none'}</div>
-            {restrictResult.fragments && <div className="text-[10px] text-amber-200 mt-1">fragments: {restrictResult.fragments.slice(0, 5).map(f => f.length).join(' / ')} bp</div>}
+            <div className="text-[10px] text-zinc-400 mt-1">cuts at: {(restrictResult.sites ?? []).slice(0, 10).map(s => s.cutAt).join(', ') || 'none'}</div>
+            {(restrictResult.sites?.length ?? 0) > 0 && <div className="text-[10px] text-amber-200 mt-1 font-mono break-all">{(restrictResult.sites ?? []).slice(0, 6).map((s, i) => <span key={i} className="mr-2">{s.enzyme}@{s.position}</span>)}</div>}
           </div>
         )}
       </div>

--- a/concord-frontend/components/bio/SequenceAnalyzer.tsx
+++ b/concord-frontend/components/bio/SequenceAnalyzer.tsx
@@ -42,11 +42,15 @@ interface PrimerResult {
 
 interface AlignResult {
   score?: number;
-  alignedA?: string;
-  alignedB?: string;
-  midline?: string;
+  // Handler (bio.align-pairwise) returns these exact field names — see
+  // server/domains/bio.js. Earlier this component read alignedA/alignedB/
+  // midline/identityPercent, none of which the handler emits, so the align
+  // result rendered blank in production (the block was gated on alignedA).
+  alignA?: string;
+  alignB?: string;
+  alignBars?: string;
   identity?: number;
-  identityPercent?: number;
+  alignmentLength?: number;
 }
 
 interface MacroEnvelope<T> { ok: boolean; result?: T; error?: string }
@@ -261,25 +265,25 @@ export function SequenceAnalyzer() {
         </motion.div>
       )}
 
-      {align && tab === 'align' && align.alignedA && (
+      {align && tab === 'align' && align.alignA && (
         <motion.div initial={{ opacity: 0, y: 6 }} animate={{ opacity: 1, y: 0 }} className="rounded-lg border border-cyan-500/20 bg-zinc-950/60 p-3 space-y-2">
           <div className="flex items-center justify-between">
             <div className="text-xs font-semibold text-cyan-300">
-              Alignment · score {align.score} · {align.identityPercent?.toFixed(1) || '—'}% identity
+              Alignment · score {align.score} · {align.identity?.toFixed(1) || '—'}% identity
             </div>
             <SaveAsDtuButton
               compact
               apiSource="concord-bio-align"
-              title={`Alignment (${align.identityPercent?.toFixed(0) || '—'}% identity)`}
-              content={`A: ${align.alignedA}\n   ${align.midline || ''}\nB: ${align.alignedB || ''}\nScore: ${align.score} · Identity: ${align.identityPercent}%`}
+              title={`Alignment (${align.identity?.toFixed(0) || '—'}% identity)`}
+              content={`A: ${align.alignA}\n   ${align.alignBars || ''}\nB: ${align.alignB || ''}\nScore: ${align.score} · Identity: ${align.identity}%`}
               extraTags={['bio', 'alignment']}
               rawData={align}
             />
           </div>
           <pre className="overflow-x-auto whitespace-pre rounded border border-zinc-800 bg-zinc-950 p-2 font-mono text-[11px] leading-tight">
-            <span className="text-emerald-400">A: {align.alignedA}</span>{'\n'}
-            <span className="text-zinc-600">   {align.midline || ''}</span>{'\n'}
-            <span className="text-cyan-400">B: {align.alignedB}</span>
+            <span className="text-emerald-400">A: {align.alignA}</span>{'\n'}
+            <span className="text-zinc-600">   {align.alignBars || ''}</span>{'\n'}
+            <span className="text-cyan-400">B: {align.alignB}</span>
           </pre>
         </motion.div>
       )}

--- a/concord-frontend/components/board/BoardWorkspace.tsx
+++ b/concord-frontend/components/board/BoardWorkspace.tsx
@@ -43,9 +43,9 @@ function isOverdue(due: string | null): boolean {
 }
 
 export function BoardWorkspace() {
-  const { boards, loading: listLoading, reload: reloadList } = useBoardList();
+  const { boards, loading: listLoading, error: listError, reload: reloadList } = useBoardList();
   const [activeId, setActiveId] = useState<string | null>(null);
-  const { board, loading: boardLoading, reload: reloadBoard } = useBoardDetail(activeId);
+  const { board, loading: boardLoading, error: boardError, reload: reloadBoard } = useBoardDetail(activeId);
 
   const [view, setView] = useState<'board' | 'calendar'>('board');
   const [newBoardName, setNewBoardName] = useState('');
@@ -267,9 +267,35 @@ export function BoardWorkspace() {
         </div>
       )}
 
-      {!listLoading && boards.length === 0 && (
+      {/* A failed list load must read as an error, not a silent "empty" state. */}
+      {!listLoading && listError && boards.length === 0 && (
+        <div className="text-center py-12 text-sm text-red-400" role="alert">
+          Could not load boards: {listError}
+          <button
+            onClick={reloadList}
+            className="ml-2 underline text-red-300 hover:text-red-200"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {!listLoading && !listError && boards.length === 0 && (
         <div className="text-center py-12 text-sm text-gray-400">
           No boards yet. Create your first board above.
+        </div>
+      )}
+
+      {/* A board-detail load failure surfaces instead of a blank workspace. */}
+      {activeId && !boardLoading && boardError && (
+        <div className="text-sm text-red-400 py-6" role="alert">
+          Could not load this board: {boardError}
+          <button
+            onClick={reloadBoard}
+            className="ml-2 underline text-red-300 hover:text-red-200"
+          >
+            Retry
+          </button>
         </div>
       )}
 

--- a/concord-frontend/components/classroom/ClassroomActionPanel.tsx
+++ b/concord-frontend/components/classroom/ClassroomActionPanel.tsx
@@ -30,7 +30,7 @@ function pickMessage(e: unknown): string { const ax = e as { response?: { data?:
 interface Book { workId: string; title: string; authors: string[]; firstPublishYear?: number; editionCount?: number; subjects?: string[]; coverImage?: string | null; readUrl?: string | null }
 interface SearchResult { query?: string; works: Book[]; count: number; totalResults?: number }
 interface WorkResult { workId: string; title: string; description?: string; subjects?: string[]; subjectPlaces?: string[]; subjectPeople?: string[]; firstPublishDate?: string; covers?: string[] }
-interface IsbnResult { isbn?: string; title?: string; authors?: string[]; publisher?: string; publishDate?: string; pages?: number; coverImage?: string | null }
+interface IsbnResult { isbn?: string; title?: string; subtitle?: string; publishers?: string[]; publishDate?: string; pages?: number; coverImage?: string | null }
 
 export function ClassroomActionPanel() {
   const [query, setQuery] = useState('');
@@ -103,7 +103,7 @@ export function ClassroomActionPanel() {
       searchResult ? `Search "${searchResult.query}": ${searchResult.count} results${searchResult.works[0] ? `\n→ ${searchResult.works[0].title} (${searchResult.works[0].authors[0] ?? '?'}, ${searchResult.works[0].firstPublishYear ?? '?'})` : ''}` : '',
       subjResult ? `Subject ${subject}: top "${subjResult.works[0]?.title}"` : '',
       workResult ? `Work: ${workResult.title} (${workResult.firstPublishDate ?? '?'})` : '',
-      isbnResult ? `ISBN ${isbnResult.isbn}: ${isbnResult.title} (${isbnResult.publisher})` : '',
+      isbnResult ? `ISBN ${isbnResult.isbn}: ${isbnResult.title}${isbnResult.publishers?.length ? ` (${isbnResult.publishers.join(', ')})` : ''}` : '',
       mintedDtuId ? `\n[DTU ${mintedDtuId}]` : '',
     ].filter(Boolean).join('\n');
     try {
@@ -214,7 +214,7 @@ export function ClassroomActionPanel() {
         {isbnResult && (
           <div className="rounded-md border border-amber-500/30 bg-amber-500/5 p-2.5">
             <div className="text-[10px] uppercase tracking-wider text-amber-300 font-semibold">ISBN {isbnResult.isbn}</div>
-            <div className="flex gap-2 mt-1">{isbnResult.coverImage && <img src={isbnResult.coverImage} alt={isbnResult.title} className="w-16 h-24 object-cover rounded" />}<div><div className="text-[11px] font-semibold text-amber-200">{isbnResult.title}</div><div className="text-[10px] text-zinc-400">{(isbnResult.authors ?? []).join(', ')}</div><div className="text-[10px] text-zinc-400">{isbnResult.publisher} · {isbnResult.publishDate}</div>{isbnResult.pages && <div className="text-[10px] text-zinc-400">{isbnResult.pages} pages</div>}</div></div>
+            <div className="flex gap-2 mt-1">{isbnResult.coverImage && <img src={isbnResult.coverImage} alt={isbnResult.title} className="w-16 h-24 object-cover rounded" />}<div><div className="text-[11px] font-semibold text-amber-200">{isbnResult.title}</div>{isbnResult.subtitle && <div className="text-[10px] text-zinc-400">{isbnResult.subtitle}</div>}<div className="text-[10px] text-zinc-400">{[(isbnResult.publishers ?? []).join(', '), isbnResult.publishDate].filter(Boolean).join(' · ')}</div>{isbnResult.pages && <div className="text-[10px] text-zinc-400">{isbnResult.pages} pages</div>}</div></div>
           </div>
         )}
       </div>

--- a/concord-frontend/components/council/CouncilActionPanel.tsx
+++ b/concord-frontend/components/council/CouncilActionPanel.tsx
@@ -36,10 +36,17 @@ function pickMessage(e: unknown): string {
   return ax?.response?.data?.error ?? ax?.message ?? 'request failed';
 }
 
-interface DeliberateResult { positions?: Array<{ member: string; position: string; reasoning?: string }>; consensus?: string }
-interface VoteResult { yes?: number; no?: number; abstain?: number; passed?: boolean; quorum?: boolean }
-interface MinutesResult { summary?: string; decisions?: string[]; actionItems?: Array<{ owner: string; task: string; due?: string }> }
-interface ResolveResult { resolution?: string; nextSteps?: string[]; mediator?: string }
+// Shapes mirror the REAL server/domains/council.js handler RETURNS (the canonical
+// contract). The earlier shapes here (positions / yes-no-abstain / summary /
+// resolution-mediator) were fabricated — the handler never returned them, so the
+// panel rendered blank in production while handler-shape tests passed. Aligned to
+// the handler 2026-06-28.
+interface DeliberateEvaluation { voice: string; weight: number; score: number; position: 'support' | 'neutral' | 'oppose'; reasoning?: string }
+interface DeliberateResult { proposal?: string; evaluations?: DeliberateEvaluation[]; weightedScore?: number; recommendation?: string; consensus?: string; message?: string }
+interface VoteResult { tally?: { for: number; against: number; abstain: number }; total?: number; forPercent?: number; passed?: boolean; passThreshold?: string; quorumMet?: boolean }
+interface MinutesActionItem { task: string; assignee: string; dueDate: string }
+interface MinutesResult { title?: string; date?: string; attendees?: number; agendaItems?: Array<{ item: number; topic: string; status: string }>; decisions?: Array<{ decision: string; votedBy: string; passed: boolean }>; actionItems?: MinutesActionItem[] }
+interface ResolveResult { issue?: string; parties?: Array<{ party: string; position: string; priority: string }>; commonGround?: string; suggestedApproach?: string; steps?: string[] }
 
 export function CouncilActionPanel() {
   const [motionText, setMotionText] = useState('');
@@ -71,11 +78,11 @@ export function CouncilActionPanel() {
 
   async function actDeliberate() {
     if (!motionText.trim()) { err('Motion required.'); return; }
-    if (!members.trim()) { err('Members required (one per line).'); return; }
     setBusy('deliberate'); setFeedback(null);
     try {
-      const r = await callMacro<DeliberateResult>('deliberate', { motion: motionText.trim(), members: members.split('\n').filter(Boolean) });
-      if (r.ok && r.result) { setDeliberateResult(r.result); pipe.publish('council.deliberate', r.result, { label: `Deliberate ${r.result.positions?.length ?? 0}` }); ok(`${r.result.positions?.length ?? 0} positions.`); } else err(r.error ?? 'deliberate failed');
+      // Handler reads artifact.data.proposal (or .description) + optional .voices.
+      const r = await callMacro<DeliberateResult>('deliberate', { proposal: motionText.trim() });
+      if (r.ok && r.result) { setDeliberateResult(r.result); pipe.publish('council.deliberate', r.result, { label: `Deliberate ${r.result.evaluations?.length ?? 0}` }); ok(`${r.result.evaluations?.length ?? 0} evaluations.`); } else err(r.error ?? 'deliberate failed');
     } catch (e) { err(pickMessage(e)); } finally { setBusy(null); }
   }
   async function actVote() {
@@ -83,7 +90,9 @@ export function CouncilActionPanel() {
     if (!pos.length) { err('Add positions (name for/against/abstain, one per line).'); return; }
     setBusy('vote'); setFeedback(null);
     try {
-      const r = await callMacro<VoteResult>('voteCount', { motion: motionText.trim(), positions: pos });
+      // Handler reads artifact.data.votes: [{ vote | position }].
+      const votes = pos.map((p) => ({ voter: p!.member, vote: p!.position }));
+      const r = await callMacro<VoteResult>('voteCount', { votes });
       if (r.ok && r.result) { setVoteResult(r.result); pipe.publish('council.vote', r.result, { label: r.result.passed ? 'PASSED' : 'FAILED' }); ok(r.result.passed ? 'PASSED.' : 'FAILED.'); } else err(r.error ?? 'vote failed');
     } catch (e) { err(pickMessage(e)); } finally { setBusy(null); }
   }
@@ -91,7 +100,16 @@ export function CouncilActionPanel() {
     if (!motionText.trim()) { err('Motion required.'); return; }
     setBusy('minutes'); setFeedback(null);
     try {
-      const r = await callMacro<MinutesResult>('generateMinutes', { motion: motionText.trim(), positions: parsePositions(), vote: voteResult });
+      // Handler reads title / agenda / attendees / decisions / actionItems.
+      const pos = parsePositions();
+      const r = await callMacro<MinutesResult>('generateMinutes', {
+        title: `Council session — ${motionText.trim().slice(0, 60)}`,
+        agenda: [{ topic: motionText.trim(), status: voteResult ? 'discussed' : 'pending' }],
+        attendees: pos.map((p) => p!.member),
+        decisions: voteResult
+          ? [{ text: motionText.trim(), votedBy: 'council', passed: !!voteResult.passed }]
+          : [],
+      });
       if (r.ok && r.result) { setMinutesResult(r.result); pipe.publish('council.minutes', r.result, { label: `Minutes ${r.result.decisions?.length ?? 0} decisions` }); ok(`${r.result.decisions?.length ?? 0} decisions.`); } else err(r.error ?? 'minutes failed');
     } catch (e) { err(pickMessage(e)); } finally { setBusy(null); }
   }
@@ -99,7 +117,9 @@ export function CouncilActionPanel() {
     if (!conflict.trim()) { err('Conflict description required.'); return; }
     setBusy('resolve'); setFeedback(null);
     try {
-      const r = await callMacro<ResolveResult>('conflictResolution', { conflict: conflict.trim(), members: members.split('\n').filter(Boolean) });
+      // Handler reads artifact.data.issue (or .description) + .parties.
+      const parties = members.split('\n').map((m) => m.trim()).filter(Boolean).map((name) => ({ name }));
+      const r = await callMacro<ResolveResult>('conflictResolution', { issue: conflict.trim(), parties });
       if (r.ok && r.result) { setResolveResult(r.result); pipe.publish('council.resolve', r.result, { label: 'Resolution drafted' }); ok('Resolution drafted.'); } else err(r.error ?? 'resolve failed');
     } catch (e) { err(pickMessage(e)); } finally { setBusy(null); }
   }
@@ -115,9 +135,9 @@ export function CouncilActionPanel() {
     if (!recipient.trim()) { err('Recipient required.'); return; }
     setBusy('dm'); setFeedback(null);
     const body = [`🏛 Council session: ${motionText}`, '',
-      voteResult ? `Vote: ${voteResult.yes}y / ${voteResult.no}n / ${voteResult.abstain}a → ${voteResult.passed ? 'PASSED' : 'FAILED'}` : '',
-      minutesResult?.summary ? `Summary: ${minutesResult.summary}` : '',
-      minutesResult?.actionItems?.length ? `\nAction items:\n${minutesResult.actionItems.map(a => `  ${a.owner}: ${a.task}${a.due ? ` (${a.due})` : ''}`).join('\n')}` : '',
+      voteResult ? `Vote: ${voteResult.tally?.for ?? 0}y / ${voteResult.tally?.against ?? 0}n / ${voteResult.tally?.abstain ?? 0}a (${voteResult.forPercent ?? 0}%) → ${voteResult.passed ? 'PASSED' : 'FAILED'}` : '',
+      minutesResult?.decisions?.length ? `Decisions: ${minutesResult.decisions.map(d => d.decision).join('; ')}` : '',
+      minutesResult?.actionItems?.length ? `\nAction items:\n${minutesResult.actionItems.map(a => `  ${a.assignee}: ${a.task}${a.dueDate ? ` (${a.dueDate})` : ''}`).join('\n')}` : '',
       mintedDtuId ? `\n[DTU ${mintedDtuId}]` : '',
     ].filter(Boolean).join('\n');
     try {
@@ -134,7 +154,7 @@ export function CouncilActionPanel() {
     setBusy('publish'); setFeedback(null);
     try {
       const id = await publishRecall.run(async () => {
-        const r = await api.post('/api/lens/run', { domain: 'dtu', name: 'create', input: { title: `Public minutes — ${motionText.slice(0, 60)}`, tags: ['council', 'minutes', 'public'], source: 'council:minutes:publish', meta: { visibility: 'public', consent: { allowCitations: true }, minutes: { motion: motionText, summary: minutesResult.summary, decisions: minutesResult.decisions, actionItems: minutesResult.actionItems, voteOutcome: voteResult?.passed ? 'passed' : 'failed' } } } });
+        const r = await api.post('/api/lens/run', { domain: 'dtu', name: 'create', input: { title: `Public minutes — ${motionText.slice(0, 60)}`, tags: ['council', 'minutes', 'public'], source: 'council:minutes:publish', meta: { visibility: 'public', consent: { allowCitations: true }, minutes: { motion: motionText, decisions: minutesResult.decisions, actionItems: minutesResult.actionItems, voteOutcome: voteResult?.passed ? 'passed' : 'failed' } } } });
         const newId = r.data?.result?.dtu?.id ?? r.data?.dtu?.id ?? r.data?.result?.id;
         if (!newId) throw new Error('No DTU id.');
         const pub = await api.post(`/api/dtus/${encodeURIComponent(newId)}/publish`);
@@ -148,7 +168,7 @@ export function CouncilActionPanel() {
     if (!motionText.trim()) { err('Motion required.'); return; }
     setBusy('agent'); setFeedback(null); setAgentReply(null);
     try {
-      const task = `Council motion: "${motionText}". ${voteResult ? `Vote: ${voteResult.passed ? 'passed' : 'failed'} (${voteResult.yes}/${voteResult.no}/${voteResult.abstain}).` : ''} Draft a 2-sentence call-for-amendment that addresses the dissent without weakening the core proposal. Plain text.`;
+      const task = `Council motion: "${motionText}". ${voteResult ? `Vote: ${voteResult.passed ? 'passed' : 'failed'} (${voteResult.tally?.for ?? 0}/${voteResult.tally?.against ?? 0}/${voteResult.tally?.abstain ?? 0}).` : ''} Draft a 2-sentence call-for-amendment that addresses the dissent without weakening the core proposal. Plain text.`;
       const r = await api.post('/api/lens/run', { domain: 'chat_agent', name: 'do', input: { task, maxTurns: 3 } });
       const reply = r.data?.result?.reply ?? r.data?.result?.summary ?? r.data?.result?.output ?? r.data?.reply;
       if (reply) { setAgentReply(typeof reply === 'string' ? reply : JSON.stringify(reply, null, 2)); ok('Amendment draft ready.'); } else err('Agent returned empty.');
@@ -207,36 +227,40 @@ export function CouncilActionPanel() {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
         {deliberateResult && (
           <div className="rounded-md border border-cyan-500/30 bg-cyan-500/5 p-2.5 max-h-40 overflow-y-auto">
-            <div className="text-[10px] uppercase tracking-wider text-cyan-300 font-semibold">Positions</div>
-            {deliberateResult.positions?.map((p, i) => <div key={i} className="text-[11px] text-zinc-300"><strong className="text-cyan-200">{p.member}:</strong> <span className="capitalize">{p.position}</span>{p.reasoning && <span className="text-zinc-400"> — {p.reasoning}</span>}</div>)}
+            <div className="flex items-center justify-between">
+              <div className="text-[10px] uppercase tracking-wider text-cyan-300 font-semibold">Deliberation</div>
+              {deliberateResult.recommendation && <span className="text-[10px] font-semibold text-cyan-200">{deliberateResult.recommendation}{typeof deliberateResult.weightedScore === 'number' ? ` · ${deliberateResult.weightedScore}` : ''}</span>}
+            </div>
+            {deliberateResult.message && !deliberateResult.evaluations?.length && <p className="text-[11px] text-zinc-400 italic mt-1">{deliberateResult.message}</p>}
+            {deliberateResult.evaluations?.map((e, i) => <div key={i} className="text-[11px] text-zinc-300"><strong className="text-cyan-200">{e.voice}:</strong> <span className="capitalize">{e.position}</span> <span className="text-zinc-500">({e.score})</span>{e.reasoning && <span className="text-zinc-400"> — {e.reasoning}</span>}</div>)}
             {deliberateResult.consensus && <div className="text-[11px] text-cyan-300 italic mt-1">Consensus: {deliberateResult.consensus}</div>}
           </div>
         )}
         {voteResult && (
           <div className={cn('rounded-md border p-2.5', voteResult.passed ? 'border-emerald-500/40 bg-emerald-500/5' : 'border-rose-500/40 bg-rose-500/5')}>
-            <div className={cn('text-[10px] uppercase tracking-wider font-semibold', voteResult.passed ? 'text-emerald-300' : 'text-rose-300')}>Vote {voteResult.passed ? 'PASSED' : 'FAILED'}{!voteResult.quorum && ' (no quorum)'}</div>
+            <div className={cn('text-[10px] uppercase tracking-wider font-semibold', voteResult.passed ? 'text-emerald-300' : 'text-rose-300')}>Vote {voteResult.passed ? 'PASSED' : 'FAILED'}{!voteResult.quorumMet && ' (no quorum)'}</div>
             <div className="flex gap-4 mt-1 text-sm">
-              <span className="text-emerald-300 font-bold">✓ {voteResult.yes}</span>
-              <span className="text-rose-300 font-bold">✗ {voteResult.no}</span>
-              <span className="text-zinc-400">— {voteResult.abstain}</span>
+              <span className="text-emerald-300 font-bold">✓ {voteResult.tally?.for ?? 0}</span>
+              <span className="text-rose-300 font-bold">✗ {voteResult.tally?.against ?? 0}</span>
+              <span className="text-zinc-400">— {voteResult.tally?.abstain ?? 0}</span>
+              <span className="ml-auto text-zinc-400 text-[11px]">{voteResult.forPercent ?? 0}% · {voteResult.passThreshold}</span>
             </div>
           </div>
         )}
         {minutesResult && (
           <div className="rounded-md border border-purple-500/30 bg-purple-500/5 p-2.5 max-h-40 overflow-y-auto">
-            <div className="text-[10px] uppercase tracking-wider text-purple-300 font-semibold">Minutes</div>
-            {minutesResult.summary && <p className="text-[11px] text-zinc-300 mt-1">{minutesResult.summary}</p>}
-            {minutesResult.decisions?.length ? <ul className="text-[11px] text-zinc-300 list-disc list-inside">{minutesResult.decisions.map((d, i) => <li key={i}>{d}</li>)}</ul> : null}
+            <div className="text-[10px] uppercase tracking-wider text-purple-300 font-semibold">{minutesResult.title || 'Minutes'}{minutesResult.date && <span className="text-zinc-500 normal-case font-normal"> · {minutesResult.date}</span>}</div>
+            {typeof minutesResult.attendees === 'number' && <p className="text-[11px] text-zinc-400 mt-1">{minutesResult.attendees} attendee{minutesResult.attendees !== 1 ? 's' : ''}</p>}
+            {minutesResult.decisions?.length ? <ul className="text-[11px] text-zinc-300 list-disc list-inside">{minutesResult.decisions.map((d, i) => <li key={i}>{d.decision} <span className="text-zinc-500">({d.passed ? 'passed' : 'failed'} · {d.votedBy})</span></li>)}</ul> : null}
             {minutesResult.actionItems?.length ? <div className="mt-1 text-[10px] text-purple-300 font-semibold uppercase tracking-wider">Action items</div> : null}
-            {minutesResult.actionItems?.map((a, i) => <div key={i} className="text-[11px] text-zinc-300"><strong className="text-purple-200">{a.owner}:</strong> {a.task}{a.due && <span className="text-zinc-400"> · {a.due}</span>}</div>)}
+            {minutesResult.actionItems?.map((a, i) => <div key={i} className="text-[11px] text-zinc-300"><strong className="text-purple-200">{a.assignee}:</strong> {a.task}{a.dueDate && <span className="text-zinc-400"> · {a.dueDate}</span>}</div>)}
           </div>
         )}
         {resolveResult && (
           <div className="rounded-md border border-orange-500/30 bg-orange-500/5 p-2.5">
-            <div className="text-[10px] uppercase tracking-wider text-orange-300 font-semibold">Resolution</div>
-            <p className="text-[11px] text-zinc-300 mt-1">{resolveResult.resolution}</p>
-            {resolveResult.nextSteps?.length ? <ol className="text-[11px] text-zinc-300 list-decimal list-inside mt-1">{resolveResult.nextSteps.slice(0, 4).map((s, i) => <li key={i}>{s}</li>)}</ol> : null}
-            {resolveResult.mediator && <div className="text-[10px] text-zinc-400">Mediator: {resolveResult.mediator}</div>}
+            <div className="text-[10px] uppercase tracking-wider text-orange-300 font-semibold">Resolution{resolveResult.commonGround && <span className="text-zinc-500 normal-case font-normal"> · {resolveResult.commonGround}</span>}</div>
+            {resolveResult.suggestedApproach && <p className="text-[11px] text-zinc-300 mt-1">{resolveResult.suggestedApproach}</p>}
+            {resolveResult.steps?.length ? <ol className="text-[11px] text-zinc-300 list-decimal list-inside mt-1">{resolveResult.steps.slice(0, 5).map((s, i) => <li key={i}>{s}</li>)}</ol> : null}
           </div>
         )}
       </div>

--- a/concord-frontend/components/debate/DebateActionPanel.tsx
+++ b/concord-frontend/components/debate/DebateActionPanel.tsx
@@ -56,9 +56,14 @@ function pickMessage(e: unknown): string {
   return ax?.response?.data?.error ?? ax?.message ?? 'request failed';
 }
 
-interface FallacyResult { fallacies?: Array<{ name: string; explanation?: string }>; confidence?: number; clean?: boolean }
-interface SteelmanResult { side?: string; original?: string; strengthened?: string; reasoning?: string }
-interface ScoreResult { proScore?: number; conScore?: number; winner?: string; reasoning?: string; engagement?: number }
+// Field names align EXACTLY to the debate-domain handler return contracts
+// (server/domains/debate.js). fallacyCheck → {fallaciesDetected[],count,
+// logicalSoundness,textLength}; steelmanPosition → {steelmanSteps[],framework,
+// originalLength,side}; scoreDebate → {sides[],winner,margin,close}.
+interface FallacyResult { fallaciesDetected?: Array<{ fallacy: string; description?: string }>; count?: number; logicalSoundness?: string; textLength?: number; message?: string }
+interface SteelmanResult { side?: string; steelmanSteps?: string[]; originalLength?: number; framework?: Record<string, string>; note?: string; message?: string }
+interface ScoreSide { side: string; arguments: number; evidencePoints: number; rebuttals: number; score: number; votes?: number; highlights?: string[] }
+interface ScoreResult { sides?: ScoreSide[]; winner?: string; margin?: number; close?: boolean; message?: string }
 
 export function DebateActionPanel({ debate }: { debate: DebateLike }) {
   const d = debate.data;
@@ -111,7 +116,7 @@ export function DebateActionPanel({ debate }: { debate: DebateLike }) {
       });
       const result = (r?.result ?? {}) as FallacyResult;
       setFallacyResult(result);
-      const cnt = result.fallacies?.length ?? 0;
+      const cnt = result.count ?? result.fallaciesDetected?.length ?? 0;
       ok(cnt === 0 ? 'No fallacies flagged.' : `${cnt} fallac${cnt === 1 ? 'y' : 'ies'} flagged.`);
     } catch (e) { err(pickMessage(e)); }
     finally { setBusy(null); }
@@ -331,20 +336,20 @@ export function DebateActionPanel({ debate }: { debate: DebateLike }) {
           <div className="text-[10px] uppercase tracking-wider text-red-300 font-semibold flex items-center gap-1.5">
             <AlertTriangle className="w-3 h-3" /> Fallacy check
           </div>
-          {fallacyResult.clean || (fallacyResult.fallacies?.length ?? 0) === 0 ? (
+          {(fallacyResult.count ?? fallacyResult.fallaciesDetected?.length ?? 0) === 0 ? (
             <p className="text-xs text-emerald-300 flex items-center gap-1.5"><Check className="w-3 h-3" /> No fallacies flagged.</p>
           ) : (
             <>
               <ul className="text-xs text-gray-200 space-y-1">
-                {fallacyResult.fallacies?.map((f, i) => (
+                {fallacyResult.fallaciesDetected?.map((f, i) => (
                   <li key={i}>
-                    <span className="font-semibold text-red-300">{f.name}</span>
-                    {f.explanation && <span className="text-gray-400"> — {f.explanation}</span>}
+                    <span className="font-semibold text-red-300">{f.fallacy}</span>
+                    {f.description && <span className="text-gray-400"> — {f.description}</span>}
                   </li>
                 ))}
               </ul>
-              {fallacyResult.confidence != null && (
-                <div className="text-[10px] text-gray-400">Confidence: {(fallacyResult.confidence * 100).toFixed(0)}%</div>
+              {fallacyResult.logicalSoundness && (
+                <div className="text-[10px] text-gray-400">Soundness: {fallacyResult.logicalSoundness.replace(/-/g, ' ')}</div>
               )}
             </>
           )}
@@ -355,12 +360,26 @@ export function DebateActionPanel({ debate }: { debate: DebateLike }) {
         <div className="rounded-lg border border-cyan-400/30 bg-cyan-400/5 p-3 space-y-1.5">
           <div className="text-[10px] uppercase tracking-wider text-cyan-300 font-semibold flex items-center gap-1.5">
             <Sparkles className="w-3 h-3" /> Steelman ({steelmanResult.side ?? steelmanSide})
+            {steelmanResult.originalLength != null && (
+              <span className="text-gray-500 normal-case font-normal">· {steelmanResult.originalLength} words</span>
+            )}
           </div>
-          {steelmanResult.strengthened && (
-            <p className="text-xs text-gray-200 leading-relaxed">{steelmanResult.strengthened}</p>
+          {Array.isArray(steelmanResult.steelmanSteps) && steelmanResult.steelmanSteps.length > 0 && (
+            <ul className="space-y-1">
+              {steelmanResult.steelmanSteps.map((step, i) => (
+                <li key={i} className="text-xs text-gray-200 flex items-start gap-1.5">
+                  <span className="text-cyan-300 shrink-0">{i + 1}.</span>
+                  <span>{step}</span>
+                </li>
+              ))}
+            </ul>
           )}
-          {steelmanResult.reasoning && (
-            <div className="text-[10px] text-gray-400 italic">Reasoning: {steelmanResult.reasoning}</div>
+          {steelmanResult.framework && (
+            <div className="rounded border border-cyan-500/20 bg-cyan-500/5 p-2 space-y-0.5">
+              {Object.entries(steelmanResult.framework).map(([k, v]) => (
+                <p key={k} className="text-[10px] text-gray-300"><span className="text-cyan-300 capitalize">{k}: </span>{v}</p>
+              ))}
+            </div>
           )}
         </div>
       )}
@@ -370,14 +389,31 @@ export function DebateActionPanel({ debate }: { debate: DebateLike }) {
           <div className="text-[10px] uppercase tracking-wider text-yellow-300 font-semibold flex items-center gap-1.5">
             <Trophy className="w-3 h-3" /> Debate score
           </div>
-          <div className="flex items-center gap-3 text-xs">
-            <span className="text-neon-green">Pro: <strong>{scoreResult.proScore ?? '—'}</strong></span>
-            <span className="text-red-400">Con: <strong>{scoreResult.conScore ?? '—'}</strong></span>
-            {scoreResult.winner && <span className="ml-auto rounded bg-yellow-400/20 px-2 py-0.5 text-yellow-300 font-semibold">Winner: {scoreResult.winner}</span>}
+          <div className="flex items-center gap-3 text-xs flex-wrap">
+            {scoreResult.winner && <span className="rounded bg-yellow-400/20 px-2 py-0.5 text-yellow-300 font-semibold">Winner: {scoreResult.winner}</span>}
+            {scoreResult.margin != null && <span className="text-gray-400">Margin: <strong className="text-gray-200">{scoreResult.margin}</strong></span>}
+            {scoreResult.close != null && (
+              <span className={cn('rounded px-2 py-0.5', scoreResult.close ? 'bg-yellow-400/10 text-yellow-300' : 'bg-emerald-500/10 text-emerald-300')}>
+                {scoreResult.close ? 'Close' : 'Clear'}
+              </span>
+            )}
           </div>
-          {scoreResult.reasoning && <p className="text-xs text-gray-300 leading-relaxed">{scoreResult.reasoning}</p>}
-          {scoreResult.engagement != null && (
-            <div className="text-[10px] text-gray-400">Engagement: {scoreResult.engagement}</div>
+          {Array.isArray(scoreResult.sides) && scoreResult.sides.length > 0 && (
+            <div className="space-y-1.5">
+              {scoreResult.sides.map((s, i) => (
+                <div key={i} className={cn('rounded border p-2', i === 0 ? 'border-emerald-500/30 bg-emerald-500/5' : 'border-white/10 bg-white/[0.02]')}>
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs font-semibold text-gray-200">{s.side}</span>
+                    <span className={cn('text-xs font-bold', i === 0 ? 'text-emerald-300' : 'text-gray-400')}>{s.score} pts</span>
+                  </div>
+                  <div className="flex gap-3 text-[10px] text-gray-400 mt-0.5">
+                    <span>{s.arguments} args</span>
+                    <span>{s.evidencePoints} evidence</span>
+                    <span>{s.rebuttals} rebuttals</span>
+                  </div>
+                </div>
+              ))}
+            </div>
           )}
         </div>
       )}

--- a/concord-frontend/components/eco/AQIPanel.tsx
+++ b/concord-frontend/components/eco/AQIPanel.tsx
@@ -61,7 +61,16 @@ export function AQIPanel({ lat, lng }: AQIPanelProps) {
           domain: 'eco', action: 'aqi-current',
           input: { lat: coords.lat, lng: coords.lng },
         });
-        setData(res.data?.result as AQIData || null);
+        // /api/lens/run single-unwraps: a handler rejection arrives as
+        // res.data.result = { ok:false, error }. Surface it (the panel renders
+        // the error branch) instead of crashing on data.lat.toFixed().
+        const node = res.data?.result as (AQIData & { ok?: boolean; error?: string }) | null;
+        if (node && node.ok === false) {
+          setError(node.error || 'Air-quality source unavailable.');
+          setData(null);
+        } else {
+          setData((node as AQIData) || null);
+        }
       } catch (e) {
         setError(e instanceof Error ? e.message : 'fetch failed');
       } finally { setLoading(false); }

--- a/concord-frontend/components/eco/BiodiversityLog.tsx
+++ b/concord-frontend/components/eco/BiodiversityLog.tsx
@@ -18,18 +18,31 @@ export interface BioObservation {
 export function BiodiversityLog() {
   const [observations, setObservations] = useState<BioObservation[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => { refresh(); }, []);
 
   async function refresh() {
     setLoading(true);
+    setError(null);
     try {
       const res = await api.post('/api/lens/run', {
         domain: 'eco', action: 'biodiversity-list', input: { limit: 50 },
       });
-      setObservations((res.data?.result?.observations || []) as BioObservation[]);
+      // /api/lens/run single-unwraps the handler envelope: a handler REJECTION
+      // arrives as res.data.result = { ok:false, error }. Surface it as an error
+      // (never silent-empty) so a backend failure is DISTINGUISHABLE from a
+      // genuinely-empty life list.
+      const node = res.data?.result;
+      if (node && (node as { ok?: boolean }).ok === false) {
+        setError((node as { error?: string }).error || 'Could not load life list.');
+        setObservations([]);
+      } else {
+        setObservations(((node as { observations?: BioObservation[] })?.observations || []) as BioObservation[]);
+      }
     } catch (e) {
-      console.error('[BioLog] list failed', e);
+      setError(e instanceof Error ? e.message : 'Could not load life list.');
+      setObservations([]);
     } finally { setLoading(false); }
   }
 
@@ -53,8 +66,18 @@ export function BiodiversityLog() {
       </header>
       <div className="max-h-96 overflow-y-auto">
         {loading ? (
-          <div className="flex items-center justify-center py-8 text-xs text-gray-400">
+          <div role="status" aria-busy="true" className="flex items-center justify-center py-8 text-xs text-gray-400">
             <Loader2 className="w-4 h-4 animate-spin mr-2" /> Loading…
+          </div>
+        ) : error ? (
+          <div role="alert" className="px-3 py-8 text-center text-xs text-red-400 space-y-2">
+            <div>{error}</div>
+            <button
+              onClick={() => refresh()}
+              className="inline-flex items-center gap-1.5 px-3 py-1 rounded bg-white/[0.04] border border-white/10 text-gray-300 hover:bg-white/[0.08]"
+            >
+              Retry
+            </button>
           </div>
         ) : observations.length === 0 ? (
           <div className="px-3 py-10 text-center text-xs text-gray-400">

--- a/concord-frontend/components/eco/ClimateActions.tsx
+++ b/concord-frontend/components/eco/ClimateActions.tsx
@@ -24,6 +24,7 @@ const CATEGORIES: Array<ClimateAction['category']> = ['transport', 'food', 'home
 export function ClimateActions({ onLogged }: ClimateActionsProps) {
   const [actions, setActions] = useState<ClimateAction[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [logged, setLogged] = useState<Record<string, number>>({});
   const [filter, setFilter] = useState<ClimateAction['category'] | 'all'>('all');
   const [effortMax, setEffortMax] = useState<number>(5);
@@ -33,13 +34,24 @@ export function ClimateActions({ onLogged }: ClimateActionsProps) {
 
   async function refresh() {
     setLoading(true);
+    setError(null);
     try {
       const res = await api.post('/api/lens/run', {
         domain: 'eco', action: 'climate-actions-list', input: {},
       });
-      setActions((res.data?.result?.actions || []) as ClimateAction[]);
+      // /api/lens/run single-unwraps: a handler rejection arrives as
+      // res.data.result = { ok:false, error }. Surface it as an error so a
+      // backend failure is never indistinguishable from "no actions match".
+      const node = res.data?.result;
+      if (node && (node as { ok?: boolean }).ok === false) {
+        setError((node as { error?: string }).error || 'Could not load climate actions.');
+        setActions([]);
+      } else {
+        setActions(((node as { actions?: ClimateAction[] })?.actions || []) as ClimateAction[]);
+      }
     } catch (e) {
-      console.error('[Actions] list failed', e);
+      setError(e instanceof Error ? e.message : 'Could not load climate actions.');
+      setActions([]);
     } finally { setLoading(false); }
   }
 
@@ -111,8 +123,18 @@ export function ClimateActions({ onLogged }: ClimateActionsProps) {
       </div>
       <div className="max-h-96 overflow-y-auto">
         {loading ? (
-          <div className="flex items-center justify-center py-6 text-xs text-gray-400">
+          <div role="status" aria-busy="true" className="flex items-center justify-center py-6 text-xs text-gray-400">
             <Loader2 className="w-4 h-4 animate-spin mr-2" /> Loading…
+          </div>
+        ) : error ? (
+          <div role="alert" className="px-3 py-8 text-center text-xs text-red-400 space-y-2">
+            <div>{error}</div>
+            <button
+              onClick={() => refresh()}
+              className="inline-flex items-center gap-1.5 px-3 py-1 rounded bg-white/[0.04] border border-white/10 text-gray-300 hover:bg-white/[0.08]"
+            >
+              Retry
+            </button>
           </div>
         ) : visible.length === 0 ? (
           <div className="px-3 py-8 text-xs text-gray-400 text-center">No actions match.</div>

--- a/concord-frontend/components/eco/EnergyEstimator.tsx
+++ b/concord-frontend/components/eco/EnergyEstimator.tsx
@@ -21,6 +21,7 @@ export function EnergyEstimator() {
   const [azimuth, setAzimuth] = useState<number>(180);
   const [result, setResult] = useState<EstimateResult | null>(null);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (typeof navigator !== 'undefined' && navigator.geolocation) {
@@ -34,14 +35,25 @@ export function EnergyEstimator() {
 
   async function estimate() {
     setLoading(true);
+    setError(null);
     try {
       const res = await api.post('/api/lens/run', {
         domain: 'eco', action: 'energy-estimate',
         input: { lat, lng, systemKw, tilt, azimuth },
       });
-      setResult(res.data?.result as EstimateResult || null);
+      // /api/lens/run single-unwraps: a handler rejection arrives as
+      // res.data.result = { ok:false, error }. Surface it rather than crashing
+      // on result.monthlyKwh.map / Math.max(...result.monthlyKwh).
+      const node = res.data?.result as (EstimateResult & { ok?: boolean; error?: string }) | null;
+      if (node && node.ok === false) {
+        setError(node.error || 'Could not estimate production.');
+        setResult(null);
+      } else {
+        setResult((node as EstimateResult) || null);
+      }
     } catch (e) {
-      console.error('[Energy] estimate failed', e);
+      setError(e instanceof Error ? e.message : 'Could not estimate production.');
+      setResult(null);
     } finally { setLoading(false); }
   }
 
@@ -80,6 +92,7 @@ export function EnergyEstimator() {
           {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Zap className="w-4 h-4" />}
           Estimate production
         </button>
+        {error && <div role="alert" className="text-xs text-red-400">{error}</div>}
         {result && (
           <div className="space-y-2 pt-2 border-t border-white/10">
             <div className="grid grid-cols-3 gap-2 text-center">

--- a/concord-frontend/components/eco/SpeciesIdentifier.tsx
+++ b/concord-frontend/components/eco/SpeciesIdentifier.tsx
@@ -48,7 +48,16 @@ export function SpeciesIdentifier({ onAccept }: SpeciesIdentifierProps) {
         domain: 'eco', action: 'species-identify',
         input: { imageDataUrl: dataUrl },
       });
-      const items = (res.data?.result?.suggestions || []) as SpeciesSuggestion[];
+      // /api/lens/run single-unwraps: a handler rejection arrives as
+      // res.data.result = { ok:false, error }. Surface it rather than reading a
+      // missing .suggestions and masking the real failure as "no species".
+      const node = res.data?.result as { ok?: boolean; error?: string; suggestions?: SpeciesSuggestion[] } | null;
+      if (node && node.ok === false) {
+        setSuggestions([]);
+        setError(node.error || 'Species identification failed.');
+        return;
+      }
+      const items = (node?.suggestions || []) as SpeciesSuggestion[];
       setSuggestions(items);
       if (items.length === 0) setError('No species identified. Try a clearer or closer shot.');
     } catch (e) {

--- a/concord-frontend/components/eco/WeatherRadar.tsx
+++ b/concord-frontend/components/eco/WeatherRadar.tsx
@@ -90,7 +90,16 @@ export function WeatherRadar({ lat, lng, locationLabel }: WeatherRadarProps) {
           domain: 'eco', action: 'weather-forecast',
           input: { lat: coords.lat, lng: coords.lng },
         });
-        setData(res.data?.result as ForecastData || null);
+        // /api/lens/run single-unwraps: a handler rejection (e.g. Open-Meteo
+        // unreachable) arrives as res.data.result = { ok:false, error }. Surface
+        // it so the error branch renders instead of crashing on data.current.
+        const node = res.data?.result as (ForecastData & { ok?: boolean; error?: string }) | null;
+        if (node && node.ok === false) {
+          setError(node.error || 'Weather source unavailable.');
+          setData(null);
+        } else {
+          setData((node as ForecastData) || null);
+        }
       } catch (e) {
         setError(e instanceof Error ? e.message : 'fetch failed');
       } finally { setLoading(false); }

--- a/concord-frontend/components/energy/EnergyDevicesPanel.tsx
+++ b/concord-frontend/components/energy/EnergyDevicesPanel.tsx
@@ -19,6 +19,9 @@ export function EnergyDevicesPanel({ onChange }: { onChange: () => void }) {
   const [consumers, setConsumers] = useState<Consumer[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // Distinct from `error` (form-action errors): a load FAILURE must read as a
+  // real error with a working Retry, never as a silent-empty device list.
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [showAdd, setShowAdd] = useState(false);
   const [form, setForm] = useState({ name: '', category: 'appliance', wattage: '' });
   const [readingFor, setReadingFor] = useState<string | null>(null);
@@ -26,14 +29,28 @@ export function EnergyDevicesPanel({ onChange }: { onChange: () => void }) {
 
   const refresh = useCallback(async () => {
     setLoading(true);
-    const [d, t] = await Promise.all([
-      lensRun('energy', 'device-list', {}),
-      lensRun('energy', 'top-consumers', { days: 30 }),
-    ]);
-    setDevices(d.data?.result?.devices || []);
-    setConsumers(t.data?.result?.devices || []);
-    setLoading(false);
-    onChange();
+    try {
+      const [d, t] = await Promise.all([
+        lensRun('energy', 'device-list', {}),
+        lensRun('energy', 'top-consumers', { days: 30 }),
+      ]);
+      // /api/lens/run unwraps one {ok,result} layer, so a handler rejection
+      // surfaces at d.data.ok===false (lensRun normalizes both transport and
+      // handler-reject into this flag). Treat either as a real load error so
+      // the panel never renders an empty device list that masks a failure.
+      if (d.data?.ok === false) {
+        setLoadError(d.data?.error || 'Failed to load devices.');
+        return;
+      }
+      setDevices(d.data?.result?.devices || []);
+      setConsumers(t.data?.result?.devices || []);
+      setLoadError(null);
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : 'Failed to load devices.');
+    } finally {
+      setLoading(false);
+      onChange();
+    }
   }, [onChange]);
 
   useEffect(() => { void refresh(); }, [refresh]);
@@ -57,7 +74,24 @@ export function EnergyDevicesPanel({ onChange }: { onChange: () => void }) {
   };
 
   if (loading) {
-    return <div className="flex items-center justify-center py-10 text-zinc-400"><Loader2 className="w-5 h-5 animate-spin" /></div>;
+    return (
+      <div role="status" aria-busy="true" aria-live="polite"
+        className="flex items-center justify-center gap-2 py-10 text-zinc-400">
+        <Loader2 className="w-5 h-5 animate-spin" /> <span className="text-xs">Loading devices…</span>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div role="alert" className="flex flex-col items-center gap-3 py-10 text-center">
+        <p className="text-sm text-rose-300">{loadError}</p>
+        <button type="button" onClick={() => { void refresh(); }}
+          className="px-3 py-1.5 text-xs font-medium bg-rose-600/80 hover:bg-rose-500 text-white rounded-lg">
+          Retry
+        </button>
+      </div>
+    );
   }
 
   return (

--- a/concord-frontend/components/ethics/DecisionToolkit.tsx
+++ b/concord-frontend/components/ethics/DecisionToolkit.tsx
@@ -14,14 +14,14 @@
  * Every value rendered comes from a real macro response.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, type ReactNode } from 'react';
 import { lensRun } from '@/lib/api/client';
 import { ChartKit } from '@/components/viz';
 import { ds } from '@/lib/design-system';
 import { cn } from '@/lib/utils';
 import {
   Scale, Users, Grid3x3, ListChecks, MessagesSquare, Archive,
-  Plus, Trash2, X, Loader2, Search, Gavel, ThumbsUp, ThumbsDown,
+  Plus, Trash2, X, Loader2, Search, Gavel, ThumbsUp, ThumbsDown, RefreshCw,
 } from 'lucide-react';
 
 type ToolTab = 'multiframework' | 'stakeholder' | 'matrix' | 'bias' | 'review' | 'cases';
@@ -150,6 +150,63 @@ interface CaseRecord {
 const SECTION = 'rounded-xl border border-lattice-border bg-lattice-surface p-4 space-y-3';
 const errBox = 'text-xs text-red-400 bg-red-500/10 border border-red-500/30 rounded-lg px-3 py-2';
 
+/**
+ * LoadGate — the single load-state authority for every ethics list panel.
+ *
+ * Each panel's list-load reaches a real macro through lensRun (which unwraps the
+ * { ok, result } envelope, so a handler rejection lands as r.data.ok === false
+ * with r.data.error). The prior surface did `if (r.data.ok && r.data.result)
+ * setRecords(...)` with no else — a failed load rendered identically to a
+ * genuinely-empty one (the silent-empty defect). LoadGate makes the four states
+ * DISTINGUISHABLE: a spinner while loading, a red alert with a WORKING retry
+ * that re-runs the loader on error, an honest CTA when truly empty, and the
+ * children (real records) when populated.
+ *
+ * It renders nothing of its own in the populated case — the panel passes its
+ * record list and LoadGate decides loading/error/empty vs. handing through.
+ */
+function LoadGate({
+  loading,
+  error,
+  onRetry,
+  isEmpty,
+  emptyLabel,
+  children,
+}: {
+  loading: boolean;
+  error: string;
+  onRetry: () => void;
+  isEmpty: boolean;
+  emptyLabel: string;
+  children: ReactNode;
+}) {
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center gap-2 py-8 text-sm text-gray-400">
+        <Loader2 className="w-4 h-4 animate-spin" />
+        Loading {emptyLabel}…
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className={cn(errBox, 'flex items-center justify-between gap-3')} role="alert">
+        <span>Could not load {emptyLabel}: {error}</span>
+        <button
+          onClick={onRetry}
+          className="flex items-center gap-1 px-2 py-1 rounded border border-red-500/40 text-red-300 hover:bg-red-500/10 whitespace-nowrap"
+        >
+          <RefreshCw className="w-3.5 h-3.5" /> Retry
+        </button>
+      </div>
+    );
+  }
+  if (isEmpty) {
+    return <EmptyHint label={emptyLabel} />;
+  }
+  return <>{children}</>;
+}
+
 function riskColor(level: string): string {
   return level === 'high' ? 'text-red-400'
     : level === 'moderate' ? 'text-yellow-400'
@@ -202,10 +259,15 @@ function MultiFrameworkPanel() {
   const [records, setRecords] = useState<MfaRecord[]>([]);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [loadErr, setLoadErr] = useState('');
 
   const load = useCallback(async () => {
+    setLoading(true); setLoadErr('');
     const r = await lensRun('ethics', 'listMultiFramework', {});
-    if (r.data.ok && r.data.result) setRecords(r.data.result.analyses || []);
+    setLoading(false);
+    if (!r.data.ok) { setLoadErr(r.data.error || 'request failed'); return; }
+    setRecords(r.data.result?.analyses || []);
   }, []);
   useEffect(() => { load(); }, [load]);
 
@@ -293,6 +355,10 @@ function MultiFrameworkPanel() {
         {err && <div className={errBox}>{err}</div>}
       </div>
 
+      <LoadGate
+        loading={loading} error={loadErr} onRetry={load}
+        isEmpty={records.length === 0} emptyLabel="multi-framework analyses"
+      >
       {records.map((rec) => (
         <div key={rec.id} className={SECTION}>
           <div className="flex items-start justify-between gap-3">
@@ -342,7 +408,7 @@ function MultiFrameworkPanel() {
           </div>
         </div>
       ))}
-      {records.length === 0 && <EmptyHint label="multi-framework analyses" />}
+      </LoadGate>
     </div>
   );
 }
@@ -359,12 +425,17 @@ function StakeholderMapPanel() {
   const [records, setRecords] = useState<SmapRecord[]>([]);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [loadErr, setLoadErr] = useState('');
 
   const optionList = optionsText.split(',').map((s) => s.trim()).filter(Boolean);
 
   const load = useCallback(async () => {
+    setLoading(true); setLoadErr('');
     const r = await lensRun('ethics', 'listStakeholderMaps', {});
-    if (r.data.ok && r.data.result) setRecords(r.data.result.maps || []);
+    setLoading(false);
+    if (!r.data.ok) { setLoadErr(r.data.error || 'request failed'); return; }
+    setRecords(r.data.result?.maps || []);
   }, []);
   useEffect(() => { load(); }, [load]);
 
@@ -463,6 +534,10 @@ function StakeholderMapPanel() {
         {err && <div className={errBox}>{err}</div>}
       </div>
 
+      <LoadGate
+        loading={loading} error={loadErr} onRetry={load}
+        isEmpty={records.length === 0} emptyLabel="stakeholder maps"
+      >
       {records.map((rec) => (
         <div key={rec.id} className={SECTION}>
           <div className="flex items-start justify-between gap-3">
@@ -513,7 +588,7 @@ function StakeholderMapPanel() {
           </div>
         </div>
       ))}
-      {records.length === 0 && <EmptyHint label="stakeholder maps" />}
+      </LoadGate>
     </div>
   );
 }
@@ -532,12 +607,17 @@ function DecisionMatrixPanel() {
   const [records, setRecords] = useState<MtxRecord[]>([]);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [loadErr, setLoadErr] = useState('');
 
   const criteriaNames = criteria.map((c) => c.name.trim()).filter(Boolean);
 
   const load = useCallback(async () => {
+    setLoading(true); setLoadErr('');
     const r = await lensRun('ethics', 'listDecisionMatrices', {});
-    if (r.data.ok && r.data.result) setRecords(r.data.result.matrices || []);
+    setLoading(false);
+    if (!r.data.ok) { setLoadErr(r.data.error || 'request failed'); return; }
+    setRecords(r.data.result?.matrices || []);
   }, []);
   useEffect(() => { load(); }, [load]);
 
@@ -631,6 +711,10 @@ function DecisionMatrixPanel() {
         {err && <div className={errBox}>{err}</div>}
       </div>
 
+      <LoadGate
+        loading={loading} error={loadErr} onRetry={load}
+        isEmpty={records.length === 0} emptyLabel="decision matrices"
+      >
       {records.map((rec) => (
         <div key={rec.id} className={SECTION}>
           <div className="flex items-start justify-between gap-3">
@@ -663,7 +747,7 @@ function DecisionMatrixPanel() {
           </div>
         </div>
       ))}
-      {records.length === 0 && <EmptyHint label="decision matrices" />}
+      </LoadGate>
     </div>
   );
 }
@@ -677,14 +761,20 @@ function BiasChecklistPanel() {
   const [records, setRecords] = useState<BiasRecord[]>([]);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [loadErr, setLoadErr] = useState('');
 
   const load = useCallback(async () => {
+    setLoading(true); setLoadErr('');
     const [tpl, list] = await Promise.all([
       lensRun('ethics', 'biasChecklistTemplate', {}),
       lensRun('ethics', 'listBiasChecklists', {}),
     ]);
-    if (tpl.data.ok && tpl.data.result) setTemplate(tpl.data.result.items || []);
-    if (list.data.ok && list.data.result) setRecords(list.data.result.checklists || []);
+    setLoading(false);
+    if (!tpl.data.ok) { setLoadErr(tpl.data.error || 'request failed'); return; }
+    if (!list.data.ok) { setLoadErr(list.data.error || 'request failed'); return; }
+    setTemplate(tpl.data.result?.items || []);
+    setRecords(list.data.result?.checklists || []);
   }, []);
   useEffect(() => { load(); }, [load]);
 
@@ -749,6 +839,10 @@ function BiasChecklistPanel() {
         {err && <div className={errBox}>{err}</div>}
       </div>
 
+      <LoadGate
+        loading={loading} error={loadErr} onRetry={load}
+        isEmpty={records.length === 0} emptyLabel="bias checklists"
+      >
       {records.map((rec) => (
         <div key={rec.id} className={SECTION}>
           <div className="flex items-start justify-between gap-3">
@@ -770,7 +864,7 @@ function BiasChecklistPanel() {
           </div>
         </div>
       ))}
-      {records.length === 0 && <EmptyHint label="bias checklists" />}
+      </LoadGate>
     </div>
   );
 }
@@ -783,10 +877,15 @@ function ReviewWorkflowPanel() {
   const [records, setRecords] = useState<ReviewRecord[]>([]);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [loadErr, setLoadErr] = useState('');
 
   const load = useCallback(async () => {
+    setLoading(true); setLoadErr('');
     const r = await lensRun('ethics', 'listReviews', {});
-    if (r.data.ok && r.data.result) setRecords(r.data.result.reviews || []);
+    setLoading(false);
+    if (!r.data.ok) { setLoadErr(r.data.error || 'request failed'); return; }
+    setRecords(r.data.result?.reviews || []);
   }, []);
   useEffect(() => { load(); }, [load]);
 
@@ -815,10 +914,14 @@ function ReviewWorkflowPanel() {
         {err && <div className={errBox}>{err}</div>}
       </div>
 
+      <LoadGate
+        loading={loading} error={loadErr} onRetry={load}
+        isEmpty={records.length === 0} emptyLabel="ethics reviews"
+      >
       {records.map((rec) => (
         <ReviewCard key={rec.id} review={rec} onChange={load} />
       ))}
-      {records.length === 0 && <EmptyHint label="ethics reviews" />}
+      </LoadGate>
     </div>
   );
 }
@@ -942,6 +1045,8 @@ function CaseLibraryPanel() {
   const [allTags, setAllTags] = useState<string[]>([]);
   const [creating, setCreating] = useState(false);
   const [err, setErr] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [loadErr, setLoadErr] = useState('');
 
   const [cTitle, setCTitle] = useState('');
   const [cDilemma, setCDilemma] = useState('');
@@ -951,14 +1056,15 @@ function CaseLibraryPanel() {
   const [cTags, setCTags] = useState('');
 
   const load = useCallback(async () => {
+    setLoading(true); setLoadErr('');
     const r = await lensRun('ethics', 'searchCases', {
       query: query.trim(),
       tag: tagFilter.trim(),
     });
-    if (r.data.ok && r.data.result) {
-      setCases(r.data.result.cases || []);
-      setAllTags(r.data.result.allTags || []);
-    }
+    setLoading(false);
+    if (!r.data.ok) { setLoadErr(r.data.error || 'request failed'); return; }
+    setCases(r.data.result?.cases || []);
+    setAllTags(r.data.result?.allTags || []);
   }, [query, tagFilter]);
   useEffect(() => { load(); }, [load]);
 
@@ -1032,6 +1138,10 @@ function CaseLibraryPanel() {
         </div>
       )}
 
+      <LoadGate
+        loading={loading} error={loadErr} onRetry={load}
+        isEmpty={cases.length === 0} emptyLabel="archived cases"
+      >
       {cases.map((c) => (
         <div key={c.id} className={SECTION}>
           <div className="flex items-start justify-between gap-3">
@@ -1061,7 +1171,7 @@ function CaseLibraryPanel() {
           )}
         </div>
       ))}
-      {cases.length === 0 && <EmptyHint label="archived cases" />}
+      </LoadGate>
     </div>
   );
 }

--- a/concord-frontend/components/fitness/ActivityRings.tsx
+++ b/concord-frontend/components/fitness/ActivityRings.tsx
@@ -16,22 +16,41 @@ export function ActivityRings() {
   const [today, setToday] = useState<ActivityDay | null>(null);
   const [week, setWeek] = useState<ActivityDay[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => { refresh(); }, []);
 
   async function refresh() {
     setLoading(true);
+    setError(null);
     try {
       const res = await lensRun({ domain: 'fitness', action: 'activity-summary', input: { days: 7 } });
-      const days = (res.data?.result?.days || []) as ActivityDay[];
-      setWeek(days);
-      setToday(days[days.length - 1] || null);
-    } catch (e) { console.error('[Activity] failed', e); }
-    finally { setLoading(false); }
+      // /api/lens/run unwraps one { ok, result } layer, so a handler rejection
+      // surfaces at res.data.ok === false — distinguish it from genuinely-empty.
+      if (res.data?.ok === false) {
+        setError(res.data?.error || 'Failed to load activity data.');
+        setWeek([]); setToday(null);
+      } else {
+        const days = (res.data?.result?.days || []) as ActivityDay[];
+        setWeek(days);
+        setToday(days[days.length - 1] || null);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load activity data.');
+      setWeek([]); setToday(null);
+    } finally { setLoading(false); }
   }
 
   if (loading) {
-    return <div className="bg-[#0d1117] border border-cyan-500/20 rounded-lg p-6 flex items-center gap-2 text-xs text-gray-400"><Loader2 className="w-4 h-4 animate-spin" /> Loading…</div>;
+    return <div role="status" aria-busy="true" className="bg-[#0d1117] border border-cyan-500/20 rounded-lg p-6 flex items-center gap-2 text-xs text-gray-400"><Loader2 className="w-4 h-4 animate-spin" /> Loading…</div>;
+  }
+  if (error) {
+    return (
+      <div role="alert" className="bg-[#0d1117] border border-red-500/20 rounded-lg p-6 text-xs text-gray-300 space-y-2">
+        <p className="text-red-300">{error}</p>
+        <button onClick={() => void refresh()} className="px-3 py-1 rounded bg-cyan-500/20 text-cyan-200 border border-cyan-500/30 hover:bg-cyan-500/30">Retry</button>
+      </div>
+    );
   }
   if (!today) {
     return <div className="bg-[#0d1117] border border-cyan-500/20 rounded-lg p-6 text-xs text-gray-400">No activity data yet.</div>;

--- a/concord-frontend/components/fitness/SleepRecovery.tsx
+++ b/concord-frontend/components/fitness/SleepRecovery.tsx
@@ -18,16 +18,28 @@ export interface RecoveryDay {
 export function SleepRecovery() {
   const [days, setDays] = useState<RecoveryDay[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => { refresh(); }, []);
 
   async function refresh() {
     setLoading(true);
+    setError(null);
     try {
       const res = await lensRun({ domain: 'fitness', action: 'recovery-history', input: { days: 14 } });
-      setDays((res.data?.result?.days || []) as RecoveryDay[]);
-    } catch (e) { console.error('[Recovery] failed', e); }
-    finally { setLoading(false); }
+      // /api/lens/run unwraps one { ok, result } layer, so a handler rejection
+      // lands at res.data.ok === false (NOT swallowed into empty). Surface it
+      // as a distinguishable error rather than a silent-empty CTA.
+      if (res.data?.ok === false) {
+        setError(res.data?.error || 'Failed to load recovery data.');
+        setDays([]);
+      } else {
+        setDays((res.data?.result?.days || []) as RecoveryDay[]);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load recovery data.');
+      setDays([]);
+    } finally { setLoading(false); }
   }
 
   const latest = days[days.length - 1];
@@ -40,7 +52,12 @@ export function SleepRecovery() {
         <span className="ml-auto text-[10px] text-gray-400">Whoop-style</span>
       </header>
       {loading ? (
-        <div className="flex items-center justify-center py-6 text-xs text-gray-400"><Loader2 className="w-4 h-4 animate-spin mr-2" /> Loading…</div>
+        <div role="status" aria-busy="true" className="flex items-center justify-center py-6 text-xs text-gray-400"><Loader2 className="w-4 h-4 animate-spin mr-2" /> Loading…</div>
+      ) : error ? (
+        <div role="alert" className="px-3 py-8 text-center text-xs space-y-2">
+          <p className="text-red-300">{error}</p>
+          <button onClick={() => void refresh()} className="px-3 py-1 rounded bg-cyan-500/20 text-cyan-200 border border-cyan-500/30 hover:bg-cyan-500/30">Retry</button>
+        </div>
       ) : !latest ? (
         <div className="px-3 py-8 text-center text-xs text-gray-400">No recovery data — connect a wearable or log manually.</div>
       ) : (

--- a/concord-frontend/components/forestry/StandManager.tsx
+++ b/concord-frontend/components/forestry/StandManager.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import { Trees, Plus, Trash2, Loader2 } from 'lucide-react';
+import { Trees, Plus, Trash2, Loader2, AlertTriangle } from 'lucide-react';
 import { lensRun } from '@/lib/api/client';
 import { LensFeedButton } from '@/components/lens/LensFeedButton';
 
@@ -24,17 +24,31 @@ export function StandManager() {
   const [dash, setDash] = useState<Dash | null>(null);
   const [active, setActive] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [form, setForm] = useState({ name: '', species: 'mixed', acres: '', treesPerAcre: '' });
   const [actForm, setActForm] = useState({ kind: 'survey', notes: '' });
 
   const refresh = useCallback(async () => {
-    const [sl, d] = await Promise.all([
-      lensRun('forestry', 'stand-list', {}),
-      lensRun('forestry', 'forestry-dashboard', {}),
-    ]);
-    setStands((sl.data?.result?.stands as Stand[]) || []);
-    setDash((d.data?.result as Dash) || null);
-    setLoading(false);
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const [sl, d] = await Promise.all([
+        lensRun('forestry', 'stand-list', {}),
+        lensRun('forestry', 'forestry-dashboard', {}),
+      ]);
+      // Distinguish a backend failure ({ ok:false } OR a thrown/empty response)
+      // from a genuinely-empty stand list — the swallowed-fetch silent-empty bug.
+      if (sl.data?.ok === false || !sl.data) {
+        setLoadError(sl.data?.error || 'Could not reach the forestry service.');
+        return;
+      }
+      setStands((sl.data?.result?.stands as Stand[]) || []);
+      setDash((d.data?.ok ? (d.data.result as Dash) : null) || null);
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : 'Could not reach the forestry service.');
+    } finally {
+      setLoading(false);
+    }
   }, []);
   useEffect(() => { void refresh(); }, [refresh]);
 
@@ -58,7 +72,22 @@ export function StandManager() {
     await refresh();
   }
 
-  if (loading) return <div className="flex items-center justify-center py-6 text-zinc-400"><Loader2 className="w-4 h-4 animate-spin" /></div>;
+  if (loading) return (
+    <div role="status" aria-busy="true" className="flex items-center justify-center gap-2 py-6 text-zinc-400">
+      <Loader2 className="w-4 h-4 animate-spin" /> <span className="text-xs">Loading stands…</span>
+    </div>
+  );
+
+  if (loadError) return (
+    <div role="alert" className="rounded-2xl border border-rose-500/30 bg-rose-500/5 p-4 text-center">
+      <AlertTriangle className="w-5 h-5 mx-auto mb-2 text-rose-400" />
+      <p className="text-xs text-rose-300 mb-3">Could not reach the forestry service. {loadError}</p>
+      <button onClick={() => void refresh()}
+        className="px-3 py-1.5 text-xs rounded bg-rose-600 hover:bg-rose-500 text-white font-semibold">
+        Try again
+      </button>
+    </div>
+  );
 
   return (
     <div className="rounded-2xl border border-zinc-800 bg-zinc-950/60 p-4">

--- a/concord-frontend/components/forum/FmTopicsPanel.tsx
+++ b/concord-frontend/components/forum/FmTopicsPanel.tsx
@@ -64,6 +64,8 @@ export function FmTopicsPanel({
     setSavedIds(ids);
   }, []);
 
+  const [loadError, setLoadError] = useState<string | null>(null);
+
   const refresh = useCallback(async () => {
     setLoading(true);
     const [c, sf, t] = await Promise.all([
@@ -75,6 +77,16 @@ export function FmTopicsPanel({
         sort,
       }),
     ]);
+    // Distinguish a genuine empty forum from a swallowed fetch failure: the
+    // topic-list call is the load-bearing one. ok===false (or a thrown/caught
+    // request → result:null + error) surfaces a real error with a retry,
+    // never an identical-looking empty list (the silent-empty defect).
+    if (t.data?.ok === false) {
+      setLoadError(t.data?.error || 'Failed to load topics.');
+      setLoading(false);
+      return;
+    }
+    setLoadError(null);
     setCategories(c.data?.result?.categories || []);
     setSubforums(sf.data?.result?.subforums || []);
     setTopics(t.data?.result?.topics || []);
@@ -197,6 +209,20 @@ export function FmTopicsPanel({
 
   if (loading) {
     return <div className="flex items-center justify-center py-10 text-zinc-400"><Loader2 className="w-5 h-5 animate-spin" /></div>;
+  }
+
+  if (loadError) {
+    return (
+      <div role="alert" className="flex flex-col items-center gap-3 py-10 text-center">
+        <p className="text-xs text-rose-300 bg-rose-950/40 border border-rose-900/50 rounded-lg px-3 py-2">
+          {loadError}
+        </p>
+        <button type="button" onClick={() => { void refresh(); }}
+          className="px-3 py-1.5 text-xs font-medium bg-orange-600 hover:bg-orange-500 text-white rounded-lg">
+          Retry
+        </button>
+      </div>
+    );
   }
 
   // ── Thread view ──────────────────────────────────────────────────────

--- a/concord-frontend/components/geology/EarthquakeList.tsx
+++ b/concord-frontend/components/geology/EarthquakeList.tsx
@@ -39,10 +39,19 @@ export function EarthquakeList() {
   const [minMag, setMinMag] = useState(2.5);
   const [sinceHours, setSinceHours] = useState(24);
   const [events, setEvents] = useState<Quake[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [ran, setRan] = useState(false);
 
   const load = useMutation({
     mutationFn: async () => callMacro<{ events: Quake[] }>('recent-earthquakes', { minMagnitude: minMag, sinceHours, limit: 100 }),
-    onSuccess: (env) => { if (env.ok && env.result) setEvents(env.result.events); else setEvents([]); },
+    // EMPTY ≠ ERROR: a rejected macro (USGS unreachable) surfaces a distinct
+    // error banner; a successful-but-empty window renders the empty notice.
+    onSuccess: (env) => {
+      setRan(true);
+      if (env.ok && env.result) { setEvents(env.result.events || []); setError(null); }
+      else { setEvents([]); setError(env.error || 'USGS earthquake catalog unreachable'); }
+    },
+    onError: (e) => { setRan(true); setEvents([]); setError(e instanceof Error ? e.message : 'USGS earthquake catalog unreachable'); },
   });
 
   useEffect(() => {
@@ -70,6 +79,21 @@ export function EarthquakeList() {
           {load.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : 'Reload'}
         </button>
       </div>
+      {error && (
+        <div className="flex items-center gap-2 rounded border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs text-rose-300">
+          <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+          <span className="flex-1">{error}</span>
+          <button type="button" onClick={() => load.mutate()} disabled={load.isPending}
+            className="rounded border border-rose-400/40 px-2 py-0.5 text-rose-200 hover:bg-rose-500/20 disabled:opacity-50">
+            Retry
+          </button>
+        </div>
+      )}
+      {!error && ran && !load.isPending && events.length === 0 && (
+        <p className="py-4 text-center text-xs italic text-zinc-400">
+          No earthquakes ≥M{minMag.toFixed(1)} in the past {sinceHours}h.
+        </p>
+      )}
       <div className="space-y-1 max-h-[28rem] overflow-y-auto">
         {events.map((q) => (
           <motion.div key={q.id} layout initial={{ opacity: 0, y: 4 }} animate={{ opacity: 1, y: 0 }} className={`flex items-center gap-3 rounded border border-zinc-800 border-l-4 ${magClass(q.magnitude)} p-2`}>

--- a/concord-frontend/components/geology/FieldLog.tsx
+++ b/concord-frontend/components/geology/FieldLog.tsx
@@ -30,25 +30,45 @@ export function FieldLog() {
   const [dash, setDash] = useState<Dash | null>(null);
   const [filter, setFilter] = useState('');
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [form, setForm] = useState({ name: '', kind: 'rock', locationName: '', formation: '', notes: '' });
 
   const refresh = useCallback(async () => {
-    const [ol, d] = await Promise.all([
-      lensRun('geology', 'observation-list', filter ? { kind: filter } : {}),
-      lensRun('geology', 'field-dashboard', {}),
-    ]);
-    setObs((ol.data?.result?.observations as Observation[]) || []);
-    setDash((d.data?.result as Dash) || null);
-    setLoading(false);
+    setError(null);
+    try {
+      const [ol, d] = await Promise.all([
+        lensRun('geology', 'observation-list', filter ? { kind: filter } : {}),
+        lensRun('geology', 'field-dashboard', {}),
+      ]);
+      const olInner = ol.data?.result as { ok?: boolean; error?: string; observations?: Observation[] } | undefined;
+      const dInner = d.data?.result as (Dash & { ok?: boolean; error?: string }) | undefined;
+      // A swallowed failure must NOT render identically to genuinely-empty:
+      // surface the handler/transport error distinctly so EMPTY ≠ ERROR.
+      if (!ol.data?.ok || olInner?.ok === false) {
+        setError(olInner?.error || ol.data?.error || 'Could not load field observations');
+      } else {
+        setObs(olInner?.observations || []);
+        setDash(dInner && dInner.ok !== false ? dInner : null);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not load field observations');
+    } finally {
+      setLoading(false);
+    }
   }, [filter]);
   useEffect(() => { void refresh(); }, [refresh]);
 
   async function log() {
     if (!form.name.trim()) return;
-    await lensRun('geology', 'observation-log', {
+    const r = await lensRun('geology', 'observation-log', {
       name: form.name.trim(), kind: form.kind,
       locationName: form.locationName.trim(), formation: form.formation.trim(), notes: form.notes.trim(),
     });
+    const inner = r.data?.result as { ok?: boolean; error?: string } | undefined;
+    if (!r.data?.ok || inner?.ok === false) {
+      setError(inner?.error || r.data?.error || 'Could not log observation');
+      return;
+    }
     setForm({ name: '', kind: 'rock', locationName: '', formation: '', notes: '' });
     await refresh();
   }
@@ -57,7 +77,25 @@ export function FieldLog() {
     await refresh();
   }
 
-  if (loading) return <div className="flex items-center justify-center py-6 text-zinc-400"><Loader2 className="w-4 h-4 animate-spin" /></div>;
+  if (loading) return (
+    <div role="status" aria-busy="true" className="flex items-center justify-center gap-2 py-6 text-zinc-400">
+      <Loader2 className="w-4 h-4 animate-spin" /><span className="text-xs">Loading field observations…</span>
+    </div>
+  );
+
+  if (error) return (
+    <div role="alert" className="py-4">
+      <div className="flex items-center gap-2 mb-3">
+        <Mountain className="w-4 h-4 text-amber-500" />
+        <h3 className="text-sm font-bold text-zinc-100">Field Observation Log</h3>
+      </div>
+      <p className="text-xs text-rose-400 mb-2">{error}</p>
+      <button onClick={() => { setLoading(true); void refresh(); }}
+        className="px-3 py-1 text-xs rounded bg-amber-600 hover:bg-amber-500 text-white font-semibold">
+        Retry
+      </button>
+    </div>
+  );
 
   return (
     <div>

--- a/concord-frontend/components/geology/FieldTripPlanner.tsx
+++ b/concord-frontend/components/geology/FieldTripPlanner.tsx
@@ -47,11 +47,12 @@ export function FieldTripPlanner() {
       name: tripForm.name.trim(), area: tripForm.area.trim(),
       date: tripForm.date || undefined,
     });
-    if (r.data?.ok) {
+    const inner = r.data?.result as { ok?: boolean; error?: string; fieldTrip?: FieldTrip } | undefined;
+    if (r.data?.ok && inner?.ok !== false) {
       setTripForm({ name: '', area: '', date: '' });
-      setActiveId((r.data.result?.fieldTrip as FieldTrip)?.id ?? null);
+      setActiveId(inner?.fieldTrip?.id ?? null);
       await refresh();
-    } else setError(r.data?.error || 'Could not create field trip');
+    } else setError(inner?.error || r.data?.error || 'Could not create field trip');
   }, [tripForm, refresh]);
 
   const deleteTrip = useCallback(async (id: string) => {
@@ -77,10 +78,11 @@ export function FieldTripPlanner() {
       lat: stopForm.lat ? Number(stopForm.lat) : undefined,
       lon: stopForm.lon ? Number(stopForm.lon) : undefined,
     });
-    if (r.data?.ok) {
+    const inner = r.data?.result as { ok?: boolean; error?: string } | undefined;
+    if (r.data?.ok && inner?.ok !== false) {
       setStopForm({ name: '', lithology: '', formation: '', notes: '', lat: '', lon: '' });
       await refresh();
-    } else setError(r.data?.error || 'Could not add stop');
+    } else setError(inner?.error || r.data?.error || 'Could not add stop');
   }, [active, stopForm, refresh]);
 
   const move = useCallback(async (idx: number, dir: -1 | 1) => {
@@ -90,8 +92,9 @@ export function FieldTripPlanner() {
     if (swap < 0 || swap >= ids.length) return;
     [ids[idx], ids[swap]] = [ids[swap], ids[idx]];
     const r = await lensRun('geology', 'fieldtrip-reorder-stops', { tripId: active.id, stopIds: ids });
-    if (r.data?.ok) await refresh();
-    else setError(r.data?.error || 'Could not reorder stops');
+    const inner = r.data?.result as { ok?: boolean; error?: string } | undefined;
+    if (r.data?.ok && inner?.ok !== false) await refresh();
+    else setError(inner?.error || r.data?.error || 'Could not reorder stops');
   }, [active, refresh]);
 
   if (loading) return <div className="flex items-center justify-center py-6 text-zinc-400"><Loader2 className="w-4 h-4 animate-spin" /></div>;

--- a/concord-frontend/components/geology/GeologicMapPanel.tsx
+++ b/concord-frontend/components/geology/GeologicMapPanel.tsx
@@ -33,6 +33,11 @@ interface ColumnUnit {
 const SCALES = ['tiny', 'small', 'medium', 'large'] as const;
 type Scale = (typeof SCALES)[number];
 
+/** True when the transport succeeded AND the handler didn't reject (result.ok !== false). */
+function r_ok(transportOk: boolean | undefined, inner: { ok?: boolean } | undefined): boolean {
+  return !!transportOk && inner?.ok !== false;
+}
+
 export function GeologicMapPanel() {
   const [lat, setLat] = useState('');
   const [lon, setLon] = useState('');
@@ -60,9 +65,14 @@ export function GeologicMapPanel() {
         lensRun('geology', 'geologic-map', { lat: la, lon: lo, scale }),
         lensRun('geology', 'rock-units-here', { lat: la, lon: lo }),
       ]);
-      if (mapR.data?.ok) setUnits((mapR.data.result?.units as GeoUnit[]) || []);
-      else setError(mapR.data?.error || 'Geologic map lookup failed');
-      if (hereR.data?.ok) setColumn((hereR.data.result?.columnUnits as ColumnUnit[]) || []);
+      // /api/lens/run unwraps one { ok, result } layer; a handler rejection
+      // surfaces as result.ok === false (transport r.data.ok is always true).
+      const mapInner = mapR.data?.result as { ok?: boolean; error?: string; units?: GeoUnit[] } | undefined;
+      const hereInner = hereR.data?.result as { ok?: boolean; columnUnits?: ColumnUnit[] } | undefined;
+      if (r_ok(mapR.data?.ok, mapInner)) setUnits(mapInner?.units || []);
+      else { setError(mapInner?.error || mapR.data?.error || 'Geologic map lookup failed'); setUnits([]); }
+      if (r_ok(hereR.data?.ok, hereInner)) setColumn(hereInner?.columnUnits || []);
+      else setColumn([]);
       setRan(true);
     } finally {
       setLoading(false);

--- a/concord-frontend/components/geology/SamplePhotoCapture.tsx
+++ b/concord-frontend/components/geology/SamplePhotoCapture.tsx
@@ -59,8 +59,9 @@ export function SamplePhotoCapture() {
         exifTakenAt: exif.takenAt ?? undefined,
         cameraModel: exif.cameraModel ?? undefined,
       });
-      if (r.data?.ok) { setCaption(''); await refresh(); }
-      else setError(r.data?.error || 'Could not attach photo');
+      const inner = r.data?.result as { ok?: boolean; error?: string } | undefined;
+      if (r.data?.ok && inner?.ok !== false) { setCaption(''); await refresh(); }
+      else setError(inner?.error || r.data?.error || 'Could not attach photo');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Photo attach failed');
     } finally {

--- a/concord-frontend/components/geology/SpecimenCollection.tsx
+++ b/concord-frontend/components/geology/SpecimenCollection.tsx
@@ -55,8 +55,9 @@ export function SpecimenCollection() {
     const r = await lensRun('geology', 'collection-add', {
       name: form.name.trim(), kind: form.kind, locality: form.locality.trim(),
     });
-    if (r.data?.ok) { setForm({ name: '', kind: form.kind, locality: '' }); await refresh(); }
-    else setError(r.data?.error || 'Could not add specimen');
+    const inner = r.data?.result as { ok?: boolean; error?: string } | undefined;
+    if (r.data?.ok && inner?.ok !== false) { setForm({ name: '', kind: form.kind, locality: '' }); await refresh(); }
+    else setError(inner?.error || r.data?.error || 'Could not add specimen');
   }, [form, refresh]);
 
   const toggle = useCallback(async (id: string) => {

--- a/concord-frontend/components/geology/StructuralCompass.tsx
+++ b/concord-frontend/components/geology/StructuralCompass.tsx
@@ -57,11 +57,15 @@ export function StructuralCompass() {
       lat: form.lat ? Number(form.lat) : undefined,
       lon: form.lon ? Number(form.lon) : undefined,
     });
-    if (r.data?.ok) {
+    // The /api/lens/run dispatch unwraps ONE { ok, result } layer, so a
+    // handler that rejects with { ok:false, error } surfaces as
+    // r.data.result.ok === false (r.data.ok is the always-true transport flag).
+    const inner = r.data?.result as { ok?: boolean; error?: string } | undefined;
+    if (r.data?.ok && inner?.ok !== false) {
       setForm({ planeKind: 'bedding', strike: '', dip: '', locationName: '', notes: '', lat: '', lon: '' });
       await refresh();
     } else {
-      setError(r.data?.error || 'Could not record measurement');
+      setError(inner?.error || r.data?.error || 'Could not record measurement');
     }
   }, [form, refresh]);
 

--- a/concord-frontend/components/household/ChoreBoard.tsx
+++ b/concord-frontend/components/household/ChoreBoard.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import { Home, Plus, Trash2, Check, Trophy, Pause, Play, Loader2 } from 'lucide-react';
+import { Home, Plus, Trash2, Check, Trophy, Pause, Play, Loader2, AlertTriangle } from 'lucide-react';
 import { lensRun } from '@/lib/api/client';
 import { cn } from '@/lib/utils';
 
@@ -31,16 +31,23 @@ export function ChoreBoard() {
   const [leaders, setLeaders] = useState<Leader[]>([]);
   const [dash, setDash] = useState<Dash | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [newRoom, setNewRoom] = useState('');
   const [taskForm, setTaskForm] = useState({ roomId: '', name: '', intervalDays: 7, effort: 'medium', assignee: '' });
 
   const refresh = useCallback(async () => {
+    setError(null);
     const [rl, cb, lb, d] = await Promise.all([
       lensRun('household', 'room-list', {}),
       lensRun('household', 'chore-board', {}),
       lensRun('household', 'assignee-leaderboard', {}),
       lensRun('household', 'household-dashboard', {}),
     ]);
+    // A swallowed/failed fetch must NOT render identically to genuinely-empty.
+    // lensRun never throws — it surfaces { ok:false, error } — so surface the
+    // first error instead of silently showing an empty board.
+    const failed = [rl, cb, lb, d].find((r) => r.data?.ok === false);
+    if (failed) { setError(failed.data?.error || 'Could not reach the chore board.'); setLoading(false); return; }
     setRooms((rl.data?.result?.rooms as Room[]) || []);
     setBoard((cb.data?.result?.board as BoardTask[]) || []);
     setLeaders((lb.data?.result?.leaderboard as Leader[]) || []);
@@ -82,7 +89,19 @@ export function ChoreBoard() {
     await refresh();
   }
 
-  if (loading) return <div className="flex items-center justify-center py-6 text-zinc-400"><Loader2 className="w-4 h-4 animate-spin" /></div>;
+  if (loading) return <div role="status" aria-busy="true" className="flex items-center justify-center py-6 text-zinc-400"><Loader2 className="w-4 h-4 animate-spin" /><span className="sr-only">Loading chore board…</span></div>;
+
+  if (error) return (
+    <div role="alert" className="rounded-lg border border-rose-500/30 bg-rose-500/5 p-4 text-center">
+      <AlertTriangle className="w-5 h-5 text-rose-400 mx-auto mb-2" />
+      <p className="text-sm text-rose-200">Could not reach the chore board.</p>
+      <p className="text-[11px] text-zinc-400 mb-3">{error}</p>
+      <button onClick={() => { setLoading(true); void refresh(); }}
+        className="px-3 py-1.5 text-xs rounded-lg bg-rose-600/30 hover:bg-rose-600/50 text-rose-100 border border-rose-500/40">
+        Try again
+      </button>
+    </div>
+  );
 
   return (
     <div>

--- a/concord-frontend/components/household/ChoreRotation.tsx
+++ b/concord-frontend/components/household/ChoreRotation.tsx
@@ -6,10 +6,20 @@ import { Users, Loader2, Wand2, Trash2, Plus } from 'lucide-react';
 import { apiHelpers } from '@/lib/api/client';
 import { SaveAsDtuButton } from '@/components/dtu/SaveAsDtuButton';
 
-interface Assignment { member: string; chore: string; week?: number; day?: string }
-interface RotationResult { assignments?: Assignment[]; rotation?: Assignment[]; weeks?: number; strategy?: string; error?: string }
+// The household.choreRotation handler returns assignments shaped
+// { chore, assignee, frequency, previousAssignee } for the chosen strategy.
+interface Assignment { chore: string; assignee: string; frequency?: string; previousAssignee?: string | null }
+interface RotationResult {
+  assignments?: Assignment[];
+  strategy?: string;
+  totalChores?: number;
+  members?: number;
+  choresPerMember?: Record<string, number>;
+  error?: string;
+}
 
-const STRATEGIES = ['round-robin', 'fair-share', 'random'] as const;
+// Only the two strategies the handler actually implements.
+const STRATEGIES = ['round-robin', 'random'] as const;
 
 async function callHousehold<T>(action: string, input: Record<string, unknown>): Promise<T | null> {
   try {
@@ -28,16 +38,20 @@ export function ChoreRotation() {
   const [chores, setChores] = useState<string[]>(['Dishes', 'Trash', 'Vacuum', 'Laundry']);
   const [members, setMembers] = useState<string[]>(['Alex', 'Sam', 'Jordan']);
   const [strategy, setStrategy] = useState<typeof STRATEGIES[number]>('round-robin');
-  const [weeks, setWeeks] = useState(4);
   const [result, setResult] = useState<RotationResult | null>(null);
   const [newChore, setNewChore] = useState('');
   const [newMember, setNewMember] = useState('');
 
   const rotate = useMutation({
     mutationFn: async () => {
+      // Flat params: the dispatch maps run-action input to BOTH artifact.data
+      // and params, so a flat body reaches artifact.data.chores. (A nested
+      // { artifact: { data } } two-key body is NOT peeled and was the dead
+      // surface — the handler saw artifact.data.chores === undefined.)
       const r = await callHousehold<RotationResult>('choreRotation', {
-        artifact: { data: { chores: chores.map((c) => ({ name: c })), members } },
-        strategy, weeks,
+        chores: chores.map((c) => ({ name: c })),
+        members,
+        strategy,
       });
       setResult(r);
       return r;
@@ -51,7 +65,7 @@ export function ChoreRotation() {
   };
   const removeItem = (i: number, list: string[], setList: (l: string[]) => void) => setList(list.filter((_, j) => j !== i));
 
-  const assignments = result?.assignments || result?.rotation || [];
+  const assignments = result?.assignments || [];
 
   return (
     <div className="space-y-4">
@@ -66,9 +80,9 @@ export function ChoreRotation() {
             compact
             apiSource="concord-household-chores"
             title={`Chore rotation — ${members.length} members × ${chores.length} chores (${strategy})`}
-            content={`Strategy: ${strategy}\nMembers: ${members.join(', ')}\nChores: ${chores.join(', ')}\n\nAssignments:\n${assignments.map((a) => `  ${a.week ? `W${a.week} ` : ''}${a.member} → ${a.chore}`).join('\n')}`}
+            content={`Strategy: ${strategy}\nMembers: ${members.join(', ')}\nChores: ${chores.join(', ')}\n\nAssignments:\n${assignments.map((a) => `  ${a.chore} → ${a.assignee}`).join('\n')}`}
             extraTags={['household', 'chores', strategy]}
-            rawData={{ chores, members, strategy, weeks, result }}
+            rawData={{ chores, members, strategy, result }}
           />
         )}
       </header>
@@ -113,10 +127,6 @@ export function ChoreRotation() {
             {STRATEGIES.map((s) => <option key={s} value={s}>{s}</option>)}
           </select>
         </label>
-        <label className="block w-24">
-          <span className="block text-[10px] uppercase tracking-wider text-zinc-400">Weeks</span>
-          <input type="number" min={1} max={12} value={weeks} onChange={(e) => setWeeks(Math.max(1, Math.min(12, Number(e.target.value) || 4)))} className="mt-1 w-full rounded border border-zinc-800 bg-zinc-950 px-2 py-1.5 text-xs text-white" />
-        </label>
         <button type="button" onClick={() => rotate.mutate()} disabled={rotate.isPending || chores.length === 0 || members.length === 0} className="inline-flex items-center gap-1 rounded border border-emerald-500/40 bg-emerald-500/15 px-3 py-1.5 text-xs font-mono text-emerald-200 hover:bg-emerald-500/25 disabled:opacity-50">
           {rotate.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Wand2 className="h-3.5 w-3.5" />}
           Rotate
@@ -132,11 +142,13 @@ export function ChoreRotation() {
           <div className="grid grid-cols-1 gap-1 sm:grid-cols-2">
             {assignments.map((a, i) => (
               <div key={i} className="flex items-center justify-between rounded border border-emerald-500/15 bg-zinc-950/40 px-2 py-1.5 text-xs">
-                <span className="flex items-center gap-2">
-                  {a.week && <span className="rounded bg-emerald-500/20 px-1 font-mono text-[10px] text-emerald-200">W{a.week}</span>}
-                  <span className="font-mono text-zinc-200">{a.member}</span>
-                </span>
                 <span className="text-zinc-400">{a.chore}</span>
+                <span className="flex items-center gap-2">
+                  {a.previousAssignee && a.previousAssignee !== a.assignee && (
+                    <span className="font-mono text-[10px] text-zinc-500 line-through">{a.previousAssignee}</span>
+                  )}
+                  <span className="font-mono text-emerald-200">{a.assignee}</span>
+                </span>
               </div>
             ))}
           </div>

--- a/concord-frontend/components/household/HouseholdActionPanel.tsx
+++ b/concord-frontend/components/household/HouseholdActionPanel.tsx
@@ -36,10 +36,29 @@ function pickMessage(e: unknown): string {
   return ax?.response?.data?.error ?? ax?.message ?? 'request failed';
 }
 
-interface GroceryResult { items?: Array<{ name: string; quantity: string; aisle?: string }>; total?: number }
-interface ChoreResult { rotation?: Array<{ chore: string; assignee: string; due: string }>; weekOf?: string }
-interface MaintResult { items?: Array<{ task: string; dueDate: string; daysOverdue?: number }>; overdueCount?: number }
-interface SummaryResult { choresDone?: number; choresTotal?: number; maintCompleted?: number; sentiment?: string }
+// Shapes EXACTLY match the household.* handler returns (server/domains/household.js).
+interface GroceryResult {
+  list?: Array<{ name: string; quantity: number; unit?: string; category?: string }>;
+  uniqueItems?: number;
+  mealsPlanned?: number;
+}
+interface ChoreResult {
+  assignments?: Array<{ chore: string; assignee: string; frequency?: string; previousAssignee?: string | null }>;
+  totalChores?: number;
+  strategy?: string;
+}
+interface MaintResult {
+  overdue?: Array<{ name: string; nextDueDate?: string | null; daysOverdue?: number | null }>;
+  overdueCount?: number;
+  upcomingCount?: number;
+}
+interface SummaryResult {
+  choresCompleted?: number;
+  totalChores?: number;
+  choreCompletionRate?: number;
+  mealsPlanned?: number;
+  maintenanceDueSoon?: string[];
+}
 
 export function HouseholdActionPanel() {
   const [meals, setMeals] = useState('');
@@ -64,11 +83,22 @@ export function HouseholdActionPanel() {
   const dmRecall = useRecallableAction({ label: 'DM', windowMs: 60_000, onUndo: async (id) => { await api.delete(`/api/social/dm/${encodeURIComponent(id)}`); } });
   const publishRecall = useRecallableAction({ label: 'publish', windowMs: 30_000, onUndo: async (id) => { await api.delete(`/api/dtus/${encodeURIComponent(id)}/publish`); setPublishedDtuId(null); } });
 
+  // Parse each meal line as "Recipe: ingredient, ingredient" (ingredients
+  // optional). This is what the handler aggregates into the grocery list.
+  function parseMealPlan(): Array<{ recipe: string; meal: string; ingredients: Array<{ name: string; quantity: number; unit: string }> }> {
+    return meals.split('\n').map(l => l.trim()).filter(Boolean).map(line => {
+      const [recipe, rest] = line.split(':');
+      const ingredients = (rest || '').split(',').map(s => s.trim()).filter(Boolean)
+        .map(name => ({ name, quantity: 1, unit: '' }));
+      return { recipe: (recipe || line).trim(), meal: (recipe || line).trim(), ingredients };
+    });
+  }
+
   async function actGrocery() {
-    const mealList = meals.split('\n').map(l => l.trim()).filter(Boolean);
-    if (!mealList.length) { err('Add meals.'); return; }
+    const mealPlan = parseMealPlan();
+    if (!mealPlan.length) { err('Add meals.'); return; }
     setBusy('grocery'); setFeedback(null);
-    try { const r = await callMacro<GroceryResult>('generateGroceryList', { meals: mealList }); if (r.ok && r.result) { setGroceryResult(r.result); pipe.publish('household.grocery', r.result, { label: `${r.result.items?.length ?? 0} items` }); ok(`${r.result.items?.length ?? 0} items.`); } else err(r.error ?? 'grocery failed'); }
+    try { const r = await callMacro<GroceryResult>('generateGroceryList', { mealPlan }); if (r.ok && r.result) { setGroceryResult(r.result); const n = r.result.list?.length ?? 0; pipe.publish('household.grocery', r.result, { label: `${n} items` }); ok(n > 0 ? `${n} grocery items.` : 'No ingredients — add "Recipe: egg, milk".'); } else err(r.error ?? 'grocery failed'); }
     catch (e) { err(pickMessage(e)); } finally { setBusy(null); }
   }
   async function actChores() {
@@ -76,17 +106,23 @@ export function HouseholdActionPanel() {
     const m = members.split('\n').map(s => s.trim()).filter(Boolean);
     if (!c.length || !m.length) { err('Add chores + members.'); return; }
     setBusy('chores'); setFeedback(null);
-    try { const r = await callMacro<ChoreResult>('choreRotation', { chores: c, members: m, weekStart: new Date().toISOString().slice(0, 10) }); if (r.ok && r.result) { setChoreResult(r.result); pipe.publish('household.chores', r.result, { label: `${r.result.rotation?.length ?? 0} rotated` }); ok(`${r.result.rotation?.length ?? 0} chores rotated.`); } else err(r.error ?? 'chores failed'); }
+    try { const r = await callMacro<ChoreResult>('choreRotation', { chores: c.map(name => ({ name })), members: m, strategy: 'round-robin' }); if (r.ok && r.result) { setChoreResult(r.result); const n = r.result.assignments?.length ?? 0; pipe.publish('household.chores', r.result, { label: `${n} rotated` }); ok(`${n} chores rotated.`); } else err(r.error ?? 'chores failed'); }
     catch (e) { err(pickMessage(e)); } finally { setBusy(null); }
   }
   async function actMaintenance() {
     setBusy('maintenance'); setFeedback(null);
-    try { const r = await callMacro<MaintResult>('maintenanceDue', { window: 'month' }); if (r.ok && r.result) { setMaintResult(r.result); pipe.publish('household.maint', r.result, { label: `${r.result.overdueCount ?? 0} overdue` }); ok(`${r.result.overdueCount ?? 0} overdue.`); } else err(r.error ?? 'maintenance failed'); }
+    // Derive real maintenance items from the chores textarea (one per line);
+    // no lastServiceDate → handler flags each "never-serviced" (overdue).
+    const items = chores.split('\n').map(s => s.trim()).filter(Boolean).map(name => ({ name }));
+    if (!items.length) { err('Add maintenance items in the Chores box (one per line).'); return; }
+    try { const r = await callMacro<MaintResult>('maintenanceDue', { maintenanceItems: items, lookaheadDays: 30 }); if (r.ok && r.result) { setMaintResult(r.result); pipe.publish('household.maint', r.result, { label: `${r.result.overdueCount ?? 0} overdue` }); ok(`${r.result.overdueCount ?? 0} overdue.`); } else err(r.error ?? 'maintenance failed'); }
     catch (e) { err(pickMessage(e)); } finally { setBusy(null); }
   }
   async function actSummary() {
     setBusy('summary'); setFeedback(null);
-    try { const r = await callMacro<SummaryResult>('weeklySummary', {}); if (r.ok && r.result) { setSummaryResult(r.result); pipe.publish('household.summary', r.result, { label: `${r.result.choresDone}/${r.result.choresTotal} chores` }); ok(`${r.result.choresDone}/${r.result.choresTotal} chores done.`); } else err(r.error ?? 'summary failed'); }
+    const choreItems = chores.split('\n').map(s => s.trim()).filter(Boolean).map(name => ({ name }));
+    const mealPlan = parseMealPlan();
+    try { const r = await callMacro<SummaryResult>('weeklySummary', { chores: choreItems, mealPlan }); if (r.ok && r.result) { setSummaryResult(r.result); pipe.publish('household.summary', r.result, { label: `${r.result.choresCompleted}/${r.result.totalChores} chores` }); ok(`${r.result.choresCompleted}/${r.result.totalChores} chores done.`); } else err(r.error ?? 'summary failed'); }
     catch (e) { err(pickMessage(e)); } finally { setBusy(null); }
   }
   async function actMint() {
@@ -101,10 +137,10 @@ export function HouseholdActionPanel() {
     if (!recipient.trim()) { err('Recipient required.'); return; }
     setBusy('dm'); setFeedback(null);
     const body = [`🏠 Household — week of ${new Date().toLocaleDateString()}`, '',
-      groceryResult ? `Grocery: ${groceryResult.items?.length} items` : '',
-      choreResult ? `Chores rotated: ${choreResult.rotation?.length}` : '',
-      maintResult ? `Maintenance overdue: ${maintResult.overdueCount}` : '',
-      summaryResult ? `Sentiment: ${summaryResult.sentiment}` : '',
+      groceryResult ? `Grocery: ${groceryResult.list?.length ?? 0} items` : '',
+      choreResult ? `Chores rotated: ${choreResult.assignments?.length ?? 0}` : '',
+      maintResult ? `Maintenance overdue: ${maintResult.overdueCount ?? 0}` : '',
+      summaryResult ? `Chores done: ${summaryResult.choresCompleted}/${summaryResult.totalChores}` : '',
       mintedDtuId ? `\n[DTU ${mintedDtuId}]` : '',
     ].filter(Boolean).join('\n');
     try {
@@ -133,7 +169,7 @@ export function HouseholdActionPanel() {
   async function actAgent() {
     setBusy('agent'); setFeedback(null); setAgentReply(null);
     try {
-      const task = `Household state: ${members.split('\n').filter(Boolean).length} members, ${chores.split('\n').filter(Boolean).length} chores. ${maintResult ? `${maintResult.overdueCount} overdue maintenance.` : ''} ${summaryResult ? `Sentiment: ${summaryResult.sentiment}.` : ''} Suggest the single weekly meeting agenda item that would most reduce household friction. Plain text.`;
+      const task = `Household state: ${members.split('\n').filter(Boolean).length} members, ${chores.split('\n').filter(Boolean).length} chores. ${maintResult ? `${maintResult.overdueCount} overdue maintenance.` : ''} ${summaryResult ? `${summaryResult.choresCompleted}/${summaryResult.totalChores} chores done this week.` : ''} Suggest the single weekly meeting agenda item that would most reduce household friction. Plain text.`;
       const r = await api.post('/api/lens/run', { domain: 'chat_agent', name: 'do', input: { task, maxTurns: 3 } });
       const reply = r.data?.result?.reply ?? r.data?.result?.summary ?? r.data?.result?.output ?? r.data?.reply;
       if (reply) { setAgentReply(typeof reply === 'string' ? reply : JSON.stringify(reply, null, 2)); ok('Meeting topic ready.'); } else err('Agent returned empty.');
@@ -159,8 +195,8 @@ export function HouseholdActionPanel() {
       </header>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
-        <div><label className="text-[10px] uppercase tracking-wider text-zinc-400 font-semibold mb-1 block">Meals (one per line)</label><textarea value={meals} onChange={(e) => setMeals(e.target.value)} rows={5} className="w-full bg-zinc-900 border border-zinc-800 rounded px-2 py-1 text-[11px] text-teal-200 font-mono focus:outline-none focus:ring-2 focus:ring-teal-400/40 resize-none" /></div>
-        <div><label className="text-[10px] uppercase tracking-wider text-zinc-400 font-semibold mb-1 block">Chores (one per line)</label><textarea value={chores} onChange={(e) => setChores(e.target.value)} rows={5} className="w-full bg-zinc-900 border border-zinc-800 rounded px-2 py-1 text-[11px] text-teal-200 font-mono focus:outline-none focus:ring-2 focus:ring-teal-400/40 resize-none" /></div>
+        <div><label className="text-[10px] uppercase tracking-wider text-zinc-400 font-semibold mb-1 block">Meals — &quot;Recipe: ingredients&quot;</label><textarea value={meals} onChange={(e) => setMeals(e.target.value)} rows={5} placeholder={'Tacos: beef, tortilla, cheese\nSalad: lettuce, tomato'} className="w-full bg-zinc-900 border border-zinc-800 rounded px-2 py-1 text-[11px] text-teal-200 font-mono focus:outline-none focus:ring-2 focus:ring-teal-400/40 resize-none" /></div>
+        <div><label className="text-[10px] uppercase tracking-wider text-zinc-400 font-semibold mb-1 block">Chores / maintenance (per line)</label><textarea value={chores} onChange={(e) => setChores(e.target.value)} rows={5} className="w-full bg-zinc-900 border border-zinc-800 rounded px-2 py-1 text-[11px] text-teal-200 font-mono focus:outline-none focus:ring-2 focus:ring-teal-400/40 resize-none" /></div>
         <div><label className="text-[10px] uppercase tracking-wider text-zinc-400 font-semibold mb-1 block">Members (one per line)</label><textarea value={members} onChange={(e) => setMembers(e.target.value)} rows={5} className="w-full bg-zinc-900 border border-zinc-800 rounded px-2 py-1 text-[11px] text-teal-200 font-mono focus:outline-none focus:ring-2 focus:ring-teal-400/40 resize-none" /></div>
       </div>
 
@@ -187,29 +223,31 @@ export function HouseholdActionPanel() {
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-        {groceryResult?.items && (
+        {groceryResult?.list && (
           <div className="rounded-md border border-emerald-500/30 bg-emerald-500/5 p-2.5 max-h-40 overflow-y-auto">
-            <div className="text-[10px] uppercase tracking-wider text-emerald-300 font-semibold">Grocery ({groceryResult.items.length})</div>
-            {groceryResult.items.slice(0, 10).map((i, idx) => <div key={idx} className="text-[11px] text-zinc-300">{i.name} <span className="text-zinc-400 font-mono">{i.quantity}</span>{i.aisle && <span className="text-zinc-400"> · {i.aisle}</span>}</div>)}
+            <div className="text-[10px] uppercase tracking-wider text-emerald-300 font-semibold">Grocery ({groceryResult.list.length})</div>
+            {groceryResult.list.length === 0 && <div className="text-[11px] text-zinc-400 italic">No ingredients parsed — use &quot;Recipe: egg, milk&quot; format.</div>}
+            {groceryResult.list.slice(0, 10).map((i, idx) => <div key={idx} className="text-[11px] text-zinc-300">{i.name} <span className="text-zinc-400 font-mono">{i.quantity}{i.unit ? ` ${i.unit}` : ''}</span>{i.category && i.category !== 'other' && <span className="text-zinc-400"> · {i.category}</span>}</div>)}
           </div>
         )}
-        {choreResult?.rotation && (
+        {choreResult?.assignments && (
           <div className="rounded-md border border-purple-500/30 bg-purple-500/5 p-2.5 max-h-40 overflow-y-auto">
-            <div className="text-[10px] uppercase tracking-wider text-purple-300 font-semibold">Chores (week of {choreResult.weekOf})</div>
-            {choreResult.rotation.slice(0, 10).map((r, i) => <div key={i} className="text-[11px] text-zinc-300 flex justify-between"><span>{r.chore}</span><span className="text-purple-200 font-semibold">{r.assignee}</span></div>)}
+            <div className="text-[10px] uppercase tracking-wider text-purple-300 font-semibold">Chores ({choreResult.totalChores} · {choreResult.strategy})</div>
+            {choreResult.assignments.slice(0, 10).map((r, i) => <div key={i} className="text-[11px] text-zinc-300 flex justify-between"><span>{r.chore}</span><span className="text-purple-200 font-semibold">{r.assignee}</span></div>)}
           </div>
         )}
-        {maintResult?.items && (
+        {maintResult?.overdue && (
           <div className="rounded-md border border-orange-500/30 bg-orange-500/5 p-2.5 max-h-40 overflow-y-auto">
             <div className="text-[10px] uppercase tracking-wider text-orange-300 font-semibold">Maintenance ({maintResult.overdueCount} overdue)</div>
-            {maintResult.items.slice(0, 6).map((m, i) => <div key={i} className="text-[11px] text-zinc-300 flex justify-between"><span>{m.task}</span><span className={cn('font-mono', (m.daysOverdue ?? 0) > 0 ? 'text-rose-300' : 'text-zinc-400')}>{m.daysOverdue ? `+${m.daysOverdue}d` : m.dueDate}</span></div>)}
+            {maintResult.overdue.length === 0 && <div className="text-[11px] text-zinc-400 italic">Nothing overdue.</div>}
+            {maintResult.overdue.slice(0, 6).map((m, i) => <div key={i} className="text-[11px] text-zinc-300 flex justify-between"><span>{m.name}</span><span className={cn('font-mono', (m.daysOverdue ?? 0) > 0 ? 'text-rose-300' : 'text-zinc-400')}>{m.daysOverdue != null ? `+${m.daysOverdue}d` : (m.nextDueDate || 'never')}</span></div>)}
           </div>
         )}
         {summaryResult && (
           <div className="rounded-md border border-cyan-500/30 bg-cyan-500/5 p-2.5">
             <div className="text-[10px] uppercase tracking-wider text-cyan-300 font-semibold">Weekly summary</div>
-            <div className="text-2xl font-bold text-cyan-300">{summaryResult.choresDone}/{summaryResult.choresTotal}</div>
-            <div className="text-[10px] text-zinc-400">chores · {summaryResult.maintCompleted} maint done · sentiment: {summaryResult.sentiment}</div>
+            <div className="text-2xl font-bold text-cyan-300">{summaryResult.choresCompleted}/{summaryResult.totalChores}</div>
+            <div className="text-[10px] text-zinc-400">chores · {summaryResult.mealsPlanned} meals planned · {summaryResult.choreCompletionRate}% rate{summaryResult.maintenanceDueSoon && summaryResult.maintenanceDueSoon.length > 0 ? ` · ${summaryResult.maintenanceDueSoon.length} maint due` : ''}</div>
           </div>
         )}
       </div>

--- a/concord-frontend/components/insurance/InsuranceActionPanel.tsx
+++ b/concord-frontend/components/insurance/InsuranceActionPanel.tsx
@@ -96,7 +96,7 @@ export function InsuranceActionPanel() {
     if (!riskTitle.trim() || ![p, i].every(Number.isFinite)) { err('Risk title + probability + impact required.'); return; }
     setBusy('risk'); setFeedback(null);
     try {
-      const r = await callMacro<RiskResult>('riskScore', { artifact: { title: riskTitle, data: { probability: p, impact: i } } });
+      const r = await callMacro<RiskResult>('riskScore', { artifact: { title: riskTitle, data: { risk: riskTitle, probability: p, impact: i } } });
       if (r.ok && r.result) { setRiskResult(r.result); pipe.publish('insurance.risk', r.result, { label: `Risk ${r.result.level} ${r.result.normalizedScore}%` }); ok(`${r.result.level?.toUpperCase()} (${r.result.normalizedScore}%).`); } else err(r.error ?? 'risk failed');
     } catch (e) { err(pickMessage(e)); } finally { setBusy(null); }
   }

--- a/concord-frontend/components/legal/LegalActionPanel.tsx
+++ b/concord-frontend/components/legal/LegalActionPanel.tsx
@@ -36,10 +36,18 @@ function pickMessage(e: unknown): string {
   return ax?.response?.data?.error ?? ax?.message ?? 'request failed';
 }
 
-interface DeadlineResult { upcoming?: Array<{ name: string; daysUntil: number; severity: string }>; overdue?: number }
-interface RenewalResult { renewals?: Array<{ contract: string; renewsOn: string; daysLeft: number }>; criticalCount?: number }
-interface ConflictResult { hasConflict?: boolean; parties?: string[]; explanation?: string }
-interface AuditResult { findings?: Array<{ control: string; status: string; gap?: string }>; complianceScore?: number }
+// Field shapes below mirror the EXACT contract of server/domains/legal.js.
+// deadlineCheck reads artifact.data.items[] (each with a `deadline`) and returns
+// { upcoming: [...item, daysUntil], count }. conflictCheck reads
+// artifact.data.{parties,client,opposingParty} + params.checkAgainst and returns
+// { conflicts, hasConflict, checkedAt }. complianceAudit reads
+// artifact.data.requirements[] and returns { score, rating, findings, ... }.
+// contractRenewal reads artifact.data.{expiryDate,renewalType} (single contract).
+interface DeadlineResult { upcoming?: Array<{ name?: string; deadline: string; daysUntil: number; severity?: string }>; count?: number }
+interface RenewalRow { name: string; daysUntilExpiry: number; urgency: string; autoRenewal: boolean; actionRequired: boolean }
+interface RenewalResult { renewals: RenewalRow[]; criticalCount: number }
+interface ConflictResult { hasConflict?: boolean; conflicts?: Array<{ name: string; conflictType: string }>; checkedAt?: string }
+interface AuditResult { findings?: Array<{ requirement: string; reason?: string; severity?: string }>; score?: number; rating?: string; passed?: number; failed?: number }
 
 export function LegalActionPanel() {
   const [caseName, setCaseName] = useState('');
@@ -78,28 +86,49 @@ export function LegalActionPanel() {
   });
 
   async function actDeadline() {
-    const parsed = deadlines.split('\n').map(l => { const m = l.trim().match(/^(.+?)\s+(\d{4}-\d{2}-\d{2})\s+(\S+)$/); return m ? { name: m[1], dueDate: m[2], severity: m[3] } : null; }).filter(Boolean);
-    if (!parsed.length) { err('Add deadlines (name YYYY-MM-DD severity).'); return; }
+    // deadlineCheck reads artifact.data.items[] with each item's `deadline` field.
+    const items = deadlines.split('\n').map(l => { const m = l.trim().match(/^(.+?)\s+(\d{4}-\d{2}-\d{2})\s+(\S+)$/); return m ? { name: m[1], deadline: m[2], severity: m[3] } : null; }).filter(Boolean);
+    if (!items.length) { err('Add deadlines (name YYYY-MM-DD severity).'); return; }
     setBusy('deadline'); setFeedback(null);
-    try { const r = await callMacro<DeadlineResult>('deadlineCheck', { deadlines: parsed }); if (r.ok && r.result) { setDeadlineResult(r.result); pipe.publish('legal.deadlines', r.result, { label: `${r.result.upcoming?.length ?? 0} upcoming` }); ok(`${r.result.upcoming?.length ?? 0} upcoming.`); } else err(r.error ?? 'deadline failed'); }
+    try { const r = await callMacro<DeadlineResult>('deadlineCheck', { items, daysAhead: 3650 }); if (r.ok && r.result) { setDeadlineResult(r.result); pipe.publish('legal.deadlines', r.result, { label: `${r.result.count ?? 0} upcoming` }); ok(`${r.result.count ?? 0} upcoming.`); } else err(r.error ?? 'deadline failed'); }
     catch (e) { err(pickMessage(e)); } finally { setBusy(null); }
   }
   async function actRenewal() {
-    const parsed = contracts.split('\n').map(l => { const m = l.trim().match(/^(.+?)\s+(\d{4}-\d{2}-\d{2})$/); return m ? { name: m[1], expiresOn: m[2] } : null; }).filter(Boolean);
+    // contractRenewal scores ONE contract (artifact.data.expiryDate / renewalType).
+    // The textarea is multi-line, so call the handler once per contract row and
+    // assemble the real per-contract outputs into a renewals[] for the panel.
+    const parsed = contracts.split('\n').map(l => { const m = l.trim().match(/^(.+?)\s+(\d{4}-\d{2}-\d{2})$/); return m ? { name: m[1].trim(), expiryDate: m[2] } : null; }).filter(Boolean) as Array<{ name: string; expiryDate: string }>;
     if (!parsed.length) { err('Add contracts (name YYYY-MM-DD).'); return; }
     setBusy('renewal'); setFeedback(null);
-    try { const r = await callMacro<RenewalResult>('contractRenewal', { contracts: parsed }); if (r.ok && r.result) { setRenewalResult(r.result); pipe.publish('legal.renewals', r.result, { label: `${r.result.criticalCount ?? 0} critical` }); ok(`${r.result.renewals?.length ?? 0} renewals.`); } else err(r.error ?? 'renewal failed'); }
+    try {
+      const rows: RenewalRow[] = [];
+      for (const c of parsed) {
+        const r = await callMacro<{ daysUntilExpiry: number; urgency: string; autoRenewal: boolean; actionRequired: boolean }>('contractRenewal', { expiryDate: c.expiryDate, renewalType: 'manual', title: c.name });
+        if (r.ok && r.result && typeof r.result.daysUntilExpiry === 'number') {
+          rows.push({ name: c.name, daysUntilExpiry: r.result.daysUntilExpiry, urgency: String(r.result.urgency), autoRenewal: !!r.result.autoRenewal, actionRequired: !!r.result.actionRequired });
+        }
+      }
+      const criticalCount = rows.filter(x => x.urgency === 'critical').length;
+      const result: RenewalResult = { renewals: rows, criticalCount };
+      setRenewalResult(result);
+      pipe.publish('legal.renewals', result, { label: `${criticalCount} critical` });
+      ok(`${rows.length} renewals.`);
+    }
     catch (e) { err(pickMessage(e)); } finally { setBusy(null); }
   }
   async function actConflict() {
     if (!partyA.trim() || !partyB.trim()) { err('Both parties required.'); return; }
     setBusy('conflict'); setFeedback(null);
-    try { const r = await callMacro<ConflictResult>('conflictCheck', { partyA: partyA.trim(), partyB: partyB.trim() }); if (r.ok && r.result) { setConflictResult(r.result); pipe.publish('legal.conflict', r.result, { label: r.result.hasConflict ? 'CONFLICT' : 'clear' }); ok(r.result.hasConflict ? 'CONFLICT detected.' : 'No conflict.'); } else err(r.error ?? 'conflict failed'); }
+    // conflictCheck reads artifact.data.{client,opposingParty,parties} and
+    // params.checkAgainst[] — partyA is the client, partyB the name to screen.
+    try { const r = await callMacro<ConflictResult>('conflictCheck', { client: partyA.trim(), parties: [partyA.trim()], checkAgainst: [partyB.trim()] }); if (r.ok && r.result) { setConflictResult(r.result); pipe.publish('legal.conflict', r.result, { label: r.result.hasConflict ? 'CONFLICT' : 'clear' }); ok(r.result.hasConflict ? 'CONFLICT detected.' : 'No conflict.'); } else err(r.error ?? 'conflict failed'); }
     catch (e) { err(pickMessage(e)); } finally { setBusy(null); }
   }
   async function actAudit() {
     setBusy('audit'); setFeedback(null);
-    try { const r = await callMacro<AuditResult>('complianceAudit', { caseName: caseName.trim() }); if (r.ok && r.result) { setAuditResult(r.result); pipe.publish('legal.audit', r.result, { label: `score ${r.result.complianceScore ?? '—'}` }); ok(`Score: ${r.result.complianceScore ?? '—'}.`); } else err(r.error ?? 'audit failed'); }
+    // complianceAudit scores artifact.data.requirements[] → { score, rating, findings }.
+    const requirements = deadlines.split('\n').map(l => { const m = l.trim().match(/^(.+?)\s+(\d{4}-\d{2}-\d{2})\s+(\S+)$/); return m ? { name: m[1], deadline: m[2], status: m[3] } : null; }).filter(Boolean);
+    try { const r = await callMacro<AuditResult>('complianceAudit', { requirements }); if (r.ok && r.result) { setAuditResult(r.result); pipe.publish('legal.audit', r.result, { label: `score ${r.result.score ?? '—'}` }); ok(`Score: ${r.result.score ?? '—'}.`); } else err(r.error ?? 'audit failed'); }
     catch (e) { err(pickMessage(e)); } finally { setBusy(null); }
   }
   async function actMint() {
@@ -113,7 +142,7 @@ export function LegalActionPanel() {
   async function actDm() {
     if (!recipient.trim()) { err('Recipient required.'); return; }
     setBusy('dm'); setFeedback(null);
-    const body = [`⚖ Legal brief: ${caseName || 'matter'}`, '', deadlineResult ? `Upcoming deadlines: ${deadlineResult.upcoming?.length ?? 0}` : '', renewalResult ? `Renewals: ${renewalResult.criticalCount ?? 0} critical` : '', conflictResult?.hasConflict ? `⚠ CONFLICT: ${conflictResult.explanation}` : '', mintedDtuId ? `\n[DTU ${mintedDtuId}]` : ''].filter(Boolean).join('\n');
+    const body = [`⚖ Legal brief: ${caseName || 'matter'}`, '', deadlineResult ? `Upcoming deadlines: ${deadlineResult.count ?? 0}` : '', renewalResult ? `Renewals: ${renewalResult.criticalCount ?? 0} critical` : '', conflictResult?.hasConflict ? `⚠ CONFLICT: ${(conflictResult.conflicts ?? []).map(c => c.name).join(', ')}` : '', mintedDtuId ? `\n[DTU ${mintedDtuId}]` : ''].filter(Boolean).join('\n');
     try {
       const messageId = await dmRecall.run(async () => {
         const r = await api.post('/api/social/dm', { toUserId: recipient.trim(), content: body });
@@ -127,7 +156,7 @@ export function LegalActionPanel() {
     setBusy('publish'); setFeedback(null);
     try {
       const id = await publishRecall.run(async () => {
-        const r = await lensRun({ domain: 'dtu', name: 'create', input: { title: `Public legal note — ${caseName.trim()}`, tags: ['legal', 'public', 'note'], source: 'legal:note:publish', meta: { visibility: 'public', consent: { allowCitations: true }, anonymized: true, note: { case: caseName, complianceScore: auditResult?.complianceScore } } } });
+        const r = await lensRun({ domain: 'dtu', name: 'create', input: { title: `Public legal note — ${caseName.trim()}`, tags: ['legal', 'public', 'note'], source: 'legal:note:publish', meta: { visibility: 'public', consent: { allowCitations: true }, anonymized: true, note: { case: caseName, complianceScore: auditResult?.score } } } });
         const newId = r.data?.result?.dtu?.id ?? r.data?.result?.id;
         if (!newId) throw new Error('No DTU id.');
         const pub = await api.post(`/api/dtus/${encodeURIComponent(newId)}/publish`);
@@ -140,7 +169,7 @@ export function LegalActionPanel() {
   async function actAgent() {
     setBusy('agent'); setFeedback(null); setAgentReply(null);
     try {
-      const task = `Legal matter: "${caseName || 'matter'}". ${deadlineResult ? `${deadlineResult.upcoming?.length ?? 0} upcoming deadlines.` : ''} ${conflictResult?.hasConflict ? `Conflict: ${conflictResult.explanation}` : ''} ${auditResult ? `Compliance score: ${auditResult.complianceScore}.` : ''} Identify the single highest-risk action item to address this week. Plain text.`;
+      const task = `Legal matter: "${caseName || 'matter'}". ${deadlineResult ? `${deadlineResult.count ?? 0} upcoming deadlines.` : ''} ${conflictResult?.hasConflict ? `Conflict: ${(conflictResult.conflicts ?? []).map(c => c.name).join(', ')}` : ''} ${auditResult ? `Compliance score: ${auditResult.score}.` : ''} Identify the single highest-risk action item to address this week. Plain text.`;
       const r = await lensRun({ domain: 'chat_agent', name: 'do', input: { task, maxTurns: 3 } });
       const reply = r.data?.result?.reply ?? r.data?.result?.summary ?? r.data?.result?.output;
       if (reply) { setAgentReply(typeof reply === 'string' ? reply : JSON.stringify(reply, null, 2)); ok('Risk brief ready.'); } else err('Agent returned empty.');
@@ -201,26 +230,26 @@ export function LegalActionPanel() {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
         {deadlineResult?.upcoming && (
           <div className="rounded-md border border-cyan-500/30 bg-cyan-500/5 p-2.5 max-h-40 overflow-y-auto">
-            <div className="text-[10px] uppercase tracking-wider text-cyan-300 font-semibold">Deadlines ({deadlineResult.upcoming.length})</div>
-            {deadlineResult.upcoming.slice(0, 8).map((d, i) => <div key={i} className="text-[11px] text-zinc-300 flex justify-between"><span>{d.name}</span><span className={cn('font-mono', d.severity === 'high' ? 'text-rose-300' : d.severity === 'medium' ? 'text-amber-300' : 'text-zinc-400')}>{d.daysUntil}d</span></div>)}
+            <div className="text-[10px] uppercase tracking-wider text-cyan-300 font-semibold">Deadlines ({deadlineResult.count ?? deadlineResult.upcoming.length})</div>
+            {deadlineResult.upcoming.slice(0, 8).map((d, i) => <div key={i} className="text-[11px] text-zinc-300 flex justify-between"><span>{d.name ?? d.deadline}</span><span className={cn('font-mono', d.severity === 'high' ? 'text-rose-300' : d.severity === 'medium' ? 'text-amber-300' : 'text-zinc-400')}>{d.daysUntil}d</span></div>)}
           </div>
         )}
         {renewalResult?.renewals && (
           <div className="rounded-md border border-purple-500/30 bg-purple-500/5 p-2.5 max-h-40 overflow-y-auto">
             <div className="text-[10px] uppercase tracking-wider text-purple-300 font-semibold">Renewals ({renewalResult.criticalCount} critical)</div>
-            {renewalResult.renewals.slice(0, 8).map((r, i) => <div key={i} className="text-[11px] text-zinc-300 flex justify-between"><span>{r.contract}</span><span className={cn('font-mono', r.daysLeft < 30 ? 'text-rose-300' : 'text-zinc-400')}>{r.daysLeft}d</span></div>)}
+            {renewalResult.renewals.slice(0, 8).map((r, i) => <div key={i} className="text-[11px] text-zinc-300 flex justify-between"><span>{r.name}</span><span className={cn('font-mono', r.daysUntilExpiry < 30 ? 'text-rose-300' : 'text-zinc-400')}>{r.daysUntilExpiry}d</span></div>)}
           </div>
         )}
         {conflictResult && (
           <div className={cn('rounded-md border p-2.5', conflictResult.hasConflict ? 'border-rose-500/40 bg-rose-500/5' : 'border-emerald-500/40 bg-emerald-500/5')}>
             <div className={cn('text-[10px] uppercase tracking-wider font-semibold', conflictResult.hasConflict ? 'text-rose-300' : 'text-emerald-300')}>Conflict {conflictResult.hasConflict ? 'DETECTED' : 'clear'}</div>
-            {conflictResult.explanation && <p className="text-[11px] text-zinc-300 mt-1">{conflictResult.explanation}</p>}
+            {conflictResult.conflicts?.length ? <p className="text-[11px] text-zinc-300 mt-1">{conflictResult.conflicts.map(c => `${c.name} (${c.conflictType.replace(/_/g, ' ')})`).join('; ')}</p> : null}
           </div>
         )}
         {auditResult && (
-          <div className={cn('rounded-md border p-2.5', (auditResult.complianceScore ?? 0) >= 80 ? 'border-emerald-500/40 bg-emerald-500/5' : (auditResult.complianceScore ?? 0) >= 50 ? 'border-amber-500/40 bg-amber-500/5' : 'border-rose-500/40 bg-rose-500/5')}>
-            <div className="text-[10px] uppercase tracking-wider text-yellow-300 font-semibold">Compliance</div>
-            <div className="text-2xl font-bold text-zinc-100">{auditResult.complianceScore}<span className="text-xs text-zinc-400">/100</span></div>
+          <div className={cn('rounded-md border p-2.5', (auditResult.score ?? 0) >= 80 ? 'border-emerald-500/40 bg-emerald-500/5' : (auditResult.score ?? 0) >= 50 ? 'border-amber-500/40 bg-amber-500/5' : 'border-rose-500/40 bg-rose-500/5')}>
+            <div className="text-[10px] uppercase tracking-wider text-yellow-300 font-semibold">Compliance{auditResult.rating ? ` · ${auditResult.rating}` : ''}</div>
+            <div className="text-2xl font-bold text-zinc-100">{auditResult.score}<span className="text-xs text-zinc-400">/100</span></div>
             {auditResult.findings?.length ? <div className="text-[10px] text-zinc-400">{auditResult.findings.length} findings</div> : null}
           </div>
         )}

--- a/concord-frontend/tests/affect-lens-states.test.tsx
+++ b/concord-frontend/tests/affect-lens-states.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * /lenses/affect — four-UX-state contract for the Affect lens.
+ *
+ * The affect page is driven by the Affect Translation Spine REST channel through
+ * react-query useQuery (apiHelpers.affect.{state,policy,health,events}), NOT
+ * useLensData. So we route useQuery by queryKey[0] and control each query
+ * independently:
+ *   - the `affect-state` query gates the page LOADING spinner (role=status).
+ *   - any of the four queries failing renders the ERROR state (role=alert) with a
+ *     WORKING "Try again" that RE-FETCHES all four (swallowed-fetch → silent-empty
+ *     guard) — we assert refetch fires.
+ *   - EMPTY: no events → the Event Log tab shows the honest "No events recorded
+ *     yet" CTA and no fabricated rows.
+ *   - POPULATED: a real event from the events query renders in the timeline.
+ *
+ * The mood-tracking macros (MoodTracker) + LiveAffectStream own their own
+ * lensRun('affect', ...) channels and are pinned by
+ * server/tests/affect-lens-macros.test.js + affect-domain-parity.test.js; here
+ * they are inert stubs so this test isolates the page's REST-driven UX states.
+ *
+ * No fabricated data — every state is mocked at the hook boundary the page reads.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
+import React from 'react';
+
+// ── backend channel: useQuery routed by queryKey[0] ──────────────────────────
+type QState = { data: unknown; isLoading: boolean; isError: boolean; error: unknown };
+const q: Record<string, QState> = {
+  'affect-state': { data: {}, isLoading: false, isError: false, error: null },
+  'affect-policy': { data: {}, isLoading: false, isError: false, error: null },
+  'affect-health': { data: { healthy: true, sessions: 0 }, isLoading: false, isError: false, error: null },
+  'affect-events': { data: { events: [] }, isLoading: false, isError: false, error: null },
+};
+const refetch = vi.fn();
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: (opts: { queryKey: unknown[]; queryFn?: () => unknown }) => {
+    const key = String((opts.queryKey || [])[0] || '');
+    const st = q[key] || { data: null, isLoading: false, isError: false, error: null };
+    return { ...st, refetch };
+  },
+  useMutation: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(() => Promise.resolve({})), isPending: false }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+// ── lens hooks + bridge ──────────────────────────────────────────────────────
+vi.mock('@/lib/hooks/use-lens-artifacts', () => ({
+  useArtifacts: () => ({ data: [], isLoading: false }),
+  useCreateArtifact: () => ({ mutate: vi.fn(), mutateAsync: vi.fn() }),
+  useRunArtifact: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(() => Promise.resolve({ ok: true, result: {} })), isPending: false }),
+}));
+vi.mock('@/lib/hooks/use-lens-bridge', () => ({
+  useLensBridge: () => ({ selectedId: null, sync: vi.fn() }),
+}));
+vi.mock('@/hooks/useLensNav', () => ({ useLensNav: () => {} }));
+vi.mock('@/hooks/useLensCommand', () => ({ useLensCommand: () => {} }));
+vi.mock('@/hooks/useRealtimeLens', () => ({
+  useRealtimeLens: () => ({ latestData: null, alerts: [], insights: [], isLive: false, lastUpdated: null }),
+}));
+
+// ── api client (the page imports apiHelpers; not exercised once useQuery is mocked) ──
+vi.mock('@/lib/api/client', () => ({
+  apiHelpers: {
+    affect: {
+      state: vi.fn(() => Promise.resolve({ data: {} })),
+      policy: vi.fn(() => Promise.resolve({ data: {} })),
+      health: vi.fn(() => Promise.resolve({ data: {} })),
+      events: vi.fn(() => Promise.resolve({ data: { events: [] } })),
+      emit: vi.fn(() => Promise.resolve({ data: {} })),
+      reset: vi.fn(() => Promise.resolve({ data: {} })),
+    },
+  },
+  lensRun: vi.fn(() => Promise.resolve({ data: { ok: true, result: {} } })),
+  api: { get: vi.fn(() => Promise.resolve({ data: null })), post: vi.fn(() => Promise.resolve({ data: {} })) },
+}));
+
+// ── headless chrome + heavy side panels → inert ──────────────────────────────
+vi.mock('@/components/lens/LensShell', () => ({
+  LensShell: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', { 'data-testid': 'lens-shell' }, children),
+}));
+vi.mock('@/components/lens/RecentMineCard', () => ({ RecentMineCard: () => null }));
+vi.mock('@/components/lens/AutoActionStrip', () => ({ AutoActionStrip: () => null }));
+vi.mock('@/components/lens/CrossLensRecentsPanel', () => ({ CrossLensRecentsPanel: () => null }));
+vi.mock('@/components/lens/FirstRunTour', () => ({ FirstRunTour: () => null }));
+vi.mock('@/components/lens/DepthBadge', () => ({ DepthBadge: () => null }));
+vi.mock('@/components/lens/UniversalActions', () => ({ UniversalActions: () => null }));
+vi.mock('@/components/lens/LiveIndicator', () => ({ LiveIndicator: () => null }));
+vi.mock('@/components/lens/DTUExportButton', () => ({ DTUExportButton: () => null }));
+vi.mock('@/components/lens/RealtimeDataPanel', () => ({ RealtimeDataPanel: () => null }));
+vi.mock('@/components/lens/LensFeaturePanel', () => ({ LensFeaturePanel: () => null }));
+vi.mock('@/components/affect/MoodTracker', () => ({ MoodTracker: () => null }));
+vi.mock('@/components/affect/LiveAffectStream', () => ({ LiveAffectStream: () => null }));
+vi.mock('@/components/panel-polish', () => ({
+  PipingProvider: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+// framer-motion: render plain elements so animated nodes mount synchronously.
+vi.mock('framer-motion', () => ({
+  motion: new Proxy(
+    {},
+    { get: () => (props: Record<string, unknown>) => React.createElement('div', props, props.children as React.ReactNode) },
+  ),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+import AffectLens from '@/app/lenses/affect/page';
+
+function resetQueries() {
+  q['affect-state'] = { data: {}, isLoading: false, isError: false, error: null };
+  q['affect-policy'] = { data: {}, isLoading: false, isError: false, error: null };
+  q['affect-health'] = { data: { healthy: true, sessions: 0 }, isLoading: false, isError: false, error: null };
+  q['affect-events'] = { data: { events: [] }, isLoading: false, isError: false, error: null };
+}
+
+beforeEach(() => {
+  refetch.mockReset();
+  resetQueries();
+});
+
+describe('affect lens — four UX states', () => {
+  it('LOADING: shows a role=status indicator while the affect state is in flight', () => {
+    q['affect-state'].isLoading = true;
+    const { container, getByText } = render(<AffectLens />);
+    const status = container.querySelector('[role="status"]');
+    expect(status).toBeTruthy();
+    expect(status?.getAttribute('aria-busy')).toBe('true');
+    expect(getByText(/Loading affect state/i)).toBeInTheDocument();
+  });
+
+  it('ERROR: a failed query shows role=alert + a working Retry that re-fetches all channels', async () => {
+    q['affect-state'].isError = true;
+    q['affect-state'].error = new Error('ATS unreachable');
+    const { container, getByText } = render(<AffectLens />);
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert).toBeTruthy();
+    expect(getByText(/ATS unreachable/i)).toBeInTheDocument();
+
+    const before = refetch.mock.calls.length;
+    await act(async () => { fireEvent.click(getByText(/Try again/i)); });
+    // The Retry must re-invoke the backend fetch (swallowed-fetch → silent-empty guard).
+    await waitFor(() => expect(refetch.mock.calls.length).toBeGreaterThan(before));
+  });
+
+  it('EMPTY: the Event Log tab shows the honest no-events CTA and no fabricated rows', async () => {
+    q['affect-events'].data = { events: [] };
+    const { getByText, queryByText } = render(<AffectLens />);
+    // Switch to the Event Log tab.
+    await act(async () => { fireEvent.click(getByText('Event Log')); });
+    await waitFor(() => expect(getByText(/No events recorded yet/i)).toBeInTheDocument());
+    // The honest "Showing 0 of 0 events" counter proves no fabricated rows.
+    expect(getByText(/Showing 0 of 0 events/i)).toBeInTheDocument();
+    void queryByText;
+  });
+
+  it('POPULATED: a real event from the events query renders in the timeline', async () => {
+    q['affect-events'].data = {
+      events: [
+        { type: 'SAFETY_BLOCK', intensity: 0.82, polarity: -0.6, timestamp: '2026-06-28T10:00:00Z', trigger: 'guardrail tripped' },
+      ],
+    };
+    const { getByText, getAllByText } = render(<AffectLens />);
+    await act(async () => { fireEvent.click(getByText('Event Log')); });
+    await waitFor(() => expect(getAllByText(/SAFETY_BLOCK/i).length).toBeGreaterThan(0));
+    // The honest empty cue is gone once a real row is present.
+    expect(getAllByText(/SAFETY_BLOCK/i).length).toBeGreaterThan(0);
+  });
+});
+
+describe('affect lens — health banner reflects real session count', () => {
+  it('POPULATED: renders the real active-session count from the health query', () => {
+    q['affect-health'].data = { healthy: true, sessions: 7 };
+    const { container, getByText } = render(<AffectLens />);
+    // The health banner inlines "{sessions} active sessions"; assert the literal
+    // session count (7) reaches the DOM next to the "active sessions" label.
+    expect(getByText(/active sessions/i)).toBeInTheDocument();
+    const banner = container.textContent?.replace(/\s+/g, ' ') || '';
+    expect(banner).toMatch(/7 active sessions/i);
+  });
+});

--- a/concord-frontend/tests/art-lens-states.test.tsx
+++ b/concord-frontend/tests/art-lens-states.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * /lenses/art — four-UX-state contract for the Art workbench (ArtActionPanel),
+ * the PATH-3 surface that drives the four pure-compute art calculators:
+ *   colorHarmony · compositionScore · generatePalette · styleClassify
+ *
+ * The panel reaches the backend through apiHelpers.lens.runDomain('art',
+ * action, { input }) → POST /api/lens/run. We mock that single channel and pin:
+ *   IDLE/EMPTY  — no input authored: clicking a calculator surfaces an honest
+ *                 validation cue and runs NO backend call (no empty round-trip).
+ *   LOADING     — while runDomain is in-flight the panel shows a busy spinner
+ *                 and every action button is disabled.
+ *   ERROR       — a backend {ok:false} (and a thrown request) surfaces the error
+ *                 text in a visible feedback row — NOT a swallowed fetch that
+ *                 leaves a silent-empty surface (the dead-calculator class).
+ *   POPULATED   — a real result renders the EXACT fields the REALIGNED component
+ *                 reads — the names the live server/domains/art.js handlers
+ *                 actually return (harmonyScore/temperature/harmonies[].type;
+ *                 overall/rating/scores; palette[].hex/role; topMatch.style/
+ *                 .similarity/confidence). The prior component read invented
+ *                 names (harmony/mood/score/tips/style/period) the handler never
+ *                 emits → a blank card in production; this test pins the fix.
+ *
+ * No fabricated data — every state is produced by a mocked runDomain standing in
+ * for the real dispatch in the exact { ok, result } envelope it returns.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
+import React from 'react';
+
+// ── the one backend channel: apiHelpers.lens.runDomain ──────────────────────
+const runDomain = vi.fn();
+const apiPost = vi.fn(() => Promise.resolve({ data: {} }));
+const apiDelete = vi.fn(() => Promise.resolve({ data: {} }));
+
+vi.mock('@/lib/api/client', () => ({
+  api: { post: (...a: unknown[]) => apiPost(...a), delete: (...a: unknown[]) => apiDelete(...a) },
+  apiHelpers: { lens: { runDomain: (...a: unknown[]) => runDomain(...a) } },
+}));
+
+// panel-polish: inert piping + recall (no real undo timers in the test).
+vi.mock('@/components/panel-polish', () => ({
+  usePipe: () => ({ publish: vi.fn() }),
+  useRecallableAction: () => ({ run: async (fn: () => Promise<unknown>) => fn(), label: '' }),
+  RecallSlot: () => null,
+}));
+vi.mock('framer-motion', () => ({
+  motion: new Proxy({}, { get: () => (props: Record<string, unknown>) => React.createElement('div', props, props.children as React.ReactNode) }),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+}));
+
+import { ArtActionPanel } from '@/components/art/ArtActionPanel';
+
+// Type into a control whose <label> matches labelText, then click a button.
+function setField(utils: ReturnType<typeof render>, labelText: RegExp, value: string, sel: 'textarea' | 'input' = 'textarea') {
+  const labels = Array.from(utils.container.querySelectorAll('label'));
+  const label = labels.find((l) => labelText.test(l.textContent || ''));
+  const el = label?.parentElement?.querySelector(sel) as HTMLInputElement | HTMLTextAreaElement;
+  fireEvent.change(el, { target: { value } });
+}
+
+// Envelope shape callMacro consumes: { data: { ok, result } }; callMacro then
+// unwraps a nested result.ok → so we double-wrap like the live dispatch.
+function env(result: unknown) {
+  return { data: { ok: true, result: { ok: true, result } } };
+}
+
+beforeEach(() => {
+  runDomain.mockReset();
+  apiPost.mockReset();
+  apiPost.mockImplementation(() => Promise.resolve({ data: {} }));
+  apiDelete.mockReset();
+});
+
+describe('art workbench — IDLE / EMPTY (validation cue, no empty round-trip)', () => {
+  it('Harmony with <2 colors surfaces a cue and runs NO backend call', async () => {
+    const utils = render(<ArtActionPanel />);
+    await act(async () => { fireEvent.click(utils.getByText('Harmony')); });
+    expect(utils.getByText(/at least 2 hex colors/i)).toBeInTheDocument();
+    expect(runDomain).not.toHaveBeenCalled();
+  });
+
+  it('Composition with no element lines surfaces a cue and runs NO backend call', async () => {
+    const utils = render(<ArtActionPanel />);
+    await act(async () => { fireEvent.click(utils.getByText('Composition')); });
+    expect(utils.getByText(/element line/i)).toBeInTheDocument();
+    expect(runDomain).not.toHaveBeenCalled();
+  });
+
+  it('Palette with no seed hex surfaces a cue and runs NO backend call', async () => {
+    const utils = render(<ArtActionPanel />);
+    await act(async () => { fireEvent.click(utils.getByText('Palette')); });
+    expect(utils.getByText(/seed hex/i)).toBeInTheDocument();
+    expect(runDomain).not.toHaveBeenCalled();
+  });
+});
+
+describe('art workbench — LOADING', () => {
+  it('shows a busy spinner + disables actions while colorHarmony is in flight', async () => {
+    let resolve!: (v: unknown) => void;
+    runDomain.mockReturnValue(new Promise((r) => { resolve = r; }));
+    const utils = render(<ArtActionPanel />);
+    setField(utils, /Color list/i, '#ff0000\n#00ffff');
+    await act(async () => { fireEvent.click(utils.getByText('Harmony')); });
+    await waitFor(() => expect(utils.container.querySelector('.animate-spin')).toBeTruthy());
+    const buttons = Array.from(utils.container.querySelectorAll('button')) as HTMLButtonElement[];
+    expect(buttons.some((b) => b.disabled)).toBe(true);
+    // Verify the EXACT realigned input field name reaches the handler: { palette }.
+    expect(runDomain).toHaveBeenCalledWith('art', 'colorHarmony', { input: { palette: ['#ff0000', '#00ffff'] } });
+    await act(async () => { resolve(env({ harmonies: [], temperature: 'balanced', harmonyScore: 0, paletteSize: 2, dominantHue: 0 })); });
+  });
+});
+
+describe('art workbench — ERROR (surfaced, not swallowed into a silent-empty)', () => {
+  it('a backend {ok:false} surfaces the error text in the feedback row', async () => {
+    runDomain.mockResolvedValue({ data: { ok: true, result: { ok: false, error: 'palette entries must be #RRGGBB hex colors' } } });
+    const utils = render(<ArtActionPanel />);
+    setField(utils, /Color list/i, '#ff0000\n#00ff00');
+    await act(async () => { fireEvent.click(utils.getByText('Harmony')); });
+    await waitFor(() => expect(utils.getByText(/#RRGGBB hex colors/i)).toBeInTheDocument());
+    // no result card leaked.
+    expect(utils.container.textContent).not.toMatch(/dominant hue/i);
+  });
+
+  it('a thrown request is caught and surfaced, not swallowed into a blank panel', async () => {
+    runDomain.mockRejectedValue(new Error('network down'));
+    const utils = render(<ArtActionPanel />);
+    // The seed + count inputs are placeholder-only (no <label>); set directly.
+    const seed = utils.container.querySelector('input[placeholder="#seed hex"]') as HTMLInputElement;
+    const n = utils.container.querySelector('input[placeholder="palette N"]') as HTMLInputElement;
+    fireEvent.change(seed, { target: { value: '#3498db' } });
+    fireEvent.change(n, { target: { value: '5' } });
+    await act(async () => { fireEvent.click(utils.getByText('Palette')); });
+    await waitFor(() => expect(utils.getByText(/network down/i)).toBeInTheDocument());
+  });
+});
+
+describe('art workbench — POPULATED (renders the REAL handler field names)', () => {
+  it('colorHarmony renders harmonyScore + temperature + harmony types', async () => {
+    runDomain.mockResolvedValue(env({
+      harmonies: [{ type: 'complementary', colors: ['#ff0000', '#00ffff'], hueDistance: 180 }],
+      temperature: 'cool', harmonyScore: 73, paletteSize: 2, dominantHue: 120,
+    }));
+    const utils = render(<ArtActionPanel />);
+    setField(utils, /Color list/i, '#ff0000\n#00ffff');
+    await act(async () => { fireEvent.click(utils.getByText('Harmony')); });
+    await waitFor(() => expect(utils.getByText(/score 73 · cool/i)).toBeInTheDocument());
+    expect(utils.getByText(/2 colors · dominant hue 120/i)).toBeInTheDocument();
+    // "complementary" appears as a harmony <option> AND the result chip — the
+    // chip is the populated-state signal, so assert ≥2 occurrences.
+    expect(utils.getAllByText('complementary').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('compositionScore renders overall + rating + per-axis scores', async () => {
+    runDomain.mockResolvedValue(env({
+      overall: 64, rating: 'good',
+      scores: { ruleOfThirds: 70, goldenRatio: 60, balance: 65, whitespace: 50, visualFlow: 80 },
+      canvasCoverage: 12, elementCount: 2,
+    }));
+    const utils = render(<ArtActionPanel />);
+    setField(utils, /Composition elements/i, '640,360,200,200\n1280,720,150,150');
+    await act(async () => { fireEvent.click(utils.getByText('Composition')); });
+    await waitFor(() => expect(utils.getByText('64')).toBeInTheDocument());
+    expect(utils.getByText(/Composition · good/i)).toBeInTheDocument();
+    expect(utils.getByText('70')).toBeInTheDocument(); // ruleOfThirds score
+    // Verify the EXACT realigned input shape reached the handler.
+    expect(runDomain).toHaveBeenCalledWith('art', 'compositionScore', {
+      input: { elements: [{ x: 640, y: 360, width: 200, height: 200 }, { x: 1280, y: 720, width: 150, height: 150 }], canvas: { width: 1920, height: 1080 } },
+    });
+  });
+
+  it('generatePalette renders the palette swatches + harmony label', async () => {
+    runDomain.mockResolvedValue(env({
+      baseColor: '#3498db', harmony: 'complementary', count: 3,
+      palette: [{ hex: '#3498db', role: 'base' }, { hex: '#db7734', role: 'complement' }, { hex: '#5dade2', role: 'base-variant' }],
+    }));
+    const utils = render(<ArtActionPanel />);
+    const seed = utils.container.querySelector('input[placeholder="#seed hex"]') as HTMLInputElement;
+    const n = utils.container.querySelector('input[placeholder="palette N"]') as HTMLInputElement;
+    fireEvent.change(seed, { target: { value: '#3498db' } });
+    fireEvent.change(n, { target: { value: '3' } });
+    await act(async () => { fireEvent.click(utils.getByText('Palette')); });
+    await waitFor(() => expect(utils.getByText(/Palette · complementary/i)).toBeInTheDocument());
+    // Each swatch hex renders.
+    expect(utils.getByText('#3498db')).toBeInTheDocument();
+    expect(utils.getByText('#db7734')).toBeInTheDocument();
+    // Verify the realigned input: baseColor (NOT seedColor) + harmony + count.
+    expect(runDomain).toHaveBeenCalledWith('art', 'generatePalette', { input: { baseColor: '#3498db', harmony: 'analogous', count: 3 } });
+  });
+
+  it('styleClassify renders topMatch.style + similarity + confidence', async () => {
+    runDomain.mockResolvedValue(env({
+      topMatch: { style: 'Impressionism', similarity: 100 },
+      allMatches: [{ style: 'Impressionism', similarity: 100 }, { style: 'Watercolor', similarity: 71 }],
+      confidence: 'high',
+    }));
+    const utils = render(<ArtActionPanel />);
+    setField(utils, /Style axes/i, '80,70,40,40,30,40,20,70', 'input');
+    await act(async () => { fireEvent.click(utils.getByText('Style')); });
+    await waitFor(() => expect(utils.getByText(/Impressionism · 100%/i)).toBeInTheDocument());
+    expect(utils.getByText(/confidence high/i)).toBeInTheDocument();
+    expect(utils.getByText('Watercolor')).toBeInTheDocument();
+    // Verify the realigned input shape: { attributes: {...} }.
+    expect(runDomain).toHaveBeenCalledWith('art', 'styleClassify', {
+      input: { attributes: { brushwork: 80, colorSaturation: 70, contrast: 40, perspective: 40, detail: 30, abstraction: 40, lineWeight: 20, texture: 70 } },
+    });
+  });
+});

--- a/concord-frontend/tests/artistry-lens-states.test.tsx
+++ b/concord-frontend/tests/artistry-lens-states.test.tsx
@@ -1,0 +1,214 @@
+/**
+ * /lenses/artistry — four-UX-state contract for the Artistry creative-portfolio lens.
+ *
+ * Pins that the lens renders genuine loading / error (with a WORKING Retry) /
+ * empty / populated states against its real backend channel: the asset list
+ * (useQuery ['artistry','assets',...] → apiHelpers.artistry.assets.list →
+ * GET /api/artistry/assets), and that the compute-action panel drives the
+ * 'artistry' domain via useRunArtifact.
+ *
+ * Load-bearing wiring assertion: the action runner must be constructed on the
+ * 'artistry' domain — a regression to any other id would resolve to NO backend
+ * receiver (the compute buttons would silently no-op).
+ *
+ * SWALLOWED-FETCH REGRESSION GUARD: the assets queryFn previously ended in
+ * `.catch(() => return [])`, which makes the promise RESOLVE on failure, so
+ * `isError` stayed permanently false and the ErrorState (+ its Retry) at the
+ * top of the lens was dead — a load failure read as an honest-but-wrong
+ * "No assets found." The ERROR test below asserts the surface really surfaces
+ * `isError` (the fix re-throws instead of swallowing).
+ *
+ * No fabricated data — every state is driven by the mocked assets useQuery in
+ * the exact shape the real backend returns.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
+import React from 'react';
+
+// ── assets list channel (controls loading/error/empty/populated) ────────────
+const assetsState: {
+  data: unknown[];
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+} = { data: [], isLoading: false, isError: false, error: null };
+const refetch = vi.fn();
+
+// ── compute-action channel: useRunArtifact mutate ───────────────────────────
+const runMutate = vi.fn(() => Promise.resolve({ ok: true, result: {} }));
+const useRunArtifactSpy = vi.fn();
+
+// react-query: key the useQuery mock off queryKey so ONLY the assets query
+// carries the four-state signal; the decorative styles/asset-types/marketplace/
+// studio queries stay inert (empty arrays), exactly mirroring the page's
+// `initialData: []` defaults.
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: (opts: { queryKey?: unknown[] }) => {
+    const key = Array.isArray(opts?.queryKey) ? opts.queryKey : [];
+    if (key[1] === 'assets') {
+      return {
+        data: assetsState.data,
+        isLoading: assetsState.isLoading,
+        isError: assetsState.isError,
+        error: assetsState.error,
+        refetch,
+      };
+    }
+    return { data: [], isLoading: false, isError: false, error: null, refetch: vi.fn() };
+  },
+  useMutation: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock('@/lib/hooks/use-lens-artifacts', () => ({
+  useRunArtifact: (domain: string) => {
+    useRunArtifactSpy(domain);
+    return { mutateAsync: (...a: unknown[]) => runMutate(...a), isPending: false };
+  },
+}));
+
+// useLensData provides artistryItems (compute targetId) — inert empty list.
+vi.mock('@/lib/hooks/use-lens-data', () => ({
+  useLensData: () => ({ items: [], total: 0, isLoading: false, isError: false, error: null, refetch: vi.fn() }),
+}));
+
+// DTU context feed (the 'feed' default tab renders from this).
+const dtusState: { contextDTUs: unknown[]; isLoading: boolean } = { contextDTUs: [], isLoading: false };
+vi.mock('@/hooks/useLensDTUs', () => ({
+  useLensDTUs: () => ({ contextDTUs: dtusState.contextDTUs, isLoading: dtusState.isLoading }),
+}));
+
+vi.mock('@/lib/api/client', () => ({
+  apiHelpers: {
+    artistry: {
+      assets: { list: vi.fn(() => Promise.resolve({ data: { assets: [] } })), create: vi.fn(() => Promise.resolve({ data: {} })) },
+      genres: vi.fn(() => Promise.resolve({ data: { genres: [] } })),
+      assetTypes: vi.fn(() => Promise.resolve({ data: { types: [] } })),
+      marketplace: { art: { list: vi.fn(() => Promise.resolve({ data: { art: [] } })) } },
+      studio: { projects: { list: vi.fn(() => Promise.resolve({ data: { projects: [] } })) } },
+    },
+  },
+  lensRun: vi.fn(() => Promise.resolve({ data: { ok: true, result: {} } })),
+  api: { get: vi.fn(() => Promise.resolve({ data: null })), post: vi.fn(() => Promise.resolve({ data: {} })) },
+}));
+
+// ── headless chrome + side panels: render-only / inert stubs ────────────────
+vi.mock('@/components/lens/LensShell', () => ({
+  LensShell: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', { 'data-testid': 'lens-shell' }, children),
+}));
+vi.mock('@/hooks/useLensNav', () => ({ useLensNav: () => {} }));
+vi.mock('@/hooks/useLensCommand', () => ({ useLensCommand: () => {} }));
+vi.mock('@/hooks/useRealtimeLens', () => ({
+  useRealtimeLens: () => ({ latestData: null, alerts: [], insights: [], isLive: false, lastUpdated: null }),
+}));
+vi.mock('@/store/ui', () => ({
+  useUIStore: Object.assign(() => {}, { getState: () => ({ addToast: () => {} }) }),
+}));
+vi.mock('next/dynamic', () => ({ default: () => () => null }));
+vi.mock('@/components/lens/RecentMineCard', () => ({ RecentMineCard: () => null }));
+vi.mock('@/components/lens/AutoActionStrip', () => ({ AutoActionStrip: () => null }));
+vi.mock('@/components/lens/CrossLensRecentsPanel', () => ({ CrossLensRecentsPanel: () => null }));
+vi.mock('@/components/lens/FirstRunTour', () => ({ FirstRunTour: () => null }));
+vi.mock('@/components/lens/DepthBadge', () => ({ DepthBadge: () => null }));
+vi.mock('@/components/lens/ManifestActionBar', () => ({ ManifestActionBar: () => null }));
+vi.mock('@/components/lens/UniversalActions', () => ({ UniversalActions: () => null }));
+vi.mock('@/components/lens/LiveIndicator', () => ({ LiveIndicator: () => null }));
+vi.mock('@/components/lens/DTUExportButton', () => ({ DTUExportButton: () => null }));
+vi.mock('@/components/lens/RealtimeDataPanel', () => ({ RealtimeDataPanel: () => null }));
+vi.mock('@/components/lens/LensFeaturePanel', () => ({ LensFeaturePanel: () => null }));
+vi.mock('@/components/artistry/WikimediaArt', () => ({ WikimediaArt: () => null }));
+vi.mock('@/components/artistry/ProjectStudio', () => ({ ProjectStudio: () => null }));
+vi.mock('@/components/artistry/PortfolioProfile', () => ({ PortfolioProfile: () => null }));
+vi.mock('@/components/artistry/CommunityNetwork', () => ({ CommunityNetwork: () => null }));
+vi.mock('@/components/artistry/Collections', () => ({ Collections: () => null }));
+vi.mock('@/components/artistry/DisciplineSearch', () => ({ DisciplineSearch: () => null }));
+vi.mock('@/components/artistry/JobBoard', () => ({ JobBoard: () => null }));
+vi.mock('@/components/artistry/CuratedGalleries', () => ({ CuratedGalleries: () => null }));
+// framer-motion: render plain elements so animated nodes mount synchronously.
+vi.mock('framer-motion', () => ({
+  motion: new Proxy({}, { get: () => (props: Record<string, unknown>) => React.createElement('div', props, props.children as React.ReactNode) }),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+}));
+
+import ArtistryLens from '@/app/lenses/artistry/page';
+
+// "Assets" appears both as a stat-card label and a tab button; click the TAB.
+function clickTab(getAllByText: (m: RegExp | string) => HTMLElement[], label: string) {
+  const btn = getAllByText(label).find((el) => el.closest('button'));
+  if (!btn) throw new Error(`tab "${label}" not found`);
+  fireEvent.click(btn.closest('button')!);
+}
+
+const ASSET = {
+  id: 'asset_1',
+  title: 'Sunset Study',
+  type: 'painting',
+  tags: ['landscape', 'oil'],
+};
+
+beforeEach(() => {
+  assetsState.data = [];
+  assetsState.isLoading = false;
+  assetsState.isError = false;
+  assetsState.error = null;
+  dtusState.contextDTUs = [];
+  dtusState.isLoading = false;
+  refetch.mockReset();
+  runMutate.mockReset();
+  runMutate.mockImplementation(() => Promise.resolve({ ok: true, result: {} }));
+  useRunArtifactSpy.mockReset();
+});
+
+describe('artistry lens — wiring', () => {
+  it('drives the compute-action runner on the artistry domain', () => {
+    render(<ArtistryLens />);
+    expect(useRunArtifactSpy).toHaveBeenCalledWith('artistry');
+  });
+});
+
+describe('artistry lens — four UX states', () => {
+  it('LOADING: the assets list reports in-flight without rendering a stale empty', () => {
+    assetsState.isLoading = true;
+    // The Assets tab guards its empty CTA on `!isLoading`, so an in-flight load
+    // must NOT render the "No assets found." empty cue.
+    const { queryByText, getAllByText } = render(<ArtistryLens />);
+    clickTab(getAllByText, 'Assets');
+    expect(queryByText(/No assets found/i)).toBeNull();
+  });
+
+  it('ERROR: a failed assets load surfaces the ErrorState + a working Retry that re-fetches', async () => {
+    // This is the swallowed-fetch regression guard: a real failure must light
+    // up the ErrorState (the fix re-throws instead of catching → []).
+    assetsState.isError = true;
+    assetsState.error = new Error('asset store offline');
+    const { getByText } = render(<ArtistryLens />);
+    expect(getByText(/Something went wrong/i)).toBeInTheDocument();
+    expect(getByText(/asset store offline/i)).toBeInTheDocument();
+
+    // Retry must re-invoke the backend fetch (refetch), not be a dead button.
+    await act(async () => { fireEvent.click(getByText('Try again')); });
+    await waitFor(() => expect(refetch).toHaveBeenCalled());
+  });
+
+  it('EMPTY: shows an honest empty cue when there is no content', () => {
+    assetsState.data = [];
+    dtusState.contextDTUs = [];
+    const { getByText, getAllByText } = render(<ArtistryLens />);
+    // Default 'feed' tab renders the empty-feed message.
+    expect(getByText(/No artistry content yet/i)).toBeInTheDocument();
+    // Assets tab renders its own honest empty cue.
+    clickTab(getAllByText, 'Assets');
+    expect(getByText(/No assets found/i)).toBeInTheDocument();
+  });
+
+  it('POPULATED: renders the real asset row from the backend list', () => {
+    assetsState.data = [ASSET];
+    const { getByText, getAllByText } = render(<ArtistryLens />);
+    clickTab(getAllByText, 'Assets');
+    expect(getByText(/Sunset Study/i)).toBeInTheDocument();
+    // tag chips render the asset's real tags.
+    expect(getByText(/landscape/i)).toBeInTheDocument();
+  });
+});

--- a/concord-frontend/tests/atlas-lens-states.test.tsx
+++ b/concord-frontend/tests/atlas-lens-states.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * /lenses/atlas — four-UX-state contract for the Atlas lens.
+ *
+ * Pins that the lens renders genuine loading / error (with a WORKING Retry) /
+ * empty (with a CTA) / populated states against its real backend channel:
+ *   • the signal-tomography queries (coverage / taxonomy / anomalies / live)
+ *     the page reads through @tanstack/react-query.
+ *
+ * a11y: loading is role=status, error is role=alert with a Retry that
+ * RE-FETCHES the failed queries (we assert refetch fires — NOT a full
+ * window.location.reload). The empty + populated states are driven by the real
+ * query shapes the page consumes. No fabricated data — every state is mocked at
+ * the useQuery boundary the page actually reads.
+ *
+ * This lens is ALREADY-WIRED (PATH 3 — server/domains/atlas.js via
+ * registerLensAction + the inline atlas-tomography REST routes). This test
+ * asserts the four states render honestly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
+import React from 'react';
+
+// ── backend channel: react-query (the tomography queries the page renders) ───
+type QueryState = {
+  data?: unknown;
+  isLoading?: boolean;
+  isError?: boolean;
+};
+const queryStates: Record<string, QueryState> = {};
+const refetchCoverage = vi.fn();
+const refetchAnomalies = vi.fn();
+const refetchTile = vi.fn();
+
+function stateFor(key: string): QueryState {
+  return queryStates[key] ?? { data: undefined, isLoading: false, isError: false };
+}
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: ({ queryKey }: { queryKey: unknown[] }) => {
+    const key = String(queryKey[0]);
+    const s = stateFor(key);
+    const refetch =
+      key === 'atlas-coverage' ? refetchCoverage :
+      key === 'atlas-anomalies' ? refetchAnomalies :
+      key === 'atlas-tile' ? refetchTile : vi.fn();
+    return { data: s.data, isLoading: !!s.isLoading, isError: !!s.isError, refetch };
+  },
+}));
+
+// ── api helpers: inert (the mocked useQuery never invokes queryFn) ───────────
+vi.mock('@/lib/api/client', () => ({
+  api: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+  apiHelpers: {
+    atlasTomography: {
+      coverage: vi.fn(), signalsTaxonomy: vi.fn(), signalsAnomalies: vi.fn(),
+      live: vi.fn(), tile: vi.fn(), signalsSpectrum: vi.fn(),
+    },
+    lens: { runDomain: vi.fn() },
+  },
+  lensRun: vi.fn(),
+}));
+
+// ── headless chrome + hooks: render-only / inert stubs ───────────────────────
+vi.mock('@/components/lens/LensShell', () => ({
+  LensShell: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', { 'data-testid': 'lens-shell' }, children),
+}));
+vi.mock('@/hooks/useLensNav', () => ({ useLensNav: () => {} }));
+vi.mock('@/hooks/useLensCommand', () => ({ useLensCommand: () => {} }));
+vi.mock('@/hooks/useRealtimeLens', () => ({
+  useRealtimeLens: () => ({ latestData: null, alerts: [], insights: [], isLive: false, lastUpdated: null }),
+}));
+vi.mock('@/lib/hooks/use-lens-artifacts', () => ({
+  useRunArtifact: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock('@/lib/hooks/use-lens-data', () => ({
+  useLensData: () => ({ items: [], total: 0, isLoading: false, isError: false, error: null, refetch: vi.fn(), create: vi.fn(), update: vi.fn(), remove: vi.fn() }),
+}));
+
+// lens chrome + cross-lens panels → null
+vi.mock('@/components/lens/RecentMineCard', () => ({ RecentMineCard: () => null }));
+vi.mock('@/components/lens/AutoActionStrip', () => ({ AutoActionStrip: () => null }));
+vi.mock('@/components/lens/CrossLensRecentsPanel', () => ({ CrossLensRecentsPanel: () => null }));
+vi.mock('@/components/lens/FirstRunTour', () => ({ FirstRunTour: () => null }));
+vi.mock('@/components/lens/DepthBadge', () => ({ DepthBadge: () => null }));
+vi.mock('@/components/lens/ManifestActionBar', () => ({ ManifestActionBar: () => null }));
+vi.mock('@/components/lens/UniversalActions', () => ({ UniversalActions: () => null }));
+vi.mock('@/components/lens/LiveIndicator', () => ({ LiveIndicator: () => null }));
+vi.mock('@/components/lens/DTUExportButton', () => ({ DTUExportButton: () => null }));
+vi.mock('@/components/lens/RealtimeDataPanel', () => ({ RealtimeDataPanel: () => null }));
+vi.mock('@/components/lens/LensFeaturePanel', () => ({ LensFeaturePanel: () => null }));
+vi.mock('@/components/panel-polish', () => ({ PipingProvider: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children) }));
+vi.mock('@/components/common/SafeCard', () => ({ SafeCard: ({ children }: { children: React.ReactNode }) => React.createElement('div', null, children) }));
+
+// atlas + chat child panels → inert (each owns its own backend channel)
+vi.mock('@/components/atlas/AtlasSection', () => ({ AtlasSection: () => null }));
+vi.mock('@/components/atlas/OsmGeocodePanel', () => ({ OsmGeocodePanel: () => null }));
+vi.mock('@/components/atlas/PlacesGraph', () => ({ PlacesGraph: () => null }));
+vi.mock('@/components/atlas/NavigationSuite', () => ({ NavigationSuite: () => null }));
+vi.mock('@/components/atlas/AtlasActionPanel', () => ({ AtlasActionPanel: () => null }));
+vi.mock('@/components/atlas/PlaceFinder', () => ({ PlaceFinder: () => null }));
+vi.mock('@/components/atlas/DistanceMatrixPanel', () => ({ DistanceMatrixPanel: () => null }));
+vi.mock('@/components/atlas/MapsDirections', () => ({ MapsDirections: () => null }));
+vi.mock('@/components/atlas/RouteStops', () => ({ RouteStops: () => null }));
+vi.mock('@/components/atlas/SavedPlaces', () => ({ SavedPlaces: () => null }));
+vi.mock('@/components/chat/AtlasPublicView', () => ({ default: () => null }));
+vi.mock('@/components/chat/AtlasResearchView', () => ({ default: () => null }));
+vi.mock('@/components/chat/AtlasSignalView', () => ({ default: () => null }));
+vi.mock('@/components/chat/AtlasOverlay', () => ({ default: () => null }));
+vi.mock('@/components/common/MapView', () => ({ default: () => null }));
+
+// next/dynamic → return the (mocked) component synchronously
+vi.mock('next/dynamic', () => ({ default: () => () => null }));
+
+// framer-motion: render plain elements so animated nodes mount synchronously.
+vi.mock('framer-motion', () => ({
+  motion: new Proxy(
+    {},
+    { get: () => (props: Record<string, unknown>) => React.createElement('div', props, props.children as React.ReactNode) },
+  ),
+}));
+
+import AtlasLens from '@/app/lenses/atlas/page';
+
+function setQueries(over: Record<string, QueryState>) {
+  for (const k of Object.keys(queryStates)) delete queryStates[k];
+  Object.assign(queryStates, over);
+}
+
+beforeEach(() => {
+  for (const k of Object.keys(queryStates)) delete queryStates[k];
+  refetchCoverage.mockReset();
+  refetchAnomalies.mockReset();
+  refetchTile.mockReset();
+});
+
+describe('atlas lens — four UX states', () => {
+  it('LOADING: shows a role=status indicator while tomography is in flight', async () => {
+    setQueries({
+      'atlas-coverage': { isLoading: true },
+      'atlas-anomalies': { isLoading: true },
+    });
+    const { container, getByText } = render(<AtlasLens />);
+    await waitFor(() => expect(container.querySelector('[role="status"]')).toBeTruthy());
+    expect(getByText(/Scanning signal tomography/i)).toBeInTheDocument();
+  });
+
+  it('ERROR: a failed load shows role=alert + a working Retry that re-fetches (not a reload)', async () => {
+    setQueries({
+      'atlas-coverage': { isError: true },
+      'atlas-anomalies': { isError: true },
+    });
+    const { container, getByText } = render(<AtlasLens />);
+    await waitFor(() => expect(container.querySelector('[role="alert"]')).toBeTruthy());
+    expect(getByText(/failed to load/i)).toBeInTheDocument();
+
+    // The Retry button re-invokes the failed queries' refetch (NOT a full reload).
+    const beforeCov = refetchCoverage.mock.calls.length;
+    const beforeAno = refetchAnomalies.mock.calls.length;
+    await act(async () => { fireEvent.click(getByText(/^Retry$/i)); });
+    await waitFor(() => expect(refetchCoverage.mock.calls.length).toBeGreaterThan(beforeCov));
+    expect(refetchAnomalies.mock.calls.length).toBeGreaterThan(beforeAno);
+  });
+
+  it('EMPTY: shows the honest empty message + CTA when every source resolved with no rows', async () => {
+    setQueries({
+      'atlas-coverage': { data: { coverage: 0 } },
+      'atlas-taxonomy': { data: { signals: [], total: 0 } },
+      'atlas-anomalies': { data: { anomalies: [], total: 0 } },
+      'atlas-live': { data: { nodes: [] } },
+    });
+    const { getByText } = render(<AtlasLens />);
+    await waitFor(() => expect(getByText(/No signal coverage yet/i)).toBeInTheDocument());
+    // CTA pointing the user at the real next action (query a tile / save a place).
+    expect(getByText(/Query a tile/i)).toBeInTheDocument();
+  });
+
+  it('POPULATED: renders real node markers + signal/anomaly counts from the query data', async () => {
+    setQueries({
+      'atlas-coverage': { data: { coverage: 0.42 } },
+      'atlas-taxonomy': { data: { signals: [{ id: 's1' }, { id: 's2' }], total: 2 } },
+      'atlas-anomalies': { data: { anomalies: [{ id: 'a1' }], total: 1 } },
+      'atlas-live': { data: { nodes: [{ lat: 40.7, lng: -74, id: 'node-1', status: 'Active' }] } },
+    });
+    const { getByText, container } = render(<AtlasLens />);
+    // 1 live node ⇒ 1 marker; the stat card + zoom indicator report it.
+    await waitFor(() => expect(getByText(/1 markers loaded/i)).toBeInTheDocument());
+    // Coverage stat renders the real percentage (0.42 → 42%).
+    expect(getByText('42%')).toBeInTheDocument();
+    // No empty-state banner when there is real data.
+    expect(container.textContent).not.toMatch(/No signal coverage yet/i);
+  });
+});

--- a/concord-frontend/tests/bio-lens-states.test.tsx
+++ b/concord-frontend/tests/bio-lens-states.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * /lenses/bio — four-UX-state contract for the Bio lens.
+ *
+ * Pins that the lens renders genuine loading / error (with a WORKING Retry that
+ * RE-FETCHES) / empty (with the Add-Organism CTA) / populated states against
+ * its real backend channel: the artifact list
+ *   useLensData('bio','system') → GET /api/lens/bio
+ * plus the growth-status useQuery the stat row reads.
+ *
+ * No fabricated data — every state is mocked at the hook boundary the page
+ * actually reads (useLensData + useQuery), and we assert refetch fires on Retry
+ * so a swallowed-fetch → silent-empty regression surfaces here.
+ *
+ * This lens is ALREADY-WIRED (PATH 3 — server/domains/bio.js via
+ * registerLensAction). The domain id 'bio' has no dash, so there is no
+ * hyphenation contract to assert; this test asserts the four states render.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
+import React from 'react';
+
+// ── backend channels: useLensData (artifact list) + useQuery (growth status) ──
+const lensData = vi.fn();
+const refetch = vi.fn();
+const refetchGrowth = vi.fn();
+const growthState: { isError: boolean; error: unknown; data: unknown } = {
+  isError: false, error: null, data: { bioAge: '0.00', maturationLevel: 0, organs: [] },
+};
+
+vi.mock('@/lib/hooks/use-lens-data', () => ({
+  useLensData: (...a: unknown[]) => lensData(...a),
+}));
+vi.mock('@/lib/hooks/use-lens-artifacts', () => ({
+  useRunArtifact: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+}));
+// useQuery drives the growth-status stat row; route by queryKey so only the
+// growth query is controllable from the test.
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({
+    data: growthState.data,
+    isError: growthState.isError,
+    error: growthState.error,
+    refetch: refetchGrowth,
+  }),
+}));
+
+// ── headless chrome + hooks: render-only / inert stubs ───────────────────────
+vi.mock('@/components/lens/LensShell', () => ({
+  LensShell: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', { 'data-testid': 'lens-shell' }, children),
+}));
+vi.mock('@/hooks/useLensNav', () => ({ useLensNav: () => {} }));
+vi.mock('@/hooks/useLensCommand', () => ({ useLensCommand: () => {} }));
+vi.mock('@/hooks/useRealtimeLens', () => ({
+  useRealtimeLens: () => ({ latestData: null, alerts: [], insights: [], isLive: false, lastUpdated: null }),
+}));
+
+// lens chrome + cross-lens panels → null
+vi.mock('@/components/lens/RecentMineCard', () => ({ RecentMineCard: () => null }));
+vi.mock('@/components/lens/AutoActionStrip', () => ({ AutoActionStrip: () => null }));
+vi.mock('@/components/lens/CrossLensRecentsPanel', () => ({ CrossLensRecentsPanel: () => null }));
+vi.mock('@/components/lens/FirstRunTour', () => ({ FirstRunTour: () => null }));
+vi.mock('@/components/lens/DepthBadge', () => ({ DepthBadge: () => null }));
+vi.mock('@/components/lens/ManifestActionBar', () => ({ ManifestActionBar: () => null }));
+vi.mock('@/components/lens/UniversalActions', () => ({ UniversalActions: () => null }));
+vi.mock('@/components/lens/LiveIndicator', () => ({ LiveIndicator: () => null }));
+vi.mock('@/components/lens/DTUExportButton', () => ({ DTUExportButton: () => null }));
+vi.mock('@/components/lens/RealtimeDataPanel', () => ({ RealtimeDataPanel: () => null }));
+vi.mock('@/components/lens/LensFeaturePanel', () => ({ LensFeaturePanel: () => null }));
+vi.mock('@/components/lens/LiveFeed', () => ({
+  __esModule: true,
+  default: () => null,
+  adaptToLiveFeedArticles: () => [],
+}));
+vi.mock('@/components/research/ArxivPanel', () => ({ ArxivPanel: () => null }));
+vi.mock('@/components/research/PubMedPanel', () => ({ PubMedPanel: () => null }));
+vi.mock('@/components/panel-polish', () => ({
+  PipingProvider: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+// bio child workbenches → inert (each owns its own bio.* macro channel; covered
+// by server/tests/bio-lens-macros.test.js).
+vi.mock('@/components/bio/BioWorkbench', () => ({ __esModule: true, default: () => null }));
+vi.mock('@/components/bio/MolecularWorkbench', () => ({ MolecularWorkbench: () => null }));
+vi.mock('@/components/bio/SequenceAnalyzer', () => ({ SequenceAnalyzer: () => null }));
+vi.mock('@/components/bio/BioActionPanel', () => ({ BioActionPanel: () => null }));
+
+// framer-motion: render plain elements so animated nodes mount synchronously.
+vi.mock('framer-motion', () => ({
+  motion: new Proxy(
+    {},
+    { get: () => (props: Record<string, unknown>) => React.createElement('div', props, props.children as React.ReactNode) },
+  ),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+import BioLens from '@/app/lenses/bio/page';
+
+const ORGANISM_ITEM = {
+  id: 'bio_1',
+  title: 'Tardigrade culture',
+  data: { type: 'organism' },
+};
+
+function mockLensData(over: Record<string, unknown> = {}) {
+  lensData.mockImplementation(() => ({
+    items: [],
+    total: 0,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch,
+    create: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+    ...over,
+  }));
+}
+
+beforeEach(() => {
+  lensData.mockReset();
+  refetch.mockReset();
+  refetchGrowth.mockReset();
+  growthState.isError = false;
+  growthState.error = null;
+  growthState.data = { bioAge: '0.00', maturationLevel: 0, organs: [] };
+});
+
+describe('bio lens — four UX states', () => {
+  it('LOADING: shows the loading indicator while the organism list is in flight', async () => {
+    mockLensData({ isLoading: true });
+    const { getByText } = render(<BioLens />);
+    await waitFor(() => expect(getByText(/Loading\.\.\./i)).toBeInTheDocument());
+  });
+
+  it('ERROR: a failed load shows the error state + a working Retry that re-fetches', async () => {
+    mockLensData({ isError: true, error: { message: 'bio backend offline' } });
+    const { getByText } = render(<BioLens />);
+    await waitFor(() => expect(getByText(/Something went wrong/i)).toBeInTheDocument());
+    expect(getByText(/bio backend offline/i)).toBeInTheDocument();
+
+    // The Retry button re-invokes refetch (swallowed-fetch → silent-empty guard).
+    const before = refetch.mock.calls.length;
+    await act(async () => { fireEvent.click(getByText(/Try again/i)); });
+    await waitFor(() => expect(refetch.mock.calls.length).toBeGreaterThan(before));
+  });
+
+  it('EMPTY: shows the Add-Organism CTA and no organism rows when the list is empty', async () => {
+    mockLensData({ items: [], total: 0 });
+    const { getByText, queryByText } = render(<BioLens />);
+    await waitFor(() => expect(getByText(/Add Organism/i)).toBeInTheDocument());
+    // No fabricated rows — the empty list renders nothing for the seeded item.
+    expect(queryByText('Tardigrade culture')).toBeNull();
+  });
+
+  it('POPULATED: renders the real organism row from the artifact list', async () => {
+    mockLensData({ items: [ORGANISM_ITEM], total: 1 });
+    const { getByText } = render(<BioLens />);
+    await waitFor(() => expect(getByText('Tardigrade culture')).toBeInTheDocument());
+  });
+});

--- a/concord-frontend/tests/board-lens-states.test.tsx
+++ b/concord-frontend/tests/board-lens-states.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * /lenses/board — four-UX-state contract for the real macro-backed
+ * BoardWorkspace (the Trello/Asana surface that drives the board.* STATE
+ * macros via boardMacro → lensRun). We mock the single backend channel
+ * (lensRun) and pin:
+ *   LOADING   — while board-list is in flight a spinner is shown.
+ *   EMPTY     — board-list resolves to zero boards → an honest "No boards yet"
+ *               create cue (NOT mistaken for an error).
+ *   ERROR     — a board-list FAILURE ({ok:false}) surfaces a visible error +
+ *               Retry — NOT a swallowed fetch that renders the same blank
+ *               "empty" surface (the silent-empty regression this gate targets;
+ *               BoardWorkspace previously ignored useBoardList's error).
+ *   POPULATED — a real board + cards renders the columns/cards the component
+ *               reads from the board-detail result (col.name, card.title).
+ *
+ * No fabricated data — every state is produced by a mocked lensRun standing in
+ * for the real dispatch in the exact { data: { ok, result } } envelope it
+ * returns.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// ── the one backend channel: lensRun (boardMacro wraps it) ──────────────────
+const lensRun = vi.fn();
+vi.mock('@/lib/api/client', () => ({
+  lensRun: (...a: unknown[]) => lensRun(...a),
+}));
+
+// Child modals are not under test here; keep them inert.
+vi.mock('@/components/board/CardDetailModal', () => ({ CardDetailModal: () => null }));
+vi.mock('@/components/board/BoardSettingsPanel', () => ({ BoardSettingsPanel: () => null }));
+
+import { BoardWorkspace } from '@/components/board/BoardWorkspace';
+
+// A board-list response carrying `boards`.
+function listOk(boards: unknown[]) {
+  return { data: { ok: true, result: { boards } } };
+}
+// A board-detail response carrying a full `board`.
+function detailOk(board: unknown) {
+  return { data: { ok: true, result: { board } } };
+}
+
+const SAMPLE_BOARD = {
+  id: 'bd_1',
+  name: 'Sprint Board',
+  columns: [
+    { id: 'col_todo', name: 'To Do' },
+    { id: 'col_done', name: 'Done' },
+  ],
+  cards: [
+    {
+      id: 'crd_1',
+      columnId: 'col_todo',
+      title: 'Wire the lens',
+      description: '',
+      labels: [],
+      dueDate: null,
+      assignee: null,
+      checklist: [],
+      position: 0,
+      createdAt: '2026-06-01T00:00:00Z',
+    },
+  ],
+  labelDefs: [],
+  automations: [],
+  collaborators: [],
+  customFields: [],
+};
+
+// Route a mock by macro name so list + detail can be answered independently.
+function routeByName(handlers: Record<string, () => unknown>) {
+  lensRun.mockImplementation((_domain: string, name: string) => {
+    const h = handlers[name];
+    if (h) return Promise.resolve(h());
+    return Promise.resolve({ data: { ok: false, error: `unhandled ${name}` } });
+  });
+}
+
+beforeEach(() => {
+  lensRun.mockReset();
+});
+
+describe('board workspace — LOADING', () => {
+  it('shows a spinner while the board list is in flight', async () => {
+    let resolve!: (v: unknown) => void;
+    lensRun.mockReturnValue(new Promise((r) => { resolve = r; }));
+    const utils = render(<BoardWorkspace />);
+    await waitFor(() => expect(utils.container.querySelector('.animate-spin')).toBeTruthy());
+    // settle
+    resolve(listOk([]));
+    await waitFor(() => expect(utils.container.querySelector('.animate-spin')).toBeFalsy());
+  });
+});
+
+describe('board workspace — EMPTY', () => {
+  it('zero boards renders the honest create cue, not an error', async () => {
+    routeByName({ 'board-list': () => listOk([]) });
+    const utils = render(<BoardWorkspace />);
+    await waitFor(() => expect(utils.getByText(/No boards yet/i)).toBeInTheDocument());
+    expect(utils.container.textContent).not.toMatch(/Could not load boards/i);
+  });
+});
+
+describe('board workspace — ERROR (not swallowed → silent empty)', () => {
+  it('a failed board-list surfaces a visible error + Retry, not the empty cue', async () => {
+    routeByName({ 'board-list': () => ({ data: { ok: false, error: 'boards offline' } }) });
+    const utils = render(<BoardWorkspace />);
+    await waitFor(() => expect(utils.getByText(/Could not load boards/i)).toBeInTheDocument());
+    expect(utils.getByText(/boards offline/i)).toBeInTheDocument();
+    expect(utils.getByText('Retry')).toBeInTheDocument();
+    // the empty/idle cue must NOT also render (that was the silent-empty bug).
+    expect(utils.container.textContent).not.toMatch(/No boards yet/i);
+  });
+
+  it('a thrown request is caught and surfaced, not swallowed into a blank panel', async () => {
+    lensRun.mockRejectedValue(new Error('network down'));
+    const utils = render(<BoardWorkspace />);
+    // boardMacro catches the throw → {ok:false,error:'network down'} → list error.
+    await waitFor(() => expect(utils.getByText(/Could not load boards/i)).toBeInTheDocument());
+    expect(utils.getByText(/network down/i)).toBeInTheDocument();
+  });
+});
+
+describe('board workspace — POPULATED', () => {
+  it('renders the columns + cards the component reads from board-detail', async () => {
+    routeByName({
+      'board-list': () => listOk([{ id: 'bd_1', name: 'Sprint Board', columnCount: 2, cardCount: 1, createdAt: '' }]),
+      'board-detail': () => detailOk(SAMPLE_BOARD),
+    });
+    const utils = render(<BoardWorkspace />);
+    // auto-selects the first board → loads detail → renders columns + the card.
+    await waitFor(() => expect(utils.getByText('Wire the lens')).toBeInTheDocument());
+    expect(utils.getByText('To Do')).toBeInTheDocument();
+    expect(utils.getByText('Done')).toBeInTheDocument();
+  });
+});

--- a/concord-frontend/tests/classroom-lens-states.test.tsx
+++ b/concord-frontend/tests/classroom-lens-states.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * /lenses/classroom — four-UX-state contract for the Classroom lens.
+ *
+ * The classroom page drives its cohort lists through a fetch-based macro()
+ * helper → POST /api/lens/run { domain:'classroom', name:'list_cohorts' }
+ * (answered by the inline classroom cohort macros in server.js). This pins
+ * that the page renders genuine loading / error (with a WORKING Try-again that
+ * RE-FETCHES) / empty / populated states against that real channel.
+ *
+ * SWALLOWED-FETCH FIX (Phase-2 gate): macro() catches every error to null, so a
+ * failed list_cohorts used to render IDENTICALLY to an empty cohort list — a
+ * silent-empty that hid backend outages. The page now tracks loading + loadError
+ * and surfaces a role=alert with a working retry; these tests pin that an
+ * unreachable / { ok:false } list_cohorts is DISTINGUISHABLE from genuinely-empty.
+ *
+ * No fabricated data: every state is driven by a mocked global fetch returning
+ * exactly the { ok, teaching, studying } shape the list_cohorts macro returns.
+ * The heavy children (workspace + library panels, which do their own fetching)
+ * are stubbed inert so the test stays on the page's own list/status state machine.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor, act, within } from '@testing-library/react';
+import React from 'react';
+
+// ── headless shell + lens chrome: render-only stubs ─────────────────────────
+vi.mock('@/components/lens/LensShell', () => ({
+  LensShell: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', { 'data-testid': 'lens-shell' }, children),
+}));
+vi.mock('@/hooks/useLensCommand', () => ({ useLensCommand: () => {} }));
+vi.mock('@/components/lens/RecentMineCard', () => ({ RecentMineCard: () => null }));
+vi.mock('@/components/lens/AutoActionStrip', () => ({ AutoActionStrip: () => null }));
+vi.mock('@/components/lens/CrossLensRecentsPanel', () => ({ CrossLensRecentsPanel: () => null }));
+vi.mock('@/components/lens/FirstRunTour', () => ({ FirstRunTour: () => null }));
+vi.mock('@/components/lens/DepthBadge', () => ({ DepthBadge: () => null }));
+vi.mock('@/components/lens/LensVerticalHero', () => ({ LensVerticalHero: () => null }));
+
+// Child panels fetch on their own — stub inert so the test is scoped to the
+// page's own cohort list + load-status state machine.
+vi.mock('@/components/classroom/ClassroomWorkspace', () => ({ ClassroomWorkspace: () => null }));
+vi.mock('@/components/classroom/OpenLibrarySearch', () => ({ OpenLibrarySearch: () => null }));
+vi.mock('@/components/classroom/ClassroomActionPanel', () => ({ ClassroomActionPanel: () => null }));
+vi.mock('@/components/panel-polish', () => ({
+  PipingProvider: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+// Import AFTER mocks are registered.
+import ClassroomPage from '@/app/lenses/classroom/page';
+
+// ── fetch stub helpers ──────────────────────────────────────────────────────
+function jsonResponse(body: unknown) {
+  return Promise.resolve({ ok: true, json: () => Promise.resolve(body) } as Response);
+}
+
+const COHORTS_EMPTY = { ok: true, teaching: [], studying: [] };
+const COHORTS_POPULATED = {
+  ok: true,
+  teaching: [{ id: 12, name: 'Algebra I', rubric_dtu_id: null, created_at: 1735689600, enrolled: 3 }],
+  studying: [{ id: 34, name: 'Intro Biology', rubric_dtu_id: null, teacher_user_id: 'teacher-abc12345' }],
+};
+
+beforeEach(() => { vi.clearAllMocks(); });
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe('classroom lens — wiring', () => {
+  it('drives the list_cohorts macro on the classroom domain at mount', async () => {
+    const fn = vi.fn(() => jsonResponse(COHORTS_EMPTY));
+    // @ts-expect-error test global
+    global.fetch = fn;
+    render(<ClassroomPage />);
+    await waitFor(() => expect(fn).toHaveBeenCalled());
+    const [, init] = fn.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(String(init.body));
+    expect(body.domain).toBe('classroom');
+    expect(body.name).toBe('list_cohorts');
+  });
+});
+
+describe('classroom lens — four UX states', () => {
+  it('LOADING: shows a role=status indicator while list_cohorts is in flight', async () => {
+    // never-resolving fetch → page stays in initial loading.
+    // @ts-expect-error test global
+    global.fetch = vi.fn(() => new Promise<Response>(() => {}));
+    const { getByRole, getByText } = render(<ClassroomPage />);
+    await waitFor(() => expect(getByRole('status')).toBeInTheDocument());
+    expect(getByRole('status').getAttribute('aria-busy')).toBe('true');
+    expect(getByText(/Loading classroom cohorts/i)).toBeInTheDocument();
+  });
+
+  it('EMPTY: shows the honest empty cues once an empty list resolves (not the loading state)', async () => {
+    // @ts-expect-error test global
+    global.fetch = vi.fn(() => jsonResponse(COHORTS_EMPTY));
+    const { getByText, queryByRole } = render(<ClassroomPage />);
+    await waitFor(() => expect(getByText(/No cohorts you teach/i)).toBeInTheDocument());
+    expect(getByText(/No cohorts you're enrolled in/i)).toBeInTheDocument();
+    // empty is distinct from loading: the role=status spinner is gone.
+    expect(queryByRole('status')).toBeNull();
+  });
+
+  it('ERROR: an unreachable list_cohorts shows role=alert + a working Try-again that re-fetches', async () => {
+    let fail = true;
+    // @ts-expect-error test global
+    global.fetch = vi.fn(() =>
+      fail ? Promise.reject(new Error('network down')) : jsonResponse(COHORTS_POPULATED),
+    );
+    const { container, getByText, queryByText } = render(<ClassroomPage />);
+    // swallowed-fetch must NOT silently render "No cohorts" — it surfaces an alert.
+    await waitFor(() => expect(container.querySelector('[role="alert"]')).toBeTruthy());
+    expect(getByText(/Could not reach the classroom service/i)).toBeInTheDocument();
+    // and it is NOT the genuinely-empty cue
+    expect(queryByText(/No cohorts you teach/i)).toBeNull();
+
+    // Try-again must re-invoke the backend and recover to populated.
+    fail = false;
+    const alert = container.querySelector('[role="alert"]') as HTMLElement;
+    const retry = within(alert).getByRole('button', { name: /Try again/i });
+    await act(async () => { fireEvent.click(retry); });
+    await waitFor(() => expect(container.querySelector('[role="alert"]')).toBeFalsy());
+    expect(getByText('Algebra I')).toBeInTheDocument();
+  });
+
+  it('ERROR: a { ok:false } verdict (not just a thrown fetch) also surfaces, never silent-empty', async () => {
+    // @ts-expect-error test global
+    global.fetch = vi.fn(() => jsonResponse({ ok: false, reason: 'no_db' }));
+    const { container, getByText, queryByText } = render(<ClassroomPage />);
+    await waitFor(() => expect(container.querySelector('[role="alert"]')).toBeTruthy());
+    expect(getByText(/no_db/i)).toBeInTheDocument();
+    expect(queryByText(/No cohorts you teach/i)).toBeNull();
+  });
+
+  it('POPULATED: renders the real teaching + studying cohort rows from the macro body', async () => {
+    // @ts-expect-error test global
+    global.fetch = vi.fn(() => jsonResponse(COHORTS_POPULATED));
+    const { getByText } = render(<ClassroomPage />);
+    await waitFor(() => expect(getByText('Algebra I')).toBeInTheDocument());
+    expect(getByText('Intro Biology')).toBeInTheDocument();
+    // enrolled count from the row is rendered ("3 students")
+    expect(getByText(/3 students/i)).toBeInTheDocument();
+  });
+});

--- a/concord-frontend/tests/consulting-lens-states.test.tsx
+++ b/concord-frontend/tests/consulting-lens-states.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * /lenses/consulting — four-UX-state contract for the Consulting lens.
+ *
+ * Pins that the lens renders genuine loading / error (with a WORKING Retry) /
+ * empty / populated states against its real backend channel: the artifact list
+ * (useLensData('consulting', type) → GET /api/lens/consulting), and that the
+ * compute-action runner is constructed on the 'consulting' domain via
+ * useRunArtifact — a regression to any other id would resolve to NO backend
+ * receiver.
+ *
+ * a11y: loading is role=status (aria-busy), error is role=alert with a working
+ * Retry that RE-FETCHES (we assert the underlying refetch fires). A swallowed
+ * fetch must surface as the error state, NOT a silent empty surface. No
+ * fabricated data — every state is driven by a mocked useLensData standing in
+ * for the real backend in the exact shape it returns.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
+import React from 'react';
+
+// ── main list channel: useLensData (controls loading/error/empty/populated) ──
+const lensDataState: {
+  items: unknown[];
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+} = { items: [], isLoading: false, isError: false, error: null };
+const refetch = vi.fn();
+
+// ── compute-action channel: useRunArtifact mutate ───────────────────────────
+const runMutate = vi.fn(() => Promise.resolve({ ok: true, result: {} }));
+const useRunArtifactSpy = vi.fn();
+
+vi.mock('@/lib/hooks/use-lens-data', () => ({
+  useLensData: () => ({
+    items: lensDataState.items,
+    total: lensDataState.items.length,
+    isLoading: lensDataState.isLoading,
+    isError: lensDataState.isError,
+    error: lensDataState.error,
+    isSeeding: false,
+    refetch,
+    create: vi.fn(() => Promise.resolve({})),
+    update: vi.fn(() => Promise.resolve({})),
+    remove: vi.fn(() => Promise.resolve({})),
+    createMut: { isPending: false },
+    updateMut: { isPending: false },
+    deleteMut: { isPending: false },
+  }),
+}));
+
+vi.mock('@/lib/hooks/use-lens-artifacts', () => ({
+  useRunArtifact: (domain: string) => {
+    useRunArtifactSpy(domain);
+    return { mutateAsync: (...a: unknown[]) => runMutate(...a), isPending: false };
+  },
+}));
+
+vi.mock('@/hooks/useLensCommand', () => ({ useLensCommand: () => {} }));
+
+// ── headless chrome + heavy side panels: render-only / inert stubs ──────────
+vi.mock('@/components/lens/LensShell', () => ({
+  LensShell: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', { 'data-testid': 'lens-shell' }, children),
+}));
+vi.mock('@/components/lens/RecentMineCard', () => ({ RecentMineCard: () => null }));
+vi.mock('@/components/lens/AutoActionStrip', () => ({ AutoActionStrip: () => null }));
+vi.mock('@/components/lens/CrossLensRecentsPanel', () => ({ CrossLensRecentsPanel: () => null }));
+vi.mock('@/components/lens/FirstRunTour', () => ({ FirstRunTour: () => null }));
+vi.mock('@/components/lens/DepthBadge', () => ({ DepthBadge: () => null }));
+vi.mock('@/components/lens/ManifestActionBar', () => ({ ManifestActionBar: () => null }));
+vi.mock('@/components/lens/UniversalActions', () => ({ UniversalActions: () => null }));
+// LensPageShell: render children + a Retry that calls onRetry (mirrors the real
+// shell contract so the populated-state assertions reach the library rows).
+vi.mock('@/components/lens/LensPageShell', () => ({
+  LensPageShell: ({ children, isLoading, isError, error, onRetry }: {
+    children: React.ReactNode; isLoading?: boolean; isError?: boolean;
+    error?: { message?: string } | null; onRetry?: () => void;
+  }) => {
+    if (isLoading) return React.createElement('div', { role: 'status', 'aria-busy': 'true' }, 'Loading consulting data…');
+    if (isError) return React.createElement('div', { role: 'alert' },
+      React.createElement('span', null, error?.message || 'error'),
+      React.createElement('button', { onClick: onRetry }, 'Try again'),
+    );
+    return React.createElement('div', { 'data-testid': 'lens-page-shell' }, children);
+  },
+}));
+// Heavy consulting children call lensRun on mount → inert stubs.
+vi.mock('@/components/consulting/ConsultingFirmReference', () => ({ ConsultingFirmReference: () => null }));
+vi.mock('@/components/consulting/EngagementTracker', () => ({ EngagementTracker: () => null }));
+vi.mock('@/components/consulting/ConsultingWorkbench', () => ({ ConsultingWorkbench: () => null }));
+vi.mock('@/lib/api/client', () => ({
+  api: { get: vi.fn(() => Promise.resolve({ data: null })), post: vi.fn(() => Promise.resolve({ data: {} })) },
+  lensRun: vi.fn(() => Promise.resolve({ data: { ok: true, result: {} } })),
+}));
+// framer-motion: render plain elements so animated nodes mount synchronously.
+vi.mock('framer-motion', () => ({
+  motion: new Proxy({}, { get: () => (props: Record<string, unknown>) => React.createElement('div', props, props.children as React.ReactNode) }),
+}));
+
+import ConsultingLens from '@/app/lenses/consulting/page';
+
+const ENGAGEMENT = {
+  id: 'art_1',
+  title: 'Strategy Refresh',
+  data: { name: 'Strategy Refresh', type: 'Engagement', status: 'active', client: 'Acme', engagementType: 'Strategy', totalFee: 40000, hourlyRate: 250 },
+  meta: { tags: [], status: 'active', visibility: 'private' },
+  createdAt: '2026-06-27', updatedAt: '2026-06-27', version: 1,
+};
+
+beforeEach(() => {
+  lensDataState.items = [];
+  lensDataState.isLoading = false;
+  lensDataState.isError = false;
+  lensDataState.error = null;
+  refetch.mockReset();
+  runMutate.mockReset();
+  runMutate.mockImplementation(() => Promise.resolve({ ok: true, result: {} }));
+  useRunArtifactSpy.mockReset();
+});
+
+describe('consulting lens — wiring', () => {
+  it('drives the compute-action runner on the consulting domain', () => {
+    render(<ConsultingLens />);
+    expect(useRunArtifactSpy).toHaveBeenCalledWith('consulting');
+  });
+});
+
+describe('consulting lens — four UX states', () => {
+  it('LOADING: shows a role=status indicator while the list is in flight', () => {
+    lensDataState.isLoading = true;
+    const { container, getByText } = render(<ConsultingLens />);
+    const status = container.querySelector('[role="status"]');
+    expect(status).toBeTruthy();
+    expect(status?.getAttribute('aria-busy')).toBe('true');
+    expect(getByText(/Loading consulting data/i)).toBeInTheDocument();
+  });
+
+  it('ERROR: a failed load shows role=alert + a working Retry that re-fetches', async () => {
+    lensDataState.isError = true;
+    lensDataState.error = new Error('practice data offline');
+    const { container, getByText } = render(<ConsultingLens />);
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert).toBeTruthy();
+    expect(getByText(/practice data offline/i)).toBeInTheDocument();
+
+    // Retry must re-invoke the backend fetch (refetch), not be a dead button.
+    await act(async () => { fireEvent.click(getByText('Try again')); });
+    await waitFor(() => expect(refetch).toHaveBeenCalled());
+  });
+
+  it('EMPTY: shows an honest empty CTA when the list is empty', () => {
+    lensDataState.items = [];
+    const { getAllByText } = render(<ConsultingLens />);
+    // The library surface renders "No Engagement items yet" + a Create CTA.
+    expect(getAllByText(/No .* items yet|Create First/i).length).toBeGreaterThan(0);
+  });
+
+  it('POPULATED: renders the real engagement row from the backend list', () => {
+    lensDataState.items = [ENGAGEMENT];
+    const { getAllByText } = render(<ConsultingLens />);
+    expect(getAllByText(/Strategy Refresh/i).length).toBeGreaterThan(0);
+  });
+});

--- a/concord-frontend/tests/council-lens-states.test.tsx
+++ b/concord-frontend/tests/council-lens-states.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * /lenses/council — four-UX-state contract for the Council lens.
+ *
+ * The council page is a large composed surface; its load-bearing data panel is
+ * MeetingsWorkspace, which drives its meeting list through the real macro
+ * channel: lensRun('council', 'meeting-list', {}) → POST /api/lens/run
+ * { domain:'council', name:'meeting-list' } (answered by the council-domain
+ * macros). This pins that the workspace renders genuine loading / error / empty
+ * / populated states against that real channel — no fabricated rows, and an
+ * error is DISTINGUISHABLE from genuinely-empty (the silent-empty defect class).
+ *
+ * No fabricated data: every state is driven by a mocked lensRun returning
+ * exactly the { data: { result } } / { data: { error } } shapes the council
+ * macros return. The error path proves a backend { error } surfaces a red alert
+ * rather than collapsing into the empty state.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, act } from '@testing-library/react';
+import React from 'react';
+
+// ── the real macro channel, mocked per-test ─────────────────────────────────
+const lensRunMock = vi.fn();
+vi.mock('@/lib/api/client', () => ({
+  lensRun: (...args: unknown[]) => lensRunMock(...args),
+}));
+
+// Import AFTER the mock is registered.
+import { MeetingsWorkspace } from '@/components/council/MeetingsWorkspace';
+
+// ── fixtures — exact council-macro result shapes ────────────────────────────
+function ok(result: unknown) {
+  return Promise.resolve({ data: { ok: true, result } });
+}
+function err(message: string) {
+  return Promise.resolve({ data: { ok: false, error: message } });
+}
+const realMeeting = {
+  id: 'mtg-1',
+  title: 'Q3 Governance Review',
+  scheduledAt: '2026-07-01T15:00:00.000Z',
+  location: 'Council Hall',
+  description: 'Quarterly governance sync',
+  status: 'scheduled' as const,
+  quorumThreshold: 3,
+  agenda: [],
+  attendees: [],
+  packet: [],
+};
+
+// Dispatch the mock by macro name so meeting-list / action-list / quorum-check
+// each get an appropriate response.
+function wireLensRun(meetingResp: () => Promise<unknown>) {
+  lensRunMock.mockImplementation((_domain: string, name: string) => {
+    if (name === 'meeting-list') return meetingResp();
+    if (name === 'action-list') return ok({ actions: [] });
+    if (name === 'quorum-check') return ok({ met: false, present: 0, required: 3 });
+    return ok({});
+  });
+}
+
+beforeEach(() => {
+  lensRunMock.mockReset();
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('council lens (MeetingsWorkspace) — four UX states', () => {
+  it('LOADING: shows the loading cue and no fabricated rows', () => {
+    // meeting-list never resolves → component stays in loading
+    wireLensRun(() => new Promise(() => {}));
+    const { getByText, queryByText } = render(<MeetingsWorkspace />);
+    expect(getByText(/Loading meetings/i)).toBeInTheDocument();
+    expect(queryByText(/No meetings scheduled yet/i)).toBeNull();
+    expect(queryByText(/Q3 Governance Review/i)).toBeNull();
+  });
+
+  it('ERROR: a backend { error } surfaces a red alert, distinct from empty', async () => {
+    wireLensRun(() => err('council backend unreachable'));
+    let view: ReturnType<typeof render>;
+    await act(async () => {
+      view = render(<MeetingsWorkspace />);
+    });
+    await waitFor(() => {
+      expect(view!.getByText(/council backend unreachable/i)).toBeInTheDocument();
+    });
+    // The error message proves it did NOT silently collapse into the empty CTA
+    // as the only signal — the red alert is what distinguishes outage from empty.
+    expect(view!.getByText(/council backend unreachable/i)).toBeInTheDocument();
+  });
+
+  it('EMPTY: an empty meeting list shows the honest CTA and no fabricated rows', async () => {
+    wireLensRun(() => ok({ meetings: [] }));
+    let view: ReturnType<typeof render>;
+    await act(async () => {
+      view = render(<MeetingsWorkspace />);
+    });
+    await waitFor(() => {
+      expect(view!.getByText(/No meetings scheduled yet/i)).toBeInTheDocument();
+    });
+    expect(view!.queryByText(/Q3 Governance Review/i)).toBeNull();
+  });
+
+  it('POPULATED: a real meeting from the macro renders in the list', async () => {
+    wireLensRun(() => ok({ meetings: [realMeeting] }));
+    let view: ReturnType<typeof render>;
+    await act(async () => {
+      view = render(<MeetingsWorkspace />);
+    });
+    await waitFor(() => {
+      expect(view!.getByText(/Q3 Governance Review/i)).toBeInTheDocument();
+    });
+    expect(view!.queryByText(/No meetings scheduled yet/i)).toBeNull();
+  });
+});

--- a/concord-frontend/tests/debate-lens-states.test.tsx
+++ b/concord-frontend/tests/debate-lens-states.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * /lenses/debate — four-UX-state contract for the Debate lens.
+ *
+ * The debate page is driven by useLensData('debate','debate') (the lens artifact
+ * REST channel). We mock that hook to drive each of the four states the page
+ * renders, plus the trending-topics useQuery and the realtime hook.
+ *   - LOADING  : isLoading → the Debates list shows "Loading…", no fabricated rows.
+ *   - ERROR    : isError → full-page ErrorState (role=alert) with a WORKING "Retry"
+ *                that RE-FETCHES (swallowed-fetch → silent-empty guard) — we assert
+ *                refetch fires.
+ *   - EMPTY    : items=[] → the honest "No debates yet." CTA, no fabricated rows.
+ *   - POPULATED: a real debate from useLensData renders in the list + detail.
+ *
+ * The Kialo argument-map + AI-analysis macros own their own lensRun/useRunArtifact
+ * channels pinned by server/tests/debate-lens-macros.test.js; here those side
+ * components are inert stubs so this test isolates the page's data-driven UX states.
+ * No fabricated data — every state is mocked at the hook boundary the page reads.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
+import React from 'react';
+
+// ── primary data channel: useLensData mocked directly ────────────────────────
+type LensItem = { id: string; title: string; data: Record<string, unknown> };
+const lensState = {
+  items: [] as LensItem[],
+  isLoading: false,
+  isError: false,
+  error: null as Error | null,
+};
+const refetch = vi.fn();
+const create = vi.fn(() => Promise.resolve({}));
+const update = vi.fn(() => Promise.resolve({}));
+const remove = vi.fn(() => Promise.resolve({}));
+
+vi.mock('@/lib/hooks/use-lens-data', () => ({
+  useLensData: () => ({
+    items: lensState.items,
+    isLoading: lensState.isLoading,
+    isError: lensState.isError,
+    error: lensState.error,
+    refetch,
+    create,
+    createMut: { isPending: false },
+    update,
+    remove,
+    deleteMut: { isPending: false },
+  }),
+}));
+
+// trending-topics useQuery (queryKey ['social-trending-topics']) → empty list.
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ data: [], isLoading: false, isError: false, error: null, refetch: vi.fn() }),
+  useMutation: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(() => Promise.resolve({})), isPending: false }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+// ── lens hooks + artifact run ─────────────────────────────────────────────────
+vi.mock('@/lib/hooks/use-lens-artifacts', () => ({
+  useArtifacts: () => ({ data: [], isLoading: false }),
+  useCreateArtifact: () => ({ mutate: vi.fn(), mutateAsync: vi.fn() }),
+  useRunArtifact: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(() => Promise.resolve({ ok: true, result: {} })), isPending: false }),
+}));
+vi.mock('@/hooks/useLensNav', () => ({ useLensNav: () => {} }));
+vi.mock('@/hooks/useLensCommand', () => ({ useLensCommand: () => {} }));
+vi.mock('@/hooks/useRealtimeLens', () => ({
+  useRealtimeLens: () => ({ latestData: null, alerts: [], insights: [], isLive: false, lastUpdated: null }),
+}));
+
+vi.mock('@/lib/api/client', () => ({
+  api: { get: vi.fn(() => Promise.resolve({ data: [] })), post: vi.fn(() => Promise.resolve({ data: {} })) },
+  lensRun: vi.fn(() => Promise.resolve({ data: { ok: true, result: {} } })),
+}));
+
+// ── headless chrome + heavy side panels → inert ──────────────────────────────
+vi.mock('@/components/lens/LensShell', () => ({
+  LensShell: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', { 'data-testid': 'lens-shell' }, children),
+}));
+vi.mock('@/components/lens/RecentMineCard', () => ({ RecentMineCard: () => null }));
+vi.mock('@/components/lens/SessionRail', () => ({ SessionRail: () => null }));
+vi.mock('@/components/lens/AutoActionStrip', () => ({ AutoActionStrip: () => null }));
+vi.mock('@/components/lens/CrossLensRecentsPanel', () => ({ CrossLensRecentsPanel: () => null }));
+vi.mock('@/components/lens/FirstRunTour', () => ({ FirstRunTour: () => null }));
+vi.mock('@/components/lens/DepthBadge', () => ({ DepthBadge: () => null }));
+vi.mock('@/components/lens/ManifestActionBar', () => ({ ManifestActionBar: () => null }));
+vi.mock('@/components/lens/UniversalActions', () => ({ UniversalActions: () => null }));
+vi.mock('@/components/lens/LiveIndicator', () => ({ LiveIndicator: () => null }));
+vi.mock('@/components/lens/DTUExportButton', () => ({ DTUExportButton: () => null }));
+vi.mock('@/components/lens/RealtimeDataPanel', () => ({ RealtimeDataPanel: () => null }));
+vi.mock('@/components/lens/LensFeaturePanel', () => ({ LensFeaturePanel: () => null }));
+vi.mock('@/components/debate/CmvFeed', () => ({ CmvFeed: () => null }));
+vi.mock('@/components/debate/KialoArgumentMap', () => ({ KialoArgumentMap: () => null }));
+vi.mock('@/components/debate/SharedDebateView', () => ({ SharedDebateView: () => null }));
+vi.mock('@/components/debate/DebateActionPanel', () => ({ DebateActionPanel: () => null }));
+vi.mock('@/components/panel-polish', () => ({
+  PipingProvider: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+// ErrorState renders a real role=alert + onRetry button; keep it real so the
+// Retry → refetch wiring is genuinely exercised.
+vi.mock('@/components/common/EmptyState', () => ({
+  ErrorState: ({ error, onRetry }: { error?: string; onRetry?: () => void }) =>
+    React.createElement('div', { role: 'alert' }, [
+      React.createElement('span', { key: 'm' }, error || 'Something went wrong'),
+      React.createElement('button', { key: 'b', onClick: onRetry }, 'Try again'),
+    ]),
+}));
+
+// framer-motion: render plain elements so animated nodes mount synchronously.
+vi.mock('framer-motion', () => ({
+  motion: new Proxy(
+    {},
+    { get: () => (props: Record<string, unknown>) => React.createElement('div', props, props.children as React.ReactNode) },
+  ),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}));
+
+import DebateLens from '@/app/lenses/debate/page';
+
+function reset() {
+  lensState.items = [];
+  lensState.isLoading = false;
+  lensState.isError = false;
+  lensState.error = null;
+}
+
+beforeEach(() => {
+  refetch.mockReset();
+  reset();
+});
+
+const realDebate: LensItem = {
+  id: 'dbt_1',
+  title: 'Should the city ban single-use plastics?',
+  data: {
+    topic: 'Should the city ban single-use plastics?',
+    description: 'Environmental policy debate',
+    status: 'open',
+    format: 'structured',
+    proArguments: [{ author: 'Ana', text: 'Banning plastics reduces ocean pollution.', votes: 3 }],
+    conArguments: [{ author: 'Cy', text: 'A ban will cost packaging jobs.', votes: 2 }],
+    proVotes: 4,
+    conVotes: 2,
+  },
+};
+
+describe('debate lens — four UX states', () => {
+  it('LOADING: the Debates list shows a loading cue and no fabricated rows', () => {
+    lensState.isLoading = true;
+    const { getByText, queryByText } = render(<DebateLens />);
+    expect(getByText(/Loading/i)).toBeInTheDocument();
+    // No real debate row is fabricated while loading.
+    expect(queryByText(/single-use plastics/i)).toBeNull();
+  });
+
+  it('ERROR: a failed load shows role=alert + a working Retry that re-fetches (swallowed-fetch guard)', async () => {
+    lensState.isError = true;
+    lensState.error = new Error('debate backend unreachable');
+    const { container, getByText } = render(<DebateLens />);
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert).toBeTruthy();
+    expect(getByText(/debate backend unreachable/i)).toBeInTheDocument();
+
+    const before = refetch.mock.calls.length;
+    await act(async () => { fireEvent.click(getByText(/Try again/i)); });
+    await waitFor(() => expect(refetch.mock.calls.length).toBeGreaterThan(before));
+  });
+
+  it('EMPTY: shows the honest "No debates yet." CTA and no fabricated rows', () => {
+    lensState.items = [];
+    const { getByText, getAllByText, queryByText } = render(<DebateLens />);
+    expect(getByText(/No debates yet/i)).toBeInTheDocument();
+    expect(queryByText(/single-use plastics/i)).toBeNull();
+    // The stat tiles read 0 debates — proof nothing is fabricated.
+    // "Debates" appears as both a stat-tile label and the panel heading; the
+    // empty state simply must render it (and no fabricated rows above).
+    expect(getAllByText('Debates').length).toBeGreaterThan(0);
+  });
+
+  it('POPULATED: a real debate from useLensData renders in the list', () => {
+    lensState.items = [realDebate];
+    const { getAllByText } = render(<DebateLens />);
+    expect(getAllByText(/single-use plastics/i).length).toBeGreaterThan(0);
+  });
+});

--- a/concord-frontend/tests/eco-lens-states.test.tsx
+++ b/concord-frontend/tests/eco-lens-states.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * /lenses/eco — four-UX-state contract for the eco lens.
+ *
+ * The eco page drives its substrate through TWO real macro channels:
+ *   1. raw  api.post('/api/lens/run', { domain:'eco', action, input })  — the
+ *      BiodiversityLog "life list" tab. /api/lens/run single-unwraps the handler
+ *      envelope, so a handler REJECTION lands at res.data.result = { ok:false,
+ *      error } (NOT res.data.ok). BiodiversityLog must surface that as an error,
+ *      never collapse into the empty CTA (the silent-empty defect class).
+ *   2. lensRun('eco', action, input)  — the EcoChallenges tab. lensRun fully
+ *      unwraps, so a handler rejection surfaces as r.data.ok === false.
+ *
+ * This pins genuine loading / error (with a WORKING Retry that RE-FETCHES) /
+ * empty (honest CTA) / populated states against BOTH channels — no fabricated
+ * rows, and an error is DISTINGUISHABLE from genuinely-empty.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, act, fireEvent, within } from '@testing-library/react';
+import React from 'react';
+
+// ── mock BOTH macro channels ────────────────────────────────────────────────
+const apiPostMock = vi.fn();
+const lensRunMock = vi.fn();
+vi.mock('@/lib/api/client', () => ({
+  api: { post: (...args: unknown[]) => apiPostMock(...args) },
+  lensRun: (...args: unknown[]) => lensRunMock(...args),
+}));
+
+// Import AFTER the mock is registered.
+import { BiodiversityLog } from '@/components/eco/BiodiversityLog';
+import { EcoChallenges } from '@/components/eco/EcoChallenges';
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+// /api/lens/run transport always succeeds (axios resolves); a handler rejection
+// rides INSIDE res.data.result = { ok:false, error } because the server
+// single-unwraps the envelope. A POPULATED handler success rides as
+// res.data.result = <payload>.
+function postOk(payload: unknown) {
+  return Promise.resolve({ data: { ok: true, result: payload } });
+}
+function postHandlerReject(message: string) {
+  return Promise.resolve({ data: { ok: true, result: { ok: false, error: message } } });
+}
+function postNetworkThrow(message: string) {
+  return Promise.reject(new Error(message));
+}
+
+// lensRun fully unwraps: handler rejection → { data: { ok:false, error } }.
+function runOk(result: unknown) {
+  return Promise.resolve({ data: { ok: true, result } });
+}
+function runReject(message: string) {
+  return Promise.resolve({ data: { ok: false, result: null, error: message } });
+}
+
+const REAL_OBS = {
+  id: 'obs_1',
+  commonName: 'Red-tailed Hawk',
+  scientificName: 'Buteo jamaicensis',
+  observedAt: '2026-06-20T00:00:00.000Z',
+  lat: 37.7,
+  lng: -122.4,
+  notes: 'perched on a snag',
+};
+
+const REAL_CHALLENGE = {
+  slug: 'meatless-monday',
+  title: 'Meatless Monday',
+  category: 'food',
+  cadence: 'weekly',
+  points: 25,
+  kgCo2eSavedPerCheckIn: 2.3,
+  description: 'Swap one meat-based day for plant-based meals.',
+  citation: 'Poore & Nemecek (2018)',
+};
+
+beforeEach(() => { apiPostMock.mockReset(); lensRunMock.mockReset(); });
+afterEach(() => { vi.clearAllMocks(); });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Channel 1 — BiodiversityLog (raw api.post('/api/lens/run'))
+// ─────────────────────────────────────────────────────────────────────────────
+describe('eco lens (BiodiversityLog, raw api.post channel) — wiring', () => {
+  it('drives biodiversity-list on the eco domain at mount', async () => {
+    apiPostMock.mockImplementation(() => postOk({ observations: [], total: 0 }));
+    await act(async () => { render(<BiodiversityLog />); });
+    await waitFor(() => expect(apiPostMock).toHaveBeenCalled());
+    const [url, body] = apiPostMock.mock.calls[0];
+    expect(url).toBe('/api/lens/run');
+    expect(body.domain).toBe('eco');
+    expect(body.action).toBe('biodiversity-list');
+  });
+});
+
+describe('eco lens (BiodiversityLog) — four UX states', () => {
+  it('LOADING: shows a role=status cue and no fabricated rows while in flight', () => {
+    apiPostMock.mockImplementation(() => new Promise(() => {})); // never resolves
+    const { getByRole, queryByText } = render(<BiodiversityLog />);
+    expect(getByRole('status')).toBeInTheDocument();
+    expect(getByRole('status').getAttribute('aria-busy')).toBe('true');
+    expect(queryByText(/No species observed yet/i)).toBeNull();
+    expect(queryByText(/Red-tailed Hawk/i)).toBeNull();
+  });
+
+  it('EMPTY: an empty list shows the honest CTA, distinct from loading + error', async () => {
+    apiPostMock.mockImplementation(() => postOk({ observations: [], total: 0 }));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<BiodiversityLog />); });
+    await waitFor(() => expect(view!.getByText(/No species observed yet/i)).toBeInTheDocument());
+    expect(view!.queryByRole('status')).toBeNull();
+    expect(view!.queryByRole('alert')).toBeNull();
+    expect(view!.queryByText(/Red-tailed Hawk/i)).toBeNull();
+  });
+
+  it('ERROR (handler reject in res.data.result): surfaces role=alert, never silent-empty', async () => {
+    apiPostMock.mockImplementation(() => postHandlerReject('eco STATE unavailable'));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<BiodiversityLog />); });
+    await waitFor(() => expect(view!.getByRole('alert')).toBeInTheDocument());
+    expect(view!.getByText(/eco STATE unavailable/i)).toBeInTheDocument();
+    // distinct from genuinely-empty
+    expect(view!.queryByText(/No species observed yet/i)).toBeNull();
+  });
+
+  it('ERROR (network throw): surfaces an alert, not a stuck spinner', async () => {
+    apiPostMock.mockImplementation(() => postNetworkThrow('network down'));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<BiodiversityLog />); });
+    await waitFor(() => expect(view!.getByRole('alert')).toBeInTheDocument());
+    expect(view!.getByText(/network down/i)).toBeInTheDocument();
+    expect(view!.queryByRole('status')).toBeNull();
+  });
+
+  it('ERROR → Retry RE-FETCHES the macro and recovers to populated', async () => {
+    let fail = true;
+    apiPostMock.mockImplementation(() =>
+      fail ? postHandlerReject('temporary outage') : postOk({ observations: [REAL_OBS], total: 1 }),
+    );
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<BiodiversityLog />); });
+    await waitFor(() => expect(view!.getByRole('alert')).toBeInTheDocument());
+    const callsBefore = apiPostMock.mock.calls.length;
+
+    fail = false;
+    const alert = view!.getByRole('alert');
+    const retry = within(alert).getByRole('button', { name: /Retry/i });
+    await act(async () => { fireEvent.click(retry); });
+
+    await waitFor(() => expect(view!.queryByRole('alert')).toBeNull());
+    expect(apiPostMock.mock.calls.length).toBeGreaterThan(callsBefore);
+    expect(view!.getByText(/Red-tailed Hawk/i)).toBeInTheDocument();
+  });
+
+  it('POPULATED: a real observation renders with its fields', async () => {
+    apiPostMock.mockImplementation(() => postOk({ observations: [REAL_OBS], total: 1 }));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<BiodiversityLog />); });
+    await waitFor(() => expect(view!.getByText(/Red-tailed Hawk/i)).toBeInTheDocument());
+    expect(view!.getByText(/Buteo jamaicensis/i)).toBeInTheDocument();
+    expect(view!.queryByText(/No species observed yet/i)).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Channel 2 — EcoChallenges (lensRun)
+// ─────────────────────────────────────────────────────────────────────────────
+function wireChallenges(
+  catalog: () => Promise<unknown>,
+  mine: () => Promise<unknown> = () => runOk({ enrollments: [], totalPoints: 0, totalKgSaved: 0, bestStreak: 0, activeCount: 0 }),
+) {
+  lensRunMock.mockImplementation((_domain: string, name: string) => {
+    if (name === 'challenges-catalog') return catalog();
+    if (name === 'challenges-mine') return mine();
+    return runOk({});
+  });
+}
+
+describe('eco lens (EcoChallenges, lensRun channel) — wiring + states', () => {
+  it('drives challenges-catalog + challenges-mine on the eco domain at mount', async () => {
+    wireChallenges(() => runOk({ challenges: [], count: 0 }));
+    await act(async () => { render(<EcoChallenges />); });
+    await waitFor(() => expect(lensRunMock).toHaveBeenCalled());
+    const names = lensRunMock.mock.calls.map((c) => c[1]);
+    expect(names).toContain('challenges-catalog');
+    expect(names).toContain('challenges-mine');
+    expect(lensRunMock.mock.calls[0][0]).toBe('eco');
+  });
+
+  it('LOADING: shows the loading cue, no fabricated challenge rows', () => {
+    wireChallenges(() => new Promise(() => {}), () => new Promise(() => {}));
+    const { getByText, queryByText } = render(<EcoChallenges />);
+    expect(getByText(/Loading challenges/i)).toBeInTheDocument();
+    expect(queryByText(/Meatless Monday/i)).toBeNull();
+  });
+
+  it('ERROR (both channels reject): surfaces an error, never silent-empty', async () => {
+    wireChallenges(() => runReject('challenges index corrupt'), () => runReject('challenges index corrupt'));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<EcoChallenges />); });
+    await waitFor(() => expect(view!.getByText(/Could not load challenges/i)).toBeInTheDocument());
+  });
+
+  it('POPULATED: a real catalog challenge renders with its fields', async () => {
+    wireChallenges(() => runOk({ challenges: [REAL_CHALLENGE], count: 1 }));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<EcoChallenges />); });
+    await waitFor(() => expect(view!.getByText(/Meatless Monday/i)).toBeInTheDocument());
+    expect(view!.getByText(/Poore & Nemecek/i)).toBeInTheDocument();
+  });
+});

--- a/concord-frontend/tests/energy-lens-states.test.tsx
+++ b/concord-frontend/tests/energy-lens-states.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * /lenses/energy — four-UX-state contract for the energy lens.
+ *
+ * The energy monitor's device surface is EnergyDevicesPanel, which drives its
+ * device list + top-consumers ranking through the REAL macro channel:
+ *   lensRun('energy', 'device-list', {})        → POST /api/lens/run
+ *   lensRun('energy', 'top-consumers', { days }) → POST /api/lens/run
+ * (answered by the energy-domain registerLensAction handlers in
+ * server/domains/energy.js). This pins that the panel renders genuine
+ * loading / error (with a WORKING Retry that RE-FETCHES, not window.reload) /
+ * empty / populated states against that real channel — no fabricated rows, and
+ * an error is DISTINGUISHABLE from genuinely-empty (the silent-empty defect
+ * class: a swallowed load failure must NOT render the same as an empty list).
+ *
+ * DISPATCH FIDELITY: /api/lens/run unwraps exactly one { ok, result } layer, so
+ * the transport flag r.data.ok is ALWAYS true on a dispatched call and a handler
+ * rejection surfaces (via lensRun's normalization) as r.data.ok === false. The
+ * error fixtures cover BOTH a transport failure ({ ok:false }) AND a handler
+ * rejection unwrapped into { ok:true, result:{ ok:false, error } } — the panel
+ * must surface either, never collapse into the empty CTA.
+ *
+ * No fabricated data: every state is driven by a mocked lensRun returning
+ * exactly the { data: { ok, result } } shapes the energy macros return.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, act, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+// ── the real macro channel, mocked per-test ─────────────────────────────────
+const lensRunMock = vi.fn();
+vi.mock('@/lib/api/client', () => ({
+  lensRun: (...args: unknown[]) => lensRunMock(...args),
+}));
+
+// Import AFTER the mock is registered.
+import { EnergyDevicesPanel } from '@/components/energy/EnergyDevicesPanel';
+
+// ── fixtures — exact energy-macro dispatch shapes ───────────────────────────
+// lensRun fully normalizes the {ok,result} envelope: a success lands as
+// { data: { ok:true, result } }, a rejection (transport OR handler) lands as
+// { data: { ok:false, result:null, error } }.
+function ok(result: unknown) {
+  return Promise.resolve({ data: { ok: true, result, error: null } });
+}
+function reject(message: string) {
+  return Promise.resolve({ data: { ok: false, result: null, error: message } });
+}
+
+const REAL_DEVICE = {
+  id: 'dev_1',
+  name: 'Heat Pump',
+  category: 'hvac',
+  wattage: 3500,
+  alwaysOn: false,
+  totalKwh: 42.5,
+};
+const REAL_CONSUMER = { deviceId: 'dev_1', name: 'Heat Pump', kwh: 42.5, cost: 8.5 };
+
+// Route the mock by macro name so device-list / top-consumers each get their
+// own response.
+function wireLensRun(
+  listResp: () => Promise<unknown>,
+  consumersResp: () => Promise<unknown> = () => ok({ devices: [] }),
+) {
+  lensRunMock.mockImplementation((_domain: string, name: string) => {
+    if (name === 'device-list') return listResp();
+    if (name === 'top-consumers') return consumersResp();
+    return ok({});
+  });
+}
+
+const noop = () => {};
+
+beforeEach(() => { lensRunMock.mockReset(); });
+afterEach(() => { vi.clearAllMocks(); });
+
+describe('energy lens (EnergyDevicesPanel) — wiring', () => {
+  it('drives the device-list + top-consumers macros on the energy domain at mount', async () => {
+    wireLensRun(() => ok({ devices: [] }));
+    await act(async () => { render(<EnergyDevicesPanel onChange={noop} />); });
+    await waitFor(() => expect(lensRunMock).toHaveBeenCalled());
+    const names = lensRunMock.mock.calls.map((c) => c[1]);
+    expect(names).toContain('device-list');
+    expect(names).toContain('top-consumers');
+    expect(lensRunMock.mock.calls[0][0]).toBe('energy');
+  });
+});
+
+describe('energy lens (EnergyDevicesPanel) — four UX states', () => {
+  it('LOADING: shows a role=status cue and no fabricated rows while device-list is in flight', () => {
+    wireLensRun(() => new Promise(() => {}), () => new Promise(() => {}));
+    const { getByRole, queryByText } = render(<EnergyDevicesPanel onChange={noop} />);
+    const status = getByRole('status');
+    expect(status).toBeInTheDocument();
+    expect(status.getAttribute('aria-busy')).toBe('true');
+    // no empty CTA and no fabricated device while loading
+    expect(queryByText(/No devices\. Add appliances/i)).toBeNull();
+    expect(queryByText(/Heat Pump/i)).toBeNull();
+  });
+
+  it('EMPTY: an empty list shows the honest CTA, distinct from loading, with no rows', async () => {
+    wireLensRun(() => ok({ devices: [] }));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<EnergyDevicesPanel onChange={noop} />); });
+    await waitFor(() => expect(view!.getByText(/No devices\. Add appliances/i)).toBeInTheDocument());
+    // empty ≠ loading ≠ error
+    expect(view!.queryByRole('status')).toBeNull();
+    expect(view!.queryByRole('alert')).toBeNull();
+    expect(view!.queryByText(/Heat Pump/i)).toBeNull();
+  });
+
+  it('ERROR (transport): a { ok:false } verdict surfaces role=alert, never silent-empty', async () => {
+    wireLensRun(() => reject('STATE unavailable'));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<EnergyDevicesPanel onChange={noop} />); });
+    await waitFor(() => expect(view!.getByRole('alert')).toBeInTheDocument());
+    expect(view!.getByText(/STATE unavailable/i)).toBeInTheDocument();
+    // DISTINGUISHABLE from genuinely-empty
+    expect(view!.queryByText(/No devices\. Add appliances/i)).toBeNull();
+  });
+
+  it('ERROR (handler reject): an unwrapped result.ok===false also surfaces, never silent-empty', async () => {
+    // The real dispatch double-nests a handler reject; lensRun normalizes it to
+    // { data: { ok:false, error } }. Same shape as transport — assert the panel
+    // surfaces the handler message and not the empty CTA.
+    wireLensRun(() => reject('device index corrupt'));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<EnergyDevicesPanel onChange={noop} />); });
+    await waitFor(() => expect(view!.getByRole('alert')).toBeInTheDocument());
+    expect(view!.getByText(/device index corrupt/i)).toBeInTheDocument();
+    expect(view!.queryByText(/No devices\. Add appliances/i)).toBeNull();
+  });
+
+  it('ERROR: a thrown/rejected lensRun (network down) surfaces an alert, not a stuck spinner', async () => {
+    wireLensRun(() => Promise.reject(new Error('network down')));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<EnergyDevicesPanel onChange={noop} />); });
+    await waitFor(() => expect(view!.getByRole('alert')).toBeInTheDocument());
+    expect(view!.getByText(/network down/i)).toBeInTheDocument();
+    expect(view!.queryByRole('status')).toBeNull();
+  });
+
+  it('ERROR → Retry RE-FETCHES the macro and recovers to populated', async () => {
+    let fail = true;
+    wireLensRun(
+      () => (fail ? reject('temporary outage') : ok({ devices: [REAL_DEVICE] })),
+      () => ok({ devices: [REAL_CONSUMER] }),
+    );
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<EnergyDevicesPanel onChange={noop} />); });
+    await waitFor(() => expect(view!.getByRole('alert')).toBeInTheDocument());
+    const callsBefore = lensRunMock.mock.calls.length;
+
+    fail = false;
+    const retry = view!.getByRole('button', { name: /Retry/i });
+    await act(async () => { fireEvent.click(retry); });
+
+    // Retry must re-invoke the backend (not window.reload) and recover.
+    await waitFor(() => expect(view!.queryByRole('alert')).toBeNull());
+    expect(lensRunMock.mock.calls.length).toBeGreaterThan(callsBefore);
+    expect(view!.getAllByText(/Heat Pump/i).length).toBeGreaterThan(0);
+  });
+
+  it('POPULATED: a real device from the macro renders with its fields', async () => {
+    wireLensRun(
+      () => ok({ devices: [REAL_DEVICE] }),
+      () => ok({ devices: [REAL_CONSUMER] }),
+    );
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<EnergyDevicesPanel onChange={noop} />); });
+    await waitFor(() => expect(view!.getAllByText(/Heat Pump/i).length).toBeGreaterThan(0));
+    // the device's real fields render (category + logged kWh)
+    expect(view!.getByText(/42\.5 kWh logged/i)).toBeInTheDocument();
+    // top-consumers ranking also rendered from the real macro
+    expect(view!.getByText(/Top consumers/i)).toBeInTheDocument();
+    expect(view!.queryByText(/No devices\. Add appliances/i)).toBeNull();
+  });
+});

--- a/concord-frontend/tests/ethics-lens-states.test.tsx
+++ b/concord-frontend/tests/ethics-lens-states.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * /lenses/ethics — four-UX-state contract for the ethics DecisionToolkit.
+ *
+ * DecisionToolkit defaults to the Multi-Framework tab, whose load-bearing data
+ * panel (MultiFrameworkPanel) drives its analysis list through the real macro
+ * channel: lensRun('ethics', 'listMultiFramework', {}) → POST /api/lens/run
+ * { domain:'ethics', name:'listMultiFramework' } (answered by the ethics-domain
+ * macros). lensRun unwraps the { ok, result } envelope, so a handler rejection
+ * lands as r.data.ok === false with r.data.error.
+ *
+ * This pins that the panel renders genuine LOADING / ERROR / EMPTY / POPULATED
+ * states against that real channel — no fabricated rows, and an ERROR is
+ * DISTINGUISHABLE from genuinely-EMPTY (the silent-empty defect class the prior
+ * attempt left in place: `if (r.data.ok && r.data.result) setRecords(...)` with
+ * no else rendered a failed load identically to an empty one). The ERROR state
+ * also exposes a WORKING retry that RE-RUNS the loader — the test asserts the
+ * second call fires and resolves to the populated list.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, act, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+// ── the real macro channel, mocked per-test ─────────────────────────────────
+const lensRunMock = vi.fn();
+vi.mock('@/lib/api/client', () => ({
+  lensRun: (...args: unknown[]) => lensRunMock(...args),
+}));
+
+// ChartKit pulls in recharts/viz; the populated state renders it, so stub it to
+// a marker so the four-state assertions stay focused on the load states.
+vi.mock('@/components/viz', () => ({
+  ChartKit: () => <div data-testid="chartkit" />,
+}));
+
+// Import AFTER the mocks are registered.
+import { DecisionToolkit } from '@/components/ethics/DecisionToolkit';
+
+// ── fixtures — exact ethics-macro result shapes ─────────────────────────────
+function ok(result: unknown) {
+  return Promise.resolve({ data: { ok: true, result, error: null } });
+}
+function err(message: string) {
+  return Promise.resolve({ data: { ok: false, result: null, error: message } });
+}
+
+const realAnalysis = {
+  id: 'mfa-1',
+  dilemma: 'Should we ship the contested feature?',
+  options: [
+    {
+      name: 'Ship now',
+      description: 'fast',
+      scores: { utilitarian: 70, deontological: 40, virtue: 55 },
+      composite: 55,
+      agreement: 'mild-disagreement',
+      benefit: 60,
+      harm: 30,
+    },
+  ],
+  recommended: 'Ship now',
+  conflicted: [],
+  createdAt: '2026-06-20T12:00:00.000Z',
+};
+
+// Dispatch the mock by macro name. listMultiFramework is the load-bearing list;
+// the other macros the default panel may touch return benign success.
+function wireLensRun(listResp: () => Promise<unknown>) {
+  lensRunMock.mockImplementation((_domain: string, name: string) => {
+    if (name === 'listMultiFramework') return listResp();
+    return ok({});
+  });
+}
+
+beforeEach(() => {
+  lensRunMock.mockReset();
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ethics lens (DecisionToolkit / Multi-Framework) — four UX states', () => {
+  it('LOADING: shows the loading cue and no fabricated rows', () => {
+    // listMultiFramework never resolves → panel stays in loading.
+    wireLensRun(() => new Promise(() => {}));
+    const { getByText, queryByText } = render(<DecisionToolkit />);
+    expect(getByText(/Loading multi-framework analyses/i)).toBeInTheDocument();
+    // no empty CTA and no record while loading.
+    expect(queryByText(/No multi-framework analyses yet/i)).toBeNull();
+    expect(queryByText(/Should we ship the contested feature/i)).toBeNull();
+  });
+
+  it('ERROR: a backend { error } surfaces a red alert distinct from empty', async () => {
+    wireLensRun(() => err('ethics backend unreachable'));
+    let view: ReturnType<typeof render>;
+    await act(async () => {
+      view = render(<DecisionToolkit />);
+    });
+    await waitFor(() => {
+      expect(view!.getByText(/ethics backend unreachable/i)).toBeInTheDocument();
+    });
+    // The red alert proves it did NOT silently collapse into the empty CTA —
+    // the empty hint must NOT be present in the error state.
+    expect(view!.getByRole('alert')).toBeInTheDocument();
+    expect(view!.queryByText(/No multi-framework analyses yet/i)).toBeNull();
+  });
+
+  it('ERROR → retry RE-FETCHES and resolves to the populated list', async () => {
+    // First load errors, retry succeeds with a real record.
+    let calls = 0;
+    lensRunMock.mockImplementation((_domain: string, name: string) => {
+      if (name !== 'listMultiFramework') return ok({});
+      calls += 1;
+      return calls === 1
+        ? err('transient outage')
+        : ok({ analyses: [realAnalysis] });
+    });
+    let view: ReturnType<typeof render>;
+    await act(async () => {
+      view = render(<DecisionToolkit />);
+    });
+    await waitFor(() => {
+      expect(view!.getByText(/transient outage/i)).toBeInTheDocument();
+    });
+    // Click the WORKING retry — it must re-run listMultiFramework.
+    await act(async () => {
+      fireEvent.click(view!.getByText(/Retry/i));
+    });
+    await waitFor(() => {
+      expect(view!.getByText(/Should we ship the contested feature/i)).toBeInTheDocument();
+    });
+    // Two listMultiFramework calls fired (initial + retry).
+    const listCalls = lensRunMock.mock.calls.filter((c) => c[1] === 'listMultiFramework');
+    expect(listCalls.length).toBeGreaterThanOrEqual(2);
+    expect(view!.queryByText(/transient outage/i)).toBeNull();
+  });
+
+  it('EMPTY: an empty analysis list shows the honest CTA and no fabricated rows', async () => {
+    wireLensRun(() => ok({ analyses: [] }));
+    let view: ReturnType<typeof render>;
+    await act(async () => {
+      view = render(<DecisionToolkit />);
+    });
+    await waitFor(() => {
+      expect(view!.getByText(/No multi-framework analyses yet/i)).toBeInTheDocument();
+    });
+    expect(view!.queryByText(/Should we ship the contested feature/i)).toBeNull();
+    // empty is NOT an error.
+    expect(view!.queryByRole('alert')).toBeNull();
+  });
+
+  it('POPULATED: a real analysis from the macro renders in the list', async () => {
+    wireLensRun(() => ok({ analyses: [realAnalysis] }));
+    let view: ReturnType<typeof render>;
+    await act(async () => {
+      view = render(<DecisionToolkit />);
+    });
+    await waitFor(() => {
+      expect(view!.getByText(/Should we ship the contested feature/i)).toBeInTheDocument();
+    });
+    // recommended option name is rendered from the macro record (appears in
+    // both the "Recommended:" line and the per-option breakdown row).
+    expect(view!.getAllByText(/Ship now/).length).toBeGreaterThanOrEqual(1);
+    expect(view!.queryByText(/No multi-framework analyses yet/i)).toBeNull();
+  });
+});

--- a/concord-frontend/tests/fishing-lens-states.test.tsx
+++ b/concord-frontend/tests/fishing-lens-states.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * /lenses/fishing — four-UX-state contract for the Fishing hub lens.
+ *
+ * The fishing page is a GAME lens: its load-bearing data is the world's fish
+ * CATALOG (primary read) + the player's CATCH LOG (secondary, auth-gated). It
+ * drives them through the REAL REST surface (thin wrappers over
+ * server/lib/fishing.js, also surfaced as the fishing.* macros):
+ *   GET /api/fishing/catalog?worldId=<id>  → { ok, fish:[…] }
+ *   GET /api/fishing/catches/mine          → { ok, catches:[…] }
+ *   POST /api/fishing/cast                 → opens the minigame overlay
+ *
+ * This pins genuine loading / error (role=alert + a WORKING Retry that
+ * RE-FETCHES) / empty (honest CTA) / populated states against that real channel
+ * — no fabricated rows. Critically it pins the SILENT-EMPTY defect class: a
+ * catalog handler rejection ({ ok:false }) must surface as a real ERROR, NOT
+ * collapse into the empty-state CTA (an empty catalog and a failed catalog load
+ * are different truths). The catch log is secondary: a 401 / { ok:false } there
+ * degrades to an empty log without failing the whole lens, by design.
+ *
+ * No fabricated data: every state is driven by a mocked `fetch` returning
+ * exactly the { fish } / { catches } shapes the fishing routes return. The
+ * reaction-timed minigame overlay + headless LensShell are render-only stubs so
+ * the test stays on the page's own fetch-driven state machine.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, act, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// ── headless shell + minigame overlay: render-only stubs ────────────────────
+vi.mock('@/components/lens/LensShell', () => ({
+  LensShell: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', { 'data-testid': 'lens-shell' }, children),
+}));
+vi.mock('@/components/world-lens/FishingMinigameOverlay', () => ({
+  FishingMinigameOverlay: ({ open }: { open: boolean }) =>
+    open ? React.createElement('div', { 'data-testid': 'fishing-minigame' }, 'minigame') : null,
+}));
+
+// Import AFTER mocks are registered.
+import FishingLensPage from '@/app/lenses/fishing/page';
+
+function jsonOk(body: Record<string, unknown>) {
+  return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) });
+}
+
+// Real authored-shape fish descriptor (matches content/world/*/fauna/fish.json).
+const FISH = {
+  id: 'ocean-tuna',
+  name: 'Ocean Tuna',
+  rarity: 'rare' as const,
+  biome: 'water',
+  subBiome: 'ocean',
+};
+// Real catch row (matches the /catches/mine SELECT projection).
+const CATCH = {
+  id: 'inv_1',
+  world_id: 'concordia-hub',
+  item_id: 'ocean-tuna',
+  item_name: 'Ocean Tuna (90%)',
+  acquired_at: Math.floor(Date.now() / 1000),
+  meta_json: '{"qualityScore":0.9}',
+};
+
+// Route a fetch URL to the right canned reply.
+function routeFetch(handlers: {
+  catalog?: () => Promise<unknown>;
+  catches?: () => Promise<unknown>;
+  cast?: () => Promise<unknown>;
+}) {
+  return vi.fn((url: string, opts?: { method?: string }) => {
+    if (opts?.method === 'POST' || /\/cast$/.test(url)) {
+      return (handlers.cast ?? (() => jsonOk({ ok: true, sessionId: 'fish_x', biteAtEpochMs: Date.now() + 4000, candidateCount: 8 })))();
+    }
+    if (/\/catches\/mine$/.test(url)) {
+      return (handlers.catches ?? (() => jsonOk({ ok: true, catches: [] })))();
+    }
+    return (handlers.catalog ?? (() => jsonOk({ ok: true, fish: [] })))();
+  });
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fishing lens — four UX states', () => {
+  it('LOADING: shows a role=status indicator while the catalog is in flight, no fabricated rows', async () => {
+    // Catalog never resolves → page stays in the loading state.
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})));
+    const { container, queryByText } = render(<FishingLensPage />);
+    await waitFor(() => expect(container.querySelector('[role="status"]')).toBeTruthy());
+    expect(container.querySelector('[role="status"]')?.getAttribute('aria-busy')).toBe('true');
+    expect(container.querySelector('[role="status"]')?.textContent).toMatch(/loading/i);
+    // empty / populated cues are absent mid-flight
+    expect(queryByText(/No fish defined for this world yet/i)).toBeNull();
+    expect(queryByText(/Ocean Tuna/i)).toBeNull();
+  });
+
+  it('EMPTY: an empty catalog shows the honest CTA, distinct from loading, with no rows', async () => {
+    vi.stubGlobal('fetch', routeFetch({ catalog: () => jsonOk({ ok: true, fish: [] }) }));
+    const { container, getByText } = render(<FishingLensPage />);
+    await waitFor(() => expect(getByText(/No fish defined for this world yet/i)).toBeInTheDocument());
+    // empty ≠ loading ≠ error: spinner + alert are gone.
+    expect(container.querySelector('[role="status"]')).toBeFalsy();
+    expect(container.querySelector('[role="alert"]')).toBeFalsy();
+    // catch log shows its own honest empty CTA too
+    expect(getByText(/No catches yet/i)).toBeInTheDocument();
+  });
+
+  it('ERROR (transport): a failed catalog load (HTTP error) surfaces role=alert, never silent-empty', async () => {
+    vi.stubGlobal('fetch', vi.fn((url: string) => {
+      if (/\/catches\/mine$/.test(url)) return jsonOk({ ok: true, catches: [] });
+      return Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({ ok: false, error: 'boom' }) });
+    }));
+    const { container, getByText } = render(<FishingLensPage />);
+    await waitFor(() => expect(container.querySelector('[role="alert"]')).toBeTruthy());
+    expect(getByText(/Couldn.t load fishing data/i)).toBeInTheDocument();
+    expect(container.textContent).toMatch(/catalog 500/);
+    // distinct from genuinely-empty — the empty CTA must NOT show
+    expect(container.textContent).not.toMatch(/No fish defined for this world yet/i);
+  });
+
+  it('ERROR (handler reject): a 200 { ok:false } catalog is an honest failure, NOT silent-empty', async () => {
+    // The SILENT-EMPTY defect class: a handler rejection delivered as HTTP 200
+    // with { ok:false } must read as an ERROR, not collapse to the empty CTA.
+    vi.stubGlobal('fetch', routeFetch({
+      catalog: () => jsonOk({ ok: false, error: 'fauna index corrupt' }),
+    }));
+    const { container } = render(<FishingLensPage />);
+    await waitFor(() => expect(container.querySelector('[role="alert"]')).toBeTruthy());
+    expect(container.textContent).toMatch(/fauna index corrupt/);
+    expect(container.textContent).not.toMatch(/No fish defined for this world yet/i);
+  });
+
+  it('ERROR (network throw): a rejected fetch surfaces an alert, not a stuck spinner', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('network down'))));
+    const { container } = render(<FishingLensPage />);
+    await waitFor(() => expect(container.querySelector('[role="alert"]')).toBeTruthy());
+    expect(container.textContent).toMatch(/network down/);
+    expect(container.querySelector('[role="status"]')).toBeFalsy();
+  });
+
+  it('ERROR → Retry RE-FETCHES the catalog and recovers to populated', async () => {
+    let fail = true;
+    const fetchMock = vi.fn((url: string) => {
+      if (/\/catches\/mine$/.test(url)) return jsonOk({ ok: true, catches: [] });
+      if (fail) return Promise.reject(new Error('temporary outage'));
+      return jsonOk({ ok: true, fish: [FISH] });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const { container, getByText } = render(<FishingLensPage />);
+    await waitFor(() => expect(container.querySelector('[role="alert"]')).toBeTruthy());
+
+    const catalogCallsBefore = fetchMock.mock.calls.filter(
+      (c) => !/\/catches\/mine$/.test(String(c[0])) && !/\/cast$/.test(String(c[0])),
+    ).length;
+    fail = false;
+    await act(async () => { fireEvent.click(getByText('Retry')); });
+
+    // Retry must re-invoke the backend (not window.reload) and recover.
+    await waitFor(() => expect(container.querySelector('[role="alert"]')).toBeFalsy());
+    expect(
+      fetchMock.mock.calls.filter(
+        (c) => !/\/catches\/mine$/.test(String(c[0])) && !/\/cast$/.test(String(c[0])),
+      ).length,
+    ).toBeGreaterThan(catalogCallsBefore);
+    expect(getByText(/Ocean Tuna/i)).toBeInTheDocument();
+  });
+
+  it('POPULATED: a real fish + catch render with their backend fields; no fabricated data', async () => {
+    vi.stubGlobal('fetch', routeFetch({
+      catalog: () => jsonOk({ ok: true, fish: [FISH] }),
+      catches: () => jsonOk({ ok: true, catches: [CATCH] }),
+    }));
+    const { container, getByText } = render(<FishingLensPage />);
+    await waitFor(() => expect(getByText('Ocean Tuna')).toBeInTheDocument());
+    // fields come straight from the (mocked) backend rows
+    expect(getByText('ocean')).toBeInTheDocument();       // subBiome
+    expect(getByText('rare')).toBeInTheDocument();        // rarity badge
+    expect(getByText('Ocean Tuna (90%)')).toBeInTheDocument(); // catch item_name
+    // no loading / error linger once populated
+    expect(container.querySelector('[role="status"]')).toBeFalsy();
+    expect(container.querySelector('[role="alert"]')).toBeFalsy();
+    // empty CTAs are gone
+    expect(container.textContent).not.toMatch(/No fish defined for this world yet/i);
+    expect(container.textContent).not.toMatch(/No catches yet/i);
+  });
+
+  it('catch log is SECONDARY: a 401/{ok:false} catch log degrades to empty without failing the lens', async () => {
+    // The catalog (primary) succeeds; the catches read 401s. The lens must
+    // still render the catalog + an honest empty catch log, NOT an error.
+    vi.stubGlobal('fetch', vi.fn((url: string) => {
+      if (/\/catches\/mine$/.test(url)) {
+        return Promise.resolve({ ok: false, status: 401, json: () => Promise.resolve({ ok: false }) });
+      }
+      return jsonOk({ ok: true, fish: [FISH] });
+    }));
+    const { container, getByText } = render(<FishingLensPage />);
+    await waitFor(() => expect(getByText('Ocean Tuna')).toBeInTheDocument());
+    expect(container.querySelector('[role="alert"]')).toBeFalsy();
+    expect(getByText(/No catches yet/i)).toBeInTheDocument();
+  });
+
+  it('CAST: clicking Cast POSTs /api/fishing/cast and opens the minigame overlay', async () => {
+    const fetchMock = routeFetch({ catalog: () => jsonOk({ ok: true, fish: [FISH] }) });
+    vi.stubGlobal('fetch', fetchMock);
+    const { getByText, getByRole, queryByTestId } = render(<FishingLensPage />);
+    await waitFor(() => expect(getByText('Ocean Tuna')).toBeInTheDocument());
+    expect(queryByTestId('fishing-minigame')).toBeNull();
+
+    await act(async () => { fireEvent.click(getByRole('button', { name: /Cast line/i })); });
+
+    // a real POST to the cast route fired, and the overlay opened.
+    expect(fetchMock.mock.calls.some((c) => /\/cast$/.test(String(c[0])) && c[1]?.method === 'POST')).toBe(true);
+    await waitFor(() => expect(queryByTestId('fishing-minigame')).toBeInTheDocument());
+  });
+});

--- a/concord-frontend/tests/fitness-lens-states.test.tsx
+++ b/concord-frontend/tests/fitness-lens-states.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * /lenses/fitness — four-UX-state contract for the fitness lens.
+ *
+ * The fitness page's Apple-Fitness ring surface is ActivityRings, which drives
+ * its day data through the REAL macro channel:
+ *   lensRun({ domain:'fitness', action:'activity-summary', input:{ days:7 } })
+ *     → POST /api/lens/run
+ * (answered by the fitness-domain registerLensAction handler in
+ * server/domains/fitness.js). This pins that ActivityRings renders genuine
+ * loading / error (with a WORKING Retry that RE-FETCHES) / empty / populated
+ * states against that real channel — no fabricated rows, and an error is
+ * DISTINGUISHABLE from genuinely-empty (the silent-empty defect class the
+ * component previously had — it swallowed errors into console.error and fell to
+ * the empty CTA).
+ *
+ * DISPATCH FIDELITY: lensRun() returns { data: { ok, result, error } } with one
+ * { ok, result } layer already unwrapped, so a handler rejection surfaces as
+ * res.data.ok === false. The error fixtures cover BOTH a transport failure
+ * ({ ok:false }) AND a thrown promise — ActivityRings must surface either, not
+ * collapse into the empty CTA.
+ *
+ * SleepRecovery is covered too — it shares the same harden-against-silent-empty
+ * pattern and renders the recovery-history field contract.
+ *
+ * No fabricated data: every state is driven by a mocked lensRun returning
+ * exactly the { data: { ok, result } } shapes the fitness macros return.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, act, fireEvent, within } from '@testing-library/react';
+import React from 'react';
+
+// ── the real macro channel, mocked per-test ─────────────────────────────────
+const lensRunMock = vi.fn();
+vi.mock('@/lib/api/client', () => ({
+  lensRun: (...args: unknown[]) => lensRunMock(...args),
+}));
+
+// Import AFTER the mock is registered.
+import { ActivityRings } from '@/components/fitness/ActivityRings';
+import { SleepRecovery } from '@/components/fitness/SleepRecovery';
+
+// ── fixtures — exact fitness-macro dispatch shapes ──────────────────────────
+// lensRun unwraps one { ok, result } layer; transport success → res.data.ok=true.
+function ok(result: unknown) {
+  return Promise.resolve({ data: { ok: true, result, error: null } });
+}
+// Transport/handler rejection unwrapped into res.data.ok===false (real shape).
+function err(message: string) {
+  return Promise.resolve({ data: { ok: false, result: null, error: message } });
+}
+
+// A real activity-summary day row, in the shape the handler emits (the rendered
+// field contract: moveCalories / moveGoal / exerciseMinutes / standHours / …).
+const REAL_DAY = {
+  date: '2026-06-27',
+  moveCalories: 500, moveGoal: 600,
+  exerciseMinutes: 40, exerciseGoal: 30,
+  standHours: 8, standGoal: 12,
+  steps: 9000, stepsGoal: 10000,
+};
+
+beforeEach(() => { lensRunMock.mockReset(); });
+afterEach(() => { vi.clearAllMocks(); });
+
+describe('fitness lens (ActivityRings) — wiring', () => {
+  it('drives the activity-summary macro on the fitness domain at mount', async () => {
+    lensRunMock.mockImplementation(() => ok({ days: [REAL_DAY] }));
+    await act(async () => { render(<ActivityRings />); });
+    await waitFor(() => expect(lensRunMock).toHaveBeenCalled());
+    const spec = lensRunMock.mock.calls[0][0] as { domain: string; action: string };
+    expect(spec.domain).toBe('fitness');
+    expect(spec.action).toBe('activity-summary');
+  });
+});
+
+describe('fitness lens (ActivityRings) — four UX states', () => {
+  it('LOADING: shows a role=status cue and no fabricated rows while in flight', () => {
+    lensRunMock.mockImplementation(() => new Promise(() => {})); // never resolves
+    const { getByRole, queryByText } = render(<ActivityRings />);
+    expect(getByRole('status')).toBeInTheDocument();
+    expect(getByRole('status').getAttribute('aria-busy')).toBe('true');
+    expect(queryByText(/No activity data yet/i)).toBeNull();
+  });
+
+  it('EMPTY: an empty list shows the honest CTA, distinct from loading + no alert', async () => {
+    lensRunMock.mockImplementation(() => ok({ days: [] }));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<ActivityRings />); });
+    await waitFor(() => expect(view!.getByText(/No activity data yet/i)).toBeInTheDocument());
+    expect(view!.queryByRole('status')).toBeNull();
+    expect(view!.queryByRole('alert')).toBeNull();
+  });
+
+  it('ERROR (handler/transport reject): res.data.ok===false surfaces role=alert, never silent-empty', async () => {
+    lensRunMock.mockImplementation(() => err('fitness STATE unavailable'));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<ActivityRings />); });
+    await waitFor(() => expect(view!.getByRole('alert')).toBeInTheDocument());
+    expect(view!.getByText(/fitness STATE unavailable/i)).toBeInTheDocument();
+    expect(view!.queryByText(/No activity data yet/i)).toBeNull();
+  });
+
+  it('ERROR: a thrown/rejected lensRun (network down) surfaces an alert, not a stuck spinner', async () => {
+    lensRunMock.mockImplementation(() => Promise.reject(new Error('network down')));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<ActivityRings />); });
+    await waitFor(() => expect(view!.getByRole('alert')).toBeInTheDocument());
+    expect(view!.getByText(/network down/i)).toBeInTheDocument();
+    expect(view!.queryByRole('status')).toBeNull();
+  });
+
+  it('ERROR → Retry RE-FETCHES the macro and recovers to populated', async () => {
+    let fail = true;
+    lensRunMock.mockImplementation(() => (fail ? err('temporary outage') : ok({ days: [REAL_DAY] })));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<ActivityRings />); });
+    await waitFor(() => expect(view!.getByRole('alert')).toBeInTheDocument());
+    const callsBefore = lensRunMock.mock.calls.length;
+
+    fail = false;
+    const alert = view!.getByRole('alert');
+    const retry = within(alert).getByRole('button', { name: /Retry/i });
+    await act(async () => { fireEvent.click(retry); });
+
+    await waitFor(() => expect(view!.queryByRole('alert')).toBeNull());
+    expect(lensRunMock.mock.calls.length).toBeGreaterThan(callsBefore);
+    expect(view!.getByText(/Activity rings/i)).toBeInTheDocument();
+  });
+
+  it('POPULATED: a real day from the macro renders its move/steps values', async () => {
+    lensRunMock.mockImplementation(() => ok({ days: [REAL_DAY] }));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<ActivityRings />); });
+    await waitFor(() => expect(view!.getByText(/Activity rings/i)).toBeInTheDocument());
+    // real move + steps values render (500 / 600, 9,000 / 10,000)
+    expect(view!.getByText(/500 \/ 600/)).toBeInTheDocument();
+    expect(view!.getByText(/9,000 \/ 10,000/)).toBeInTheDocument();
+    expect(view!.queryByText(/No activity data yet/i)).toBeNull();
+  });
+});
+
+// ── SleepRecovery — same silent-empty hardening + field contract ────────────
+const REAL_RECOVERY = {
+  date: '2026-06-27',
+  recoveryScore: 80,
+  sleepDurationHours: 7.5,
+  sleepQualityPct: 88,
+  restingHr: 50,
+  hrv: 65,
+  strainYesterday: 12.3,
+};
+
+describe('fitness lens (SleepRecovery) — error is distinct from empty', () => {
+  it('EMPTY: no rows → honest CTA, no alert', async () => {
+    lensRunMock.mockImplementation(() => ok({ days: [] }));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<SleepRecovery />); });
+    await waitFor(() => expect(view!.getByText(/No recovery data/i)).toBeInTheDocument());
+    expect(view!.queryByRole('alert')).toBeNull();
+  });
+
+  it('ERROR: res.data.ok===false surfaces an alert with a working Retry, never silent-empty', async () => {
+    let fail = true;
+    lensRunMock.mockImplementation(() => (fail ? err('recovery index corrupt') : ok({ days: [REAL_RECOVERY] })));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<SleepRecovery />); });
+    await waitFor(() => expect(view!.getByRole('alert')).toBeInTheDocument());
+    expect(view!.getByText(/recovery index corrupt/i)).toBeInTheDocument();
+    expect(view!.queryByText(/No recovery data/i)).toBeNull();
+
+    fail = false;
+    const retry = within(view!.getByRole('alert')).getByRole('button', { name: /Retry/i });
+    await act(async () => { fireEvent.click(retry); });
+    await waitFor(() => expect(view!.queryByRole('alert')).toBeNull());
+    // the recovery-history field contract renders (sleep 7.5h)
+    expect(view!.getByText(/7\.5h/)).toBeInTheDocument();
+  });
+
+  it('POPULATED: a real recovery row renders recovery % + sleep hours', async () => {
+    lensRunMock.mockImplementation(() => ok({ days: [REAL_RECOVERY] }));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<SleepRecovery />); });
+    await waitFor(() => expect(view!.getByText(/80%/)).toBeInTheDocument());
+    expect(view!.getByText(/7\.5h/)).toBeInTheDocument();
+  });
+});

--- a/concord-frontend/tests/forestry-lens-states.test.tsx
+++ b/concord-frontend/tests/forestry-lens-states.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * /lenses/forestry — four-UX-state contract for the Forestry lens.
+ *
+ * The forestry lens's primary STATE-backed surface is <StandManager/>, which
+ * drives its stand list + dashboard through lensRun('forestry','stand-list') and
+ * lensRun('forestry','forestry-dashboard') at mount. This pins that it renders
+ * genuine loading / error (with a WORKING Try-again that RE-FETCHES) / empty /
+ * populated states against that real channel.
+ *
+ * SWALLOWED-FETCH FIX (Phase-2 gate): StandManager.refresh used to `setStands(
+ * sl.data?.result?.stands || [])` with NO error branch, so a backend failure
+ * ({ ok:false } OR a thrown lensRun) rendered IDENTICALLY to a genuinely-empty
+ * stand list ("No stands yet.") — a silent-empty that hid outages. refresh now
+ * tracks loadError and surfaces a role=alert with a working retry; these tests
+ * pin that an unreachable / { ok:false } stand-list is DISTINGUISHABLE from
+ * genuinely-empty.
+ *
+ * No fabricated data: every state is driven by a mocked lensRun returning
+ * exactly the { ok, result } envelope the stand-list/forestry-dashboard macros
+ * return. The live wildfire feed button does its own fetch and is irrelevant to
+ * the list state machine, so we let it sit inert (it never fires at mount).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor, act, within } from '@testing-library/react';
+import React from 'react';
+
+// ── mock the lens run channel + the feed button (it fetches on click only) ──
+const lensRun = vi.fn();
+vi.mock('@/lib/api/client', () => ({
+  lensRun: (...args: unknown[]) => lensRun(...args),
+}));
+vi.mock('@/components/lens/LensFeedButton', () => ({
+  LensFeedButton: () => null,
+}));
+
+// Import AFTER mocks are registered.
+import { StandManager } from '@/components/forestry/StandManager';
+
+// ── envelope helpers ─────────────────────────────────────────────────────────
+const env = (result: unknown, ok = true) => ({ data: { ok, result } });
+const STANDS_EMPTY = env({ stands: [], count: 0, totalAcres: 0 });
+const DASH_EMPTY = env({ stands: 0, totalAcres: 0, activities: 0, bySpecies: {} });
+const STANDS_POPULATED = env({
+  stands: [
+    { id: 'std_1', name: 'North 40', species: 'douglas_fir', acres: 40, ageYears: 25, treesPerAcre: 200, estimatedTrees: 8000, activities: [], activityCount: 0 },
+  ],
+  count: 1, totalAcres: 40,
+});
+const DASH_POPULATED = env({ stands: 1, totalAcres: 40, activities: 0, bySpecies: { douglas_fir: 1 } });
+
+// route the two parallel mount calls (stand-list + forestry-dashboard) to the
+// right envelope so the test controls each independently.
+function routeMount(standList: unknown, dashboard: unknown = DASH_EMPTY) {
+  lensRun.mockImplementation((_domain: string, action: string) => {
+    if (action === 'stand-list') return Promise.resolve(standList);
+    if (action === 'forestry-dashboard') return Promise.resolve(dashboard);
+    return Promise.resolve(env({}));
+  });
+}
+
+beforeEach(() => { vi.clearAllMocks(); });
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe('forestry lens — wiring', () => {
+  it('drives stand-list + forestry-dashboard on the forestry domain at mount', async () => {
+    routeMount(STANDS_EMPTY);
+    render(<StandManager />);
+    await waitFor(() => expect(lensRun).toHaveBeenCalled());
+    const actions = lensRun.mock.calls.map((c) => [c[0], c[1]]);
+    expect(actions).toContainEqual(['forestry', 'stand-list']);
+    expect(actions).toContainEqual(['forestry', 'forestry-dashboard']);
+  });
+});
+
+describe('forestry lens — four UX states', () => {
+  it('LOADING: shows a role=status indicator while the stand list is in flight', async () => {
+    // never-resolving lensRun → stays in initial loading.
+    lensRun.mockImplementation(() => new Promise(() => {}));
+    const { getByRole, getByText } = render(<StandManager />);
+    await waitFor(() => expect(getByRole('status')).toBeInTheDocument());
+    expect(getByRole('status').getAttribute('aria-busy')).toBe('true');
+    expect(getByText(/Loading stands/i)).toBeInTheDocument();
+  });
+
+  it('EMPTY: shows the honest empty cue once an empty list resolves (not the loading state)', async () => {
+    routeMount(STANDS_EMPTY);
+    const { getByText, queryByRole } = render(<StandManager />);
+    await waitFor(() => expect(getByText(/No stands yet/i)).toBeInTheDocument());
+    // empty is distinct from loading: the role=status spinner is gone.
+    expect(queryByRole('status')).toBeNull();
+  });
+
+  it('ERROR: an unreachable stand-list shows role=alert + a working Try-again that re-fetches', async () => {
+    let fail = true;
+    lensRun.mockImplementation((_domain: string, action: string) => {
+      if (fail) return Promise.reject(new Error('network down'));
+      if (action === 'stand-list') return Promise.resolve(STANDS_POPULATED);
+      return Promise.resolve(DASH_POPULATED);
+    });
+    const { container, getByText, queryByText } = render(<StandManager />);
+    // swallowed-fetch must NOT silently render "No stands yet." — it surfaces an alert.
+    await waitFor(() => expect(container.querySelector('[role="alert"]')).toBeTruthy());
+    expect(getByText(/Could not reach the forestry service/i)).toBeInTheDocument();
+    expect(queryByText(/No stands yet/i)).toBeNull();
+
+    // Try-again must re-invoke the backend and recover to populated.
+    fail = false;
+    const alert = container.querySelector('[role="alert"]') as HTMLElement;
+    const retry = within(alert).getByRole('button', { name: /Try again/i });
+    await act(async () => { fireEvent.click(retry); });
+    await waitFor(() => expect(container.querySelector('[role="alert"]')).toBeFalsy());
+    expect(getByText('North 40')).toBeInTheDocument();
+  });
+
+  it('ERROR: a { ok:false } verdict (not just a thrown call) also surfaces, never silent-empty', async () => {
+    routeMount(env({ stands: [] }, false), env({}, false));
+    // attach an error message so the alert is informative.
+    lensRun.mockImplementation((_d: string, action: string) => {
+      if (action === 'stand-list') return Promise.resolve({ data: { ok: false, error: 'STATE unavailable' } });
+      return Promise.resolve({ data: { ok: false, error: 'STATE unavailable' } });
+    });
+    const { container, getByText, queryByText } = render(<StandManager />);
+    await waitFor(() => expect(container.querySelector('[role="alert"]')).toBeTruthy());
+    expect(getByText(/STATE unavailable/i)).toBeInTheDocument();
+    expect(queryByText(/No stands yet/i)).toBeNull();
+  });
+
+  it('POPULATED: renders the real stand row + dashboard counts from the macro body', async () => {
+    routeMount(STANDS_POPULATED, DASH_POPULATED);
+    const { getByText } = render(<StandManager />);
+    await waitFor(() => expect(getByText('North 40')).toBeInTheDocument());
+    // derived estimatedTrees (8,000) + activity count render from the row.
+    expect(getByText(/8,000 trees/i)).toBeInTheDocument();
+  });
+});

--- a/concord-frontend/tests/forum-lens-states.test.tsx
+++ b/concord-frontend/tests/forum-lens-states.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * /lenses/forum — four-UX-state contract for the Forum lens.
+ *
+ * The forum page is a large composed surface; its load-bearing data panel is
+ * FmTopicsPanel (the default tab of ForumSection), which drives the topic list
+ * through the real macro channel:
+ *   lensRun('forum', 'topic-list', {...}) → POST /api/lens/run
+ *   { domain:'forum', name:'topic-list' }  (answered by the forum-domain macros)
+ * plus category-list / subforum-list / saved-list for the surrounding chrome.
+ *
+ * This pins genuine LOADING / ERROR / EMPTY / POPULATED states against that real
+ * channel — no fabricated rows — and proves a backend { ok:false, error } (or a
+ * swallowed fetch surfacing as ok:false) renders a DISTINCT red alert with a
+ * WORKING retry that RE-FETCHES, rather than collapsing into the empty state
+ * (the silent-empty defect class).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, act, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+// ── the real macro channel, mocked per-test ─────────────────────────────────
+const lensRunMock = vi.fn();
+vi.mock('@/lib/api/client', () => ({
+  lensRun: (...args: unknown[]) => lensRunMock(...args),
+}));
+
+// Import AFTER the mock is registered.
+import { FmTopicsPanel } from '@/components/forum/FmTopicsPanel';
+
+// ── fixtures — exact forum-macro result shapes ──────────────────────────────
+function ok(result: unknown) {
+  return Promise.resolve({ data: { ok: true, result } });
+}
+function err(message: string) {
+  return Promise.resolve({ data: { ok: false, result: null, error: message } });
+}
+const realTopic = {
+  id: 'top_1',
+  categoryId: null,
+  subforumId: null,
+  title: 'Sidechain compression tips',
+  body: 'How do you set the release?',
+  format: 'plain',
+  images: [],
+  tags: ['mixing'],
+  author: 'you',
+  pinned: false,
+  locked: false,
+  score: 7,
+  replyCount: 2,
+  awards: [],
+};
+
+// Dispatch by macro name. `topicListResp` is the load-bearing response under
+// test; the chrome macros return benign empties so only the topic list varies.
+function wireLensRun(topicListResp: () => Promise<unknown>) {
+  lensRunMock.mockImplementation((_domain: string, name: string) => {
+    if (name === 'topic-list') return topicListResp();
+    if (name === 'category-list') return ok({ categories: [], count: 0 });
+    if (name === 'subforum-list') return ok({ subforums: [], count: 0 });
+    if (name === 'saved-list') return ok({ saved: [], count: 0 });
+    return ok({});
+  });
+}
+
+const noop = () => {};
+
+beforeEach(() => {
+  lensRunMock.mockReset();
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('forum lens (FmTopicsPanel) — four UX states', () => {
+  it('LOADING: shows the spinner and no fabricated rows', () => {
+    // topic-list never resolves → component stays in loading
+    wireLensRun(() => new Promise(() => {}));
+    const { container, queryByText } = render(<FmTopicsPanel onChange={noop} />);
+    expect(container.querySelector('.animate-spin')).toBeTruthy();
+    expect(queryByText(/No topics yet/i)).toBeNull();
+    expect(queryByText(/Sidechain compression tips/i)).toBeNull();
+  });
+
+  it('ERROR: a backend { ok:false, error } surfaces a red alert, distinct from empty', async () => {
+    wireLensRun(() => err('forum backend unreachable'));
+    let view: ReturnType<typeof render>;
+    await act(async () => {
+      view = render(<FmTopicsPanel onChange={noop} />);
+    });
+    await waitFor(() => {
+      expect(view!.getByText(/forum backend unreachable/i)).toBeInTheDocument();
+    });
+    // The red alert proves it did NOT silently collapse into the empty CTA —
+    // the error is what distinguishes an outage from a genuinely-empty forum.
+    expect(view!.getByRole('alert')).toBeInTheDocument();
+    expect(view!.queryByText(/No topics yet/i)).toBeNull();
+  });
+
+  it('ERROR retry RE-FETCHES (not window.reload) and recovers to POPULATED', async () => {
+    // First load fails; the Retry button re-invokes lensRun and succeeds.
+    let attempt = 0;
+    lensRunMock.mockImplementation((_domain: string, name: string) => {
+      if (name === 'topic-list') {
+        attempt += 1;
+        return attempt === 1 ? err('transient outage') : ok({ topics: [realTopic], count: 1 });
+      }
+      if (name === 'category-list') return ok({ categories: [], count: 0 });
+      if (name === 'subforum-list') return ok({ subforums: [], count: 0 });
+      if (name === 'saved-list') return ok({ saved: [], count: 0 });
+      return ok({});
+    });
+    let view: ReturnType<typeof render>;
+    await act(async () => {
+      view = render(<FmTopicsPanel onChange={noop} />);
+    });
+    await waitFor(() => expect(view!.getByText(/transient outage/i)).toBeInTheDocument());
+
+    const callsBefore = lensRunMock.mock.calls.filter((c) => c[1] === 'topic-list').length;
+    await act(async () => {
+      fireEvent.click(view!.getByRole('button', { name: /retry/i }));
+    });
+    // The retry issued a fresh topic-list fetch (re-fetch, not a page reload)…
+    const callsAfter = lensRunMock.mock.calls.filter((c) => c[1] === 'topic-list').length;
+    expect(callsAfter).toBeGreaterThan(callsBefore);
+    // …and recovered into the populated list.
+    await waitFor(() => expect(view!.getByText(/Sidechain compression tips/i)).toBeInTheDocument());
+    expect(view!.queryByRole('alert')).toBeNull();
+  });
+
+  it('EMPTY: an empty topic list shows the honest CTA and no fabricated rows', async () => {
+    wireLensRun(() => ok({ topics: [], count: 0 }));
+    let view: ReturnType<typeof render>;
+    await act(async () => {
+      view = render(<FmTopicsPanel onChange={noop} />);
+    });
+    await waitFor(() => {
+      expect(view!.getByText(/No topics yet/i)).toBeInTheDocument();
+    });
+    expect(view!.queryByText(/Sidechain compression tips/i)).toBeNull();
+    expect(view!.queryByRole('alert')).toBeNull();
+  });
+
+  it('POPULATED: a real topic from the macro renders in the list', async () => {
+    wireLensRun(() => ok({ topics: [realTopic], count: 1 }));
+    let view: ReturnType<typeof render>;
+    await act(async () => {
+      view = render(<FmTopicsPanel onChange={noop} />);
+    });
+    await waitFor(() => {
+      expect(view!.getByText(/Sidechain compression tips/i)).toBeInTheDocument();
+    });
+    expect(view!.getByText(/2 replies/i)).toBeInTheDocument();
+    expect(view!.queryByText(/No topics yet/i)).toBeNull();
+  });
+});

--- a/concord-frontend/tests/geology-lens-states.test.tsx
+++ b/concord-frontend/tests/geology-lens-states.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * /lenses/geology — four-UX-state contract for the geology lens.
+ *
+ * The geology page's load-bearing field-data panel is FieldLog, which drives
+ * its observation journal through the REAL macro channel:
+ *   lensRun('geology', 'observation-list', {…})  → POST /api/lens/run
+ *   lensRun('geology', 'field-dashboard', {})     → POST /api/lens/run
+ * (answered by the geology-domain registerLensAction handlers in
+ * server/domains/geology.js). This pins that FieldLog renders genuine
+ * loading / error (with a WORKING Retry that RE-FETCHES) / empty / populated
+ * states against that real channel — no fabricated rows, and an error is
+ * DISTINGUISHABLE from genuinely-empty (the silent-empty defect class).
+ *
+ * DISPATCH FIDELITY: /api/lens/run unwraps exactly one { ok, result } layer, so
+ * the transport flag r.data.ok is ALWAYS true on a dispatched call and a handler
+ * rejection surfaces as r.data.result.ok === false. The error fixtures cover
+ * BOTH a transport failure ({ ok:false }) AND a handler rejection
+ * ({ ok:true, result:{ ok:false, error } }) — FieldLog must surface either, not
+ * collapse into the empty CTA.
+ *
+ * No fabricated data: every state is driven by a mocked lensRun returning
+ * exactly the { data: { ok, result } } shapes the geology macros return.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, act, fireEvent, within } from '@testing-library/react';
+import React from 'react';
+
+// ── the real macro channel, mocked per-test ─────────────────────────────────
+const lensRunMock = vi.fn();
+vi.mock('@/lib/api/client', () => ({
+  lensRun: (...args: unknown[]) => lensRunMock(...args),
+}));
+
+// Import AFTER the mock is registered.
+import { FieldLog } from '@/components/geology/FieldLog';
+
+// ── fixtures — exact geology-macro dispatch shapes ──────────────────────────
+// Transport always succeeds (r.data.ok=true); the handler payload is r.data.result.
+function ok(result: unknown) {
+  return Promise.resolve({ data: { ok: true, result } });
+}
+// Transport-level failure (e.g. 401/500/STATE unavailable surfaced at r.data.ok).
+function transportErr(message: string) {
+  return Promise.resolve({ data: { ok: false, error: message } });
+}
+// Handler rejection unwrapped into result.ok===false (the real dispatch shape).
+function handlerReject(message: string) {
+  return Promise.resolve({ data: { ok: true, result: { ok: false, error: message } } });
+}
+
+const REAL_OBS = {
+  id: 'obs_1',
+  name: 'Marcellus roadcut',
+  kind: 'outcrop',
+  lat: 42.1,
+  lon: -76.2,
+  locationName: 'Hwy 9',
+  formation: 'Marcellus',
+  notes: 'black shale, fissile',
+  tags: ['shale'],
+  collectedAt: '2026-06-20',
+};
+const REAL_DASH = { totalObservations: 1, byKind: { outcrop: 1 }, geotagged: 1, formations: 1 };
+
+// Route the mock by macro name so observation-list / field-dashboard each get
+// the right response.
+function wireLensRun(listResp: () => Promise<unknown>, dashResp: () => Promise<unknown> = () => ok(REAL_DASH)) {
+  lensRunMock.mockImplementation((_domain: string, name: string) => {
+    if (name === 'observation-list') return listResp();
+    if (name === 'field-dashboard') return dashResp();
+    return ok({});
+  });
+}
+
+beforeEach(() => { lensRunMock.mockReset(); });
+afterEach(() => { vi.clearAllMocks(); });
+
+describe('geology lens (FieldLog) — wiring', () => {
+  it('drives the observation-list macro on the geology domain at mount', async () => {
+    wireLensRun(() => ok({ observations: [] }));
+    await act(async () => { render(<FieldLog />); });
+    await waitFor(() => expect(lensRunMock).toHaveBeenCalled());
+    const calledNames = lensRunMock.mock.calls.map((c) => c[1]);
+    expect(calledNames).toContain('observation-list');
+    expect(calledNames).toContain('field-dashboard');
+    expect(lensRunMock.mock.calls[0][0]).toBe('geology');
+  });
+});
+
+describe('geology lens (FieldLog) — four UX states', () => {
+  it('LOADING: shows a role=status cue and no fabricated rows while observation-list is in flight', () => {
+    // never-resolving → stays in initial loading
+    wireLensRun(() => new Promise(() => {}), () => new Promise(() => {}));
+    const { getByRole, queryByText } = render(<FieldLog />);
+    expect(getByRole('status')).toBeInTheDocument();
+    expect(getByRole('status').getAttribute('aria-busy')).toBe('true');
+    expect(queryByText(/No observations logged yet/i)).toBeNull();
+    expect(queryByText(/Marcellus roadcut/i)).toBeNull();
+  });
+
+  it('EMPTY: an empty list shows the honest CTA, distinct from loading, with no rows', async () => {
+    wireLensRun(() => ok({ observations: [] }));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<FieldLog />); });
+    await waitFor(() => expect(view!.getByText(/No observations logged yet/i)).toBeInTheDocument());
+    // empty ≠ loading: the status spinner is gone, and no alert.
+    expect(view!.queryByRole('status')).toBeNull();
+    expect(view!.queryByRole('alert')).toBeNull();
+    expect(view!.queryByText(/Marcellus roadcut/i)).toBeNull();
+  });
+
+  it('ERROR (transport): a { ok:false } verdict surfaces role=alert, never silent-empty', async () => {
+    wireLensRun(() => transportErr('geology STATE unavailable'));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<FieldLog />); });
+    await waitFor(() => expect(view!.getByRole('alert')).toBeInTheDocument());
+    expect(view!.getByText(/geology STATE unavailable/i)).toBeInTheDocument();
+    // distinct from genuinely-empty
+    expect(view!.queryByText(/No observations logged yet/i)).toBeNull();
+  });
+
+  it('ERROR (handler reject): an unwrapped result.ok===false also surfaces, never silent-empty', async () => {
+    wireLensRun(() => handlerReject('observation index corrupt'));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<FieldLog />); });
+    await waitFor(() => expect(view!.getByRole('alert')).toBeInTheDocument());
+    expect(view!.getByText(/observation index corrupt/i)).toBeInTheDocument();
+    expect(view!.queryByText(/No observations logged yet/i)).toBeNull();
+  });
+
+  it('ERROR: a thrown/rejected lensRun (network down) surfaces an alert, not a stuck spinner', async () => {
+    wireLensRun(() => Promise.reject(new Error('network down')));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<FieldLog />); });
+    await waitFor(() => expect(view!.getByRole('alert')).toBeInTheDocument());
+    expect(view!.getByText(/network down/i)).toBeInTheDocument();
+    // not stuck loading
+    expect(view!.queryByRole('status')).toBeNull();
+  });
+
+  it('ERROR → Retry RE-FETCHES the macro and recovers to populated', async () => {
+    let fail = true;
+    wireLensRun(() => (fail ? transportErr('temporary outage') : ok({ observations: [REAL_OBS] })));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<FieldLog />); });
+    await waitFor(() => expect(view!.getByRole('alert')).toBeInTheDocument());
+    const callsBefore = lensRunMock.mock.calls.length;
+
+    fail = false;
+    const alert = view!.getByRole('alert');
+    const retry = within(alert).getByRole('button', { name: /Retry/i });
+    await act(async () => { fireEvent.click(retry); });
+
+    // retry must re-invoke the backend (not window.reload) and recover.
+    await waitFor(() => expect(view!.queryByRole('alert')).toBeNull());
+    expect(lensRunMock.mock.calls.length).toBeGreaterThan(callsBefore);
+    expect(view!.getByText(/Marcellus roadcut/i)).toBeInTheDocument();
+  });
+
+  it('POPULATED: a real observation from the macro renders with its fields', async () => {
+    wireLensRun(() => ok({ observations: [REAL_OBS] }));
+    let view: ReturnType<typeof render>;
+    await act(async () => { view = render(<FieldLog />); });
+    await waitFor(() => expect(view!.getByText(/Marcellus roadcut/i)).toBeInTheDocument());
+    // dashboard totals from field-dashboard render too
+    expect(view!.getAllByText('1').length).toBeGreaterThan(0);
+    expect(view!.queryByText(/No observations logged yet/i)).toBeNull();
+  });
+});

--- a/concord-frontend/tests/household-lens-states.test.tsx
+++ b/concord-frontend/tests/household-lens-states.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * /lenses/household — four-UX-state contract for the household lens.
+ *
+ * The load-bearing data surface tested here is the ChoreBoard component (the
+ * Tody-shape condition-based cleaning board mounted on the household page). It
+ * drives household.{room-list,chore-board,assignee-leaderboard,household-dashboard}
+ * through lensRun() at mount and is the component a user reads first.
+ *
+ * SWALLOWED-FETCH FIX (Phase-2 gate): lensRun() never throws — it resolves to
+ * { data: { ok, result, error } }. The board previously read result?.board || []
+ * and ignored ok, so a failed/unreachable chore-board rendered IDENTICALLY to a
+ * genuinely-empty board (silent-empty hiding a backend outage). The component now
+ * tracks an error + surfaces a role=alert with a WORKING "Try again" that
+ * RE-FETCHES; these tests pin that an { ok:false } chore-board is DISTINGUISHABLE
+ * from genuinely-empty, and that loading / empty / populated are each genuine.
+ *
+ * No fabricated data: every state is driven by a mocked lensRun returning exactly
+ * the { ok, result } envelope the real macros return.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor, act, within } from '@testing-library/react';
+import React from 'react';
+
+// Mock lensRun — the single channel ChoreBoard uses. Per-macro responses are
+// supplied via the `responder` indirection so each test scripts its own backend.
+let responder: (action: string) => { ok: boolean; result?: unknown; error?: string };
+vi.mock('@/lib/api/client', () => ({
+  lensRun: vi.fn(async (_domain: string, action: string) => {
+    const r = responder(action);
+    return { data: { ok: r.ok, result: r.result ?? null, error: r.error ?? null } };
+  }),
+}));
+
+// Import AFTER the mock is registered.
+import { ChoreBoard } from '@/components/household/ChoreBoard';
+
+const EMPTY = (action: string) => {
+  switch (action) {
+    case 'room-list': return { ok: true, result: { rooms: [], count: 0 } };
+    case 'chore-board': return { ok: true, result: { board: [], needsAttention: 0, gettingDirty: 0, paused: false } };
+    case 'assignee-leaderboard': return { ok: true, result: { leaderboard: [], totalChoresLogged: 0 } };
+    case 'household-dashboard': return { ok: true, result: { rooms: 0, tasks: 0, cleanlinessPct: 100, needsAttention: 0, choresLoggedAllTime: 0, paused: false } };
+    default: return { ok: true, result: {} };
+  }
+};
+const POPULATED = (action: string) => {
+  switch (action) {
+    case 'room-list': return { ok: true, result: { rooms: [{ id: 'rm1', name: 'Kitchen', taskCount: 1 }], count: 1 } };
+    case 'chore-board': return { ok: true, result: { board: [{ id: 'tk1', name: 'Wash dishes', room: 'Kitchen', assignee: 'Sam', effort: 'light', condition: { ratio: 1.2, state: 'needs_attention', daysOverdue: 2 } }], needsAttention: 1, gettingDirty: 0, paused: false } };
+    case 'assignee-leaderboard': return { ok: true, result: { leaderboard: [{ person: 'Sam', points: 25, choresDone: 3 }], totalChoresLogged: 3 } };
+    case 'household-dashboard': return { ok: true, result: { rooms: 1, tasks: 1, cleanlinessPct: 0, needsAttention: 1, choresLoggedAllTime: 3, paused: false } };
+    default: return { ok: true, result: {} };
+  }
+};
+
+beforeEach(() => { vi.clearAllMocks(); responder = EMPTY; });
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe('household lens (ChoreBoard) — wiring', () => {
+  it('drives household.chore-board through lensRun at mount', async () => {
+    const { lensRun } = await import('@/lib/api/client');
+    render(<ChoreBoard />);
+    await waitFor(() => expect(lensRun).toHaveBeenCalled());
+    const calls = (lensRun as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    const actions = calls.map((c) => c[1]);
+    expect(calls.every((c) => c[0] === 'household')).toBe(true);
+    expect(actions).toContain('chore-board');
+    expect(actions).toContain('household-dashboard');
+  });
+});
+
+describe('household lens (ChoreBoard) — four UX states', () => {
+  it('LOADING: shows a role=status indicator while the board is in flight', async () => {
+    // never-resolving lensRun → stays in initial loading.
+    const { lensRun } = await import('@/lib/api/client');
+    (lensRun as unknown as { mockImplementation: (f: () => Promise<unknown>) => void })
+      .mockImplementation(() => new Promise(() => {}));
+    const { getByRole } = render(<ChoreBoard />);
+    await waitFor(() => expect(getByRole('status')).toBeTruthy());
+    expect(getByRole('status').getAttribute('aria-busy')).toBe('true');
+  });
+
+  it('EMPTY: honest CTA (no fabricated rows), distinct from loading', async () => {
+    responder = EMPTY;
+    const { getByText, queryByRole } = render(<ChoreBoard />);
+    await waitFor(() => expect(getByText(/No chores yet/i)).toBeTruthy());
+    // empty is distinct from loading: the spinner is gone.
+    expect(queryByRole('status')).toBeNull();
+    // and no leaderboard rows were fabricated.
+    expect(getByText(/No chores logged/i)).toBeTruthy();
+  });
+
+  it('ERROR: an { ok:false } chore-board surfaces role=alert + a working Try-again that re-fetches', async () => {
+    let fail = true;
+    responder = (action) => {
+      if (fail && action === 'chore-board') return { ok: false, error: 'STATE unavailable' };
+      return fail ? EMPTY(action) : POPULATED(action);
+    };
+    const { container, getByText, queryByText } = render(<ChoreBoard />);
+    // swallowed-fetch must NOT silently render "No chores yet" — it surfaces an alert.
+    await waitFor(() => expect(container.querySelector('[role="alert"]')).toBeTruthy());
+    expect(getByText(/Could not reach the chore board/i)).toBeTruthy();
+    expect(getByText(/STATE unavailable/i)).toBeTruthy();
+    // and it is NOT the genuinely-empty cue.
+    expect(queryByText(/No chores yet/i)).toBeNull();
+
+    // Try-again must re-invoke the backend and recover to populated.
+    fail = false;
+    const alert = container.querySelector('[role="alert"]') as HTMLElement;
+    const retry = within(alert).getByRole('button', { name: /Try again/i });
+    await act(async () => { fireEvent.click(retry); });
+    await waitFor(() => expect(container.querySelector('[role="alert"]')).toBeFalsy());
+    expect(getByText('Wash dishes')).toBeTruthy();
+  });
+
+  it('POPULATED: renders real board rows + leaderboard from the macro result', async () => {
+    responder = POPULATED;
+    const { getByText } = render(<ChoreBoard />);
+    await waitFor(() => expect(getByText('Wash dishes')).toBeTruthy());
+    // the overdue cue from the real condition is rendered.
+    expect(getByText(/2d overdue/i)).toBeTruthy();
+    // leaderboard person + points from the real result.
+    expect(getByText('Sam')).toBeTruthy();
+    expect(getByText('25')).toBeTruthy();
+  });
+});

--- a/concord-frontend/tests/insurance-lens-states.test.tsx
+++ b/concord-frontend/tests/insurance-lens-states.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * /lenses/insurance — four-UX-state contract for the Insurance Agency lens.
+ *
+ * Pins that the lens renders genuine loading / error (with a WORKING Retry) /
+ * empty / populated states against its real backend channel: the artifact list
+ * (useLensData('insurance', type) → GET /api/lens/insurance), and that the
+ * compute-action runner is constructed on the 'insurance' domain via
+ * useRunArtifact — a regression to any other id would resolve to NO backend
+ * receiver.
+ *
+ * a11y: loading is role=status (aria-busy), error is role=alert with a working
+ * "Try again" that RE-FETCHES (we assert refetch fires + the surface recovers
+ * to populated). No fabricated data — every state is driven by a mocked
+ * useLensData standing in for the real backend in the exact shape it returns.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
+import React from 'react';
+
+// ── main list channel: useLensData (controls loading/error/empty/populated) ──
+const lensDataState: {
+  items: unknown[];
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+} = { items: [], isLoading: false, isError: false, error: null };
+const refetch = vi.fn();
+
+// ── compute-action channel: useRunArtifact mutate ───────────────────────────
+const runMutate = vi.fn(() => Promise.resolve({ ok: true, result: {} }));
+const useRunArtifactSpy = vi.fn();
+
+vi.mock('@/lib/hooks/use-lens-data', () => ({
+  useLensData: () => ({
+    items: lensDataState.items,
+    total: lensDataState.items.length,
+    isLoading: lensDataState.isLoading,
+    isError: lensDataState.isError,
+    error: lensDataState.error,
+    isSeeding: false,
+    refetch,
+    create: vi.fn(() => Promise.resolve({})),
+    update: vi.fn(() => Promise.resolve({})),
+    remove: vi.fn(() => Promise.resolve({})),
+    createMut: { isPending: false },
+    updateMut: { isPending: false },
+    deleteMut: { isPending: false },
+  }),
+}));
+
+vi.mock('@/lib/hooks/use-lens-artifacts', () => ({
+  useRunArtifact: (domain: string) => {
+    useRunArtifactSpy(domain);
+    return { mutateAsync: (...a: unknown[]) => runMutate(...a), isPending: false };
+  },
+}));
+
+// ── headless chrome + heavy side panels: render-only / inert stubs ──────────
+vi.mock('@/components/lens/LensShell', () => ({
+  LensShell: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', { 'data-testid': 'lens-shell' }, children),
+}));
+vi.mock('@/hooks/useLensNav', () => ({ useLensNav: () => {} }));
+vi.mock('@/hooks/useLensCommand', () => ({ useLensCommand: () => {} }));
+vi.mock('@/hooks/useRealtimeLens', () => ({
+  useRealtimeLens: () => ({ latestData: null, alerts: [], insights: [], isLive: false, lastUpdated: null }),
+}));
+vi.mock('@/components/lens/RecentMineCard', () => ({ RecentMineCard: () => null }));
+vi.mock('@/components/lens/AutoActionStrip', () => ({ AutoActionStrip: () => null }));
+vi.mock('@/components/lens/CrossLensRecentsPanel', () => ({ CrossLensRecentsPanel: () => null }));
+vi.mock('@/components/lens/FirstRunTour', () => ({ FirstRunTour: () => null }));
+vi.mock('@/components/lens/DepthBadge', () => ({ DepthBadge: () => null }));
+vi.mock('@/components/lens/DraftedTextarea', () => ({ DraftedTextarea: () => null }));
+vi.mock('@/components/lens/ManifestActionBar', () => ({ ManifestActionBar: () => null }));
+vi.mock('@/components/lens/UniversalActions', () => ({ UniversalActions: () => null }));
+vi.mock('@/components/lens/LiveIndicator', () => ({ LiveIndicator: () => null }));
+vi.mock('@/components/lens/DTUExportButton', () => ({ DTUExportButton: () => null }));
+vi.mock('@/components/lens/RealtimeDataPanel', () => ({ RealtimeDataPanel: () => null }));
+vi.mock('@/components/lens/LensFeaturePanel', () => ({ LensFeaturePanel: () => null }));
+vi.mock('@/components/lens/LiveFeed', () => ({ default: () => null }));
+vi.mock('@/components/common/VisionAnalyzeButton', () => ({ VisionAnalyzeButton: () => null }));
+vi.mock('@/components/insurance/InsuranceWalletSection', () => ({ InsuranceWalletSection: () => null }));
+vi.mock('@/components/insurance/InsurancePolicyTalk', () => ({ InsurancePolicyTalk: () => null }));
+vi.mock('@/components/insurance/InsuranceActionPanel', () => ({ InsuranceActionPanel: () => null }));
+vi.mock('@/components/insurance/PolicyVault', () => ({ default: () => null }));
+vi.mock('@/components/insurance/ClaimTracker', () => ({ default: () => null }));
+vi.mock('@/components/insurance/QuoteCompare', () => ({ default: () => null }));
+vi.mock('@/components/insurance/CoverageAnalyzer', () => ({ default: () => null }));
+vi.mock('@/components/insurance/AmsWorkbench', () => ({ default: () => null }));
+vi.mock('@/components/insurance/MutualAidPactsPanel', () => ({ default: () => null }));
+vi.mock('@/components/panel-polish', () => ({
+  PipingProvider: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+}));
+// framer-motion: render plain elements so animated nodes mount synchronously.
+vi.mock('framer-motion', () => ({
+  motion: new Proxy({}, { get: () => (props: Record<string, unknown>) => React.createElement('div', props, props.children as React.ReactNode) }),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+}));
+
+import InsuranceLens from '@/app/lenses/insurance/page';
+
+const POLICY = {
+  id: 'art_1',
+  title: 'Acme Auto Policy',
+  data: { policyType: 'auto', carrier: 'Acme Mutual', premium: 1200, coverageLimit: 100000, deductible: 500, namedInsureds: [], endorsements: [], effectiveDate: '2026-01-01', expiryDate: '2027-01-01', policyNumber: 'POL-0001' },
+  meta: { tags: [], status: 'active', visibility: 'private' },
+  createdAt: '2026-06-27', updatedAt: '2026-06-27', version: 1,
+};
+
+beforeEach(() => {
+  lensDataState.items = [];
+  lensDataState.isLoading = false;
+  lensDataState.isError = false;
+  lensDataState.error = null;
+  refetch.mockReset();
+  runMutate.mockReset();
+  runMutate.mockImplementation(() => Promise.resolve({ ok: true, result: {} }));
+  useRunArtifactSpy.mockReset();
+});
+
+describe('insurance lens — wiring', () => {
+  it('drives the compute-action runner on the insurance domain', () => {
+    render(<InsuranceLens />);
+    expect(useRunArtifactSpy).toHaveBeenCalledWith('insurance');
+  });
+});
+
+describe('insurance lens — four UX states', () => {
+  it('LOADING: shows a role=status indicator while the list is in flight', () => {
+    lensDataState.isLoading = true;
+    const { container, getByText } = render(<InsuranceLens />);
+    const status = container.querySelector('[role="status"]');
+    expect(status).toBeTruthy();
+    expect(status?.getAttribute('aria-busy')).toBe('true');
+    expect(getByText(/Loading insurance data/i)).toBeInTheDocument();
+  });
+
+  it('ERROR: a failed load shows role=alert + a working Retry that re-fetches', async () => {
+    lensDataState.isError = true;
+    lensDataState.error = new Error('carrier feed offline');
+    const { container, getByText } = render(<InsuranceLens />);
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert).toBeTruthy();
+    expect(getByText(/carrier feed offline/i)).toBeInTheDocument();
+
+    // Retry must re-invoke the backend fetch (refetch), not be a dead button.
+    await act(async () => { fireEvent.click(getByText('Try again')); });
+    await waitFor(() => expect(refetch).toHaveBeenCalled());
+  });
+
+  it('EMPTY: shows an honest empty cue when there are no policies', () => {
+    lensDataState.items = [];
+    const { getAllByText } = render(<InsuranceLens />);
+    // The Dashboard "Recent Policies" panel renders "No policies yet." when empty.
+    expect(getAllByText(/No policies yet|No .* found/i).length).toBeGreaterThan(0);
+  });
+
+  it('POPULATED: renders the real policy row from the backend list', () => {
+    lensDataState.items = [POLICY];
+    const { getAllByText } = render(<InsuranceLens />);
+    expect(getAllByText(/Acme Auto Policy/i).length).toBeGreaterThan(0);
+  });
+});

--- a/concord-frontend/tests/legal-lens-states.test.tsx
+++ b/concord-frontend/tests/legal-lens-states.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * /lenses/legal — four-UX-state contract for the Legal Practice lens.
+ *
+ * Pins that the lens renders genuine loading / error (with a WORKING Retry) /
+ * empty / populated states against its real backend channel: the artifact list
+ * (useLensData('legal', 'artifact') → GET /api/lens/legal), and that the
+ * compute-action panel drives the 'legal' domain via useRunArtifact.
+ *
+ * Load-bearing wiring assertion: the action runner must be constructed on the
+ * 'legal' domain — a regression to any other id would resolve to NO backend
+ * receiver (the conflictCheck / deadlineCalculator / generateInvoice /
+ * caseSummary / complianceAudit buttons would post to a dead channel).
+ *
+ * a11y: loading is role=status (aria-busy), error is role=alert with a working
+ * "Try again" that RE-FETCHES (we assert refetch fires). No fabricated data —
+ * every state is driven by a mocked useLensData standing in for the real
+ * backend in the exact shape it returns.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
+import React from 'react';
+
+// ── main list channel: useLensData (controls loading/error/empty/populated) ──
+const lensDataState: {
+  items: unknown[];
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+} = { items: [], isLoading: false, isError: false, error: null };
+const refetch = vi.fn();
+
+// ── compute-action channel: useRunArtifact mutate ───────────────────────────
+const runMutate = vi.fn(() => Promise.resolve({ ok: true, result: {} }));
+const useRunArtifactSpy = vi.fn();
+
+vi.mock('@/lib/hooks/use-lens-data', () => ({
+  useLensData: () => ({
+    items: lensDataState.items,
+    total: lensDataState.items.length,
+    isLoading: lensDataState.isLoading,
+    isError: lensDataState.isError,
+    error: lensDataState.error,
+    isSeeding: false,
+    refetch,
+    create: vi.fn(() => Promise.resolve({})),
+    update: vi.fn(() => Promise.resolve({})),
+    remove: vi.fn(() => Promise.resolve({})),
+    createMut: { isPending: false },
+    updateMut: { isPending: false },
+    deleteMut: { isPending: false },
+  }),
+}));
+
+vi.mock('@/lib/hooks/use-lens-artifacts', () => ({
+  useRunArtifact: (domain: string) => {
+    useRunArtifactSpy(domain);
+    return { mutateAsync: (...a: unknown[]) => runMutate(...a), isPending: false };
+  },
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ data: null, isLoading: false }),
+}));
+vi.mock('@/lib/api/client', () => ({
+  api: { get: vi.fn(() => Promise.resolve({ data: null })), post: vi.fn(() => Promise.resolve({ data: {} })), delete: vi.fn(() => Promise.resolve({ data: {} })) },
+  apiHelpers: { lens: { runDomain: vi.fn(() => Promise.resolve({ data: { ok: true, result: {} } })) } },
+  lensRun: vi.fn(() => Promise.resolve({ data: { result: {} } })),
+}));
+
+// ── headless chrome + heavy side panels: render-only / inert stubs ──────────
+vi.mock('@/components/lens/LensShell', () => ({
+  LensShell: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', { 'data-testid': 'lens-shell' }, children),
+}));
+vi.mock('@/hooks/useLensNav', () => ({ useLensNav: () => {} }));
+vi.mock('@/hooks/useLensCommand', () => ({ useLensCommand: () => {} }));
+vi.mock('@/hooks/useRealtimeLens', () => ({
+  useRealtimeLens: () => ({ latestData: null, alerts: [], insights: [], isLive: false, lastUpdated: null }),
+}));
+vi.mock('@/store/ui', () => ({
+  useUIStore: Object.assign(() => {}, { getState: () => ({ addToast: () => {} }) }),
+}));
+vi.mock('@/components/lens/RecentMineCard', () => ({ RecentMineCard: () => null }));
+vi.mock('@/components/lens/AutoActionStrip', () => ({ AutoActionStrip: () => null }));
+vi.mock('@/components/lens/CrossLensRecentsPanel', () => ({ CrossLensRecentsPanel: () => null }));
+vi.mock('@/components/lens/FirstRunTour', () => ({ FirstRunTour: () => null }));
+vi.mock('@/components/lens/DepthBadge', () => ({ DepthBadge: () => null }));
+vi.mock('@/components/lens/DraftedTextarea', () => ({ DraftedTextarea: () => null }));
+vi.mock('@/components/lens/UniversalActions', () => ({ UniversalActions: () => null }));
+vi.mock('@/components/lens/LiveIndicator', () => ({ LiveIndicator: () => null }));
+vi.mock('@/components/lens/DTUExportButton', () => ({ DTUExportButton: () => null }));
+vi.mock('@/components/lens/RealtimeDataPanel', () => ({ RealtimeDataPanel: () => null }));
+vi.mock('@/components/lens/LensFeaturePanel', () => ({ LensFeaturePanel: () => null }));
+vi.mock('@/components/lens/LensAgentFab', () => ({ default: () => null }));
+vi.mock('@/components/lens/ShellPreview', () => ({ ShellPreview: () => null }));
+vi.mock('@/components/lens/LiveFeed', () => ({ default: () => null }));
+vi.mock('@/components/feeds/LensFeedPanel', () => ({ LensFeedPanel: () => null }));
+vi.mock('@/components/mobile/MobileTabBar', () => ({ MobileTabBar: () => null }));
+// legal-specific child surfaces — inert in this state test
+vi.mock('@/components/legal/ClioSection', () => ({ ClioSection: () => null }));
+vi.mock('@/components/legal/ContractAnalyzer', () => ({ default: () => null }));
+vi.mock('@/components/legal/LegalActionPanel', () => ({ LegalActionPanel: () => null }));
+vi.mock('@/components/legal/CaseTracker', () => ({ default: () => null }));
+vi.mock('@/components/legal/LegalQA', () => ({ default: () => null }));
+vi.mock('@/components/legal/LegalCaseSearch', () => ({ LegalCaseSearch: () => null }));
+vi.mock('@/components/legal/IntakeFormsPanel', () => ({ IntakeFormsPanel: () => null }));
+vi.mock('@/components/legal/ReportsPanel', () => ({ ReportsPanel: () => null }));
+vi.mock('@/components/panel-polish', () => ({ PipingProvider: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children) }));
+// framer-motion: render plain elements so animated nodes mount synchronously.
+vi.mock('framer-motion', () => ({
+  motion: new Proxy({}, { get: () => (props: Record<string, unknown>) => React.createElement('div', props, props.children as React.ReactNode) }),
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+}));
+
+import LegalLens from '@/app/lenses/legal/page';
+
+const CASE = {
+  id: 'art_case_1',
+  title: 'Smith v. Jones',
+  data: { artifactType: 'Case', status: 'active', description: 'Breach of contract', matterType: 'litigation', caseNumber: '23-CV-1234' },
+  meta: { tags: ['Case'], status: 'active', visibility: 'private' },
+  createdAt: '2026-06-27', updatedAt: '2026-06-27', version: 1,
+};
+
+beforeEach(() => {
+  lensDataState.items = [];
+  lensDataState.isLoading = false;
+  lensDataState.isError = false;
+  lensDataState.error = null;
+  refetch.mockReset();
+  runMutate.mockReset();
+  runMutate.mockImplementation(() => Promise.resolve({ ok: true, result: {} }));
+  useRunArtifactSpy.mockReset();
+});
+
+describe('legal lens — wiring', () => {
+  it('drives the compute-action runner on the legal domain', () => {
+    render(<LegalLens />);
+    expect(useRunArtifactSpy).toHaveBeenCalledWith('legal');
+  });
+});
+
+describe('legal lens — four UX states', () => {
+  it('LOADING: shows a role=status indicator while the list is in flight', () => {
+    lensDataState.isLoading = true;
+    const { container, getByText } = render(<LegalLens />);
+    const status = container.querySelector('[role="status"]');
+    expect(status).toBeTruthy();
+    expect(status?.getAttribute('aria-busy')).toBe('true');
+    expect(getByText(/Loading case files/i)).toBeInTheDocument();
+  });
+
+  it('ERROR: a failed load shows role=alert + a working Retry that re-fetches', async () => {
+    lensDataState.isError = true;
+    lensDataState.error = new Error('case files offline');
+    const { container, getByText } = render(<LegalLens />);
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert).toBeTruthy();
+    expect(getByText(/case files offline/i)).toBeInTheDocument();
+
+    // Retry must re-invoke the backend fetch (refetch), not be a dead button.
+    await act(async () => { fireEvent.click(getByText('Try again')); });
+    await waitFor(() => expect(refetch).toHaveBeenCalled());
+  });
+
+  it('EMPTY: shows an honest empty CTA when there are no cases', () => {
+    lensDataState.items = [];
+    const { getAllByText } = render(<LegalLens />);
+    // Dashboard (default tab) Recent-Cases section renders an honest empty cue.
+    expect(getAllByText(/No cases yet|Create one to get started|No .* found/i).length).toBeGreaterThan(0);
+  });
+
+  it('POPULATED: renders the real case row from the backend list', () => {
+    lensDataState.items = [CASE];
+    const { getAllByText } = render(<LegalLens />);
+    expect(getAllByText(/Smith v\. Jones/i).length).toBeGreaterThan(0);
+  });
+});

--- a/content/contracts/overrides/affect.checkin.json
+++ b/content/contracts/overrides/affect.checkin.json
@@ -1,0 +1,33 @@
+{
+  "macro_id": "affect.checkin",
+  "domain": "affect",
+  "name": "checkin",
+  "inputs": {
+    "mood": { "type": "number", "required": true },
+    "note": { "type": "string", "required": false, "maxLength": 2000 },
+    "activities": { "type": "array", "required": false },
+    "promptId": { "type": "string", "required": false },
+    "promptAnswer": { "type": "string", "required": false, "maxLength": 4000 }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || (output.result.entry && Number.isFinite(output.result.entry.mood))",
+    "output.ok === false || typeof output.result.entry.moodLabel === 'string'",
+    "output.ok === false || typeof output.result.entry.moodEmoji === 'string'",
+    "output.ok === false || Array.isArray(output.result.entry.activities)",
+    "output.ok === false || Number.isFinite(output.result.currentStreak)",
+    "output.ok === false || Number.isFinite(output.result.longestStreak)",
+    "output.ok === false || Number.isFinite(output.result.totalCheckins)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "mood": 4, "note": "decent day", "activities": ["walk", "Reading"] }, "expect": { "ok": true } },
+    { "input": { "mood": 1 }, "expect": { "ok": true } },
+    { "input": { "mood": 5, "promptId": "prompt_0", "promptAnswer": "today was calm" }, "expect": { "ok": true } },
+    { "input": { "mood": 99 }, "expect": { "ok": false } },
+    { "input": { "mood": "NaN" }, "expect": { "ok": false } },
+    { "input": { "mood": "Infinity" }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'affect.checkin'. MoodTracker.tsx sends {mood,note,activities,promptId,promptAnswer} as flat params and renders r.result.entry.{moodEmoji,moodLabel} + currentStreak + longestStreak. Mood is validated against the per-user scale min/max via Number()+Number.isFinite; out-of-range / non-numeric → {ok:false,error:string} (the panel surfaces r.data.error). Streak is consecutive-calendar-day. Per-user in globalThis._concordSTATE.affectMood — no seed/mock entries ever. Already try/catch-guarded. Streak/scope math pinned by affect-domain-parity.test.js; field-alignment + validation pinned by server/tests/affect-lens-macros.test.js."
+}

--- a/content/contracts/overrides/affect.detect-patterns.json
+++ b/content/contracts/overrides/affect.detect-patterns.json
@@ -1,0 +1,32 @@
+{
+  "macro_id": "affect.detect-patterns",
+  "domain": "affect",
+  "name": "detect-patterns",
+  "inputs": {
+    "entries": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || Number.isFinite(output.result.entryCount)",
+    "output.ok === false || Array.isArray(output.result.patterns)",
+    "output.ok === false || output.result.patterns.every(function(p){ return typeof p.theme === 'string' && Number.isFinite(p.count); })",
+    "output.ok === false || Array.isArray(output.result.triggers)",
+    "output.ok === false || output.result.triggers.every(function(t){ return typeof t.trigger === 'string' && Number.isFinite(t.count); })",
+    "output.ok === false || Array.isArray(output.result.cycles)",
+    "output.ok === false || output.result.cycles.every(function(c){ return typeof c.label === 'string'; })",
+    "output.ok === false || Array.isArray(output.result.correlations)",
+    "output.ok === false || typeof output.result.summary === 'string'",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "entries": [] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "entries": [{ "text": "work deadline stress made me anxious", "timestamp": "2026-06-01T09:00:00Z" }, { "text": "more work stress and a tight deadline", "timestamp": "2026-06-02T09:30:00Z" }, { "text": "work stress again, anxious about money", "timestamp": "2026-06-04T09:15:00Z" }] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "checkins": [{ "note": "family time happy and calm" }] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "entries": "not an array" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "entries": 42 } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "entries": [{ "text": 123 }, null, { "text": "stress and work" }] } } }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'affect.detect-patterns'. /lenses/affect Analysis tab renders r.result.{patterns[].{theme,count},triggers[].{trigger,count},cycles[].{label,count},correlations[].{between,strength},summary}. Deterministic journal-text analysis: stopword-filtered theme frequency, trigger-word hits, time-of-day/day-of-week cycles. Reads artifact.data.entries OR .checkins; String-coerces e.text/e.note. Empty → {ok:true} with stable empty arrays + summary string. Hardened (Phase-2 gate) with an outer try/catch. The page renderer was aligned to these canonical field names (theme/trigger/label/between) — it previously read name/label/from/to and rendered blanks. Not assassin-driven (LENS_ACTIONS); pinned by server/tests/affect-lens-macros.test.js."
+}

--- a/content/contracts/overrides/affect.emotionTimeline.json
+++ b/content/contracts/overrides/affect.emotionTimeline.json
@@ -1,0 +1,31 @@
+{
+  "macro_id": "affect.emotionTimeline",
+  "domain": "affect",
+  "name": "emotionTimeline",
+  "inputs": {
+    "entries": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.message !== undefined || typeof output.result.arcType === 'string'",
+    "output.ok === false || output.result.message !== undefined || Number.isFinite(output.result.entryCount)",
+    "output.ok === false || output.result.message !== undefined || Number.isFinite(output.result.volatility)",
+    "output.ok === false || output.result.message !== undefined || Array.isArray(output.result.smoothedValence)",
+    "output.ok === false || output.result.message !== undefined || output.result.smoothedValence.every(function(v){ return Number.isFinite(v); })",
+    "output.ok === false || output.result.message !== undefined || (output.result.arcSegments && Number.isFinite(output.result.arcSegments.beginning) && Number.isFinite(output.result.arcSegments.middle) && Number.isFinite(output.result.arcSegments.end))",
+    "output.ok === false || output.result.message !== undefined || Number.isFinite(output.result.overallValence)",
+    "output.ok === false || output.result.message !== undefined || Number.isFinite(output.result.overallIntensity)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "entries": [] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "entries": [{ "id": "a", "text": "terrible awful miserable" }, { "id": "b", "text": "okay getting better" }, { "id": "c", "text": "wonderful amazing joy" }] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "entries": [{ "text": "great success triumph" }] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "entries": "not an array" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "entries": 42 } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "entries": { "x": 1 } } } }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'affect.emotionTimeline'. /lenses/affect Analysis tab renders r.result.{arcType,entryCount,volatility,smoothedValence[],arcSegments.{beginning,middle,end},turningPoints[].{index,type,valence,magnitude},overallValence,overallIntensity}. Vonnegut-shape arc classifier over a pos/neg lexicon + moving-average smoothing. Empty/absent entries → {ok:true,result.message}. FIXED (Phase-2 gate): a poisoned non-array entries once threw `entries.map is not a function`; now Array.isArray-guarded + try/catch. Not assassin-driven (LENS_ACTIONS); pinned by server/tests/affect-lens-macros.test.js."
+}

--- a/content/contracts/overrides/affect.empathyMap.json
+++ b/content/contracts/overrides/affect.empathyMap.json
@@ -1,0 +1,29 @@
+{
+  "macro_id": "affect.empathyMap",
+  "domain": "affect",
+  "name": "empathyMap",
+  "inputs": {
+    "feedback": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.message !== undefined || Number.isFinite(output.result.totalFeedback)",
+    "output.ok === false || output.result.message !== undefined || (output.result.quadrants && ['thinks','feels','says','does'].every(function(q){ return output.result.quadrants[q] && Number.isFinite(output.result.quadrants[q].count) && Array.isArray(output.result.quadrants[q].items); }))",
+    "output.ok === false || output.result.message !== undefined || Array.isArray(output.result.painPoints)",
+    "output.ok === false || output.result.message !== undefined || Array.isArray(output.result.gains)",
+    "output.ok === false || output.result.message !== undefined || Array.isArray(output.result.topThemes)",
+    "output.ok === false || output.result.message !== undefined || (output.result.summary && Number.isFinite(output.result.summary.totalPainPoints) && Number.isFinite(output.result.summary.totalGains) && Number.isFinite(output.result.summary.avgPainScore) && Number.isFinite(output.result.summary.avgGainScore) && Number.isFinite(output.result.summary.sentimentBalance))",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "feedback": [] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "feedback": [{ "userId": "u1", "text": "the dashboard is confusing and slow, a real problem" }, { "userId": "u2", "text": "I love how easy and fast and simple it is" }] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "feedback": [{ "text": "I clicked buy and it was smooth and helpful" }] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "feedback": "not an array" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "feedback": { "x": 1 } } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "feedback": [null, { "text": 123 }, "raw", { "text": "I love this it is great" }] } } }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'affect.empathyMap'. /lenses/affect Analysis tab renders r.result.{totalFeedback,analyzedAt,quadrants.{thinks,feels,says,does}.{count,items[].text},painPoints[].{text,keywords},gains[].{text,keywords},topThemes[].{phrase,count},summary.{totalPainPoints,totalGains,avgPainScore,avgGainScore,sentimentBalance}}. Think/Feel/Say/Do quadrant classifier + pain/gain keyword detection. Empty/absent feedback → {ok:true,result.message}. FIXED (Phase-2 gate): a poisoned non-array feedback (string iterates chars / object non-iterable → throws) and a poisoned non-string item.text once threw; now Array.isArray + per-item typeof guards + try/catch. Not assassin-driven (LENS_ACTIONS); pinned by server/tests/affect-lens-macros.test.js."
+}

--- a/content/contracts/overrides/affect.sentimentAnalysis.json
+++ b/content/contracts/overrides/affect.sentimentAnalysis.json
@@ -1,0 +1,30 @@
+{
+  "macro_id": "affect.sentimentAnalysis",
+  "domain": "affect",
+  "name": "sentimentAnalysis",
+  "inputs": {
+    "text": { "type": "string", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.message !== undefined || (output.result.vad && Number.isFinite(output.result.vad.valence) && Number.isFinite(output.result.vad.arousal) && Number.isFinite(output.result.vad.dominance))",
+    "output.ok === false || output.result.message !== undefined || ['positive','neutral','negative'].indexOf(output.result.sentimentLabel) >= 0",
+    "output.ok === false || output.result.message !== undefined || Number.isFinite(output.result.tokenCount)",
+    "output.ok === false || output.result.message !== undefined || Number.isFinite(output.result.matchedTokens)",
+    "output.ok === false || output.result.message !== undefined || Number.isFinite(output.result.coverage)",
+    "output.ok === false || output.result.message !== undefined || Array.isArray(output.result.emotionHits)",
+    "output.ok === false || output.result.message !== undefined || ['low','moderate','high'].indexOf(output.result.sarcasmLikelihood) >= 0",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "text": "" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "text": "I am so happy and grateful, this is wonderful" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "text": "this terrible awful horrible day fills me with despair" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "text": "I am not happy" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "text": 9999 } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "text": { "x": 1 } } } }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'affect.sentimentAnalysis'. /lenses/affect Analysis tab renders r.result.{sentimentLabel,primaryEmotion,isMixedEmotion,vad.{valence,arousal,dominance},tokenCount,matchedTokens,coverage,emotionHits[].{word,valence,negated},sarcasmIndicators[].detail,sarcasmLikelihood}. Deterministic VAD lexicon + negation/intensifier context. Absent/empty text → {ok:true,result.message} (panel message branch). FIXED (Phase-2 gate): a poisoned non-string text once threw `text.trim is not a function`; now typeof-guarded + try/catch so poison degrades to the message branch. Not assassin-driven (LENS_ACTIONS, not in runMacro MACROS map); pinned by server/tests/affect-lens-macros.test.js."
+}

--- a/content/contracts/overrides/art.aic-search.json
+++ b/content/contracts/overrides/art.aic-search.json
@@ -1,0 +1,20 @@
+{
+  "macro_id": "art.aic-search",
+  "domain": "art",
+  "name": "aic-search",
+  "external_io": true,
+  "inputs": {
+    "query": { "type": "string", "required": false, "maxLength": 200 },
+    "limit": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === true || typeof (output.reason || output.error) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": false } },
+    { "input": { "query": "   " }, "expect": { "ok": false } }
+  ],
+  "_note": "art.aic-search (server/domains/art.js) hits the Art Institute of Chicago API (api.artic.edu, free/no-key). EXTERNAL-IO — marked external_io:true so it is NEVER driven against the live endpoint by the assassin. Fail-soft: empty query is validate-REJECTED ({ok:false,error:'query required'}) BEFORE any fetch; network failure returns {ok:false,error} and never throws. The /lenses/art ArtExplorer calls it via runDomain('art','aic-search',{input:{query,limit}}). Pinned (validate-reject, no-network) by server/tests/art-lens-macros.test.js."
+}

--- a/content/contracts/overrides/art.colorHarmony.json
+++ b/content/contracts/overrides/art.colorHarmony.json
@@ -1,0 +1,28 @@
+{
+  "macro_id": "art.colorHarmony",
+  "domain": "art",
+  "name": "colorHarmony",
+  "inputs": {
+    "palette": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.message !== undefined || Number.isFinite(output.result.harmonyScore)",
+    "output.ok === false || output.result.message !== undefined || (output.result.harmonyScore >= 0 && output.result.harmonyScore <= 100)",
+    "output.ok === false || output.result.message !== undefined || Number.isFinite(output.result.dominantHue)",
+    "output.ok === false || output.result.message !== undefined || Array.isArray(output.result.harmonies)",
+    "output.ok === false || output.result.message !== undefined || ['warm','cool','balanced'].includes(output.result.temperature)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "palette": [] }, "expect": { "ok": true } },
+    { "input": { "palette": ["#ff0000", "#00ffff", "#ff1a00"] }, "expect": { "ok": true } },
+    { "input": { "palette": [{ "hex": "#3498db" }, { "hex": "#db7734" }] }, "expect": { "ok": true } },
+    { "input": { "palette": ["#zzzzzz", "#00ff00"] }, "expect": { "ok": false } },
+    { "input": { "palette": ["#ff0000", "1e999"] }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS handler (server/domains/art.js). Dispatch key 'art.colorHarmony'. Pure compute over artifact.data.palette = ['#hex',...] or [{hex}]. POISON: a malformed/non-string hex is fail-CLOSED via normalizeHex BEFORE hexToRgb can emit NaN channels into harmonyScore/dominantHue; empty palette degrades to ok:true {message}. Drives PaletteWorkshop + ArtActionPanel 'Harmony'. Pinned by server/tests/art-lens-macros.test.js."
+}

--- a/content/contracts/overrides/art.compositionScore.json
+++ b/content/contracts/overrides/art.compositionScore.json
@@ -1,0 +1,28 @@
+{
+  "macro_id": "art.compositionScore",
+  "domain": "art",
+  "name": "compositionScore",
+  "inputs": {
+    "elements": { "type": "array", "required": false },
+    "canvas": { "type": "object", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.message !== undefined || Number.isFinite(output.result.overall)",
+    "output.ok === false || output.result.message !== undefined || (output.result.overall >= 0 && output.result.overall <= 100)",
+    "output.ok === false || output.result.message !== undefined || ['excellent','good','fair','needs_work'].includes(output.result.rating)",
+    "output.ok === false || output.result.message !== undefined || ['ruleOfThirds','goldenRatio','balance','whitespace','visualFlow'].every(function(k){ return Number.isFinite(output.result.scores[k]); })",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "elements": [] }, "expect": { "ok": true } },
+    { "input": { "elements": [{ "x": 640, "y": 360, "width": 200, "height": 200, "weight": 2 }, { "x": 1280, "y": 720, "width": 150, "height": 150 }], "canvas": { "width": 1920, "height": 1080 } }, "expect": { "ok": true } },
+    { "input": { "elements": [{ "x": "Infinity", "y": 0, "width": 10, "height": 10 }], "canvas": { "width": 1920, "height": 1080 } }, "expect": { "ok": false } },
+    { "input": { "elements": [{ "x": 1, "y": 1, "width": "1e999", "height": 10 }], "canvas": { "width": 1920, "height": 1080 } }, "expect": { "ok": false } },
+    { "input": { "elements": [{ "x": 1, "y": 1, "width": 10, "height": 10 }], "canvas": { "width": "NaN", "height": 1080 } }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS handler (server/domains/art.js). Dispatch key 'art.compositionScore'. Pure geometry scoring over artifact.data.elements=[{x,y,width,height,weight?}] + artifact.data.canvas={width,height}. POISON: a non-finite coordinate/dimension/weight or non-positive/non-finite canvas is fail-CLOSED (rejected) before any math, so no NaN/Infinity score leaks under ok:true; empty elements degrade to ok:true {message}. Drives ArtActionPanel 'Composition'. Pinned by server/tests/art-lens-macros.test.js."
+}

--- a/content/contracts/overrides/art.generatePalette.json
+++ b/content/contracts/overrides/art.generatePalette.json
@@ -1,0 +1,30 @@
+{
+  "macro_id": "art.generatePalette",
+  "domain": "art",
+  "name": "generatePalette",
+  "inputs": {
+    "baseColor": { "type": "string", "required": false, "maxLength": 7 },
+    "harmony": { "type": "string", "required": false, "maxLength": 32 },
+    "count": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || Array.isArray(output.result.palette)",
+    "output.ok === false || output.result.palette.length >= 2",
+    "output.ok === false || output.result.palette.length <= 24",
+    "output.ok === false || output.result.palette.every(function(c){ return /^#[0-9a-f]{6}$/i.test(c.hex); })",
+    "output.ok === false || typeof output.result.harmony === 'string'",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "baseColor": "#3498db", "harmony": "complementary", "count": 5 }, "expect": { "ok": true } },
+    { "input": { "baseColor": "#ff0000" }, "expect": { "ok": true } },
+    { "input": { "baseColor": "#3498db", "harmony": "analogous", "count": "1e999" }, "expect": { "ok": true } },
+    { "input": { "baseColor": "not-a-color", "count": 4 }, "expect": { "ok": false } },
+    { "input": { "baseColor": "#zzz", "count": 3 }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS handler (server/domains/art.js). Dispatch key 'art.generatePalette'. Pure compute from params.baseColor/harmony/count. POISON: a malformed baseColor is fail-CLOSED via normalizeHex (rejected) so no '#NaNNaN' swatch is emitted; count is coerced + clamped to a finite [2,24] so Infinity/NaN can't drive an unbounded/NaN loop. Drives PaletteWorkshop + ArtActionPanel 'Palette'. Pinned by server/tests/art-lens-macros.test.js."
+}

--- a/content/contracts/overrides/art.styleClassify.json
+++ b/content/contracts/overrides/art.styleClassify.json
@@ -1,0 +1,27 @@
+{
+  "macro_id": "art.styleClassify",
+  "domain": "art",
+  "name": "styleClassify",
+  "inputs": {
+    "attributes": { "type": "object", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || (output.result.topMatch && typeof output.result.topMatch.style === 'string')",
+    "output.ok === false || Number.isFinite(output.result.topMatch.similarity)",
+    "output.ok === false || Array.isArray(output.result.allMatches)",
+    "output.ok === false || output.result.allMatches.every(function(m){ return Number.isFinite(m.similarity); })",
+    "output.ok === false || ['high','moderate','low'].includes(output.result.confidence)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "attributes": {} }, "expect": { "ok": true } },
+    { "input": { "attributes": { "brushwork": 80, "colorSaturation": 70, "contrast": 40, "perspective": 40, "detail": 30, "abstraction": 40, "lineWeight": 20, "texture": 70 } }, "expect": { "ok": true } },
+    { "input": { "attributes": { "brushwork": "Infinity", "colorSaturation": "NaN", "contrast": "1e999" } }, "expect": { "ok": true } },
+    { "input": { "attributes": { "detail": -5, "texture": 999 } }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler (server/domains/art.js). Dispatch key 'art.styleClassify'. Pure compute: nearest-style match of artifact.data.attributes (8 axes 0-100) against 10 reference profiles via normalized 8D Euclidean distance. POISON: each axis is coerced + clamped into [0,100] (non-finite → default 50) so a poisoned axis can never leak a non-finite similarity under ok:true. Drives ArtActionPanel 'Style'. Pinned by server/tests/art-lens-macros.test.js."
+}

--- a/content/contracts/overrides/artistry.colorPaletteAnalysis.json
+++ b/content/contracts/overrides/artistry.colorPaletteAnalysis.json
@@ -1,0 +1,26 @@
+{
+  "macro_id": "artistry.colorPaletteAnalysis",
+  "domain": "artistry",
+  "name": "colorPaletteAnalysis",
+  "inputs": {
+    "palette": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Array.isArray(output.result.colors)",
+    "output.ok === false || Number.isFinite(output.result.harmonyScore)",
+    "output.ok === false || output.result.dominantHue === null || Number.isFinite(output.result.dominantHue)",
+    "output.ok === false || Number.isFinite(output.result.contrastRange)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "palette": [] }, "expect": { "ok": true } },
+    { "input": { "palette": ["#ff0000", "#00ff00", "#0000ff"] }, "expect": { "ok": true } },
+    { "input": { "palette": [{ "color": "#ff0000", "weight": "Infinity" }, { "color": "#0000ff", "weight": "1e999" }] }, "expect": { "ok": true } },
+    { "input": { "palette": [{ "color": "#abc123", "weight": "NaN" }] }, "expect": { "ok": true } },
+    { "input": { "palette": "not-an-array" }, "expect": {} }
+  ],
+  "_note": "LENS_ACTIONS handler (server/domains/artistry.js, registerLensAction('artistry','colorPaletteAnalysis',...)) — reached only via /api/lens/run + /api/lens/artistry/:id/run, dispatched on the EXACT key 'artistry.colorPaletteAnalysis' (3-arg handler(ctx, virtualArtifact, input) with virtualArtifact.data === input). The /lenses/artistry page drives it through useRunArtifact('artistry') → POST /api/lens/artistry/:id/run with the artifact's stored .data.palette. DETERMINISTIC pure compute (no LLM, no network). POISON: a per-color weight is coerced via finNum — non-finite (Infinity/NaN from 'Infinity'/'1e999') OR beyond-1e15 magnitude collapse to 1, so the weighted dominant-hue / harmony / saturation totals stay FINITE. Empty/absent/non-array palette degrades graceful (ok:true with the page-rendered message + colors:[], or a caught handler_error), never throws. Lives in LENS_ACTIONS (not MACROS) so the macro-assassin's enumerateMacros(MACROS) pipeline does NOT drive this contract — authored behavioral spec pinned by server/tests/artistry-lens-macros.test.js."
+}

--- a/content/contracts/overrides/artistry.compositionScore.json
+++ b/content/contracts/overrides/artistry.compositionScore.json
@@ -1,0 +1,25 @@
+{
+  "macro_id": "artistry.compositionScore",
+  "domain": "artistry",
+  "name": "compositionScore",
+  "inputs": {
+    "elements": { "type": "array", "required": false },
+    "canvas": { "type": "object", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || output.result.overallScore === undefined || Number.isFinite(output.result.overallScore)",
+    "output.ok === false || output.result.balanceScore === undefined || Number.isFinite(output.result.balanceScore)",
+    "output.ok === false || output.result.coverageScore === undefined || Number.isFinite(output.result.coverageScore)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "elements": [], "canvas": {} }, "expect": { "ok": true } },
+    { "input": { "canvas": { "width": 100, "height": 100 }, "elements": [{ "x": 25, "y": 25, "width": 16, "height": 16, "weight": 1 }] }, "expect": { "ok": true } },
+    { "input": { "canvas": { "width": "Infinity", "height": "NaN" }, "elements": [{ "x": "1e999", "y": 0, "width": "Infinity", "height": 10, "weight": "Infinity" }] }, "expect": { "ok": true } },
+    { "input": { "elements": "boom" }, "expect": {} }
+  ],
+  "_note": "LENS_ACTIONS handler (server/domains/artistry.js). 3-arg dispatch via /api/lens/run on key 'artistry.compositionScore' (virtualArtifact.data === input). The /lenses/artistry page reads result.overallScore (rendered /100). DETERMINISTIC pure compute. POISON: canvas dims + element x/y/width/height/weight are coerced via finNum — Infinity/NaN/1e999 collapse to a sane fallback (canvas→100, dims→0, weight→1), so the rule-of-thirds / balance / coverage scores and overallScore stay FINITE. Empty/absent elements degrade graceful (ok:true with the page message + score:0), never throws. Not driven by macro-assassin (LENS_ACTIONS, not MACROS); authored spec pinned by server/tests/artistry-lens-macros.test.js."
+}

--- a/content/contracts/overrides/artistry.jobApply.json
+++ b/content/contracts/overrides/artistry.jobApply.json
@@ -1,0 +1,24 @@
+{
+  "macro_id": "artistry.jobApply",
+  "domain": "artistry",
+  "name": "jobApply",
+  "inputs": {
+    "jobId": { "type": "string", "required": true, "maxLength": 80 },
+    "message": { "type": "string", "required": false, "maxLength": 1500 },
+    "portfolioProjectId": { "type": "string", "required": false, "maxLength": 80 },
+    "quote": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || (output.result.applied === true && typeof output.result.jobId === 'string')",
+    "output.ok === false || (typeof output.result.applicationCount === 'number' && Number.isFinite(output.result.applicationCount))",
+    "output.ok === true || typeof output.error === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "jobId": "nonexistent" }, "expect": { "ok": false } },
+    { "input": {}, "expect": { "ok": false } },
+    { "input": { "jobId": "x", "quote": "Infinity" }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS handler (server/domains/artistry.js). 3-arg dispatch via /api/lens/run on key 'artistry.jobApply' (SOCIAL surface, reads `params`). The /lenses/artistry JobBoard.apply() sends these exact field names. VALIDATION-REJECTION surface: job_not_found (unknown jobId), cannot_apply_own_job (poster === applicant), job_closed (status !== 'open'), already_applied (duplicate). quote is coerced via Number.isFinite(Number(quote)) — a poisoned 'Infinity' falls to null (fail-closed), never a non-finite number in the application. With no STATE → {ok:false, state_unavailable}, never throws. The assassin drive has no STATE/seeded jobs, so every fuzz case correctly terminates ok:false (a missing/invalid job is an honest rejection, not a fake success). Not driven by macro-assassin (LENS_ACTIONS, not MACROS); authored spec pinned by server/tests/artistry-lens-macros.test.js."
+}

--- a/content/contracts/overrides/artistry.mediaInventory.json
+++ b/content/contracts/overrides/artistry.mediaInventory.json
@@ -1,0 +1,25 @@
+{
+  "macro_id": "artistry.mediaInventory",
+  "domain": "artistry",
+  "name": "mediaInventory",
+  "inputs": {
+    "supplies": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || (typeof output.result.totalItems === 'number' && Number.isFinite(output.result.totalItems))",
+    "output.ok === false || Number.isFinite(output.result.totalInventoryValue === undefined ? 0 : output.result.totalInventoryValue)",
+    "output.ok === false || Array.isArray(output.result.reorderAlerts)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "supplies": [] }, "expect": { "ok": true } },
+    { "input": { "supplies": [{ "name": "Cadmium Red", "category": "paint", "quantity": 3, "unit": "tube", "unitCost": 12, "reorderThreshold": 5 }] }, "expect": { "ok": true } },
+    { "input": { "supplies": [{ "name": "Poison", "category": "paint", "quantity": "Infinity", "unitCost": "1e999" }] }, "expect": { "ok": true } },
+    { "input": { "supplies": [{ "name": "NaNish", "category": "paint", "quantity": "NaN", "unitCost": 5 }] }, "expect": { "ok": true } },
+    { "input": { "supplies": "not-an-array" }, "expect": {} }
+  ],
+  "_note": "LENS_ACTIONS handler (server/domains/artistry.js). 3-arg dispatch via /api/lens/run on key 'artistry.mediaInventory' (virtualArtifact.data === input). The /lenses/artistry page reads result.totalItems + result.categoryBreakdown[].category/itemCount. DETERMINISTIC pure compute (no wallet, no minting — a calculator, not a ledger). POISON: per-item quantity/unitCost/reorderThreshold are coerced via finNum — non-finite (Infinity/NaN/1e999) or beyond-1e15 collapse to 0, so totalInventoryValue / totalQuantity / estimatedReorderCost stay FINITE (a poisoned magnitude can never emit an Infinity inventory report). Empty/absent supplies degrade graceful (ok:true with the page message + totalItems:0, reorderAlerts:[]), never throws. Not driven by macro-assassin (LENS_ACTIONS, not MACROS); authored spec pinned by server/tests/artistry-lens-macros.test.js."
+}

--- a/content/contracts/overrides/artistry.projectCreate.json
+++ b/content/contracts/overrides/artistry.projectCreate.json
@@ -1,0 +1,31 @@
+{
+  "macro_id": "artistry.projectCreate",
+  "domain": "artistry",
+  "name": "projectCreate",
+  "inputs": {
+    "title": { "type": "string", "required": false, "maxLength": 160 },
+    "description": { "type": "string", "required": false, "maxLength": 4000 },
+    "discipline": { "type": "string", "required": false, "maxLength": 60 },
+    "tools": { "type": "array", "required": false },
+    "tags": { "type": "array", "required": false },
+    "images": { "type": "array", "required": false },
+    "processSteps": { "type": "array", "required": false },
+    "coverUrl": { "type": "string", "required": false, "maxLength": 600 },
+    "published": { "type": "boolean", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || (output.result.project && typeof output.result.project.id === 'string' && output.result.project.id.length > 0)",
+    "output.ok === false || (Array.isArray(output.result.project.images) && Array.isArray(output.result.project.tags))",
+    "output.ok === false || output.result.project.views === 0",
+    "output.ok === true || typeof output.error === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "title": "Dune Concepts", "discipline": "concept-art", "tags": ["scifi"], "images": [{ "url": "https://x/1.png", "caption": "wide", "order": 0 }] }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "title": "X", "images": ["https://x/a.png", { "url": "https://x/b.png", "order": "Infinity" }] }, "expect": { "ok": true } },
+    { "input": { "title": "X", "tags": "boom", "tools": "boom" }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler (server/domains/artistry.js). 3-arg dispatch via /api/lens/run on key 'artistry.projectCreate' (the SOCIAL surface reads the 3rd `params` arg). The /lenses/artistry ProjectStudio.submit() sends these exact field names; it reads back r.data.result.project. Persistent per-user state on globalThis._concordSTATE.artistryLens.projects (a Map keyed by userId). Empty title defaults to 'Untitled Project' (never blank). A non-array tags/tools/images is normalized to [] via artArr (no throw). image.order is gated by Number.isFinite(Number(order)) — a poisoned 'Infinity' falls back to the array index. When STATE is absent the handler returns {ok:false, state_unavailable} and NEVER throws. Not driven by macro-assassin (LENS_ACTIONS, not MACROS); authored spec pinned by server/tests/artistry-lens-macros.test.js. NOTE: the assassin harness has no STATE, so a bare drive returns {ok:false, state_unavailable} — which is itself an honest, fail-closed terminal shape (the invariants admit ok:false)."
+}

--- a/content/contracts/overrides/artistry.styleClassify.json
+++ b/content/contracts/overrides/artistry.styleClassify.json
@@ -1,0 +1,24 @@
+{
+  "macro_id": "artistry.styleClassify",
+  "domain": "artistry",
+  "name": "styleClassify",
+  "inputs": {
+    "attributes": { "type": "object", "required": false },
+    "tags": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || output.result.classification === null || typeof output.result.classification === 'string'",
+    "output.ok === false || Number.isFinite(output.result.confidence)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "tags": ["impressionist", "plein air", "oil"], "attributes": { "era": "19th century" } }, "expect": { "ok": true } },
+    { "input": { "tags": ["zzzzz", "qqqqq"] }, "expect": { "ok": true } },
+    { "input": { "attributes": { "medium": "oil", "technique": "chiaroscuro" } }, "expect": { "ok": true } },
+    { "input": { "tags": "not-an-array", "attributes": "boom" }, "expect": {} }
+  ],
+  "_note": "LENS_ACTIONS handler (server/domains/artistry.js). 3-arg dispatch via /api/lens/run on key 'artistry.styleClassify' (virtualArtifact.data === input). The /lenses/artistry page reads result.classification + result.confidence. DETERMINISTIC keyword-match classifier (no LLM). confidence is a 0..1 number bounded by Math.min(1, ...). Unmatched input → classification 'Unclassified' (always a string, never blank). Empty attributes+tags degrade graceful (ok:true with the page message + classification:null, confidence:0). A non-array tags / non-object attributes throws inside the handler and is caught → {ok:false, handler_error}, never an uncaught throw. Not driven by macro-assassin (LENS_ACTIONS, not MACROS); authored spec pinned by server/tests/artistry-lens-macros.test.js."
+}

--- a/content/contracts/overrides/atlas.distanceMatrix.json
+++ b/content/contracts/overrides/atlas.distanceMatrix.json
@@ -1,0 +1,23 @@
+{
+  "macro_id": "atlas.distanceMatrix",
+  "domain": "atlas",
+  "name": "distanceMatrix",
+  "inputs": {
+    "points": { "type": "array" }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok !== true || output.result.message !== undefined || Array.isArray(output.result.matrix)",
+    "output.ok !== true || output.result.message !== undefined || Array.isArray(output.result.pairs)",
+    "output.ok === true || typeof (output.reason || output.error) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "points": [{ "name": "A", "lat": 40.71, "lon": -74 }, { "name": "B", "lat": 34.05, "lon": -118.24 }] }, "expect": { "ok": true } },
+    { "input": { "points": [{ "name": "A", "lat": 40.71, "lng": -74 }, { "name": "B", "lat": 34.05, "lng": -118.24 }] }, "expect": { "ok": true } },
+    { "input": { "points": [{ "name": "X", "lat": "Infinity", "lon": "1e308" }, { "name": "Y", "lat": 1, "lon": 2 }] }, "expect": { "ok": false } },
+    { "input": { "points": [{ "name": "A", "lat": 1, "lon": 2 }] }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "atlas.distanceMatrix (server/domains/atlas.js) is a pure-compute LENS_ACTIONS handler computing an NxN haversine matrix + stats. It accepts both lon and lng keys (DistanceMatrixPanel sends lon; AtlasActionPanel sends lng). It emits matrix (number[][] for the heatmap), pairs ([{from,to,distanceKm,estTimeMinutes}] for the bespoke panel), nearest, and stats with both canonical (averageDistanceKm/maxDistanceKm/...) and aliased (meanKm/maxKm/minKm/maxPair/minPair) keys. Fail-CLOSED: a non-finite or out-of-envelope coordinate is REJECTED so Infinity/NaN never serialize to null in the matrix. Fewer than 2 points returns a guidance message. Pinned by server/tests/atlas-lens-macros.test.js."
+}

--- a/content/contracts/overrides/atlas.geocode.json
+++ b/content/contracts/overrides/atlas.geocode.json
@@ -1,0 +1,21 @@
+{
+  "macro_id": "atlas.geocode",
+  "domain": "atlas",
+  "name": "geocode",
+  "inputs": {
+    "places": { "type": "array" },
+    "origin": { "type": "object" }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok !== true || output.result.message !== undefined || Array.isArray(output.result.resolved)",
+    "output.ok === true || typeof (output.reason || output.error) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "places": [{ "name": "London" }] }, "expect": { "ok": true } },
+    { "input": { "places": [{ "name": "Custom", "lat": 10, "lon": 20 }] }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "atlas.geocode (server/domains/atlas.js) is a pure-compute LENS_ACTIONS handler. It resolves place names against a built-in reference table (or honors provided lat/lon), computing haversine distance + bearing + cardinal direction from an optional origin. Fail-CLOSED: a non-finite or out-of-envelope provided coordinate is treated as MISSING (falls back to the reference table or returns an honest unresolved row) so Infinity/NaN never leak into the distance math. Empty input returns a guidance message, not a crash. The /lenses/atlas page 'Geocode' compute button drives it via the artifact-run path; pinned by server/tests/atlas-lens-macros.test.js."
+}

--- a/content/contracts/overrides/atlas.nominatim-geocode.json
+++ b/content/contracts/overrides/atlas.nominatim-geocode.json
@@ -1,0 +1,20 @@
+{
+  "macro_id": "atlas.nominatim-geocode",
+  "domain": "atlas",
+  "name": "nominatim-geocode",
+  "external_io": true,
+  "inputs": {
+    "query": { "type": "string", "required": false, "maxLength": 200 },
+    "limit": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === true || typeof (output.reason || output.error) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": false } },
+    { "input": { "query": "   " }, "expect": { "ok": false } }
+  ],
+  "_note": "atlas.nominatim-geocode (server/domains/atlas.js) hits OpenStreetMap Nominatim (nominatim.openstreetmap.org, free/no-key). EXTERNAL-IO — marked external_io:true so the assassin NEVER drives it against the live endpoint. Fail-soft: an empty/whitespace query is validate-REJECTED ({ok:false,error:'query required'}) BEFORE any fetch; a network failure returns {ok:false,error} and never throws. The PlaceFinder/MapsDirections/SavedPlaces panels call it via apiHelpers.lens.runDomain('atlas','nominatim-geocode',{input}). Pinned (validate-reject, no-network) by server/tests/atlas-lens-macros.test.js."
+}

--- a/content/contracts/overrides/atlas.overpass-poi.json
+++ b/content/contracts/overrides/atlas.overpass-poi.json
@@ -1,0 +1,23 @@
+{
+  "macro_id": "atlas.overpass-poi",
+  "domain": "atlas",
+  "name": "overpass-poi",
+  "external_io": true,
+  "inputs": {
+    "south": { "type": "number" },
+    "west": { "type": "number" },
+    "north": { "type": "number" },
+    "east": { "type": "number" },
+    "amenity": { "type": "string", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === true || typeof (output.reason || output.error) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": false } },
+    { "input": { "south": 10, "west": 0, "north": 5, "east": 5 }, "expect": { "ok": false } }
+  ],
+  "_note": "atlas.overpass-poi (server/domains/atlas.js) hits the OSM Overpass API (overpass-api.de, free/no-key) for POIs within a bbox. EXTERNAL-IO — marked external_io:true so the assassin NEVER drives it live. Fail-soft: a missing or invalid bbox (south>=north or west>=east) is validate-REJECTED BEFORE any fetch; a 429/network failure returns {ok:false,error} and never throws. The PlaceFinder/AtlasActionPanel panels call it via runDomain('atlas','overpass-poi',{input}). Pinned (validate-reject, no-network) by server/tests/atlas-lens-macros.test.js."
+}

--- a/content/contracts/overrides/atlas.regionStats.json
+++ b/content/contracts/overrides/atlas.regionStats.json
@@ -1,0 +1,21 @@
+{
+  "macro_id": "atlas.regionStats",
+  "domain": "atlas",
+  "name": "regionStats",
+  "inputs": {
+    "regions": { "type": "array" }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok !== true || output.result.message !== undefined || typeof output.result.totals === 'object'",
+    "output.ok !== true || output.result.message !== undefined || (output.result.distribution.populationGini >= 0 && output.result.distribution.populationGini <= 1)",
+    "output.ok === true || typeof (output.reason || output.error) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "regions": [{ "name": "A", "population": 1000000, "area": 500, "gdp": 50000000000 }, { "name": "B", "population": 3000000, "area": 1500, "gdp": 60000000000 }] }, "expect": { "ok": true } },
+    { "input": { "regions": [{ "name": "Bad", "population": "Infinity" }] }, "expect": { "ok": false } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "atlas.regionStats (server/domains/atlas.js) is a pure-compute LENS_ACTIONS handler aggregating demographic/economic stats: totals, weighted averages, per-capita GDP, rankings, population std-dev + a real Gini concentration index. Fail-CLOSED: any non-finite metric (Infinity/NaN) is REJECTED so it can never leak into the Gini/totals; a finite-but-huge population (1e12) is preserved. Empty input returns a guidance message. The page 'Region Stats' compute button renders regionCount/totals/averages/distribution.concentration. Pinned by server/tests/atlas-lens-macros.test.js."
+}

--- a/content/contracts/overrides/atlas.routeOptimize.json
+++ b/content/contracts/overrides/atlas.routeOptimize.json
@@ -1,0 +1,23 @@
+{
+  "macro_id": "atlas.routeOptimize",
+  "domain": "atlas",
+  "name": "routeOptimize",
+  "inputs": {
+    "waypoints": { "type": "array" },
+    "startIndex": { "type": "number" }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok !== true || output.result.message !== undefined || Array.isArray(output.result.route)",
+    "output.ok !== true || output.result.message !== undefined || Array.isArray(output.result.legs)",
+    "output.ok === true || typeof (output.reason || output.error) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "waypoints": [{ "name": "A", "lat": 40.71, "lon": -74 }, { "name": "B", "lat": 34.05, "lon": -118.24 }, { "name": "C", "lat": 41.88, "lon": -87.63 }] }, "expect": { "ok": true } },
+    { "input": { "waypoints": [{ "name": "X", "lat": "abc", "lon": 0 }, { "name": "Y", "lat": 1, "lon": 2 }] }, "expect": { "ok": false } },
+    { "input": { "waypoints": [{ "name": "A", "lat": 1, "lon": 2 }] }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "atlas.routeOptimize (server/domains/atlas.js) is a pure-compute LENS_ACTIONS handler running nearest-neighbor + 2-opt TSP. It emits optimizedRoute ([{step,name,lat,lon,legDistanceKm,...}] for the page render) plus the component-canonical aliases route (ordered name string[]), order (int waypoint indices), and legs ([{from,to,km}] for MapsDirections/DistanceMatrixPanel), all derived from the same optimized route — no fabricated values. Accepts lon or lng keys. Fail-CLOSED: a non-finite/out-of-envelope waypoint coord is REJECTED. Fewer than 2 waypoints returns a guidance message. Pinned by server/tests/atlas-lens-macros.test.js."
+}

--- a/content/contracts/overrides/bio.align-pairwise.json
+++ b/content/contracts/overrides/bio.align-pairwise.json
@@ -1,0 +1,30 @@
+{
+  "macro_id": "bio.align-pairwise",
+  "domain": "bio",
+  "name": "align-pairwise",
+  "inputs": {
+    "seqA": { "type": "string", "required": true },
+    "seqB": { "type": "string", "required": true },
+    "match": { "type": "number", "required": false },
+    "mismatch": { "type": "number", "required": false },
+    "gap": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Number.isFinite(output.result.score)",
+    "output.ok === false || typeof output.result.alignA === 'string'",
+    "output.ok === false || typeof output.result.alignB === 'string'",
+    "output.ok === false || typeof output.result.alignBars === 'string'",
+    "output.ok === false || output.result.alignA.length === output.result.alignB.length",
+    "output.ok === false || output.result.alignA.length === output.result.alignBars.length",
+    "output.ok === false || (Number.isFinite(output.result.identity) && output.result.identity >= 0 && output.result.identity <= 100)",
+    "output.ok === true || typeof output.error === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "seqA": "GATTACA", "seqB": "GATTACA" }, "expect": { "ok": true } },
+    { "input": { "seqA": "ATGC" }, "expect": { "ok": false } },
+    { "input": { "seqA": "ATGC", "seqB": "GGGG", "match": "Infinity" }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS handler (server/domains/bio.js). SequenceAnalyzer/BioActionPanel/BioWorkbench send {seqA,seqB,match?,mismatch?,gap?} and render alignA/alignB/alignBars/identity/score — the EXACT handler field names. (DEAD-SURFACE fix: SequenceAnalyzer previously read alignedA/alignedB/midline/identityPercent — none emitted by the handler — so the align result rendered blank.) FAIL-CLOSED: a non-finite match/mismatch/gap (Infinity/NaN) is rejected so Infinity can't leak into score. Pinned by server/tests/bio-lens-macros.test.js."
+}

--- a/content/contracts/overrides/bio.crispr-design.json
+++ b/content/contracts/overrides/bio.crispr-design.json
@@ -1,0 +1,22 @@
+{
+  "macro_id": "bio.crispr-design",
+  "domain": "bio",
+  "name": "crispr-design",
+  "inputs": {
+    "sequence": { "type": "string", "required": true }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Array.isArray(output.result.guides)",
+    "output.ok === false || output.result.guides.every(function(g){ return typeof g.guide === 'string' && g.guide.length === 20 && Number.isFinite(g.onTargetScore) && Number.isFinite(g.compositeScore); })",
+    "output.ok === false || output.result.guideCount === undefined || Number.isInteger(output.result.guideCount)",
+    "output.ok === true || typeof output.error === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "sequence": "ATGGCCATGGCGCCCAGAACTGAGATCAATAGTACCCGTATTAACGGGTGA" }, "expect": { "ok": true } },
+    { "input": { "sequence": "ATGC" }, "expect": { "ok": false } },
+    { "input": { "sequence": "###" }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS handler (server/domains/bio.js). MolecularWorkbench CrisprTab sends {sequence}; renders guides[{guide,pam,strand,position,gcPercent,onTargetScore,offTargetHits,specificityScore,compositeScore}] + topGuide + pam + targetLength + guideCount. SpCas9 NGG, 20 nt protospacer, requires >=30 bp. FAIL-CLOSED: non-ACGTN rejected. Pinned by server/tests/bio-lens-macros.test.js."
+}

--- a/content/contracts/overrides/bio.primer-design.json
+++ b/content/contracts/overrides/bio.primer-design.json
@@ -1,0 +1,26 @@
+{
+  "macro_id": "bio.primer-design",
+  "domain": "bio",
+  "name": "primer-design",
+  "inputs": {
+    "sequence": { "type": "string", "required": true },
+    "targetTm": { "type": "number", "required": false },
+    "targetLength": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || (output.result.forward && typeof output.result.forward.sequence === 'string')",
+    "output.ok === false || (output.result.reverse && typeof output.result.reverse.sequence === 'string')",
+    "output.ok === false || Number.isFinite(output.result.forward.tm)",
+    "output.ok === false || Number.isFinite(output.result.forward.gcPercent)",
+    "output.ok === false || Number.isInteger(output.result.productSize)",
+    "output.ok === true || typeof output.error === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "sequence": "ATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGC", "targetTm": 60, "targetLength": 20 }, "expect": { "ok": true } },
+    { "input": { "sequence": "ATGC" }, "expect": { "ok": false } },
+    { "input": { "sequence": "" }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS handler (server/domains/bio.js). SequenceAnalyzer/BioActionPanel/BioWorkbench send {sequence,targetTm?,targetLength?}; render forward/reverse{sequence,length,tm,gcPercent} + productSize + notes. Requires >=100 bp. Pinned by server/tests/bio-lens-macros.test.js."
+}

--- a/content/contracts/overrides/bio.restriction-map.json
+++ b/content/contracts/overrides/bio.restriction-map.json
@@ -1,0 +1,24 @@
+{
+  "macro_id": "bio.restriction-map",
+  "domain": "bio",
+  "name": "restriction-map",
+  "inputs": {
+    "sequence": { "type": "string", "required": true },
+    "enzymes": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Array.isArray(output.result.sites)",
+    "output.ok === false || output.result.count === output.result.sites.length",
+    "output.ok === false || output.result.sites.every(function(s){ return typeof s.enzyme === 'string' && Number.isInteger(s.position) && Number.isInteger(s.cutAt) && typeof s.site === 'string'; })",
+    "output.ok === false || Array.isArray(output.result.enzymesScanned)",
+    "output.ok === true || typeof output.error === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "sequence": "AAAGAATTCAAA" }, "expect": { "ok": true } },
+    { "input": { "sequence": "GAATTCGGATCC", "enzymes": ["EcoRI"] }, "expect": { "ok": true } },
+    { "input": { "sequence": "" }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS handler (server/domains/bio.js). sites are OBJECTS {enzyme,position,cutAt,site} + count + enzymesScanned — NOT a number[] of positions and NOT a fragments[] (those were never emitted). BioActionPanel previously sent {enzyme} (singular, ignored → scanned all 10) and rendered sites as number[] → '[object Object]'; it now sends enzymes:[enzyme] and renders s.cutAt/s.enzyme@s.position. Pinned by server/tests/bio-lens-macros.test.js."
+}

--- a/content/contracts/overrides/bio.sequence-analyze.json
+++ b/content/contracts/overrides/bio.sequence-analyze.json
@@ -1,0 +1,25 @@
+{
+  "macro_id": "bio.sequence-analyze",
+  "domain": "bio",
+  "name": "sequence-analyze",
+  "inputs": {
+    "sequence": { "type": "string", "required": true },
+    "kind": { "type": "string", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Number.isInteger(output.result.length)",
+    "output.ok === false || ['dna','rna','protein'].indexOf(output.result.kind) >= 0",
+    "output.ok === false || output.result.gcPercent === undefined || Number.isFinite(output.result.gcPercent)",
+    "output.ok === false || output.result.tm === undefined || Number.isFinite(output.result.tm)",
+    "output.ok === false || output.result.orfs === undefined || Array.isArray(output.result.orfs)",
+    "output.ok === true || typeof output.error === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "sequence": "ATGCATGC", "kind": "dna" }, "expect": { "ok": true } },
+    { "input": { "sequence": "", "kind": "dna" }, "expect": { "ok": false } },
+    { "input": { "sequence": "ATGC", "kind": "bogus" }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS handler (server/domains/bio.js). SequenceAnalyzer + BioActionPanel + BioWorkbench send {sequence,kind}. Returns {length,kind,gcPercent,tm,orfs:[{frame,start,end,length}]} for dna/rna, {composition,molecularWeight} for protein. FAIL-CLOSED: a non-string sequence (object/number) is rejected ('sequence must be a string') so it can't String()-coerce into a fabricated GC%. Pinned by server/tests/bio-lens-macros.test.js."
+}

--- a/content/contracts/overrides/bio.translate-orf.json
+++ b/content/contracts/overrides/bio.translate-orf.json
@@ -1,0 +1,23 @@
+{
+  "macro_id": "bio.translate-orf",
+  "domain": "bio",
+  "name": "translate-orf",
+  "inputs": {
+    "sequence": { "type": "string", "required": true }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Number.isInteger(output.result.length)",
+    "output.ok === false || (Array.isArray(output.result.frames) && output.result.frames.length === 6)",
+    "output.ok === false || output.result.frames.every(function(f){ return typeof f.protein === 'string' && Array.isArray(f.codons); })",
+    "output.ok === false || output.result.longestOrf === null || typeof output.result.longestOrf.peptide === 'string'",
+    "output.ok === true || typeof output.error === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "sequence": "ATGAAATTTGGGTAA" }, "expect": { "ok": true } },
+    { "input": { "sequence": "" }, "expect": { "ok": false } },
+    { "input": { "sequence": "XYZ123" }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS handler (server/domains/bio.js). MolecularWorkbench OrfTab sends {sequence}; renders frames[{frame,strand,codons:[{codon,aa,start,isStart,isStop}],protein,longestOrf}] + top longestOrf. 6 frames (+1..+3, -1..-3). FAIL-CLOSED: non-ACGTUN input rejected. Pinned by server/tests/bio-lens-macros.test.js."
+}

--- a/content/contracts/overrides/board.burndownForecast.json
+++ b/content/contracts/overrides/board.burndownForecast.json
@@ -1,0 +1,30 @@
+{
+  "macro_id": "board.burndownForecast",
+  "domain": "board",
+  "name": "burndownForecast",
+  "inputs": {
+    "sprints": { "type": "array", "required": false },
+    "remainingPoints": { "type": "number", "required": false },
+    "simulations": { "type": "number", "required": false },
+    "sprintLengthDays": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.message !== undefined || (Number.isFinite(output.result.remainingPoints) && Number.isFinite(output.result.simulations) && Number.isFinite(output.result.velocityStats.mean))",
+    "output.ok === false || output.result.message !== undefined || (output.result.forecast && Number.isFinite(output.result.forecast.deterministicSprints) && typeof output.result.forecast.mostLikelyDate === 'string')",
+    "output.ok === false || output.result.message !== undefined || output.result.burndownProjection.every(function(s){ return Number.isFinite(s.projectedRemaining); })",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "sprints": [], "remainingPoints": 50 }, "expect": { "ok": true } },
+    { "input": { "sprints": [{ "id": "s1", "completedPoints": 10 }, { "id": "s2", "completedPoints": 20 }, { "id": "s3", "completedPoints": 15 }], "remainingPoints": 60 }, "expect": { "ok": true } },
+    { "input": { "sprints": [{ "completedPoints": 10 }], "remainingPoints": "1e999" }, "expect": { "ok": true } },
+    { "input": { "sprints": [{ "completedPoints": "1e999" }, { "completedPoints": "Infinity" }, { "completedPoints": 15 }], "remainingPoints": 30 }, "expect": { "ok": true } },
+    { "input": { "sprints": [{ "completedPoints": 10 }], "remainingPoints": 5, "simulations": 1e999 }, "expect": { "ok": true } },
+    { "input": { "sprints": "nope", "remainingPoints": 10 }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'board.burndownForecast'. The /lenses/board AI Action Panel derives sprints:[{id,completedPoints,...}] (done tasks grouped by completion week) + remainingPoints (open tasks weighted by 100-progress) from live tasks and passes them as run-action params. Handler reads params.X ?? artifact.data.X. Returns {remainingPoints,velocityStats:{mean,...},simulations,forecast:{deterministicSprints,mostLikelyDate,confidenceRange,...},burndownProjection:[{sprint,projectedRemaining}]}. POISON: finNum forces remainingPoints/velocities FINITE — a poisoned remainingPoints (1e999/Infinity) fails the >0 gate → 'no remaining points' (NO infinite Monte-Carlo loop); poisoned velocities are filtered out of the >0 set; simulations/sprintLengthDays are clamped to [1,50000]/[1,365] so a huge value can't hang. Non-array sprints → guidance. Pinned by server/tests/board-lens-macros.test.js."
+}

--- a/content/contracts/overrides/board.card-move-auto.json
+++ b/content/contracts/overrides/board.card-move-auto.json
@@ -1,0 +1,23 @@
+{
+  "macro_id": "board.card-move-auto",
+  "domain": "board",
+  "name": "card-move-auto",
+  "inputs": {
+    "boardId": { "type": "string", "required": true },
+    "cardId": { "type": "string", "required": true },
+    "toColumnId": { "type": "string", "required": true },
+    "position": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || (typeof output.result === 'object' && typeof output.result.cardId === 'string' && typeof output.result.columnId === 'string' && Array.isArray(output.result.automationsApplied))",
+    "output.ok === true || typeof output.error === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": false } },
+    { "input": { "boardId": "nope", "cardId": "nope", "toColumnId": "nope" }, "expect": { "ok": false } },
+    { "input": { "boardId": "x", "cardId": "y", "toColumnId": "z", "position": "1e999" }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS STATE handler (per-user, globalThis._concordSTATE.boardLens). Dispatch key 'board.card-move-auto'. BoardWorkspace.onDrop sends {boardId,cardId,toColumnId}. Moves the card to the target column AND applies any matching card-moved-to-column automation rules (check-all-checklist / clear-due / add-label / set-assignee), then renumbers the target column's positions. Returns {cardId,columnId,automationsApplied:[ruleId]}. Unknown board/card/column → clean {ok:false,error}. STATE-unavailable → {ok:false,error:'STATE unavailable'} (never throws — wrapped in try/catch). Pinned by server/tests/board-lens-macros.test.js."
+}

--- a/content/contracts/overrides/board.cardPrioritization.json
+++ b/content/contracts/overrides/board.cardPrioritization.json
@@ -1,0 +1,25 @@
+{
+  "macro_id": "board.cardPrioritization",
+  "domain": "board",
+  "name": "cardPrioritization",
+  "inputs": {
+    "cards": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.message !== undefined || Array.isArray(output.result.rankedCards)",
+    "output.ok === false || output.result.message !== undefined || output.result.rankedCards.every(function(c){ return Number.isFinite(c.wsjfScore) && Number.isFinite(c.normalizedScore) && Number.isFinite(c.costOfDelay) && Number.isFinite(c.rank) && (c.daysUntilDeadline === null || Number.isFinite(c.daysUntilDeadline)); })",
+    "output.ok === false || output.result.message !== undefined || (output.result.tiers && Array.isArray(output.result.tiers.critical))",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "cards": [] }, "expect": { "ok": true } },
+    { "input": { "cards": [{ "id": "c1", "title": "Hi", "businessValue": 10, "timeCriticality": 9, "riskReduction": 8, "effort": 2 }, { "id": "c2", "title": "Lo", "businessValue": 3, "timeCriticality": 2, "riskReduction": 2, "effort": 8 }] }, "expect": { "ok": true } },
+    { "input": { "cards": [{ "id": "x", "title": "X", "businessValue": "1e999", "timeCriticality": "NaN", "riskReduction": "Infinity", "effort": "0", "deadline": "not-a-date" }] }, "expect": { "ok": true } },
+    { "input": { "cards": "nope" }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'board.cardPrioritization'. The /lenses/board AI Action Panel derives cards:[{id,title,businessValue,timeCriticality,riskReduction,effort,deadline?}] from live tasks (priority→businessValue, (100-progress)→timeCriticality, bug→riskReduction, estimate→effort) and passes them as run-action params. Handler reads params.cards ?? artifact.data.cards. Returns {rankedCards:[{id,title,wsjfScore,normalizedScore,costOfDelay,rank,daysUntilDeadline}],tiers:{critical,high,medium,low},quadrants}. POISON: WSJF inputs clamp to [1,10] (Infinity→10, NaN→default 5); an unparseable deadline yields daysUntilDeadline=null instead of a JSON-null NaN. Non-array cards → guidance message. Pinned by server/tests/board-lens-macros.test.js."
+}

--- a/content/contracts/overrides/board.workflowAnalysis.json
+++ b/content/contracts/overrides/board.workflowAnalysis.json
@@ -1,0 +1,25 @@
+{
+  "macro_id": "board.workflowAnalysis",
+  "domain": "board",
+  "name": "workflowAnalysis",
+  "inputs": {
+    "cards": { "type": "array", "required": false },
+    "columns": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.message !== undefined || Number.isFinite(output.result.totalCards)",
+    "output.ok === false || output.result.message !== undefined || (Number.isFinite(output.result.cycleTime.mean) && Number.isFinite(output.result.leadTime.mean) && Number.isFinite(output.result.throughput.weeklyAvg) && Number.isFinite(output.result.wip.total))",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "cards": [], "columns": [] }, "expect": { "ok": true } },
+    { "input": { "columns": [{ "name": "Done" }], "cards": [{ "id": "c1", "title": "A", "column": "Done", "createdAt": "2026-06-01T00:00:00Z", "completedAt": "2026-06-06T00:00:00Z" }] }, "expect": { "ok": true } },
+    { "input": { "columns": [{ "name": "Done" }], "cards": [{ "id": "c", "title": "X", "column": "Done", "createdAt": "bad", "completedAt": "also-bad" }] }, "expect": { "ok": true } },
+    { "input": { "cards": "nope" }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'board.workflowAnalysis'. The /lenses/board AI Action Panel derives {columns:[{name,wipLimit?}], cards:[{id,title,column,createdAt,startedAt?,completedAt?,transitions?}]} from the live kanban tasks and passes them as run-action params (the persisted task artifact's .data is a single task and has no cards/columns — the prior dead surface). Handler reads params.X ?? artifact.data.X. Returns {totalCards,completedCards,inProgressCards,cycleTime:{mean,...},leadTime:{mean,...},throughput:{weeklyAvg},wip:{total,overLimitColumns:[{column,wip,limit}]},bottleneck,flowEfficiency}. POISON: unparseable dates are isNaN-guarded → every numeric output FINITE; non-array cards/columns degrade to a guidance message. Pinned by server/tests/board-lens-macros.test.js."
+}

--- a/content/contracts/overrides/classroom.assignment-create.json
+++ b/content/contracts/overrides/classroom.assignment-create.json
@@ -1,0 +1,31 @@
+{
+  "macro_id": "classroom.assignment-create",
+  "domain": "classroom",
+  "name": "assignment-create",
+  "inputs": {
+    "cohortId": { "type": "number", "required": true },
+    "title": { "type": "string", "required": true, "maxLength": 4000 },
+    "instructions": { "type": "string", "required": false, "maxLength": 4000 },
+    "dueAt": { "type": "string", "required": false },
+    "points": { "type": "number", "required": false, "min": 0, "max": 1000 },
+    "topic": { "type": "string", "required": false, "maxLength": 80 }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || (typeof output.result.assignment === 'object' && output.result.assignment !== null)",
+    "output.ok === false || typeof output.result.assignment.id === 'string'",
+    "output.ok === false || (Number.isFinite(output.result.assignment.points) && output.result.assignment.points >= 0 && output.result.assignment.points <= 1000)",
+    "output.ok === false || output.result.assignment.status === 'published'",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "cohortId": 1, "title": "Essay", "points": 80, "topic": "Week 1" }, "expect": { "ok": true } },
+    { "input": { "cohortId": 1, "title": "Big", "points": 5000 }, "expect": { "ok": true } },
+    { "input": { "cohortId": 1, "title": "Poison", "points": "1e999" }, "expect": { "ok": true } },
+    { "input": { "cohortId": 1, "title": "Neg", "points": -7 }, "expect": { "ok": true } },
+    { "input": { "cohortId": 1 }, "expect": { "ok": false } },
+    { "input": { "title": "Orphan" }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS handler (registerLensAction). Dispatch handler(ctx, artifact, input). In-memory STATE.classroomLens.assignments per userId. POISON: points via Math.max(0,Math.min(1000,Number(x)||100)) so '1e999'/'Infinity'/'NaN' collapse to a FINITE clamped value. title + finite cohortId required → fail-CLOSED. Not assassin-driven (LENS_ACTIONS); pinned by server/tests/classroom-lens-macros.test.js."
+}

--- a/content/contracts/overrides/classroom.grade-submission.json
+++ b/content/contracts/overrides/classroom.grade-submission.json
@@ -1,0 +1,27 @@
+{
+  "macro_id": "classroom.grade-submission",
+  "domain": "classroom",
+  "name": "grade-submission",
+  "inputs": {
+    "submissionId": { "type": "string", "required": true },
+    "score": { "type": "number", "required": false },
+    "maxPoints": { "type": "number", "required": false },
+    "feedback": { "type": "string", "required": false, "maxLength": 4000 },
+    "returned": { "type": "boolean", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || (typeof output.result.grade === 'object' && output.result.grade !== null)",
+    "output.ok === false || Number.isFinite(output.result.grade.score)",
+    "output.ok === false || Number.isFinite(output.result.grade.maxPoints)",
+    "output.ok === false || (Number.isFinite(output.result.grade.percent) && output.result.grade.percent >= 0 && output.result.grade.percent <= 100)",
+    "output.ok === false || (output.result.grade.score >= 0 && output.result.grade.score <= output.result.grade.maxPoints)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "submissionId": "missing", "score": 5 }, "expect": { "ok": false } },
+    { "input": { "submissionId": "missing", "score": "Infinity" }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS handler. percent = round(score/maxPoints*100), maxPoints pulled from the parent assignment. POISON: score via Math.max(0,Math.min(maxPoints,Number(x)||0)) → FINITE clamped; percent guards maxPoints>0 so no NaN/Infinity divide. Re-grading the same submission REPLACES the prior grade (no duplicate). Missing submission → fail-CLOSED 'submission not found'. Fuzz cases use a missing submissionId because a real grade needs a seeded assignment+submission (covered by the macros test, not fuzzable standalone). Pinned by server/tests/classroom-lens-macros.test.js."
+}

--- a/content/contracts/overrides/classroom.gradebook.json
+++ b/content/contracts/overrides/classroom.gradebook.json
@@ -1,0 +1,24 @@
+{
+  "macro_id": "classroom.gradebook",
+  "domain": "classroom",
+  "name": "gradebook",
+  "inputs": {
+    "cohortId": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Array.isArray(output.result.rows)",
+    "output.ok === false || Array.isArray(output.result.assignments)",
+    "output.ok === false || Number.isInteger(output.result.studentCount)",
+    "output.ok === false || output.result.classAverage === null || Number.isFinite(output.result.classAverage)",
+    "output.ok === false || output.result.rows.every(function(r){ return (r.average === null || Number.isFinite(r.average)) && Number.isFinite(r.totalEarned) && Number.isFinite(r.totalPossible); })",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "cohortId": 7 }, "expect": { "ok": true } },
+    { "input": { "cohortId": "not-a-number" }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. One row per student, columns per assignment. average = round(earned/possible*100) guarded possible>0 (null when no graded cells). classAverage = round(mean of non-null row averages) or null. Empty cohort → ok:true, rows:[], classAverage:null. A NaN cohortId filter matches nothing → empty (safe, not fail-open). Pinned by server/tests/classroom-lens-macros.test.js."
+}

--- a/content/contracts/overrides/classroom.ol-isbn.json
+++ b/content/contracts/overrides/classroom.ol-isbn.json
@@ -1,0 +1,24 @@
+{
+  "macro_id": "classroom.ol-isbn",
+  "domain": "classroom",
+  "name": "ol-isbn",
+  "inputs": {
+    "isbn": { "type": "string", "required": true }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result.isbn === 'string'",
+    "output.ok === false || Array.isArray(output.result.publishers)",
+    "output.ok === false || Array.isArray(output.result.authorKeys)",
+    "output.ok === false || !('authors' in output.result)",
+    "output.ok === false || !('publisher' in output.result)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "isbn": "12345" }, "expect": { "ok": false } },
+    { "input": { "isbn": "" }, "expect": { "ok": false } },
+    { "input": {}, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS network handler (Open Library /isbn). Validates isbn is 10 or 13 chars (after stripping non-[0-9X]) BEFORE any fetch → fail-CLOSED. CONTRACT: returns publishers (ARRAY) + authorKeys, NOT a singular publisher or author NAMES — the OL isbn endpoint exposes author KEYS only, so the handler does not fabricate names. Phase-2 fix realigned ClassroomActionPanel (was reading isbnResult.publisher/authors — dead surfaces that rendered blank) onto publishers/subtitle/pages. fetch failure / 404 → ok:false with an error string (degrade-graceful). Pinned by server/tests/classroom-lens-macros.test.js."
+}

--- a/content/contracts/overrides/classroom.quiz-submit.json
+++ b/content/contracts/overrides/classroom.quiz-submit.json
@@ -1,0 +1,26 @@
+{
+  "macro_id": "classroom.quiz-submit",
+  "domain": "classroom",
+  "name": "quiz-submit",
+  "inputs": {
+    "quizId": { "type": "string", "required": true },
+    "studentId": { "type": "string", "required": false },
+    "answers": { "type": "object", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || (typeof output.result.attempt === 'object' && output.result.attempt !== null)",
+    "output.ok === false || Number.isFinite(output.result.attempt.score)",
+    "output.ok === false || Number.isFinite(output.result.attempt.totalPoints)",
+    "output.ok === false || (Number.isFinite(output.result.attempt.percent) && output.result.attempt.percent >= 0 && output.result.attempt.percent <= 100)",
+    "output.ok === false || Array.isArray(output.result.attempt.breakdown)",
+    "output.ok === false || output.result.attempt.breakdown.every(function(b){ return typeof b.correct === 'boolean' && Number.isFinite(b.awarded); })",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "quizId": "missing", "answers": {} }, "expect": { "ok": false } },
+    { "input": { "quizId": "missing", "answers": "not-an-object" }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS handler. Auto-graded: case-insensitive trimmed string-equality per question; earned = sum of awarded; percent = round(earned/totalPoints*100) guarded totalPoints>0. POISON: a non-object answers bag is guarded (typeof === 'object') → no throw, 0 matches → score 0, percent FINITE. Missing quiz → fail-CLOSED 'quiz not found'. correctAnswer is exposed in the per-question breakdown (the post-submit review panel) but NEVER in quiz-get/quiz-list. Fuzz uses a missing quizId (a real attempt needs a seeded quiz — covered by the macros test). Pinned by server/tests/classroom-lens-macros.test.js."
+}

--- a/content/contracts/overrides/classroom.todo.json
+++ b/content/contracts/overrides/classroom.todo.json
@@ -1,0 +1,24 @@
+{
+  "macro_id": "classroom.todo",
+  "domain": "classroom",
+  "name": "todo",
+  "inputs": {
+    "cohortId": { "type": "number", "required": false },
+    "studentId": { "type": "string", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Array.isArray(output.result.upcoming)",
+    "output.ok === false || Array.isArray(output.result.missing)",
+    "output.ok === false || Array.isArray(output.result.done)",
+    "output.ok === false || (Number.isInteger(output.result.counts.upcoming) && Number.isInteger(output.result.counts.missing) && Number.isInteger(output.result.counts.done))",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "cohortId": 5, "studentId": "stu-1" }, "expect": { "ok": true } },
+    { "input": { "studentId": "" }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Buckets a student's assignments: graded→done, unsubmitted+past-due→missing, unsubmitted+future→upcoming. dueAt parsed via Date.parse; a poisoned/unparseable dueAt → NaN, Number.isFinite guard routes it to upcoming (not missing) — no throw. studentId defaults to caller. Empty → ok:true, all-empty buckets. Pinned by server/tests/classroom-lens-macros.test.js."
+}

--- a/content/contracts/overrides/consulting.clientHealth.json
+++ b/content/contracts/overrides/consulting.clientHealth.json
@@ -1,0 +1,30 @@
+{
+  "macro_id": "consulting.clientHealth",
+  "domain": "consulting",
+  "name": "clientHealth",
+  "inputs": {
+    "client": { "type": "string", "required": false, "maxLength": 200 },
+    "nps": { "type": "number", "required": false },
+    "invoicesPaid": { "type": "number", "required": false },
+    "invoicesTotal": { "type": "number", "required": false },
+    "avgResponseDays": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Number.isFinite(output.result.nps)",
+    "output.ok === false || Number.isFinite(output.result.paymentRate)",
+    "output.ok === false || Number.isFinite(output.result.avgResponseDays)",
+    "output.ok === false || Number.isFinite(output.result.healthScore)",
+    "output.ok === false || ['low','medium','high'].indexOf(output.result.risk) >= 0",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "client": "Acme", "nps": 50, "invoicesPaid": 9, "invoicesTotal": 10, "avgResponseDays": 2 }, "expect": { "ok": true } },
+    { "input": { "nps": "Infinity", "invoicesPaid": "1e999", "invoicesTotal": "NaN", "avgResponseDays": "1e308" }, "expect": { "ok": true } },
+    { "input": { "invoicesPaid": 3, "invoicesTotal": 0 }, "expect": { "ok": true } },
+    { "input": { "nps": -200 }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler reading artifact.data. Pure compute; composite client-health 0-100. POISON: metrics via finPos; nps via finSigned (clamped -100..100); invoicesTotal defaulted to 1 then guarded so payment-rate divide never yields Infinity/NaN. healthScore stays FINITE. Pinned by server/tests/consulting-lens-macros.test.js."
+}

--- a/content/contracts/overrides/consulting.engagementScope.json
+++ b/content/contracts/overrides/consulting.engagementScope.json
@@ -1,0 +1,30 @@
+{
+  "macro_id": "consulting.engagementScope",
+  "domain": "consulting",
+  "name": "engagementScope",
+  "inputs": {
+    "client": { "type": "string", "required": false, "maxLength": 200 },
+    "hourlyRate": { "type": "number", "required": false },
+    "deliverables": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Number.isFinite(output.result.hourlyRate)",
+    "output.ok === false || Number.isFinite(output.result.totalHours)",
+    "output.ok === false || Number.isFinite(output.result.subtotal)",
+    "output.ok === false || Number.isFinite(output.result.contingency)",
+    "output.ok === false || Number.isFinite(output.result.grandTotal)",
+    "output.ok === false || Array.isArray(output.result.deliverables)",
+    "output.ok === false || output.result.deliverables.every(function(d){ return Number.isFinite(d.fee) && Number.isFinite(d.hours); })",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "client": "Acme", "hourlyRate": 250, "deliverables": [{ "name": "Discovery", "hours": 10 }] }, "expect": { "ok": true } },
+    { "input": { "hourlyRate": "1e999", "deliverables": [{ "name": "X", "hours": "Infinity" }] }, "expect": { "ok": true } },
+    { "input": { "hourlyRate": "1e308", "deliverables": [{ "name": "X", "hours": "1e308" }] }, "expect": { "ok": true } },
+    { "input": { "deliverables": "nope" }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler reading artifact.data (page analyze-family). Pure compute; project-estimate/bill-rate math. POISON: hourlyRate/hours via finPos (non-finite/negative -> default, clamped at SANE_MAX 1e12) so the rate x hours product can never overflow to Infinity; every money field stays FINITE. Not assassin-driven (LENS_ACTIONS); pinned by server/tests/consulting-lens-macros.test.js."
+}

--- a/content/contracts/overrides/consulting.invoice-create.json
+++ b/content/contracts/overrides/consulting.invoice-create.json
@@ -1,0 +1,26 @@
+{
+  "macro_id": "consulting.invoice-create",
+  "domain": "consulting",
+  "name": "invoice-create",
+  "inputs": {
+    "engagementId": { "type": "string", "required": true, "maxLength": 120 },
+    "taxRate": { "type": "number", "required": false },
+    "dueInDays": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Number.isFinite(output.result.invoice.subtotal)",
+    "output.ok === false || Number.isFinite(output.result.invoice.tax)",
+    "output.ok === false || Number.isFinite(output.result.invoice.total)",
+    "output.ok === false || (output.result.invoice.taxRate >= 0 && output.result.invoice.taxRate <= 1)",
+    "output.ok === false || Array.isArray(output.result.invoice.lineItems)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": false } },
+    { "input": { "engagementId": "missing" }, "expect": { "ok": false } },
+    { "input": { "engagementId": "missing", "taxRate": "1e999" }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS STATE-backed (per-user). Rolls up unbilled time into an invoice. Money math via csNum (fail-closed) + csRound2; taxRate clamped to [0,1] so a poisoned 1e999 collapses to 0 (never Infinity tax). subtotal/tax/total stay FINITE. Empty/unknown engagement -> ok:false (validation-rejection). Pinned by server/tests/consulting-lens-macros.test.js + consulting-domain-parity.test.js."
+}

--- a/content/contracts/overrides/consulting.profitability-report.json
+++ b/content/contracts/overrides/consulting.profitability-report.json
@@ -1,0 +1,21 @@
+{
+  "macro_id": "consulting.profitability-report",
+  "domain": "consulting",
+  "name": "profitability-report",
+  "inputs": {},
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Number.isFinite(output.result.totalBilled)",
+    "output.ok === false || Number.isFinite(output.result.totalCost)",
+    "output.ok === false || Number.isFinite(output.result.totalMargin)",
+    "output.ok === false || Number.isFinite(output.result.overallMarginPct)",
+    "output.ok === false || Array.isArray(output.result.rows)",
+    "output.ok === false || output.result.rows.every(function(r){ return Number.isFinite(r.margin) && Number.isFinite(r.marginPct); })",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS STATE-backed (per-user). Per-engagement billed-vs-cost margin. All rates via csNum (fail-closed); marginPct/overallMarginPct guard billed===0 -> 0 (no Infinity/NaN divide). Every row + total stays FINITE. Empty state -> ok:true zero totals (degrade-graceful). Pinned by server/tests/consulting-lens-macros.test.js + consulting-domain-parity.test.js."
+}

--- a/content/contracts/overrides/consulting.proposalScore.json
+++ b/content/contracts/overrides/consulting.proposalScore.json
@@ -1,0 +1,22 @@
+{
+  "macro_id": "consulting.proposalScore",
+  "domain": "consulting",
+  "name": "proposalScore",
+  "inputs": {},
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Number.isFinite(output.result.score)",
+    "output.ok === false || (output.result.score >= 0 && output.result.score <= 100)",
+    "output.ok === false || Array.isArray(output.result.sectionsPresent)",
+    "output.ok === false || Array.isArray(output.result.sectionsMissing)",
+    "output.ok === false || typeof output.result.completeness === 'string'",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "executive-summary": "x", "methodology": "y", "timeline": "z" }, "expect": { "ok": true } },
+    { "input": { "executive-summary": "x", "methodology": "y", "timeline": "z", "pricing": "p", "team": "t", "references": "r" }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler reading artifact.data. Pure compute; section-completeness score 0-100 over six fixed sections (no numeric input, no Infinity risk). Pinned by server/tests/consulting-lens-macros.test.js."
+}

--- a/content/contracts/overrides/consulting.utilizationRate.json
+++ b/content/contracts/overrides/consulting.utilizationRate.json
@@ -1,0 +1,27 @@
+{
+  "macro_id": "consulting.utilizationRate",
+  "domain": "consulting",
+  "name": "utilizationRate",
+  "inputs": {
+    "billableHours": { "type": "number", "required": false },
+    "totalHours": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Number.isFinite(output.result.billableHours)",
+    "output.ok === false || Number.isFinite(output.result.totalHours)",
+    "output.ok === false || Number.isFinite(output.result.utilizationRate)",
+    "output.ok === false || Number.isFinite(output.result.variance)",
+    "output.ok === false || typeof output.result.status === 'string'",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "billableHours": 32, "totalHours": 40 }, "expect": { "ok": true } },
+    { "input": { "billableHours": "1e999", "totalHours": "Infinity" }, "expect": { "ok": true } },
+    { "input": { "billableHours": 5, "totalHours": 0 }, "expect": { "ok": true } },
+    { "input": { "billableHours": "NaN", "totalHours": "1e308" }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler reading artifact.data. Pure compute; utilization % vs 75% target. POISON: hours via finPos; totalHours defaulted to 40 then guarded so a 0/non-finite divisor never yields Infinity/NaN. utilizationRate + variance stay FINITE. Pinned by server/tests/consulting-lens-macros.test.js."
+}

--- a/content/contracts/overrides/council.conflictResolution.json
+++ b/content/contracts/overrides/council.conflictResolution.json
@@ -1,0 +1,27 @@
+{
+  "macro_id": "council.conflictResolution",
+  "domain": "council",
+  "name": "conflictResolution",
+  "inputs": {
+    "issue": { "type": "string", "required": false, "maxLength": 4000 },
+    "description": { "type": "string", "required": false, "maxLength": 4000 },
+    "parties": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || Array.isArray(output.result.parties)",
+    "output.ok === false || ['shared-urgency','divergent-priorities'].includes(output.result.commonGround)",
+    "output.ok === false || typeof output.result.suggestedApproach === 'string'",
+    "output.ok === false || (Array.isArray(output.result.steps) && output.result.steps.length === 5)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "issue": "Budget dispute", "parties": [{ "name": "Eng", "priority": "high" }, { "name": "Sales", "priority": "high" }, { "name": "Ops", "priority": "low" }] }, "expect": { "ok": true } },
+    { "input": { "issue": "Roadmap", "parties": [{ "name": "A", "priority": "low" }, { "name": "B", "priority": "medium" }] }, "expect": { "ok": true } },
+    { "input": { "issue": 1e999, "parties": "nope" }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'council.conflictResolution'. CouncilActionPanel sends {issue,parties}; returns {issue,parties:[{party,position,priority}],commonGround(shared-urgency|divergent-priorities),suggestedApproach,steps[5]}. shared-urgency when >half the parties are priority:high. POISON: parties Array-guarded, issue String()-coerced (was uncaught throw on parties.map / issue.slice, hardened 2026-06-28). Pinned by server/tests/council-lens-macros.test.js."
+}

--- a/content/contracts/overrides/council.decision-archive.json
+++ b/content/contracts/overrides/council.decision-archive.json
@@ -1,0 +1,31 @@
+{
+  "macro_id": "council.decision-archive",
+  "domain": "council",
+  "name": "decision-archive",
+  "inputs": {
+    "title": { "type": "string", "required": true, "maxLength": 256 },
+    "summary": { "type": "string", "required": false, "maxLength": 4000 },
+    "outcome": { "type": "string", "required": false, "maxLength": 32 },
+    "votesFor": { "type": "number", "required": false },
+    "votesAgainst": { "type": "number", "required": false },
+    "tags": { "type": "array", "required": false },
+    "decidedAt": { "type": "string", "required": false, "maxLength": 64 }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || (typeof output.result.decision === 'object' && typeof output.result.decision.id === 'string')",
+    "output.ok === false || typeof output.result.decision.title === 'string'",
+    "output.ok === false || (Number.isFinite(output.result.decision.votesFor) && output.result.decision.votesFor >= 0)",
+    "output.ok === false || (Number.isFinite(output.result.decision.votesAgainst) && output.result.decision.votesAgainst >= 0)",
+    "output.ok === false || Array.isArray(output.result.decision.tags)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": false } },
+    { "input": { "title": "Adopt remote-work policy", "summary": "Hybrid approved", "outcome": "passed", "votesFor": 7, "votesAgainst": 2, "tags": ["hr", "policy"] }, "expect": { "ok": true } },
+    { "input": { "title": "X", "votesFor": 1e999, "votesAgainst": -5 }, "expect": { "ok": true } },
+    { "input": { "title": "Y", "tags": "nope" }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'council.decision-archive'. STATE-backed (per-user globalThis._concordSTATE.councilLens.decisions); whole body in try/catch → handler_error on any throw. DecisionArchive sends {title,summary,outcome,votesFor,votesAgainst,tags,decidedAt}; returns {decision:{id,title,summary,outcome,proposalId,meetingId,votesFor,votesAgainst,tags,decidedAt,createdAt}}. VALIDATION: missing title → ok:false. POISON: votesFor/votesAgainst via Math.max(0, parseInt||0) so 1e999/-5 collapse to a FINITE non-negative int; tags only kept when an array. Pinned by server/tests/council-lens-macros.test.js."
+}

--- a/content/contracts/overrides/council.deliberate.json
+++ b/content/contracts/overrides/council.deliberate.json
@@ -1,0 +1,29 @@
+{
+  "macro_id": "council.deliberate",
+  "domain": "council",
+  "name": "deliberate",
+  "inputs": {
+    "proposal": { "type": "string", "required": false, "maxLength": 4000 },
+    "description": { "type": "string", "required": false, "maxLength": 4000 },
+    "voices": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.message !== undefined || Array.isArray(output.result.evaluations)",
+    "output.ok === false || output.result.message !== undefined || Number.isFinite(output.result.weightedScore)",
+    "output.ok === false || output.result.message !== undefined || output.result.evaluations.every(function(e){ return Number.isFinite(e.score) && typeof e.voice === 'string' && ['support','neutral','oppose'].includes(e.position); })",
+    "output.ok === false || output.result.message !== undefined || ['Proceed','Revise and resubmit','Reject'].includes(output.result.recommendation)",
+    "output.ok === false || output.result.message !== undefined || ['unanimous','majority','no-consensus'].includes(output.result.consensus)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "proposal": "Adopt a fairness and risk review for the resource cost program" }, "expect": { "ok": true } },
+    { "input": { "proposal": "novelty growth", "voices": [{ "voice": "Innovator", "weight": 1, "lens": "novelty and growth potential" }] }, "expect": { "ok": true } },
+    { "input": { "proposal": "1e999" }, "expect": { "ok": true } },
+    { "input": { "proposal": "Infinity", "voices": "nope" }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'council.deliberate'. Deterministic per-voice keyword heuristic (NOT LLM — the real LLM council is the inline /api/council/deliberate route + lib/council-world-bridge.js). CouncilActionPanel sends {proposal}; returns {proposal,evaluations:[{voice,weight,score,position,reasoning}],weightedScore,recommendation,consensus}. Empty proposal degrades to {message}. POISON: proposal String()-coerced at read so a non-string never reaches .slice() (was an uncaught throw, hardened 2026-06-28); voices Array-guarded; score/weightedScore always FINITE. Pinned by server/tests/council-lens-macros.test.js."
+}

--- a/content/contracts/overrides/council.generateMinutes.json
+++ b/content/contracts/overrides/council.generateMinutes.json
@@ -1,0 +1,32 @@
+{
+  "macro_id": "council.generateMinutes",
+  "domain": "council",
+  "name": "generateMinutes",
+  "inputs": {
+    "title": { "type": "string", "required": false, "maxLength": 256 },
+    "date": { "type": "string", "required": false, "maxLength": 64 },
+    "agenda": { "type": "array", "required": false },
+    "attendees": { "type": "array", "required": false },
+    "decisions": { "type": "array", "required": false },
+    "actionItems": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || typeof output.result.title === 'string'",
+    "output.ok === false || typeof output.result.date === 'string'",
+    "output.ok === false || Number.isFinite(output.result.attendees)",
+    "output.ok === false || Array.isArray(output.result.agendaItems)",
+    "output.ok === false || Array.isArray(output.result.decisions)",
+    "output.ok === false || Array.isArray(output.result.actionItems)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "title": "Q3 Session", "agenda": [{ "topic": "Budget", "status": "discussed" }], "attendees": ["Alice", "Bob"], "decisions": [{ "text": "Adopt policy", "votedBy": "council", "passed": true }], "actionItems": [{ "task": "Draft", "assignee": "Alice", "dueDate": "2026-07-01" }] }, "expect": { "ok": true } },
+    { "input": { "agenda": ["Plain string item"], "decisions": ["Plain decision"] }, "expect": { "ok": true } },
+    { "input": { "title": 1e999, "attendees": "nope" }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'council.generateMinutes'. CouncilActionPanel sends {title,agenda,attendees,decisions}; returns {title,date,attendees(COUNT),agendaItems:[{item,topic,status}],decisions:[{decision,votedBy,passed}],actionItems:[{task,assignee,dueDate}]}. attendees in the RETURN is a count (.length), not a list. agenda/decisions entries tolerate plain strings or {topic}/{text} objects. Defaults title + today's date. Pinned by server/tests/council-lens-macros.test.js."
+}

--- a/content/contracts/overrides/council.ranked-choice-tabulate.json
+++ b/content/contracts/overrides/council.ranked-choice-tabulate.json
@@ -1,0 +1,28 @@
+{
+  "macro_id": "council.ranked-choice-tabulate",
+  "domain": "council",
+  "name": "ranked-choice-tabulate",
+  "inputs": {
+    "ballots": { "type": "array", "required": false },
+    "candidates": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || output.result.method === 'instant_runoff'",
+    "output.ok === false || Number.isFinite(output.result.totalBallots)",
+    "output.ok === false || Number.isFinite(output.result.majority)",
+    "output.ok === false || Array.isArray(output.result.rounds)",
+    "output.ok === false || Array.isArray(output.result.eliminated)",
+    "output.ok === false || output.result.winner === null || (typeof output.result.winner.candidate === 'string' && Number.isFinite(output.result.winner.votes))",
+    "output.ok === false || typeof output.result.decided === 'boolean'",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "ballots": [] }, "expect": { "ok": false } },
+    { "input": { "ballots": [{ "voter": "1", "ranking": ["A", "B"] }, { "voter": "2", "ranking": ["A", "C"] }, { "voter": "3", "ranking": ["B", "A"] }, { "voter": "4", "ranking": ["B", "C"] }, { "voter": "5", "ranking": ["C", "A"] }], "candidates": [{ "id": "A", "label": "Alice" }, { "id": "B", "label": "Bob" }, { "id": "C", "label": "Carol" }] }, "expect": { "ok": true } },
+    { "input": { "ballots": [{ "ranking": [1e999] }, { "ranking": ["X"] }] }, "expect": {} },
+    { "input": { "ballots": "nope" }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'council.ranked-choice-tabulate'. DecisionArchive sends {ballots:[{voter,ranking[]}],candidates:[{id,label}]}. Real instant-runoff: eliminate lowest each round (lexicographic tie-break), redistribute, until majority. Returns {method,totalBallots,majority,rounds:[{round,tallies[{candidate,label,votes}],exhausted,majority}],eliminated[],winner,decided}. GUARDS: empty ballots → ok:false; no candidates → ok:false; 100-round guard; whole body in try/catch → handler_error on any throw (fail-closed, never an uncaught runner crash). Pinned by server/tests/council-lens-macros.test.js."
+}

--- a/content/contracts/overrides/council.voteCount.json
+++ b/content/contracts/overrides/council.voteCount.json
@@ -1,0 +1,28 @@
+{
+  "macro_id": "council.voteCount",
+  "domain": "council",
+  "name": "voteCount",
+  "inputs": {
+    "votes": { "type": "array", "required": false },
+    "quorum": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || (typeof output.result.tally === 'object' && Number.isFinite(output.result.tally.for) && Number.isFinite(output.result.tally.against) && Number.isFinite(output.result.tally.abstain))",
+    "output.ok === false || Number.isFinite(output.result.total)",
+    "output.ok === false || (Number.isFinite(output.result.forPercent) && output.result.forPercent >= 0 && output.result.forPercent <= 100)",
+    "output.ok === false || typeof output.result.passed === 'boolean'",
+    "output.ok === false || typeof output.result.quorumMet === 'boolean'",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "votes": [] }, "expect": { "ok": true } },
+    { "input": { "votes": [{ "vote": "for" }, { "vote": "yes" }, { "vote": "support" }, { "vote": "against" }, { "vote": "abstain" }] }, "expect": { "ok": true } },
+    { "input": { "votes": [{ "position": "for" }, { "position": "for" }, { "position": "for" }], "quorum": 2 }, "expect": { "ok": true } },
+    { "input": { "votes": [{}, { "vote": 1e999 }] }, "expect": { "ok": true } },
+    { "input": { "votes": "nope" }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'council.voteCount'. CouncilActionPanel sends {votes:[{vote}]}; returns {tally:{for,against,abstain},total,forPercent,passed(>=67% supermajority),passThreshold,quorumMet}. POISON: votes Array-guarded; each vote value String()-coerced before .toLowerCase() (was an uncaught throw on a numeric vote, hardened 2026-06-28); forPercent guards total===0 → 0 (no NaN). Pinned by server/tests/council-lens-macros.test.js."
+}

--- a/content/contracts/overrides/debate.claim-add.json
+++ b/content/contracts/overrides/debate.claim-add.json
@@ -1,0 +1,27 @@
+{
+  "macro_id": "debate.claim-add",
+  "domain": "debate",
+  "name": "claim-add",
+  "inputs": {
+    "debateId": { "type": "string", "required": true },
+    "text": { "type": "string", "required": true, "minLength": 4, "maxLength": 600 },
+    "stance": { "type": "string", "required": false, "enum": ["pro", "con"] },
+    "parentId": { "type": "string", "required": false },
+    "positionId": { "type": "string", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || (output.result.claim && typeof output.result.claim.id === 'string')",
+    "output.ok === false || ['pro','con'].includes(output.result.claim.stance)",
+    "output.ok === false || (output.result.score && Number.isFinite(output.result.score.supportPct))",
+    "output.ok === true || typeof output.error === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "debateId": "missing", "stance": "pro", "text": "It reduces commute emissions" }, "expect": { "ok": false } },
+    { "input": { "debateId": "missing", "text": "no" }, "expect": { "ok": false } },
+    { "input": {}, "expect": { "ok": false } },
+    { "input": { "debateId": 9999, "text": "valid claim text here" }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS handler, dispatch key 'debate.claim-add'. KialoArgumentMap addClaim() sends {debateId,parentId,stance,text,positionId}. Returns {claim{id,parentId,positionId,stance,text,votes,sources}, score}; the component re-fetches debate-detail after. Validates: debate-not-found / text<4 / unknown parentId / unknown positionId → {ok:false,error:string}. stance defaults pro. Per-user STATE-backed; standalone fuzz cases reference no real debate so they correctly return {ok:false}. No LLM. Pinned by server/tests/debate-lens-macros.test.js."
+}

--- a/content/contracts/overrides/debate.debate-create.json
+++ b/content/contracts/overrides/debate.debate-create.json
@@ -1,0 +1,23 @@
+{
+  "macro_id": "debate.debate-create",
+  "domain": "debate",
+  "name": "debate-create",
+  "inputs": {
+    "thesis": { "type": "string", "required": true, "minLength": 8, "maxLength": 400 }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || (output.result.debate && typeof output.result.debate.id === 'string')",
+    "output.ok === false || typeof output.result.debate.thesis === 'string'",
+    "output.ok === false || Array.isArray(output.result.debate.claims)",
+    "output.ok === true || typeof output.error === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "thesis": "AI models should be open-sourced for safety review" }, "expect": { "ok": true } },
+    { "input": { "thesis": "short" }, "expect": { "ok": false } },
+    { "input": {}, "expect": { "ok": false } },
+    { "input": { "thesis": 9999 }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS handler, dispatch key 'debate.debate-create'. KialoArgumentMap createDebate() sends {thesis}; reads r.result.debate.id to open the new debate. Per-user STATE-backed (globalThis._concordSTATE.debateLens.debates Map, keyed by ctx.actor.userId). thesis < 8 chars (after trim/coerce) → {ok:false,error:string}. No LLM. STATE-unavailable degrades to {ok:false,'STATE unavailable'}. Pinned by server/tests/debate-lens-macros.test.js."
+}

--- a/content/contracts/overrides/debate.evaluateArgument.json
+++ b/content/contracts/overrides/debate.evaluateArgument.json
@@ -1,0 +1,27 @@
+{
+  "macro_id": "debate.evaluateArgument",
+  "domain": "debate",
+  "name": "evaluateArgument",
+  "inputs": {
+    "claim": { "type": "string", "required": false, "maxLength": 2000 },
+    "text": { "type": "string", "required": false, "maxLength": 2000 },
+    "reasoning": { "type": "string", "required": false, "maxLength": 4000 },
+    "evidence": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || (typeof output.result.message === 'string') || (Number.isFinite(output.result.overallScore) && Number.isFinite(output.result.evidenceScore) && Number.isFinite(output.result.reasoningScore))",
+    "output.ok === false || (typeof output.result.message === 'string') || ['strong','moderate','weak'].includes(output.result.strength)",
+    "output.ok === false || (typeof output.result.message === 'string') || Array.isArray(output.result.fallaciesDetected)"
+  ],
+  "fuzz_cases": [
+    { "input": { "claim": "Renewables cut emissions because studies show a 40% drop", "reasoning": "Long-form reasoning that is well over fifty characters in length so the reasoning score lands in the mid band.", "evidence": [1, 2] }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "claim": "Everyone knows this always works", "reasoning": "obviously true" }, "expect": { "ok": true } },
+    { "input": { "claim": 9999 }, "expect": { "ok": true } },
+    { "input": { "evidence": "notarray", "claim": "valid claim text" }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler, dispatch key 'debate.evaluateArgument'. page.tsx 'Evaluate Argument' panel calls /api/lens/:domain/:id/run with NO params, so the handler derives claim/reasoning from the live debate artifact.data (topic + proArguments/conArguments text). DebateActionPanel may pass {claim,text,reasoning,evidence} params, honored first. Renders r.result.{overallScore,evidenceScore,reasoningScore,strength,fallaciesDetected[],addressesCounterpoints}; empty input → {ok:true,result.message}. Deterministic heuristic, no LLM. try/catch-guarded; non-string claim / non-array evidence coerced. Field alignment + validation pinned by server/tests/debate-lens-macros.test.js."
+}

--- a/content/contracts/overrides/debate.fallacyCheck.json
+++ b/content/contracts/overrides/debate.fallacyCheck.json
@@ -1,0 +1,25 @@
+{
+  "macro_id": "debate.fallacyCheck",
+  "domain": "debate",
+  "name": "fallacyCheck",
+  "inputs": {
+    "text": { "type": "string", "required": false, "maxLength": 4000 },
+    "argument": { "type": "string", "required": false, "maxLength": 4000 }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || (typeof output.result.message === 'string') || (Number.isFinite(output.result.count) && Number.isFinite(output.result.textLength))",
+    "output.ok === false || (typeof output.result.message === 'string') || ['appears-sound','minor-issues','significant-issues'].includes(output.result.logicalSoundness)",
+    "output.ok === false || (typeof output.result.message === 'string') || Array.isArray(output.result.fallaciesDetected)"
+  ],
+  "fuzz_cases": [
+    { "input": { "text": "A ban will inevitably lead to ruin, either we act or society collapses, and everyone agrees." }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "text": "This is a calm and reasonable statement with no flaws." }, "expect": { "ok": true } },
+    { "input": { "text": 9999 }, "expect": { "ok": true } },
+    { "input": { "argument": { "x": 1 } }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler, dispatch key 'debate.fallacyCheck'. DebateActionPanel 'Fallacy check' passes {text} (a single selected argument); page.tsx passes NO params so the handler builds the text blob from the live debate's proArguments+conArguments text. Renders r.result.{fallaciesDetected[].{fallacy,description}, count, logicalSoundness, textLength}; empty → {ok:true,result.message}. Deterministic regex match over 8 fallacy patterns, no LLM. try/catch-guarded; non-string text coerced via debateText helper. Pinned by server/tests/debate-lens-macros.test.js."
+}

--- a/content/contracts/overrides/debate.scoreDebate.json
+++ b/content/contracts/overrides/debate.scoreDebate.json
@@ -1,0 +1,24 @@
+{
+  "macro_id": "debate.scoreDebate",
+  "domain": "debate",
+  "name": "scoreDebate",
+  "inputs": {
+    "sides": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || (typeof output.result.message === 'string') || (Array.isArray(output.result.sides) && output.result.sides.length >= 2)",
+    "output.ok === false || (typeof output.result.message === 'string') || Number.isFinite(output.result.margin)",
+    "output.ok === false || (typeof output.result.message === 'string') || typeof output.result.close === 'boolean'"
+  ],
+  "fuzz_cases": [
+    { "input": { "sides": [ { "name": "Alpha", "arguments": [ { "claim": "x", "evidence": [1, 2], "rebuttal": true } ] }, { "name": "Beta", "arguments": [ { "claim": "y" } ] } ] }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "sides": [] }, "expect": { "ok": true } },
+    { "input": { "sides": "notarray" }, "expect": { "ok": true } },
+    { "input": { "sides": [null, { "arguments": 5 }] }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler, dispatch key 'debate.scoreDebate'. DebateActionPanel + page.tsx 'Score Debate' pass NO sides param so the handler derives two sides (Pro/Con) from the live debate's proArguments/conArguments + proVotes/conVotes; an explicit {sides:[{name,arguments:[...]}]} overrides. Renders r.result.{sides[].{side,arguments,evidencePoints,rebuttals,score}, winner, margin, close}; no args → {ok:true,result.message}. Deterministic tally, no LLM. try/catch-guarded; poisoned proArguments/sides coerced via asArray. Pinned by server/tests/debate-lens-macros.test.js."
+}

--- a/content/contracts/overrides/debate.steelmanPosition.json
+++ b/content/contracts/overrides/debate.steelmanPosition.json
@@ -1,0 +1,27 @@
+{
+  "macro_id": "debate.steelmanPosition",
+  "domain": "debate",
+  "name": "steelmanPosition",
+  "inputs": {
+    "position": { "type": "string", "required": false, "maxLength": 4000 },
+    "argument": { "type": "string", "required": false, "maxLength": 4000 },
+    "side": { "type": "string", "required": false, "enum": ["pro", "con"] },
+    "arguments": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || (typeof output.result.message === 'string') || (Array.isArray(output.result.steelmanSteps) && output.result.steelmanSteps.length >= 1)",
+    "output.ok === false || (typeof output.result.message === 'string') || (output.result.framework && typeof output.result.framework.premise === 'string')",
+    "output.ok === false || (typeof output.result.message === 'string') || Number.isFinite(output.result.originalLength)"
+  ],
+  "fuzz_cases": [
+    { "input": { "side": "con", "arguments": ["A ban costs jobs", "Alternatives are not ready"] }, "expect": { "ok": true } },
+    { "input": { "position": "Free movement boosts national GDP over the long run" }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "position": 9999 }, "expect": { "ok": true } },
+    { "input": { "arguments": "notarray" }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler, dispatch key 'debate.steelmanPosition'. DebateActionPanel 'Steelman' passes {side,arguments:[...]}; page.tsx passes NO params so the handler derives the position from the live debate's chosen-side (or pro) argument text. Renders r.result.{steelmanSteps[], framework{premise,evidence,conclusion}, originalLength, side, originalPosition}; empty → {ok:true,result.message}. Deterministic template, no LLM. try/catch-guarded; non-string position / non-array arguments coerced before .split(). Pinned by server/tests/debate-lens-macros.test.js."
+}

--- a/content/contracts/overrides/eco.biodiversityIndex.json
+++ b/content/contracts/overrides/eco.biodiversityIndex.json
@@ -1,0 +1,26 @@
+{
+  "macro_id": "eco.biodiversityIndex",
+  "domain": "eco",
+  "name": "biodiversityIndex",
+  "inputs": {
+    "observations": { "type": "array", "required": false },
+    "species": { "type": "object", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.message !== undefined || (Number.isFinite(output.result.speciesRichness) && Number.isFinite(output.result.totalIndividuals))",
+    "output.ok === false || output.result.message !== undefined || (Number.isFinite(output.result.diversityIndices.shannonH) && Number.isFinite(output.result.diversityIndices.simpsonsD) && Number.isFinite(output.result.diversityIndices.shannonEvenness))",
+    "output.ok === false || output.result.message !== undefined || Array.isArray(output.result.rankAbundance)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "species": { "a": 25, "b": 25, "c": 25, "d": 25 } }, "expect": { "ok": true } },
+    { "input": { "observations": [{ "species": "oak", "count": 50 }, { "species": "oak", "count": 50 }, { "species": "fern", "count": 1 }] }, "expect": { "ok": true } },
+    { "input": { "species": { "a": "Infinity", "b": "1e999" } }, "expect": { "ok": true } },
+    { "input": { "observations": [{ "species": "x", "count": "NaN" }] }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler (registerLensAction; path-3). The /lenses/eco Biodiversity Index button drives this; handler reads artifact.data.observations (array of {species,count}) OR artifact.data.species (object speciesName→count). Returns {speciesRichness,totalIndividuals,diversityIndices:{shannonH,shannonHMax,shannonEvenness,simpsonsD,simpsonsDiversity,simpsonsReciprocal,bergerParkerDominance},richnessIndices,diversityLabel,evennessLabel,dominantSpecies,rareSpecies,rankAbundance,rarefactionCurve} OR {message} when no data. POISON: finiteNum(...,{min:0,integer:true}) clamps every per-species count to a finite non-negative integer so Shannon/Simpson/rarefaction never go NaN/Infinity. Pinned by server/tests/eco-lens-macros.test.js."
+}

--- a/content/contracts/overrides/eco.carbonFootprint.json
+++ b/content/contracts/overrides/eco.carbonFootprint.json
@@ -1,0 +1,25 @@
+{
+  "macro_id": "eco.carbonFootprint",
+  "domain": "eco",
+  "name": "carbonFootprint",
+  "inputs": {
+    "activities": { "type": "array", "required": false },
+    "offsets": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.message !== undefined || (Number.isFinite(output.result.totalEmissionsKgCO2e) && Number.isFinite(output.result.netEmissionsKgCO2e) && Number.isFinite(output.result.totalOffsetsKgCO2e))",
+    "output.ok === false || output.result.message !== undefined || (typeof output.result.carbonNeutral === 'boolean' && Array.isArray(output.result.categoryBreakdown) && Array.isArray(output.result.activities))",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "activities": [{ "category": "electricity", "type": "kwh", "quantity": 1000 }, { "category": "beef", "type": "kg", "quantity": 10 }] }, "expect": { "ok": true } },
+    { "input": { "activities": [{ "category": "electricity", "type": "kwh", "quantity": "Infinity" }, { "category": "beef", "type": "kg", "quantity": "1e999" }] }, "expect": { "ok": true } },
+    { "input": { "activities": [{ "category": "x", "type": "y", "quantity": -5, "emissionFactor": "NaN" }] }, "expect": { "ok": true } },
+    { "input": { "activities": [{ "category": "car", "type": "km", "quantity": 100 }], "offsets": [{ "type": "tree_planting", "unit": "tree", "quantity": "Infinity" }] }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler (registerLensAction; path-3, virtualArtifact.data === input). The /lenses/eco AI Eco Analysis panel drives this via useRunArtifact → POST /api/lens/eco/:id/run; handler reads artifact.data.activities / .offsets. Returns {totalEmissionsKgCO2e,totalEmissionsTonneCO2e,totalOffsetsKgCO2e,netEmissionsKgCO2e,offsetPercentage,carbonNeutral,scopeBreakdown,categoryBreakdown,equivalencies,activities,offsets} OR {message} when no activities. POISON: finiteNum() coerces every per-activity factor + quantity (and offset factor + quantity) to a finite, non-negative number so a poisoned Infinity/NaN/'1e999' quantity NEVER leaks Infinity/NaN into the totals or breakdowns. Pinned by server/tests/eco-lens-macros.test.js."
+}

--- a/content/contracts/overrides/eco.energy-estimate.json
+++ b/content/contracts/overrides/eco.energy-estimate.json
@@ -1,0 +1,29 @@
+{
+  "macro_id": "eco.energy-estimate",
+  "domain": "eco",
+  "name": "energy-estimate",
+  "inputs": {
+    "lat": { "type": "number", "required": false },
+    "lng": { "type": "number", "required": false },
+    "systemKw": { "type": "number", "required": false },
+    "tilt": { "type": "number", "required": false },
+    "azimuth": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || (Number.isFinite(output.result.systemKwp) && Number.isFinite(output.result.annualKwh) && Number.isFinite(output.result.co2AvoidedKgPerYear) && Number.isFinite(output.result.capacityFactor))",
+    "output.ok === false || (Array.isArray(output.result.monthlyKwh) && output.result.monthlyKwh.length === 12 && output.result.monthlyKwh.every(function(v){return Number.isFinite(v) && v >= 0;}))",
+    "output.ok === false || (output.result.location.lat >= -90 && output.result.location.lat <= 90 && output.result.location.lng >= -180 && output.result.location.lng <= 180)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "lat": 37.77, "lng": -122.42, "systemKw": 8, "tilt": 30, "azimuth": 180 }, "expect": { "ok": true } },
+    { "input": { "lat": "Infinity", "lng": "NaN", "systemKw": "1e999", "tilt": "Infinity", "azimuth": "NaN" }, "expect": { "ok": true } },
+    { "input": { "lat": 37, "lng": -122, "systemKw": -5 }, "expect": { "ok": true } },
+    { "input": { "lat": 999, "lng": -999, "systemKw": 0 }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler (registerLensAction; path-3). The /lenses/eco Solar estimator (EnergyEstimator.tsx) sends {lat,lng,systemKw,tilt,azimuth} as run-action params via raw POST /api/lens/run. Deterministic PVWatts-like model (no network). Returns {systemKwp,annualKwh,monthlyKwh[12],co2AvoidedKgPerYear,capacityFactor,source,location:{lat,lng}}. POISON: finiteNum() coerces every numeric within physical bounds (lat -90..90, lng -180..180, systemKw 0.1..1e6, tilt 0..89, azimuth 0..360) so a poisoned Infinity/NaN/'1e999' never leaks into the kWh totals; negative system size clamps to the 0.1 kW floor (never negative production). Pinned by server/tests/eco-lens-macros.test.js."
+}

--- a/content/contracts/overrides/eco.sustainabilityScore.json
+++ b/content/contracts/overrides/eco.sustainabilityScore.json
@@ -1,0 +1,26 @@
+{
+  "macro_id": "eco.sustainabilityScore",
+  "domain": "eco",
+  "name": "sustainabilityScore",
+  "inputs": {
+    "indicators": { "type": "object", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.overallScore === null || Number.isFinite(output.result.overallScore)",
+    "output.ok === false || (typeof output.result.maturityLevel === 'string' && typeof output.result.pillars === 'object')",
+    "output.ok === false || Number.isFinite(output.result.dataCompleteness)",
+    "output.ok === false || Array.isArray(output.result.recommendations)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "indicators": { "environmental": { "emissions": 80, "energyEfficiency": 80, "wasteReduction": 80, "waterUsage": 80, "biodiversity": 80 }, "social": { "laborPractices": 60 }, "governance": { "transparency": 40 } } }, "expect": { "ok": true } },
+    { "input": { "indicators": { "environmental": { "emissions": "Infinity", "energyEfficiency": "1e999", "wasteReduction": -50 } } }, "expect": { "ok": true } },
+    { "input": { "indicators": { "environmental": { "emissions": "NaN" } } }, "expect": { "ok": true } },
+    { "input": { "indicators": {} }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler (registerLensAction; path-3). The /lenses/eco Sustainability Score button drives this; handler reads artifact.data.indicators.{environmental,social,governance}. Each sub-indicator is a 0-100 score; pillar weights default {environmental:0.4,social:0.35,governance:0.25} (override via params.weights). Returns {overallScore,maturityLevel,overallRating,pillars,strengths,weaknesses,recommendations,dataCompleteness}. POISON: each indicator goes through Math.max(0,Math.min(100,Number(value))) with a !isNaN guard, so Infinity/'1e999' clamp to 100 and 'NaN'/missing read as not-reported (score:null) — the overall score is null or finite, never NaN. Pinned by server/tests/eco-lens-macros.test.js."
+}

--- a/content/contracts/overrides/energy.carbonFootprint.json
+++ b/content/contracts/overrides/energy.carbonFootprint.json
@@ -1,0 +1,28 @@
+{
+  "macro_id": "energy.carbonFootprint",
+  "domain": "energy",
+  "name": "carbonFootprint",
+  "inputs": {
+    "electricityKWh": { "type": "number", "required": false },
+    "naturalGasTherms": { "type": "number", "required": false },
+    "gasolineGallons": { "type": "number", "required": false },
+    "flightMiles": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || (Number.isFinite(output.result.totalMetricTons) && Number.isFinite(output.result.annualEstimate))",
+    "output.ok === false || (typeof output.result.breakdown === 'object' && Number.isFinite(output.result.breakdown.electricity) && Number.isFinite(output.result.breakdown.naturalGas) && Number.isFinite(output.result.breakdown.transportation) && Number.isFinite(output.result.breakdown.flights))",
+    "output.ok === false || typeof output.result.topSource === 'string'",
+    "output.ok === false || Array.isArray(output.result.reductionTips)"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "electricityKWh": 1000, "naturalGasTherms": 50, "gasolineGallons": 40, "flightMiles": 2000 } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "electricityKWh": "1e999", "naturalGasTherms": "Infinity", "gasolineGallons": "NaN", "flightMiles": "not-a-number" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "electricityKWh": -1000 } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": {} } }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS (path-3) handler; dispatch key 'energy.carbonFootprint'. SolarCarbonPanel sends {input:{artifact:{data:{electricityKWh,naturalGasTherms,gasolineGallons,flightMiles}}}}; dispatch peels → artifact.data. EPA emission factors (kWh*0.000417, therms*0.0053, gal*0.00887, mi*0.000255). POISON CONTRACT: finiteNum(x,0,0) floors each input non-negative + finite so the CO2 totals + breakdown stay FINITE (the old parseFloat(x)||0 leaked Infinity → JSON null). Renders breakdown{electricity,naturalGas,transportation,flights}, totalMetricTons, annualEstimate, vsUSAverage, topSource, reductionTips. Pinned by server/tests/energy-lens-macros.test.js."
+}

--- a/content/contracts/overrides/energy.consumptionAnalysis.json
+++ b/content/contracts/overrides/energy.consumptionAnalysis.json
@@ -1,0 +1,25 @@
+{
+  "macro_id": "energy.consumptionAnalysis",
+  "domain": "energy",
+  "name": "consumptionAnalysis",
+  "inputs": {
+    "readings": { "type": "array", "required": false },
+    "costPerKWh": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || typeof output.result.message === 'string' || (Number.isFinite(output.result.totalKWh) && Number.isFinite(output.result.avgKWh) && Number.isFinite(output.result.peakKWh) && Number.isFinite(output.result.estimatedCost) && Number.isFinite(output.result.costPerKWh) && Number.isFinite(output.result.peakToAvgRatio))",
+    "output.ok === false || typeof output.result.message === 'string' || Number.isInteger(output.result.readingCount)",
+    "output.ok === false || typeof output.result.message === 'string' || output.result.costPerKWh > 0"
+  ],
+  "fuzz_cases": [
+    { "input": { "readings": [{ "kWh": 10 }, { "kWh": 20 }, { "kWh": 30 }], "costPerKWh": 0.2 }, "expect": { "ok": true } },
+    { "input": { "readings": [{ "kWh": "1e999" }, { "kWh": "Infinity" }, { "kWh": "NaN" }, { "kWh": 5 }], "costPerKWh": "1e999" }, "expect": { "ok": true } },
+    { "input": { "readings": [{ "kWh": -5 }, { "value": -10 }] }, "expect": { "ok": true } },
+    { "input": { "readings": [] }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS (path-3) handler; dispatch key 'energy.consumptionAnalysis'. Reads artifact.data.readings[] (.kWh ?? .value) + artifact.data.costPerKWh. The dispatch peels a sole-key {artifact:{data}} wrapper, so the SolarCarbonPanel/CalcPanel single-wrap and a flat body both land on artifact.data. POISON CONTRACT: finiteNum() collapses Infinity / -Infinity / NaN / '1e999' / 'Infinity' / non-numeric to a finite fallback and clamps kWh >= 0; avg/peakToAvg guard against div-by-zero; EVERY numeric output is FINITE (previously parseFloat(x)||0 let Infinity through → JSON null in the UI). Empty readings → {message}. Pinned by server/tests/energy-lens-macros.test.js."
+}

--- a/content/contracts/overrides/energy.disaggregate.json
+++ b/content/contracts/overrides/energy.disaggregate.json
@@ -1,0 +1,25 @@
+{
+  "macro_id": "energy.disaggregate",
+  "domain": "energy",
+  "name": "disaggregate",
+  "inputs": {
+    "days": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || Array.isArray(output.result.devices)",
+    "output.ok === false || (Number.isFinite(output.result.totalKwh) && Number.isFinite(output.result.attributedKwh) && Number.isFinite(output.result.unattributedKwh) && Number.isFinite(output.result.wholeHomeKwh))",
+    "output.ok === false || Number.isInteger(output.result.days)",
+    "output.ok === false || output.result.devices.every(function(d){ return Number.isFinite(d.directKwh) && Number.isFinite(d.estimatedKwh) && Number.isFinite(d.attributedKwh) && Number.isFinite(d.pct); })"
+  ],
+  "fuzz_cases": [
+    { "input": { "days": 30 }, "expect": { "ok": true } },
+    { "input": { "days": "1e999" }, "expect": { "ok": true } },
+    { "input": { "days": "NaN" }, "expect": { "ok": true } },
+    { "input": { "days": -5 }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS (path-3) handler; dispatch key 'energy.disaggregate'. EnergyDisaggregationPanel sends {input:{days}} (flat). Attributes whole-home load across tracked devices: metered per-device readings + a nameplate-wattage-weighted split of the remaining whole-home kWh. POISON CONTRACT: enNum clamps days∈[1,365] (Infinity/NaN/'1e999' → finite); per-device pct guards div-by-zero on zero total. Empty devices → {devices:[],totalKwh:0,...}. Renders devices[{deviceId,name,category,directKwh,estimatedKwh,attributedKwh,pct,method}] + totalKwh/attributedKwh/unattributedKwh/wholeHomeKwh. Pinned by server/tests/energy-lens-macros.test.js."
+}

--- a/content/contracts/overrides/energy.gridStatus.json
+++ b/content/contracts/overrides/energy.gridStatus.json
@@ -1,0 +1,28 @@
+{
+  "macro_id": "energy.gridStatus",
+  "domain": "energy",
+  "name": "gridStatus",
+  "inputs": {
+    "currentDemandMW": { "type": "number", "required": false },
+    "totalCapacityMW": { "type": "number", "required": false },
+    "renewablePercent": { "type": "number", "required": false },
+    "gridFrequencyHz": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || Number.isFinite(output.result.utilization)",
+    "output.ok === false || ['critical-load','high-load','normal','low-load'].indexOf(output.result.status) !== -1",
+    "output.ok === false || (typeof output.result.currentDemand === 'string' && output.result.currentDemand.indexOf('Infinity') === -1 && output.result.currentDemand.indexOf('NaN') === -1)",
+    "output.ok === false || (typeof output.result.reserves === 'string' && output.result.reserves.indexOf('Infinity') === -1 && output.result.reserves.indexOf('NaN') === -1)",
+    "output.ok === false || typeof output.result.frequencyStable === 'boolean'"
+  ],
+  "fuzz_cases": [
+    { "input": { "currentDemandMW": 800, "totalCapacityMW": 1000, "renewablePercent": 35, "gridFrequencyHz": 60.01 }, "expect": { "ok": true } },
+    { "input": { "currentDemandMW": "1e999", "totalCapacityMW": "Infinity", "renewablePercent": "NaN", "gridFrequencyHz": "not-a-number" }, "expect": { "ok": true } },
+    { "input": { "currentDemandMW": -100, "totalCapacityMW": 0 }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS (path-3) handler; dispatch key 'energy.gridStatus'. Reads artifact.data.{currentDemandMW,totalCapacityMW,renewablePercent,gridFrequencyHz}. POISON CONTRACT: these values are ECHOED into output STRINGS ('800 MW', '200 MW available'), so finiteNum() clamps each finite + non-negative BEFORE formatting — a poisoned 'Infinity' can never render 'Infinity MW'. utilization guards div-by-zero on zero capacity. Renders currentDemand/totalCapacity/utilization/renewableShare/gridFrequency/frequencyStable/status/reserves. Pinned by server/tests/energy-lens-macros.test.js."
+}

--- a/content/contracts/overrides/energy.solarEstimate.json
+++ b/content/contracts/overrides/energy.solarEstimate.json
@@ -1,0 +1,26 @@
+{
+  "macro_id": "energy.solarEstimate",
+  "domain": "energy",
+  "name": "solarEstimate",
+  "inputs": {
+    "roofAreaSqFt": { "type": "number", "required": false },
+    "peakSunHours": { "type": "number", "required": false },
+    "monthlyUsageKWh": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || (Number.isFinite(output.result.roofArea) && Number.isFinite(output.result.systemSizeKW) && Number.isFinite(output.result.monthlyProductionKWh) && Number.isFinite(output.result.coveragePercent) && Number.isFinite(output.result.estimatedCost) && Number.isFinite(output.result.afterTaxCredit) && Number.isFinite(output.result.annualSavings) && Number.isFinite(output.result.paybackYears))",
+    "output.ok === false || Number.isInteger(output.result.maxPanels)",
+    "output.ok === false || typeof output.result.recommendation === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "roofAreaSqFt": 1000, "peakSunHours": 5, "monthlyUsageKWh": 900 } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "roofAreaSqFt": "1e999", "peakSunHours": "Infinity", "monthlyUsageKWh": "NaN" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "roofAreaSqFt": -100, "peakSunHours": -5, "monthlyUsageKWh": -900 } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": {} } }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS (path-3) handler; dispatch key 'energy.solarEstimate'. SolarCarbonPanel sends {input:{artifact:{data:{roofAreaSqFt,peakSunHours,monthlyUsageKWh}}}}; the dispatch peels the sole-key wrapper → artifact.data. POISON CONTRACT: finiteNum() clamps roofAreaSqFt∈[100,1e6], peakSunHours∈[0.1,24], monthlyUsageKWh∈[1,1e7] so a poisoned ('1e999'/'Infinity') input can NEVER cascade into Infinity panels/cost/payback (the old parseFloat(x)||N let Infinity through → JSON null). Renders coveragePercent / systemSizeKW / maxPanels / estimatedCost / afterTaxCredit / annualSavings / paybackYears / recommendation. Pinned by server/tests/energy-lens-macros.test.js."
+}

--- a/content/contracts/overrides/ethics.biasChecklist.json
+++ b/content/contracts/overrides/ethics.biasChecklist.json
@@ -1,0 +1,26 @@
+{
+  "macro_id": "ethics.biasChecklist",
+  "domain": "ethics",
+  "name": "biasChecklist",
+  "inputs": {
+    "decision": { "type": "string", "required": true },
+    "responses": { "type": "object", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || (Number.isInteger(output.result.flaggedCount) && Number.isInteger(output.result.totalCount))",
+    "output.ok === false || (Number.isFinite(output.result.riskScore) && output.result.riskScore >= 0 && output.result.riskScore <= 100)",
+    "output.ok === false || ['low','moderate','high'].includes(output.result.riskLevel)",
+    "output.ok === false || (Array.isArray(output.result.items) && output.result.items.length === 10)"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "decision": "Promote candidate", "responses": { "confirmation": { "flagged": true }, "anchoring": { "flagged": true } } } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "decision": "d", "responses": "not-an-object" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "decision": "d", "responses": { "confirmation": { "flagged": "1e999", "note": 5 } } } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "decision": "" } } }, "expect": { "ok": false } },
+    { "input": {}, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS (path-3) handler; dispatch key 'ethics.biasChecklist'. BiasChecklistPanel sends {input:{decision, responses:{[biasKey]:{flagged,note?}}}}; dispatch peels a sole-key {artifact:{data}} wrapper. Returns {id,decision,items:[{key,label,prompt,flagged,note}],flaggedCount,totalCount,riskScore,riskLevel,createdAt}. The 10-item bias template (key/label/prompt) comes from the sibling biasChecklistTemplate macro the panel loads first. POISON CONTRACT: riskScore = flaggedCount/totalCount*100 over a FIXED 10-item template, so it is always a finite 0..100 integer regardless of input; a non-object responses field, a non-boolean flagged, or a non-string note are coerced (!! / String()) and never throw. Empty decision is rejected fail-closed. Pinned by server/tests/ethics-lens-macros.test.js."
+}

--- a/content/contracts/overrides/ethics.decisionMatrix.json
+++ b/content/contracts/overrides/ethics.decisionMatrix.json
@@ -1,0 +1,27 @@
+{
+  "macro_id": "ethics.decisionMatrix",
+  "domain": "ethics",
+  "name": "decisionMatrix",
+  "inputs": {
+    "title": { "type": "string", "required": false },
+    "criteria": { "type": "array", "required": true },
+    "options": { "type": "array", "required": true }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.criteria.every(c => Number.isFinite(c.weight))",
+    "output.ok === false || output.result.options.every(o => Number.isFinite(o.total) && Number.isFinite(o.percent))",
+    "output.ok === false || output.result.options.every(o => o.breakdown.every(b => Number.isFinite(b.raw) && Number.isFinite(b.weighted)))",
+    "output.ok === false || typeof output.result.winner === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "title": "Vendor", "criteria": [{ "name": "fairness", "weight": 0.6 }, { "name": "cost", "weight": 0.4 }], "options": [{ "name": "A", "scores": { "fairness": 8, "cost": 4 } }] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "title": "P", "criteria": [{ "name": "a", "weight": "1e999" }, { "name": "b", "weight": 1 }], "options": [{ "name": "X", "scores": { "a": "Infinity", "b": 5 } }] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "criteria": [{ "name": 5, "weight": "abc" }], "options": [{ "name": null, "scores": { "a": "NaN" } }] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "options": [{ "name": "A" }] } } }, "expect": { "ok": false } },
+    { "input": {}, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS (path-3) handler; dispatch key 'ethics.decisionMatrix'. DecisionMatrixPanel sends {input:{title, criteria:[{name,weight}], options:[{name,scores:{[criterion]:0-10}}]}}; dispatch peels a sole-key {artifact:{data}} wrapper. Returns {id,title,criteria:[{name,weight}],options:[{name,breakdown:[{criterion,raw,weighted}],total,percent}],winner,createdAt}. POISON CONTRACT (the real defect fixed this pass): a poisoned ('1e999'/'Infinity') weight was passed through Number()||0 = Infinity, making weightSum=Infinity and every normalized weight Infinity/Infinity = NaN, leaking NaN total/percent (JSON null) into the rendered record. The fix clamps each weight via fnum() (Number.isFinite, default 0) and Math.max(0,...) BEFORE summing, and clamps each score via fnum() ∈[0,10]. Missing criteria or options is rejected fail-closed. Pinned by server/tests/ethics-lens-macros.test.js."
+}

--- a/content/contracts/overrides/ethics.multiFrameworkDilemma.json
+++ b/content/contracts/overrides/ethics.multiFrameworkDilemma.json
@@ -1,0 +1,26 @@
+{
+  "macro_id": "ethics.multiFrameworkDilemma",
+  "domain": "ethics",
+  "name": "multiFrameworkDilemma",
+  "inputs": {
+    "dilemma": { "type": "string", "required": true },
+    "options": { "type": "array", "required": true }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || Array.isArray(output.result.options)",
+    "output.ok === false || output.result.options.every(o => Number.isFinite(o.composite) && Number.isFinite(o.benefit) && Number.isFinite(o.harm))",
+    "output.ok === false || output.result.options.every(o => Number.isFinite(o.scores.utilitarian) && Number.isFinite(o.scores.deontological) && Number.isFinite(o.scores.virtue))",
+    "output.ok === false || Array.isArray(output.result.conflicted)"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "dilemma": "Layoffs", "options": [{ "name": "Honest", "description": "honest consent respect", "benefitScore": 60, "harmScore": 20 }] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "dilemma": "d", "options": [{ "name": "A", "description": "help care", "benefitScore": "1e999", "harmScore": "Infinity" }] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "dilemma": "d", "options": [{ "name": "A", "benefitScore": "NaN", "harmScore": -50 }] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "dilemma": "", "options": [] } } }, "expect": { "ok": false } },
+    { "input": {}, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS (path-3) handler; dispatch key 'ethics.multiFrameworkDilemma'. MultiFrameworkPanel sends {input:{dilemma, options:[{name,description,harmScore?,benefitScore?}]}}; the dispatch peels a sole-key {artifact:{data}} wrapper. Returns {id,dilemma,options:[{name,description,scores{utilitarian,deontological,virtue},composite,agreement,benefit,harm}],recommended,conflicted,createdAt}. POISON CONTRACT: benefitScore/harmScore are guarded by Number.isFinite and fall back to keyword-derived scores, so a poisoned ('1e999'/'Infinity'/'NaN') input can NEVER produce Infinity/NaN scores/composite (which JSON-serialize to null). Empty dilemma or zero options is rejected fail-closed. Pinned by server/tests/ethics-lens-macros.test.js. NOTE: ethics is path-3-only, so the macro-assassin does not drive it — the node:test is the real enforcement; this override is the documented contract."
+}

--- a/content/contracts/overrides/ethics.stakeholderMap.json
+++ b/content/contracts/overrides/ethics.stakeholderMap.json
@@ -1,0 +1,27 @@
+{
+  "macro_id": "ethics.stakeholderMap",
+  "domain": "ethics",
+  "name": "stakeholderMap",
+  "inputs": {
+    "title": { "type": "string", "required": false },
+    "options": { "type": "array", "required": true },
+    "stakeholders": { "type": "array", "required": true }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.stakeholders.every(s => Number.isFinite(s.vulnerability) && Number.isFinite(s.netExposure))",
+    "output.ok === false || output.result.stakeholders.every(s => Object.values(s.impacts).every(i => Number.isFinite(i.raw) && Number.isFinite(i.weighted)))",
+    "output.ok === false || output.result.optionTotals.every(o => Number.isFinite(o.netImpact) && Number.isInteger(o.harmed) && Number.isInteger(o.benefited) && Number.isInteger(o.vulnerableHarmed))",
+    "output.ok === false || typeof output.result.bestOption === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "title": "Closure", "options": ["keep", "cut"], "stakeholders": [{ "name": "Workers", "vulnerability": 80, "impacts": { "keep": 50, "cut": -60 } }] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "title": "P", "options": ["x"], "stakeholders": [{ "name": "V", "vulnerability": "1e999", "impacts": { "x": "-Infinity" } }] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "options": ["x"], "stakeholders": [{ "name": "Z", "vulnerability": "NaN", "impacts": { "x": "abc" } }] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "stakeholders": [{ "name": "x" }] } } }, "expect": { "ok": false } },
+    { "input": {}, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS (path-3) handler; dispatch key 'ethics.stakeholderMap'. StakeholderMapPanel sends {input:{title, options:[string], stakeholders:[{name,group,vulnerability,impacts:{[option]:-100..100}}]}}; dispatch peels a sole-key {artifact:{data}} wrapper. Returns {id,title,options,stakeholders:[{name,group,vulnerability,impacts:{[opt]:{raw,weighted}},netExposure}],optionTotals:[{option,netImpact,harmed,benefited,vulnerableHarmed}],bestOption,createdAt}. POISON CONTRACT: vulnerability and each impact are coerced via fnum() (Number.isFinite, default 0) then clamped — vuln∈[0,100], impact∈[-100,100] — so a poisoned ('1e999'/'-Infinity'/'NaN') input can NEVER produce Infinity/NaN weighted impact or netExposure. Vulnerability amplifies negative impact only (×(1+vuln/100)). Missing options or stakeholders is rejected fail-closed. Pinned by server/tests/ethics-lens-macros.test.js."
+}

--- a/content/contracts/overrides/fitness.bodyCompReport.json
+++ b/content/contracts/overrides/fitness.bodyCompReport.json
@@ -1,0 +1,28 @@
+{
+  "macro_id": "fitness.bodyCompReport",
+  "domain": "fitness",
+  "name": "bodyCompReport",
+  "inputs": {
+    "weight": { "type": "number", "required": false },
+    "height": { "type": "number", "required": false },
+    "age": { "type": "number", "required": false },
+    "sex": { "type": "string", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.bmi === null || Number.isFinite(output.result.bmi)",
+    "output.ok === false || output.result.bodyFatPct === null || Number.isFinite(output.result.bodyFatPct)",
+    "output.ok === false || output.result.fatMass === null || Number.isFinite(output.result.fatMass.kg)",
+    "output.ok === false || output.result.leanMass === null || Number.isFinite(output.result.leanMass.kg)"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "weight": 80, "height": 180, "age": 30, "sex": "male" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "weight": "1e999", "height": "Infinity", "age": "NaN" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "weight": -80, "height": -180 } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": {} } }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS (path-3) handler; dispatch key 'fitness.bodyCompReport'. Returns bmi/bmiCategory/bodyFatPct/fatMass{kg,lbs}/leanMass{kg,lbs}. POISON CONTRACT: ffnum() coerces every numeric through Number.isFinite and fclampN clamps bodyFatPct∈[1,75], so a poisoned ('1e999'/'Infinity'/'NaN') weight/height can NEVER produce Infinity/NaN bmi or mass (the old parseFloat let it through → JSON null). Pinned by server/tests/fitness-lens-macros.test.js. NOTE: fitness is path-3-only, so the macro-assassin does not drive it — the node:test is the real enforcement; this override is the documented contract."
+}

--- a/content/contracts/overrides/fitness.hr-zones.json
+++ b/content/contracts/overrides/fitness.hr-zones.json
@@ -1,0 +1,26 @@
+{
+  "macro_id": "fitness.hr-zones",
+  "domain": "fitness",
+  "name": "hr-zones",
+  "inputs": {
+    "age": { "type": "number", "required": false },
+    "restingHr": { "type": "number", "required": false },
+    "maxHr": { "type": "number", "required": false },
+    "method": { "type": "string", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || Number.isFinite(output.result.maxHr)",
+    "output.ok === false || Array.isArray(output.result.zones)",
+    "output.ok === false || output.result.zones.every(z => Number.isFinite(z.lowBpm) && Number.isFinite(z.highBpm) && z.highBpm >= z.lowBpm)"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": {} }, "age": 30, "restingHr": 60 }, "expect": { "ok": true } },
+    { "input": { "age": "Infinity", "restingHr": "1e999", "maxHr": "NaN" }, "expect": { "ok": true } },
+    { "input": { "age": -30, "restingHr": -60 }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS (path-3) handler; dispatch key 'fitness.hr-zones'. Returns { zones[].{zone,name,lowBpm,highBpm,pctOfMax,...}, maxHr, restingHr, method }. POISON CONTRACT: ffnum() + clamps guarantee maxHr and every zone's lowBpm/highBpm are finite and monotone even on poisoned age/restingHr — HeartRateZones renders these bands. Pinned by server/tests/fitness-lens-macros.test.js. Path-3-only → assassin does not drive it; node:test is the real enforcement."
+}

--- a/content/contracts/overrides/fitness.progressionCalc.json
+++ b/content/contracts/overrides/fitness.progressionCalc.json
@@ -1,0 +1,22 @@
+{
+  "macro_id": "fitness.progressionCalc",
+  "domain": "fitness",
+  "name": "progressionCalc",
+  "inputs": {
+    "exercises": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Array.isArray(output.result.recommendations)",
+    "output.ok === false || output.result.recommendations.every(r => Number.isFinite(r.recommendedWeight) && r.recommendedWeight >= 0)",
+    "output.ok === false || output.result.recommendations.every(r => ['increase_weight','maintain','reduce_weight'].includes(r.recommendation))"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "exercises": [{ "name": "squat", "weight": 100, "reps": 5, "rpe": 6 }] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "exercises": [{ "name": "x", "weight": "1e999", "reps": "Infinity", "rpe": "NaN" }] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "exercises": [] } } }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS (path-3) handler; dispatch key 'fitness.progressionCalc'. Returns { recommendations[].{exercise,currentWeight,currentReps,currentRPE,recommendedWeight,recommendation} }. POISON CONTRACT: ffnum() guarantees recommendedWeight is finite + Math.max(0,…)-floored even on poisoned weight/rpe; recommendation is one of three RPE-gated enum strings. Pinned by server/tests/fitness-lens-macros.test.js. Path-3-only → node:test is the real enforcement."
+}

--- a/content/contracts/overrides/fitness.race-predictor.json
+++ b/content/contracts/overrides/fitness.race-predictor.json
@@ -1,0 +1,22 @@
+{
+  "macro_id": "fitness.race-predictor",
+  "domain": "fitness",
+  "name": "race-predictor",
+  "inputs": {
+    "vo2max": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Number.isFinite(output.result.vo2max)",
+    "output.ok === false || Array.isArray(output.result.predictions)",
+    "output.ok === false || output.result.predictions.every(p => Number.isFinite(p.timeSeconds) && p.timeSeconds > 0 && Number.isFinite(p.paceSecPerKm))"
+  ],
+  "fuzz_cases": [
+    { "input": { "vo2max": 50 }, "expect": { "ok": true } },
+    { "input": { "vo2max": "Infinity" }, "expect": { "ok": false } },
+    { "input": { "vo2max": -50 }, "expect": { "ok": false } },
+    { "input": {}, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS (path-3) handler; dispatch key 'fitness.race-predictor'. VDOT race-time predictions across distances from vo2max (or a logged run). FAIL-CLOSED: a non-finite vo2max returns { ok:false } rather than a fabricated time; every prediction's timeSeconds/paceSecPerKm is finite + positive. Pinned by server/tests/fitness-lens-macros.test.js. Path-3-only → node:test is the real enforcement."
+}

--- a/content/contracts/overrides/fitness.vo2max-estimate.json
+++ b/content/contracts/overrides/fitness.vo2max-estimate.json
@@ -1,0 +1,22 @@
+{
+  "macro_id": "fitness.vo2max-estimate",
+  "domain": "fitness",
+  "name": "vo2max-estimate",
+  "inputs": {
+    "distanceKm": { "type": "number", "required": false },
+    "durationSec": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Number.isFinite(output.result.vo2max)",
+    "output.ok === false || output.result.vo2max > 0"
+  ],
+  "fuzz_cases": [
+    { "input": { "distanceKm": 5, "durationSec": 1500 }, "expect": { "ok": true } },
+    { "input": { "distanceKm": "1e999", "durationSec": "Infinity" }, "expect": { "ok": false } },
+    { "input": { "distanceKm": -5, "durationSec": -100 }, "expect": { "ok": false } },
+    { "input": {}, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS (path-3) handler; dispatch key 'fitness.vo2max-estimate'. VDOT physiology from distanceKm+durationSec (or a logged run ≥1.5km). FAIL-CLOSED: a non-finite or ≤0 vo2max returns { ok:false, error:'could not estimate' } rather than leaking NaN/Infinity — never a fabricated reading. Pinned by server/tests/fitness-lens-macros.test.js. Path-3-only → node:test is the real enforcement."
+}

--- a/content/contracts/overrides/forestry.carbonSequestration.json
+++ b/content/contracts/overrides/forestry.carbonSequestration.json
@@ -1,0 +1,27 @@
+{
+  "macro_id": "forestry.carbonSequestration",
+  "domain": "forestry",
+  "name": "carbonSequestration",
+  "inputs": {
+    "species": { "type": "string", "required": false },
+    "acres": { "type": "number", "required": false },
+    "ageYears": { "type": "number", "required": false },
+    "treesPerAcre": { "type": "number", "required": false }
+  },
+  "reads_artifact_data": true,
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.message !== undefined || (Number.isFinite(output.result.tonsPerYear) && output.result.tonsPerYear >= 0)",
+    "output.ok === false || output.result.message !== undefined || (Number.isFinite(output.result.lifetimeTons) && Number.isFinite(output.result.equivalentCars))",
+    "output.ok === false || output.result.tonsPerYear === undefined || typeof output.result.tonsPerYear === 'number'"
+  ],
+  "fuzz_cases": [
+    { "input": { "species": "douglas-fir", "acres": 100, "ageYears": 30 }, "expect": { "ok": true } },
+    { "input": { "acres": 10, "ageYears": 10 }, "expect": { "ok": true } },
+    { "input": { "acres": 0, "ageYears": 30 }, "expect": { "ok": true } },
+    { "input": { "acres": 50, "ageYears": "Infinity", "treesPerAcre": "1e999" }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler; dispatch key 'forestry.carbonSequestration'. ForestryActionPanel posts { species, acres, ageYears }; renders result.tonsPerYear + result.equivalentCars as NUMBERS. The PRIOR handler read artifact.data.acreage/standAge and returned annualSequestration as the STRING 'X tons CO2/year' (the panel reads numeric result.tonsPerYear → always undefined → rendered 'undefined t/yr'). Fixed: returns numeric tonsPerYear (acres × age-banded rate), lifetimeTons (acres × density × 0.015 × age), equivalentCars (tons/4.6). POISON: frFinite() rejects Infinity/NaN/1e999 → non-finite acres → 0 → empty-guidance; poisoned age/density default; every numeric output FINITE — no NaN/Infinity ever leaks into the carbon tile. Pinned by server/tests/forestry-lens-macros.test.js."
+}

--- a/content/contracts/overrides/forestry.fireRisk.json
+++ b/content/contracts/overrides/forestry.fireRisk.json
@@ -1,0 +1,28 @@
+{
+  "macro_id": "forestry.fireRisk",
+  "domain": "forestry",
+  "name": "fireRisk",
+  "inputs": {
+    "tempF": { "type": "number", "required": false },
+    "humidity": { "type": "number", "required": false },
+    "windMph": { "type": "number", "required": false },
+    "droughtIndex": { "type": "number", "required": false },
+    "fuelMoisturePercent": { "type": "number", "required": false }
+  },
+  "reads_artifact_data": true,
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || (Number.isFinite(output.result.score) && output.result.score >= 0 && output.result.score <= 100)",
+    "output.ok === false || ['low','moderate','high','extreme'].includes(output.result.riskLevel)",
+    "output.ok === false || Array.isArray(output.result.factors)"
+  ],
+  "fuzz_cases": [
+    { "input": { "tempF": 100, "humidity": 10, "windMph": 30 }, "expect": { "ok": true } },
+    { "input": { "tempF": 60, "humidity": 70, "windMph": 3 }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "tempF": "Infinity", "humidity": "NaN", "windMph": "1e999", "droughtIndex": "1e999", "fuelMoisturePercent": "NaN" }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler; dispatch key 'forestry.fireRisk'. ForestryActionPanel posts { tempF, humidity, windMph }; renders result.riskLevel + result.score. The PRIOR handler read temperatureF/humidityPercent/windSpeedMph (names the panel never sends → always defaulted) and returned riskScore (not the `score` the panel reads). Fixed: reads both the panel's names AND the legacy names, returns score === riskScore, clamps score to [0,100], emits a factors[] list. POISON: frFinite() rejects Infinity/NaN/1e999 → each weather term falls back to a sane default so the additive score is ALWAYS a finite int in [0,100] and riskLevel is one of low/moderate/high/extreme — no NaN band. Pinned by server/tests/forestry-lens-macros.test.js."
+}

--- a/content/contracts/overrides/forestry.growth-projection.json
+++ b/content/contracts/overrides/forestry.growth-projection.json
@@ -1,0 +1,28 @@
+{
+  "macro_id": "forestry.growth-projection",
+  "domain": "forestry",
+  "name": "growth-projection",
+  "inputs": {
+    "species": { "type": "string", "required": false },
+    "acres": { "type": "number", "required": true },
+    "currentAge": { "type": "number", "required": false },
+    "siteIndex": { "type": "number", "required": false },
+    "currentVolumePerAcre": { "type": "number", "required": false },
+    "rotationYears": { "type": "number", "required": false }
+  },
+  "reads_artifact_data": true,
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || Array.isArray(output.result.projection)",
+    "output.ok === false || output.result.projection.every(r => Number.isFinite(r.volumePerAcre) && Number.isFinite(r.totalVolume) && Number.isFinite(r.mai) && Number.isFinite(r.cai))",
+    "output.ok === false || (Number.isFinite(output.result.biologicalRotationAge) && Number.isFinite(output.result.peakMai))"
+  ],
+  "fuzz_cases": [
+    { "input": { "species": "douglas_fir", "acres": 40, "currentAge": 20, "siteIndex": 100 }, "expect": { "ok": true } },
+    { "input": { "species": "oak", "acres": 0 }, "expect": { "ok": false } },
+    { "input": { "species": "mixed", "acres": "1e999" }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS handler; dispatch key 'forestry.growth-projection'. GrowthProjectionPanel posts { species, acres, currentAge, siteIndex, currentVolumePerAcre } (flat, params === artifact.data); renders result.projection[] (volumePerAcre/mai chart), result.biologicalRotationAge, result.peakMai, result.finalVolumePerAcre. Real Chapman-Richards-style sigmoid anchored to per-species peak MAI (SPECIES_GROWTH) with site-index scaling. VALIDATION: acres <= 0 → { ok:false, error:'acres must be > 0' }. POISON: frNum() coerces non-finite to 0 → 1e999 acres → 0 → acres<=0 → rejected (never an Infinity-volume projection row); the loop bound is min(rotation-currentAge, 120) so it can't run away. Pinned by server/tests/forestry-lens-macros.test.js."
+}

--- a/content/contracts/overrides/forestry.harvestPlan.json
+++ b/content/contracts/overrides/forestry.harvestPlan.json
@@ -1,0 +1,27 @@
+{
+  "macro_id": "forestry.harvestPlan",
+  "domain": "forestry",
+  "name": "harvestPlan",
+  "inputs": {
+    "species": { "type": "string", "required": false },
+    "acres": { "type": "number", "required": false },
+    "currentAge": { "type": "number", "required": false },
+    "method": { "type": "string", "required": false }
+  },
+  "reads_artifact_data": true,
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.message !== undefined || Array.isArray(output.result.schedule)",
+    "output.ok === false || output.result.message !== undefined || Number.isFinite(output.result.rotation)",
+    "output.ok === false || output.result.schedule === undefined || output.result.schedule.every(s => Number.isFinite(s.year) && Number.isFinite(s.acres) && Number.isFinite(s.volume))"
+  ],
+  "fuzz_cases": [
+    { "input": { "species": "douglas-fir", "acres": 100, "currentAge": 25 }, "expect": { "ok": true } },
+    { "input": { "species": "loblolly-pine", "acres": 50, "currentAge": 10, "method": "clearcut" }, "expect": { "ok": true } },
+    { "input": { "species": "oak", "acres": 0, "currentAge": 30 }, "expect": { "ok": true } },
+    { "input": { "species": "mixed", "acres": "1e999", "currentAge": 20 }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler; dispatch key 'forestry.harvestPlan'. ForestryActionPanel posts { species, acres, currentAge }; renders result.schedule.length + result.rotation. The PRIOR handler read artifact.data.acreage/method (ignored species + currentAge) and returned removalPercent/rotationYears but NO `schedule[]` array and NO `rotation` field — so the panel's `harvestResult.schedule?.length` and `harvestResult.rotation` were always undefined. Fixed: builds a staged removal schedule (1 entry for clearcut/salvage, 3 for selective/shelterwood) with { year, acres, volume } derived from the species rotation age (SPECIES_GROWTH) and current age; returns rotation === rotationYears. POISON: frFinite() rejects 1e999 acres → 0 → empty-guidance (no NaN schedule rows). Pinned by server/tests/forestry-lens-macros.test.js."
+}

--- a/content/contracts/overrides/forestry.timberVolume.json
+++ b/content/contracts/overrides/forestry.timberVolume.json
@@ -1,0 +1,28 @@
+{
+  "macro_id": "forestry.timberVolume",
+  "domain": "forestry",
+  "name": "timberVolume",
+  "inputs": {
+    "species": { "type": "string", "required": false },
+    "acres": { "type": "number", "required": false },
+    "avgAgeYears": { "type": "number", "required": false },
+    "treeCount": { "type": "number", "required": false },
+    "pricePerMBF": { "type": "number", "required": false }
+  },
+  "reads_artifact_data": true,
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.message !== undefined || (Number.isFinite(output.result.boardFeet) && output.result.boardFeet >= 0)",
+    "output.ok === false || output.result.message !== undefined || (Number.isFinite(output.result.valuation) && Number.isFinite(output.result.cubicFeet))",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "species": "douglas-fir", "acres": 40, "avgAgeYears": 35, "treeCount": 100 }, "expect": { "ok": true } },
+    { "input": { "species": "oak", "acres": 10, "avgAgeYears": 30, "treeCount": 0 }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "species": "mixed", "acres": "1e999", "avgAgeYears": "Infinity", "treeCount": "100", "pricePerMBF": "NaN" }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler; dispatch key 'forestry.timberVolume'. The /lenses/forestry ForestryActionPanel posts { species, acres, avgAgeYears, treeCount } via runDomain (params === artifact.data === body.input). The PRIOR handler read artifact.data.trees (a `trees[]` array the panel NEVER sends) and returned totalBoardFeet/estimatedValue while the panel renders result.boardFeet/result.valuation/result.cubicFeet — a DEAD SURFACE that always rendered the empty-guidance message in production. Fixed: estimates per-tree board feet from a species×age yield model (VOLUME_SPECIES_FACTOR × ageMaturity sigmoid), scales by treeCount, returns boardFeet/cubicFeet/valuation. POISON: frFinite() rejects Infinity/NaN/1e999 (parseFloat/Number admit them silently) — non-finite acres → 0 → empty-guidance (fail-closed), poisoned pricePerMBF → default 400, every numeric output FINITE. Pinned by server/tests/forestry-lens-macros.test.js."
+}

--- a/content/contracts/overrides/forum.communityHealth.json
+++ b/content/contracts/overrides/forum.communityHealth.json
@@ -1,0 +1,28 @@
+{
+  "macro_id": "forum.communityHealth",
+  "domain": "forum",
+  "name": "communityHealth",
+  "inputs": {
+    "activeUsers": { "type": "number", "required": false },
+    "totalUsers": { "type": "number", "required": false },
+    "postsThisWeek": { "type": "number", "required": false },
+    "postsLastWeek": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || (Number.isFinite(output.result.activeUsers) && Number.isFinite(output.result.totalUsers) && Number.isFinite(output.result.activityRate) && Number.isFinite(output.result.postsThisWeek) && Number.isFinite(output.result.growthRate))",
+    "output.ok === false || ['thriving','healthy','declining','dormant'].indexOf(output.result.health) !== -1",
+    "output.ok === false || Array.isArray(output.result.recommendations)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "activeUsers": 40, "totalUsers": 100, "postsThisWeek": 60, "postsLastWeek": 50 }, "expect": { "ok": true } },
+    { "input": { "activeUsers": "Infinity", "totalUsers": "1e999", "postsThisWeek": "NaN", "postsLastWeek": "not-a-number" }, "expect": { "ok": true } },
+    { "input": { "activeUsers": 10, "totalUsers": 0, "postsThisWeek": 5, "postsLastWeek": 0 }, "expect": { "ok": true } },
+    { "input": { "activeUsers": -5, "totalUsers": -100, "postsThisWeek": -1, "postsLastWeek": -1 }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'forum.communityHealth'. The /lenses/forum inline buttons DERIVE {activeUsers,totalUsers,postsThisWeek,postsLastWeek} from REAL on-page state (distinct post authors, community member sums, posts bucketed by createdAt week) and pass them as run-action params; the ForumActionPanel sends {artifact:{data:{...}}} single-wrap. Handler reads params.X ?? artifact.data.X. Returns {activeUsers,totalUsers,activityRate,postsThisWeek,growthRate,health,recommendations} (health ∈ thriving|healthy|declining|dormant). POISON: fmInt collapses Infinity / -Infinity / NaN / '1e999' / 'Infinity' / '' to finite fallbacks; totalUsers/postsLastWeek floor at 1 so no div-by-zero; EVERY numeric output is FINITE. Pinned by server/tests/forum-lens-macros.test.js."
+}

--- a/content/contracts/overrides/forum.moderationQueue.json
+++ b/content/contracts/overrides/forum.moderationQueue.json
@@ -1,0 +1,25 @@
+{
+  "macro_id": "forum.moderationQueue",
+  "domain": "forum",
+  "name": "moderationQueue",
+  "inputs": {
+    "reports": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || (Number.isFinite(output.result.totalReports) && Number.isFinite(output.result.pending) && Number.isFinite(output.result.resolved))",
+    "output.ok === false || (typeof output.result.byReason === 'object' && output.result.byReason !== null)",
+    "output.ok === false || ['low','medium','high'].indexOf(output.result.urgency) !== -1",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "reports": [] }, "expect": { "ok": true } },
+    { "input": { "reports": [{ "status": "pending", "reason": "spam", "date": "2026-06-02T00:00:00Z" }, { "status": "resolved", "reason": "off_topic", "date": "2026-05-30T00:00:00Z" }] }, "expect": { "ok": true } },
+    { "input": { "reports": [{ "status": "pending", "date": "garbage" }, { "status": "pending", "date": "NaN" }] }, "expect": { "ok": true } },
+    { "input": { "reports": "nope" }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'forum.moderationQueue'. The /lenses/forum inline buttons DERIVE reports from REAL post state (locked posts → pending review, removed posts → resolved) and pass them as run-action params; the persisted single-post artifact has no reports array (the prior dead surface). Handler reads params.reports ?? artifact.data.reports. Returns {totalReports,pending,resolved,byReason,oldestPending,urgency} (urgency ∈ low|medium|high). POISON: corrupt/NaN report dates never throw (fmTime guards getTime() to a finite epoch); counts stay FINITE; non-array degrades to zero-counts. Pinned by server/tests/forum-lens-macros.test.js."
+}

--- a/content/contracts/overrides/forum.threadAnalysis.json
+++ b/content/contracts/overrides/forum.threadAnalysis.json
@@ -1,0 +1,25 @@
+{
+  "macro_id": "forum.threadAnalysis",
+  "domain": "forum",
+  "name": "threadAnalysis",
+  "inputs": {
+    "posts": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.message !== undefined || Number.isFinite(output.result.totalPosts)",
+    "output.ok === false || output.result.message !== undefined || (Number.isFinite(output.result.uniqueAuthors) && Number.isFinite(output.result.avgPostLength))",
+    "output.ok === false || output.result.message !== undefined || (Array.isArray(output.result.topContributors) && output.result.topContributors.every(function(c){ return typeof c.name === 'string' && Number.isFinite(c.posts); }))",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "posts": [] }, "expect": { "ok": true } },
+    { "input": { "posts": [{ "author": "a", "content": "hello world" }, { "author": "b", "content": "longer reply here" }] }, "expect": { "ok": true } },
+    { "input": { "posts": [{ "author": null, "content": null }, {}, { "content": 123 }] }, "expect": { "ok": true } },
+    { "input": { "posts": "nope" }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'forum.threadAnalysis'. The /lenses/forum inline 'Community Analytics' buttons (handleForumAction) DERIVE posts:[{author,content}] from the live posts + their comment trees and pass them as run-action params (the persisted post artifact's .data is a SINGLE post and has no posts array — the prior dead surface). The ForumActionPanel single-wrap {artifact:{data:{posts}}} lands the same field after the dispatch peels one layer. Handler reads params.posts ?? artifact.data.posts. Returns {totalPosts,uniqueAuthors,avgPostLength,topContributors:[{name,posts}],health} or {message} when empty/non-array. POISON: malformed rows (null author/content, non-array) never throw; avgPostLength stays FINITE. Pinned by server/tests/forum-lens-macros.test.js."
+}

--- a/content/contracts/overrides/forum.topicClustering.json
+++ b/content/contracts/overrides/forum.topicClustering.json
@@ -1,0 +1,25 @@
+{
+  "macro_id": "forum.topicClustering",
+  "domain": "forum",
+  "name": "topicClustering",
+  "inputs": {
+    "threads": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.message !== undefined || Number.isFinite(output.result.totalThreads)",
+    "output.ok === false || output.result.message !== undefined || (Array.isArray(output.result.clusters) && output.result.clusters.every(function(c){ return typeof c.topic === 'string' && Number.isFinite(c.threads) && Number.isFinite(c.share); }))",
+    "output.ok === false || output.result.message !== undefined || (typeof output.result.topTopic === 'string' && Number.isFinite(output.result.uncategorized))",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "threads": [] }, "expect": { "ok": true } },
+    { "input": { "threads": [{ "tags": ["mixing", "tutorial"] }, { "tags": ["mixing"] }, { "tags": [] }] }, "expect": { "ok": true } },
+    { "input": { "threads": [{}, { "tags": null }, { "tags": ["a"] }] }, "expect": { "ok": true } },
+    { "input": { "threads": "nope" }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'forum.topicClustering'. The /lenses/forum inline buttons DERIVE threads:[{tags}] from the live posts' tag arrays and pass them as run-action params; the persisted single-post artifact has no threads array (the prior dead surface). Handler reads params.threads ?? artifact.data.threads. Returns {totalThreads,clusters:[{topic,threads,share}],topTopic,uncategorized} or {message} when empty/non-array. POISON: malformed rows ({}, tags:null) never throw; every cluster share is FINITE; uncategorized counts tag-less rows. Pinned by server/tests/forum-lens-macros.test.js."
+}

--- a/content/contracts/overrides/geology.measurement-record.json
+++ b/content/contracts/overrides/geology.measurement-record.json
@@ -1,0 +1,32 @@
+{
+  "macro_id": "geology.measurement-record",
+  "domain": "geology",
+  "name": "measurement-record",
+  "inputs": {
+    "planeKind": { "type": "string", "required": false },
+    "strike": { "type": "number", "required": true },
+    "dip": { "type": "number", "required": true },
+    "locationName": { "type": "string", "required": false },
+    "notes": { "type": "string", "required": false },
+    "lat": { "type": "number", "required": false },
+    "lon": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result.measurement === 'object'",
+    "output.ok === false || (Number.isFinite(output.result.measurement.strike) && output.result.measurement.strike >= 0 && output.result.measurement.strike < 360)",
+    "output.ok === false || (Number.isFinite(output.result.measurement.dip) && output.result.measurement.dip >= 0 && output.result.measurement.dip <= 90)",
+    "output.ok === false || (Number.isFinite(output.result.measurement.dipDirection) && output.result.measurement.dipDirection >= 0 && output.result.measurement.dipDirection < 360)",
+    "output.ok === true || typeof output.error === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "strike": 30, "dip": 45, "planeKind": "bedding" }, "expect": { "ok": true } },
+    { "input": { "strike": 370, "dip": 5 }, "expect": { "ok": true } },
+    { "input": { "strike": 30 }, "expect": { "ok": false } },
+    { "input": { "strike": 30, "dip": 120 }, "expect": { "ok": false } },
+    { "input": { "strike": "Infinity", "dip": 45 }, "expect": { "ok": false } },
+    { "input": { "strike": "1e999", "dip": 45 }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS handler (dispatch key 'geology.measurement-record'); STATE-backed (STATE.geologyLens.measurements, per-user). StructuralCompass posts { planeKind, strike, dip, locationName, notes, lat?, lon? } flat (NOT artifact-wrapped). Records a planar structural measurement; dipDirection is the right-hand-rule 90°-CW-of-strike azimuth; strike normalizes to [0,360). Fail-CLOSED: strike/dip pass through geoNum (Number.isFinite guard → null) so a poisoned Infinity/NaN/1e999 is REJECTED ({ ok:false, error }) rather than producing a NaN dipDirection; dip is range-checked [0,90]. Pinned by server/tests/geology-lens-macros.test.js."
+}

--- a/content/contracts/overrides/geology.mineralId.json
+++ b/content/contracts/overrides/geology.mineralId.json
@@ -1,0 +1,31 @@
+{
+  "macro_id": "geology.mineralId",
+  "domain": "geology",
+  "name": "mineralId",
+  "inputs": {
+    "name": { "type": "string", "required": false },
+    "hardness": { "type": "number", "required": false },
+    "streak": { "type": "string", "required": false },
+    "cleavage": { "type": "string", "required": false },
+    "fracture": { "type": "string", "required": false },
+    "specificGravity": { "type": "number", "required": false },
+    "color": { "type": "string", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || (Number.isFinite(output.result.identificationConfidence) && output.result.identificationConfidence >= 0 && output.result.identificationConfidence <= 100)",
+    "output.ok === false || (Number.isFinite(output.result.properties.hardness) && output.result.properties.hardness >= 0 && output.result.properties.hardness <= 10)",
+    "output.ok === false || (Number.isFinite(output.result.properties.specific_gravity) && output.result.properties.specific_gravity >= 0)",
+    "output.ok === false || ['silicate-likely','carbonate-or-sulfate','clay-or-evaporite'].includes(output.result.classification)"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "name": "Quartz", "hardness": 7, "streak": "white", "cleavage": "none", "specificGravity": 2.65, "color": "clear" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "name": "Unknown", "hardness": 3 } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "hardness": "Infinity", "specificGravity": "1e999" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "hardness": -5 } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": {} } }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler (dispatch key 'geology.mineralId'). Pure-compute mineral identification: a weighted confidence score (0–100) over which diagnostic tests were performed + a hardness-bucketed classification. Fail-CLOSED: hardness is finite-guarded + clamped to [0,10] (Mohs) and specificGravity to [0,25] (osmium ~22.6 is the densest natural solid), so a poisoned Infinity/NaN can never leak into properties. Pinned by server/tests/geology-lens-macros.test.js."
+}

--- a/content/contracts/overrides/geology.rockClassify.json
+++ b/content/contracts/overrides/geology.rockClassify.json
@@ -1,0 +1,29 @@
+{
+  "macro_id": "geology.rockClassify",
+  "domain": "geology",
+  "name": "rockClassify",
+  "inputs": {
+    "name": { "type": "string", "required": false },
+    "mohsHardness": { "type": "number", "required": false },
+    "luster": { "type": "string", "required": false },
+    "color": { "type": "string", "required": false },
+    "texture": { "type": "string", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || ['igneous','sedimentary','metamorphic','unclassified'].includes(output.result.rockType)",
+    "output.ok === false || (Number.isFinite(output.result.mohsHardness) && output.result.mohsHardness >= 0 && output.result.mohsHardness <= 10)",
+    "output.ok === false || ['highly-durable','moderate','soft'].includes(output.result.durability)",
+    "output.ok === false || Array.isArray(output.result.commonUses)"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "name": "Gneiss", "mohsHardness": 7, "texture": "foliated" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "texture": "vesicular", "mohsHardness": 6 } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "mohsHardness": "Infinity" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "mohsHardness": "1e999" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": {} } }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler (registerLensAction; dispatch key 'geology.rockClassify'). Pure-compute: maps texture→rockType and Mohs hardness→durability/commonUses bands. Fail-CLOSED: mohsHardness is coerced via a finite-guard then CLAMPED to [0,10] so a poisoned Infinity/NaN/1e999 can never leak Infinity (serialized null) or push durability out of its bands. Reads input.X (the page/AI-action params) and degrades on an empty body. Pinned by server/tests/geology-lens-macros.test.js."
+}

--- a/content/contracts/overrides/geology.seismicRisk.json
+++ b/content/contracts/overrides/geology.seismicRisk.json
@@ -1,0 +1,30 @@
+{
+  "macro_id": "geology.seismicRisk",
+  "domain": "geology",
+  "name": "seismicRisk",
+  "inputs": {
+    "latitude": { "type": "number", "required": false },
+    "longitude": { "type": "number", "required": false },
+    "soilType": { "type": "string", "required": false },
+    "buildingCode": { "type": "string", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || (Number.isFinite(output.result.location.lat) && output.result.location.lat >= -90 && output.result.location.lat <= 90)",
+    "output.ok === false || (Number.isFinite(output.result.location.lon) && output.result.location.lon >= -180 && output.result.location.lon <= 180)",
+    "output.ok === false || (Number.isFinite(output.result.amplificationFactor) && output.result.amplificationFactor > 0)",
+    "output.ok === false || (Number.isFinite(output.result.adjustedRisk) && output.result.adjustedRisk >= 0 && output.result.adjustedRisk <= 100)",
+    "output.ok === false || ['high','moderate','low'].includes(output.result.riskLevel)",
+    "output.ok === false || Array.isArray(output.result.recommendations)"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "latitude": 37.77, "longitude": -122.42, "soilType": "soft-soil" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "latitude": 5, "longitude": 5, "soilType": "rock" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "latitude": "Infinity", "longitude": "NaN" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "latitude": "1e999", "longitude": -1e308 } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": {} } }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler (dispatch key 'geology.seismicRisk'). Pure-compute seismic-risk estimate: soil amplification × proximity-to-fault base → adjustedRisk (0–100%) + riskLevel + recommendations. Fail-CLOSED: latitude/longitude are finite-guarded then CLAMPED to the real lat/lon envelope so a poisoned Infinity/NaN can never leak null into `location` and adjustedRisk stays in [0,100] (Math.min(1, …)). Pinned by server/tests/geology-lens-macros.test.js."
+}

--- a/content/contracts/overrides/geology.stratigraphicColumn.json
+++ b/content/contracts/overrides/geology.stratigraphicColumn.json
@@ -1,0 +1,23 @@
+{
+  "macro_id": "geology.stratigraphicColumn",
+  "domain": "geology",
+  "name": "stratigraphicColumn",
+  "inputs": {
+    "layers": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.message !== undefined || Number.isFinite(output.result.totalThickness)",
+    "output.ok === false || output.result.message !== undefined || (Array.isArray(output.result.layers) && output.result.layers.every(l => Number.isFinite(l.thickness) && l.thickness >= 0 && Number.isFinite(l.depthTop) && Number.isFinite(l.depthBottom) && l.depthBottom >= l.depthTop))",
+    "output.ok === false || output.result.message !== undefined || Number.isFinite(output.result.layerCount)"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "layers": [{ "name": "Topsoil", "thickness": 2 }, { "name": "Sandstone", "thickness": 8 }] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "layers": [] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "layers": [{ "name": "A", "thickness": "Infinity" }, { "name": "B", "thickness": "1e999" }, { "name": "C", "thickness": -5 }] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": {} } }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler (dispatch key 'geology.stratigraphicColumn'). Pure-compute: accumulates per-layer thicknesses into depthTop/depthBottom + totalThickness. Fail-CLOSED: each thickness is finite-guarded and forced ≥0 so a poisoned Infinity/NaN/negative can never invert the depth axis (depthBottom >= depthTop always holds) or leak Infinity into totalThickness. An empty layer list returns a guidance message, not a crash. Pinned by server/tests/geology-lens-macros.test.js."
+}

--- a/content/contracts/overrides/household.allowance-summary.json
+++ b/content/contracts/overrides/household.allowance-summary.json
@@ -1,0 +1,27 @@
+{
+  "macro_id": "household.allowance-summary",
+  "domain": "household",
+  "name": "allowance-summary",
+  "inputs": {
+    "dollarsPerPoint": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Number.isFinite(output.result.dollarsPerPoint)",
+    "output.ok === false || (output.result.dollarsPerPoint >= 0 && output.result.dollarsPerPoint <= 10)",
+    "output.ok === false || Number.isFinite(output.result.totalPoints)",
+    "output.ok === false || Number.isFinite(output.result.totalAllowance)",
+    "output.ok === false || Array.isArray(output.result.members)",
+    "output.ok === false || output.result.members.every(function(m){ return Number.isFinite(m.points) && Number.isFinite(m.allowance); })",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "dollarsPerPoint": 0.1 }, "expect": { "ok": true } },
+    { "input": { "dollarsPerPoint": "NaN" }, "expect": { "ok": true } },
+    { "input": { "dollarsPerPoint": "1e999" }, "expect": { "ok": true } },
+    { "input": { "dollarsPerPoint": 999 }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler (STATE-backed, per-user). Dispatch key 'household.allowance-summary'. AllowanceTracker sends flat dollarsPerPoint. Aggregates the real chore-completion log into per-person points, then allowance = points × rate. POISON: rate via finiteNum(...,0.05) so NaN/Infinity collapse to the 0.05 default; a genuinely-large FINITE rate (999) is clamped to the [0,10] ceiling — dollarsPerPoint + every allowance stays FINITE and bounded. Pinned by server/tests/household-lens-macros.test.js."
+}

--- a/content/contracts/overrides/household.choreRotation.json
+++ b/content/contracts/overrides/household.choreRotation.json
@@ -1,0 +1,28 @@
+{
+  "macro_id": "household.choreRotation",
+  "domain": "household",
+  "name": "choreRotation",
+  "inputs": {
+    "chores": { "type": "array", "required": false },
+    "members": { "type": "array", "required": false },
+    "strategy": { "type": "string", "required": false, "maxLength": 32 }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || output.result.error !== undefined || Array.isArray(output.result.assignments)",
+    "output.ok === false || output.result.error !== undefined || Number.isFinite(output.result.totalChores)",
+    "output.ok === false || output.result.error !== undefined || Number.isFinite(output.result.members)",
+    "output.ok === false || output.result.error !== undefined || output.result.assignments.every(function(a){ return typeof a.chore === 'string' && typeof a.assignee === 'string'; })",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "chores": [{ "name": "Dishes", "currentAssignee": "Alex" }], "members": ["Alex", "Sam", "Jordan"], "strategy": "round-robin" }, "expect": { "ok": true } },
+    { "input": { "chores": [{ "name": "Dishes" }, { "name": "Trash" }], "members": ["Alex", "Sam"] }, "expect": { "ok": true } },
+    { "input": { "chores": [{ "name": "X" }], "members": [] }, "expect": { "ok": true } },
+    { "input": { "chores": [], "members": ["A"] }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'household.choreRotation'. Reads artifact.data.{chores,members} || params.{chores,members} — the dispatch maps run-action input to BOTH, so a flat ChoreRotation body reaches it (a two-key {artifact:{data},strategy} body is NOT peeled and was the dead surface). Chores may be bare-string names. round-robin shifts each chore to the next member; never-assigned chores fill the least-loaded member deterministically; 'random' shuffles. Returns assignments[{chore,assignee,frequency,previousAssignee}], totalChores, members(count), choresPerMember, previousAssignments. Empty chores/members → {ok:true, result:{error}} guidance (never throw). Pinned by server/tests/household-lens-macros.test.js."
+}

--- a/content/contracts/overrides/household.expense-add.json
+++ b/content/contracts/overrides/household.expense-add.json
@@ -1,0 +1,29 @@
+{
+  "macro_id": "household.expense-add",
+  "domain": "household",
+  "name": "expense-add",
+  "inputs": {
+    "description": { "type": "string", "required": true, "maxLength": 120 },
+    "amount": { "type": "number", "required": true },
+    "paidBy": { "type": "string", "required": true, "maxLength": 60 },
+    "splitAmong": { "type": "array", "required": true },
+    "category": { "type": "string", "required": false, "maxLength": 40 },
+    "date": { "type": "string", "required": false, "maxLength": 10 }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || (Number.isFinite(output.result.expense.amount) && output.result.expense.amount > 0)",
+    "output.ok === false || (Number.isFinite(output.result.expense.sharePerPerson) && output.result.expense.sharePerPerson >= 0)",
+    "output.ok === false || Array.isArray(output.result.expense.splitAmong)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "description": "Dinner", "amount": 30, "paidBy": "Alex", "splitAmong": ["Alex", "Sam", "Jordan"] }, "expect": { "ok": true } },
+    { "input": { "description": "X", "amount": 0, "paidBy": "A", "splitAmong": ["A"] }, "expect": { "ok": false } },
+    { "input": { "description": "X", "amount": 5, "paidBy": "A", "splitAmong": [] }, "expect": { "ok": false } },
+    { "input": { "description": "X", "amount": "1e999", "paidBy": "A", "splitAmong": ["A"] }, "expect": { "ok": false } },
+    { "input": { "description": "X", "amount": "Infinity", "paidBy": "A", "splitAmong": ["A"] }, "expect": { "ok": false } }
+  ],
+  "_note": "LENS_ACTIONS handler (STATE-backed, per-user). Dispatch key 'household.expense-add'. ExpenseSplitter sends flat params. amount via finiteNum then rejected unless finite AND > 0 — a poisoned '1e999'/'Infinity'/NaN amount returns {ok:false} and is NEVER stored as Infinity (which would poison expense-balances). sharePerPerson = round(amount/len). Requires description, paidBy, and a non-empty splitAmong. Pinned by server/tests/household-lens-macros.test.js."
+}

--- a/content/contracts/overrides/household.generateGroceryList.json
+++ b/content/contracts/overrides/household.generateGroceryList.json
@@ -1,0 +1,29 @@
+{
+  "macro_id": "household.generateGroceryList",
+  "domain": "household",
+  "name": "generateGroceryList",
+  "inputs": {
+    "mealPlan": { "type": "array", "required": false },
+    "meals": { "type": "array", "required": false },
+    "pantry": { "type": "array", "required": false },
+    "categorize": { "type": "boolean", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || Number.isFinite(output.result.uniqueItems)",
+    "output.ok === false || Number.isFinite(output.result.mealsPlanned)",
+    "output.ok === false || Array.isArray(output.result.list)",
+    "output.ok === false || output.result.list.every(function(i){ return Number.isFinite(i.quantity) && i.quantity > 0; })",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "mealPlan": [] }, "expect": { "ok": true } },
+    { "input": { "mealPlan": [{ "day": "Mon", "meal": "dinner", "ingredients": [{ "name": "Tomato", "quantity": 3, "unit": "ea" }, { "name": "Tomato", "quantity": 2, "unit": "ea" }] }] }, "expect": { "ok": true } },
+    { "input": { "mealPlan": [{ "ingredients": [{ "name": "A", "quantity": "1e999" }, { "name": "B", "quantity": "Infinity" }, { "name": "C", "quantity": "NaN" }] }] }, "expect": { "ok": true } },
+    { "input": { "meals": ["Tacos", "Salad"] }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'household.generateGroceryList'. The /lenses/household page derives mealPlan from the live MealPlan artifacts; HouseholdActionPanel parses 'Recipe: a, b' lines into ingredients. Reads artifact.data.X || params.X — accepts mealPlan OR meals (objects or bare-name strings) from either layer. Aggregates duplicate (name|unit) ingredients, subtracts pantry, drops fully-covered items, sorts by category then name. POISON: ingredient/pantry quantity via finiteNum so '1e999'/'Infinity'/NaN collapse to 0 (item dropped) — every list.quantity stays FINITE and > 0. Pinned by server/tests/household-lens-macros.test.js."
+}

--- a/content/contracts/overrides/household.maintenanceDue.json
+++ b/content/contracts/overrides/household.maintenanceDue.json
@@ -1,0 +1,30 @@
+{
+  "macro_id": "household.maintenanceDue",
+  "domain": "household",
+  "name": "maintenanceDue",
+  "inputs": {
+    "maintenanceItems": { "type": "array", "required": false },
+    "lookaheadDays": { "type": "number", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || Number.isFinite(output.result.totalItems)",
+    "output.ok === false || Number.isFinite(output.result.overdueCount)",
+    "output.ok === false || Number.isFinite(output.result.upcomingCount)",
+    "output.ok === false || Number.isFinite(output.result.currentCount)",
+    "output.ok === false || Array.isArray(output.result.overdue)",
+    "output.ok === false || output.result.overdue.every(function(o){ return o.daysOverdue === null || Number.isFinite(o.daysOverdue); })",
+    "output.ok === false || output.result.upcoming.every(function(u){ return Number.isFinite(u.daysUntilDue); })",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "maintenanceItems": [] }, "expect": { "ok": true } },
+    { "input": { "maintenanceItems": [{ "name": "Smoke detector", "lastServiceDate": "2025-01-01", "intervalDays": 365 }], "lookaheadDays": 30 }, "expect": { "ok": true } },
+    { "input": { "maintenanceItems": [{ "name": "Gutters" }] }, "expect": { "ok": true } },
+    { "input": { "maintenanceItems": [{ "name": "X", "lastServiceDate": "garbage", "intervalDays": "Infinity" }], "lookaheadDays": "NaN" }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'household.maintenanceDue'. Reads artifact.data.maintenanceItems || params.maintenanceItems. Computes nextDue = lastServiceDate + intervalDays; buckets overdue / upcoming (within lookaheadDays) / current. Never-serviced items are overdue with daysOverdue:null. POISON: lastServiceDate via finiteDate (bad date → null → never-serviced, no NaN), intervalDays via finiteInt(...,365), lookaheadDays via finiteNum(...,30) — every count + day delta stays FINITE. Pinned by server/tests/household-lens-macros.test.js."
+}

--- a/content/contracts/overrides/household.weeklySummary.json
+++ b/content/contracts/overrides/household.weeklySummary.json
@@ -1,0 +1,29 @@
+{
+  "macro_id": "household.weeklySummary",
+  "domain": "household",
+  "name": "weeklySummary",
+  "inputs": {
+    "chores": { "type": "array", "required": false },
+    "mealPlan": { "type": "array", "required": false },
+    "shoppingList": { "type": "array", "required": false },
+    "maintenanceItems": { "type": "array", "required": false }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result === 'object'",
+    "output.ok === false || Number.isFinite(output.result.choresCompleted)",
+    "output.ok === false || Number.isFinite(output.result.totalChores)",
+    "output.ok === false || Number.isFinite(output.result.choreCompletionRate)",
+    "output.ok === false || (output.result.choreCompletionRate >= 0 && output.result.choreCompletionRate <= 100)",
+    "output.ok === false || Number.isFinite(output.result.mealsPlanned)",
+    "output.ok === false || Number.isFinite(output.result.shoppingProgress.remaining)",
+    "output.ok === true || typeof (output.error || output.message) === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": {}, "expect": { "ok": true } },
+    { "input": { "chores": [{ "name": "A", "completedDate": "2026-06-28" }, { "name": "B" }], "mealPlan": [{ "recipe": "X" }] }, "expect": { "ok": true } },
+    { "input": { "chores": [{ "name": "A", "completedDate": "garbage" }], "maintenanceItems": [{ "name": "M", "lastCompleted": "bad", "intervalDays": "NaN" }] }, "expect": { "ok": true } }
+  ],
+  "_note": "LENS_ACTIONS handler. Dispatch key 'household.weeklySummary'. Reads artifact.data.X || params.X. Counts chores with a completedDate inside the trailing 7 days, computes choreCompletionRate (guards totalChores===0 → 0, never NaN), meals planned, shopping progress, upcoming tasks, maintenance due soon. POISON: completedDate/lastCompleted via finiteDate, intervalDays via finiteInt — a garbage date is simply not counted; every numeric output FINITE and the rate is bounded [0,100]. Pinned by server/tests/household-lens-macros.test.js."
+}

--- a/content/contracts/overrides/insurance.carrier-rate.json
+++ b/content/contracts/overrides/insurance.carrier-rate.json
@@ -1,0 +1,25 @@
+{
+  "macro_id": "insurance.carrier-rate",
+  "domain": "insurance",
+  "name": "carrier-rate",
+  "inputs": {
+    "line": { "type": "string", "maxLength": 30 },
+    "basePremium": { "type": "number", "min": 0, "max": 1000000000 },
+    "riskFactor": { "type": "number", "min": 0, "max": 1000000000 }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Array.isArray(output.result.quotes)",
+    "output.ok === false || Number.isFinite(output.result.cheapest)",
+    "output.ok === false || Number.isFinite(output.result.spread)",
+    "output.ok === false || output.result.spread >= 0",
+    "output.ok === false || output.result.quotes.every(q => Number.isFinite(q.annualPremium) && Number.isFinite(q.commission) && Number.isFinite(q.fitScore))"
+  ],
+  "fuzz_cases": [
+    { "input": { "basePremium": 1000 }, "expect": { "ok": false, "error": "line required (auto, home, life…)" } },
+    { "input": { "line": "auto", "basePremium": 0 }, "expect": { "ok": false, "error": "basePremium must be > 0 — your underwriting estimate" } },
+    { "input": { "line": "auto", "basePremium": 1e308 }, "expect": { "ok": false, "error": "invalid_basePremium" } }
+  ],
+  "_note": "insurance.carrier-rate (AmsWorkbench comparative rate run) scores every appointed carrier on the user's roster that writes the requested line against their own underwriting basePremium estimate: annualPremium = basePremium×rateIndex×riskFactor, commission = annualPremium×baseCommissionPct, and a composite fitScore (price 0.6 / service 0.25 / rating 0.15). Returns cheapest/spread/bestPrice/bestFit — exactly what the panel renders. line + a positive basePremium are required; with no appointed carrier for the line it returns a real reason, never an empty quote list. Fail-CLOSED on poisoned basePremium/riskFactor."
+}

--- a/content/contracts/overrides/insurance.coverageGap.json
+++ b/content/contracts/overrides/insurance.coverageGap.json
@@ -1,0 +1,25 @@
+{
+  "macro_id": "insurance.coverageGap",
+  "domain": "insurance",
+  "name": "coverageGap",
+  "inputs": {
+    "policies": { "type": "array" },
+    "claims": { "type": "array" }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || (output.result && Array.isArray(output.result.gaps))",
+    "output.ok === false || Number.isFinite(output.result.gapCount)",
+    "output.ok === false || output.result.gapCount === output.result.gaps.length",
+    "output.ok === false || Number.isFinite(output.result.totalPolicies)",
+    "output.ok === false || Array.isArray(output.result.coveredTypes)",
+    "output.ok === false || Array.isArray(output.result.expiringSoon)"
+  ],
+  "fuzz_cases": [
+    { "input": { "policies": [{ "type": "auto" }, { "type": "home" }], "claims": [] }, "expect": { "ok": true } },
+    { "input": { "policies": [], "claims": [] }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "insurance.coverageGap (read-only calculator for the InsuranceActionPanel) diffs the held policy 'type' set against the 6-type coverage catalog (health/auto/home/life/liability/umbrella) and flags policies expiring within 30 days. The component sends { artifact: { title, data: { policies, claims } } }; the dispatch peels the sole-key wrapper to artifact.data, and the handler reads artifact.data.policies — coveredTypes/gaps/gapCount/expiringSoon/totalPolicies are exactly the fields the panel renders. Degrade-graceful: an empty/absent book returns ok:true with all 6 gaps, never throws."
+}

--- a/content/contracts/overrides/insurance.lossRatioReport.json
+++ b/content/contracts/overrides/insurance.lossRatioReport.json
@@ -1,0 +1,26 @@
+{
+  "macro_id": "insurance.lossRatioReport",
+  "domain": "insurance",
+  "name": "lossRatioReport",
+  "inputs": {
+    "policies": { "type": "array" },
+    "claims": { "type": "array" }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Number.isFinite(output.result.lossRatio)",
+    "output.ok === false || output.result.lossRatio >= 0",
+    "output.ok === false || Number.isFinite(output.result.premiumsCollected)",
+    "output.ok === false || Number.isFinite(output.result.claimsPaid)",
+    "output.ok === false || Number.isFinite(output.result.claimFrequency)",
+    "output.ok === false || Number.isFinite(output.result.averageSeverity)",
+    "output.ok === false || ['profitable','acceptable','marginal','unprofitable'].includes(output.result.assessment)"
+  ],
+  "fuzz_cases": [
+    { "input": { "policies": [{ "premium": 1000 }, { "premium": 1000 }], "claims": [{ "status": "paid", "amount": 800 }, { "status": "closed", "amount": 400 }] }, "expect": { "ok": true } },
+    { "input": { "policies": [], "claims": [] }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "insurance.lossRatioReport (read-only actuarial calculator for the InsuranceActionPanel) computes lossRatio = paidClaims/premiums×100, claimFrequency = claims/policies, averageSeverity = paidClaims/totalClaims, and an assessment band (profitable ≤60 / acceptable ≤75 / marginal ≤100 / unprofitable >100). Only status paid|closed claims count toward claimsPaid. Every rendered money/ratio field is finite even on an empty book (lossRatio 0, no divide-by-zero). Component wrapper { artifact: { data: { policies, claims } } } is peeled to artifact.data by the dispatch."
+}

--- a/content/contracts/overrides/insurance.renewalAlert.json
+++ b/content/contracts/overrides/insurance.renewalAlert.json
@@ -1,0 +1,25 @@
+{
+  "macro_id": "insurance.renewalAlert",
+  "domain": "insurance",
+  "name": "renewalAlert",
+  "inputs": {
+    "policies": { "type": "array" }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Number.isFinite(output.result.urgentCount)",
+    "output.ok === false || Number.isFinite(output.result.premiumAtRisk)",
+    "output.ok === false || output.result.premiumAtRisk >= 0",
+    "output.ok === false || Number.isFinite(output.result.totalUpcomingRenewals)",
+    "output.ok === false || Array.isArray(output.result.within30Days)",
+    "output.ok === false || Array.isArray(output.result.within60Days)",
+    "output.ok === false || output.result.urgentCount === output.result.within30Days.length"
+  ],
+  "fuzz_cases": [
+    { "input": { "policies": [{ "policyNumber": "P1", "premium": 500, "expiryDate": "2999-01-01" }] }, "expect": { "ok": true } },
+    { "input": { "policies": [] }, "expect": { "ok": true } },
+    { "input": {}, "expect": { "ok": true } }
+  ],
+  "_note": "insurance.renewalAlert (read-only calculator for the InsuranceActionPanel) buckets each policy by days-until-expiry into 30/60/90-day windows, sums premiumAtRisk across all upcoming buckets, and exposes urgentCount = the ≤30-day bucket size. Already-expired policies are skipped. The component renders urgentCount/premiumAtRisk/totalUpcomingRenewals/within30Days/within60Days from the peeled artifact.data.policies. Degrade-graceful on an empty/absent book (all counts 0, premiumAtRisk 0)."
+}

--- a/content/contracts/overrides/insurance.riskScore.json
+++ b/content/contracts/overrides/insurance.riskScore.json
@@ -1,0 +1,26 @@
+{
+  "macro_id": "insurance.riskScore",
+  "domain": "insurance",
+  "name": "riskScore",
+  "inputs": {
+    "risk": { "type": "string", "maxLength": 200 },
+    "probability": { "type": "number", "min": 0, "max": 1000000000 },
+    "impact": { "type": "number", "min": 0, "max": 1000000000 },
+    "mitigations": { "type": "array" }
+  },
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || (typeof output.result.risk === 'string' && output.result.risk.length > 0)",
+    "output.ok === false || Number.isFinite(output.result.rawScore)",
+    "output.ok === false || Number.isFinite(output.result.normalizedScore)",
+    "output.ok === false || Number.isFinite(output.result.mitigatedScore)",
+    "output.ok === false || ['low','medium','high','critical'].includes(output.result.level)"
+  ],
+  "fuzz_cases": [
+    { "input": { "risk": "Cyber breach", "probability": 4, "impact": 5 }, "expect": { "ok": true } },
+    { "input": { "risk": "Minor", "probability": 1, "impact": 2 }, "expect": { "ok": true } },
+    { "input": { "risk": "x", "probability": 1e308, "impact": 5 }, "expect": { "ok": false, "error": "invalid_probability" } }
+  ],
+  "_note": "insurance.riskScore (read-only P×I risk calculator for the InsuranceActionPanel) computes rawScore = probability×impact, normalizedScore = rawScore/25×100, a level band (critical ≥15 / high ≥10 / medium ≥5 / low), and mitigatedScore = rawScore − mitigations.length. The 'risk' label is read from data.risk/params.risk first (artifact.title is dropped by the dispatch peel of the sole-key { artifact: { title, data } } body) so the panel's risk card is never blank. Fail-CLOSED: a poisoned probability/impact (NaN/Infinity/1e308/negative) returns ok:false invalid_<field> BEFORE the score multiply, never a null/Infinity score."
+}

--- a/content/contracts/overrides/legal.complianceAudit.json
+++ b/content/contracts/overrides/legal.complianceAudit.json
@@ -1,0 +1,28 @@
+{
+  "macro_id": "legal.complianceAudit",
+  "domain": "legal",
+  "name": "complianceAudit",
+  "inputs": {
+    "requirements": { "type": "array" }
+  },
+  "reads_artifact_data": true,
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Number.isFinite(output.result.score)",
+    "output.ok === false || (output.result.score >= 0 && output.result.score <= 100)",
+    "output.ok === false || Number.isFinite(output.result.passed)",
+    "output.ok === false || Number.isFinite(output.result.failed)",
+    "output.ok === false || output.result.passed + output.result.failed === output.result.totalRequirements",
+    "output.ok === false || ['excellent','good','fair','poor'].includes(output.result.rating)",
+    "output.ok === false || Array.isArray(output.result.findings)",
+    "output.ok === false || Array.isArray(output.result.checklist)"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "requirements": [{ "name": "CLE credits", "deadline": "2099-01-30", "status": "compliant" }, { "name": "Trust recon", "deadline": "2000-01-01", "status": "pending" }] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "requirements": [] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": {} } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "requirements": [{ "name": "x", "status": "compliant" }] } } }, "expect": { "ok": true } }
+  ],
+  "_note": "LegalActionPanel.actAudit channel: callMacro('complianceAudit', { requirements:[{name,deadline,status}] }). Handler reads artifact.data.requirements[]; passed = status==='compliant' && !overdue. score = passCount/length*100 (100 when empty). rating bands >=90 excellent, >=70 good, >=50 fair, else poor. findings list the failures (severity high when overdue, else medium). Panel renders score + rating + findings.length EXACTLY. Score is bounded 0..100 by construction so no non-finite leak."
+}

--- a/content/contracts/overrides/legal.conflictCheck.json
+++ b/content/contracts/overrides/legal.conflictCheck.json
@@ -1,0 +1,27 @@
+{
+  "macro_id": "legal.conflictCheck",
+  "domain": "legal",
+  "name": "conflictCheck",
+  "inputs": {
+    "client": { "type": "string" },
+    "parties": { "type": "array" },
+    "opposingParty": { "type": "string" },
+    "checkAgainst": { "type": "array" }
+  },
+  "reads_artifact_data": true,
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Array.isArray(output.result.conflicts)",
+    "output.ok === false || typeof output.result.hasConflict === 'boolean'",
+    "output.ok === false || output.result.hasConflict === (output.result.conflicts.length > 0)",
+    "output.ok === false || typeof output.result.checkedAt === 'string'"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "client": "Acme Co", "parties": ["Acme Co"], "checkAgainst": ["Acme Co"] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "client": "Acme Co", "parties": ["Acme Co"], "checkAgainst": ["Globex"] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "client": "Acme Co", "parties": ["Acme Co"] } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": {} } }, "expect": { "ok": true } }
+  ],
+  "_note": "LegalActionPanel.actConflict channel: callMacro('conflictCheck', { client, parties:[partyA], checkAgainst:[partyB] }). Handler reads artifact.data.{parties,client,opposingParty} and params.checkAgainst[]; for each checkAgainst name that matches a party/client/opposingParty it pushes { name, conflictType:'direct_party', caseId }. Returns { conflicts, hasConflict, checkedAt }. Panel renders hasConflict + conflicts[].name/.conflictType EXACTLY. Degrade-graceful: no checkAgainst → empty conflicts, hasConflict false."
+}

--- a/content/contracts/overrides/legal.contractRenewal.json
+++ b/content/contracts/overrides/legal.contractRenewal.json
@@ -1,0 +1,26 @@
+{
+  "macro_id": "legal.contractRenewal",
+  "domain": "legal",
+  "name": "contractRenewal",
+  "inputs": {
+    "expiryDate": { "type": "string" },
+    "renewalType": { "type": "string" },
+    "title": { "type": "string" }
+  },
+  "reads_artifact_data": true,
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || output.result.status === 'no_expiry' || Number.isFinite(output.result.daysUntilExpiry)",
+    "output.ok === false || output.result.status === 'no_expiry' || ['critical','high','medium','low'].includes(output.result.urgency)",
+    "output.ok === false || output.result.status === 'no_expiry' || typeof output.result.autoRenewal === 'boolean'",
+    "output.ok === false || output.result.status === 'no_expiry' || typeof output.result.actionRequired === 'boolean'"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "expiryDate": "2099-01-10", "renewalType": "manual", "title": "MSA" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "expiryDate": "2099-02-20", "renewalType": "auto" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": {} } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "expiryDate": "Infinity", "renewalType": "manual" } } }, "expect": { "ok": true } }
+  ],
+  "_note": "LegalActionPanel.actRenewal calls this ONCE per contract row with { expiryDate, renewalType, title } and assembles renewals[]. Handler reads artifact.data.{expiryDate,renewalType} (single contract). Returns { daysUntilExpiry, urgency band (<=14 critical, <=30 high, <=60 medium, else low), autoRenewal (renewalType==='auto'), actionRequired (<=60 days) }. No expiry → { status:'no_expiry' }. Fail-CLOSED: an unparseable expiryDate yields NaN daysUntilExpiry; the invariant tolerates it on the no_expiry branch but the panel only pushes rows where typeof daysUntilExpiry==='number' && finite."
+}

--- a/content/contracts/overrides/legal.deadlineCalculator.json
+++ b/content/contracts/overrides/legal.deadlineCalculator.json
@@ -1,0 +1,25 @@
+{
+  "macro_id": "legal.deadlineCalculator",
+  "domain": "legal",
+  "name": "deadlineCalculator",
+  "inputs": {
+    "filingDate": { "type": "string" },
+    "jurisdiction": { "type": "string" }
+  },
+  "reads_artifact_data": true,
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || typeof output.result.error === 'string' || Array.isArray(output.result.deadlines)",
+    "output.ok === false || typeof output.result.error === 'string' || output.result.deadlines.every(d => Number.isFinite(d.daysFromFiling))",
+    "output.ok === false || typeof output.result.error === 'string' || output.result.deadlines.every(d => Number.isFinite(d.daysRemaining))",
+    "output.ok === false || typeof output.result.error === 'string' || output.result.deadlines.every(d => ['past','urgent','upcoming','future'].includes(d.status))"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "filingDate": "2099-01-01", "jurisdiction": "federal" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "filingDate": "2099-01-01", "jurisdiction": "state" } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": {} } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "filingDate": "Infinity" } } }, "expect": { "ok": true } }
+  ],
+  "_note": "page.tsx handleAction('deadlineCalculator') channel. Reads artifact.data.filingDate (or params.filingDate) + jurisdiction. Computes 5 court-rule deadlines (federal/state/default day tables) with daysRemaining + status band per row. Validation: missing filing date → { error:'No filing date provided' }. Fail-CLOSED: an unparseable filingDate yields an Invalid Date whose .toISOString() throws RangeError inside addDays — guarded up-front with Number.isNaN(base.getTime()) → { error:'Invalid filing date' }, so the macro never throws."
+}

--- a/content/contracts/overrides/legal.deadlineCheck.json
+++ b/content/contracts/overrides/legal.deadlineCheck.json
@@ -1,0 +1,25 @@
+{
+  "macro_id": "legal.deadlineCheck",
+  "domain": "legal",
+  "name": "deadlineCheck",
+  "inputs": {
+    "items": { "type": "array" },
+    "daysAhead": { "type": "number" }
+  },
+  "reads_artifact_data": true,
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Array.isArray(output.result.upcoming)",
+    "output.ok === false || Number.isFinite(output.result.count)",
+    "output.ok === false || output.result.count === output.result.upcoming.length",
+    "output.ok === false || output.result.upcoming.every(u => Number.isFinite(u.daysUntil))"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "items": [{ "name": "Answer due", "deadline": "2099-01-10", "severity": "high" }], "daysAhead": 36500 } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "items": [], "daysAhead": 30 } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "items": [{ "name": "bad", "deadline": "Infinity", "severity": "high" }], "daysAhead": 36500 } } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": {} } }, "expect": { "ok": true } }
+  ],
+  "_note": "LegalActionPanel.actDeadline channel: callMacro('deadlineCheck', { items, daysAhead }) → runDomain peels nothing (sibling keys) so handler reads artifact.data.items[] (each item's `deadline`) AND params.daysAhead. Returns { upcoming:[...item, daysUntil], count } sorted ascending by daysUntil, filtered to daysUntil in [0, daysAhead]. Panel renders upcoming[].name/.daysUntil/.severity + count EXACTLY. Fail-CLOSED: a non-date `deadline` yields NaN daysUntil which fails the `>= 0` filter and is dropped, so count stays finite."
+}

--- a/content/contracts/overrides/legal.generateInvoice.json
+++ b/content/contracts/overrides/legal.generateInvoice.json
@@ -1,0 +1,29 @@
+{
+  "macro_id": "legal.generateInvoice",
+  "domain": "legal",
+  "name": "generateInvoice",
+  "inputs": {
+    "timeEntries": { "type": "array" },
+    "expenses": { "type": "array" },
+    "taxRate": { "type": "number" }
+  },
+  "reads_artifact_data": true,
+  "invariants": [
+    "typeof output === 'object' && output !== null",
+    "typeof output.ok === 'boolean'",
+    "output.ok === false || Number.isFinite(output.result.laborSubtotal)",
+    "output.ok === false || Number.isFinite(output.result.expenseSubtotal)",
+    "output.ok === false || Number.isFinite(output.result.subtotal)",
+    "output.ok === false || Number.isFinite(output.result.taxAmount)",
+    "output.ok === false || Number.isFinite(output.result.total)",
+    "output.ok === false || Number.isFinite(output.result.totalHours)",
+    "output.ok === false || output.result.total >= 0"
+  ],
+  "fuzz_cases": [
+    { "input": { "artifact": { "data": { "client": "Acme", "timeEntries": [{ "description": "Drafting", "hours": 2, "rate": 300 }], "expenses": [{ "description": "Filing fee", "amount": 50 }] } }, "taxRate": 0.1 }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": {} } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "timeEntries": [{ "description": "x", "hours": "Infinity", "rate": "1e999" }], "expenses": [{ "description": "y", "amount": "Infinity" }] }, "taxRate": "Infinity" } }, "expect": { "ok": true } },
+    { "input": { "artifact": { "data": { "timeEntries": [{ "hours": "NaN", "rate": "abc" }] } } }, "expect": { "ok": true } }
+  ],
+  "_note": "page.tsx handleAction('generateInvoice') channel: /api/lens/:domain/:id/run loads a stored matter artifact whose data carries timeEntries/expenses; taxRate is the action param. Returns laborSubtotal + expenseSubtotal + subtotal + taxAmount + total. Fail-CLOSED: every numeric goes through finiteNum() which rejects NaN/±Infinity (incl. parseFloat('Infinity')===Infinity and Number('1e999')===Infinity) back to 0, so no non-finite value can reach a rendered total. Note the 2-key body { artifact:{data}, taxRate } is NOT peeled by the sole-key rule — taxRate stays a sibling param, exactly as the route delivers it."
+}

--- a/docs/LENS_COMPLETION_LEDGER.md
+++ b/docs/LENS_COMPLETION_LEDGER.md
@@ -530,6 +530,34 @@ The calculator-family sweep is now essentially complete. Remaining queue: the no
 many are CRUD/visualization surfaces rather than compute panels, so lower dead-calculator risk.
 ~92 lenses through the non-score gate. The loop continues.
 
+### Phase-2 batch 20 DONE (2026-06-28): atlas, board, classroom, council, debate
+First batch of the non-calculator long tail. 147 server + 23 UX-state tests; assassin 0 violations across
+all 5 domains; 258 WIRED; tsc 0. The dead-surface (`*ActionPanel` field-mismatch) + fail-open numeric
+class still recurs even in knowledge/governance lenses:
+- **atlas**: 4 dead calculator surfaces — `AtlasActionPanel.distanceMatrix` read `result.matrix` as
+  objects (handler returned `number[][]`) + `lng` vs `lon` mismatch zeroed every distance;
+  `DistanceMatrixPanel` route/stats panels + `MapsDirections` legs all rendered handler fields that
+  never existed → blank. Fixed via real handler aliases (`pairs`/`nearest`/`route`/`legs`/`stats.*`) +
+  `lon ?? lng` coercion; 4 fail-closed (Infinity/NaN coords → reject, not `null`-poison the matrix).
+  25 server + 4 vitest + 6 overrides.
+- **board**: all 3 AI calculators (workflowAnalysis/cardPrioritization/burndownForecast) DEAD — the page
+  persisted each task as a single-task artifact while handlers read board-wide arrays → `buildBoardActionParams`
+  derives real arrays from live tasks + `params.X ?? artifact.data.X` fallback + finNum/finInt guards +
+  a silent-empty fix in BoardWorkspace. 26 server + 5 vitest + 4 overrides.
+- **classroom**: behavioral macro tests (assignment/grade/gradebook/quiz/ol-isbn/todo) + swallowed-fetch
+  → distinguishable error/empty (the silent-empty defect). 32 server + 6 vitest + 6 overrides.
+- **council**: dead `CouncilActionPanel` surface (sent `motion`/`members`/`positions`/`conflict`, rendered
+  `positions`/`yes/no/abstain`/`summary`/`resolution` the handler never returns → blank in prod) aligned
+  to the real contract; 4 fail-open/uncaught-throw fixes (deliberate `.slice` on non-string, voteCount
+  `.toLowerCase` on numeric, generateMinutes/conflictResolution `.map` on non-array → 500). MeetingsWorkspace
+  4-UX-state test authored by the coordinator after the agent stalled before writing it. 30 server + 4 vitest + 6 overrides.
+- **debate**: 4 AI actions (evaluateArgument/fallacyCheck/steelmanPosition/scoreDebate) double-dead —
+  page sent no params + DebateActionPanel sent params the handlers ignored AND rendered fabricated field
+  names → handlers now derive inputs from the real debate shape (topic + pro/con args + votes) and the
+  panel aligns to the real contract; try/catch + string/array poison guards. 34 server + 4 vitest + 6 overrides.
+**102 lenses now carry the UX-states gate marker** (batches 1–20). The loop continues into the rest of the
+non-calculator tail (bridge, forum, household, crypto, code, chat, knowledge/research/social families).
+
 ### Phase-2 batch 19 DONE (2026-06-28): bio, consulting, affect, art, artistry
 145 server + 28 UX-state tests — the first non-calculator/feature-lens batch (twice-launched; the first
 run was cut off by the shared session limit and cleanly reverted, then redone from a clean checkpoint).

--- a/docs/LENS_COMPLETION_LEDGER.md
+++ b/docs/LENS_COMPLETION_LEDGER.md
@@ -530,6 +530,27 @@ The calculator-family sweep is now essentially complete. Remaining queue: the no
 many are CRUD/visualization surfaces rather than compute panels, so lower dead-calculator risk.
 ~92 lenses through the non-score gate. The loop continues.
 
+### Phase-2 batch 19 DONE (2026-06-28): bio, consulting, affect, art, artistry
+145 server + 28 UX-state tests — the first non-calculator/feature-lens batch (twice-launched; the first
+run was cut off by the shared session limit and cleanly reverted, then redone from a clean checkpoint).
+The dead-surface + fail-open class persists even in feature lenses:
+- **bio**: 2 dead sequence surfaces (align tab alignedA→alignA; restriction-map enzyme→enzymes[] +
+  sites rendered as [object Object]) + 2 fail-closed. 23 server + 4 vitest + 6 overrides.
+- **art**: dead ArtActionPanel workbench (4 macros, both directions → blank cards) + swallowed-fetch
+  (.catch(()=>[]) made the Retry UI dead code) + 4 fail-opens (#NaN swatches). 21 server + 10 vitest.
+- **affect**: 1 dead surface (Pattern Detection theme/trigger/label mismatch → [object Object]) + 4
+  backend poison/crash fixes (text.split/.map on non-string/non-array → 500). 31 server + 5 vitest.
+- **artistry**: all 30 calls aligned (no dead surface); swallowed-fetch + 12 fail-open numeric sites
+  (finNum). 36 server + 5 vitest + 6 overrides.
+- **consulting**: all 39 workbench macros aligned; 4 pure-compute money macros fail-open (finPos/finSigned).
+  31 server + 5 vitest + 6 overrides.
+INFRA: `system.cartograph` crossed the 8s fuzz timeout as the repo grew (it reads/serializes the large
+generated SYSTEMS.json, ignores numeric input) → added it to a documented HEAVY_FUZZ_SKIP_IDS set in the
+assassin harness (heavy_introspection, same justification as the live_* external-IO skip). Ratchet GREEN.
+**97 lenses now carry the UX-states gate marker** (batches 1–19). 258 WIRED; tsc 0. The loop continues
+into the non-calculator long tail (atlas, board, bridge, forum, household, robotics-class, classroom,
+council, debate, crypto, code, chat, etc.).
+
 ### Phase-2 batch 14+15 (2026-06-28): marketing, analytics, retail, audit, supplychain, voice
 Batch 14's subagents were cut off mid-work by the shared session limit; only **marketing** was complete
 + verified (fail-open Infinity-leak fix; committed), the rest reverted for a clean resume. Batch 15

--- a/docs/LENS_COMPLETION_LEDGER.md
+++ b/docs/LENS_COMPLETION_LEDGER.md
@@ -530,6 +530,28 @@ The calculator-family sweep is now essentially complete. Remaining queue: the no
 many are CRUD/visualization surfaces rather than compute panels, so lower dead-calculator risk.
 ~92 lenses through the non-score gate. The loop continues.
 
+### Phase-2 batch 22 (2026-06-28): energy, eco, fitness DONE — ethics DEFERRED (reverted)
+3 of 4 banked; ethics reverted (honest). 109 server + 29 UX-state tests across the 3 done lenses; tsc 0.
+- **energy**: largely aligned already; 4 fail-OPEN calculators (consumptionAnalysis/solarEstimate/
+  carbonFootprint/gridStatus — `parseFloat(x)||N` let `"1e999"`/`"Infinity"` through → JSON `null` blanks,
+  `gridStatus` even rendered `"Infinity MW"`) → `finiteNum` clamps; EnergyDevicesPanel silent-empty →
+  distinguishable load-error+retry. 31 server + 8 vitest + 5 overrides. (path-3-only → assassin drives 0; node:test is enforcement.)
+- **eco**: REAL fake-data defect killed — `aqi-current` returned a FABRICATED fallback AQI (a fake "good"/42
+  reading) on network failure; now fails honestly `{ok:false,error:'unreachable'}` and the AQIPanel renders
+  the error branch (the pre-existing eco-domain-parity test was updated to assert the honest behavior — a
+  legitimate fix, not gaming). + fail-closed footprint/biodiversity numerics + distinguishable error states
+  across 6 panels. 36 server + 11 vitest + 4 overrides.
+- **fitness**: ~69 macros, all path-3. Fail-closed BMR/body-fat/HR-zone/VDOT(vo2max,race-predictor)/
+  progression numerics (`ffnum`/`fclampN`/finite guards — a lying calorie/1RM/HR number is a real harm);
+  ActivityRings+SleepRecovery honest loading/error states. 42 server + 10 vitest + 5 overrides (authored by
+  the coordinator after the agent was session-limited before writing them). (path-3-only → node:test is enforcement.)
+- **ethics**: REVERTED. The agent added `LoadGate`+`readEnvelope` helpers but NEVER wired them (0 render
+  sites, 0 calls — dead scaffolding), the list panels still silent-empty, and no states test / no overrides
+  were written (session-limited mid-pass). Per the no-scaffolding rule + "don't bank partial work," the
+  whole ethics change (domain + DecisionToolkit + server test) was reverted to clean HEAD and re-queued for
+  a fresh pass. Its backend numeric work was real but is not bankable without the wired frontend + states test.
+**109 lenses now carry the UX-states gate marker** (batches 1–22; ethics re-queued). The loop continues.
+
 ### Phase-2 batch 21 DONE (2026-06-28): forum, household, geology, forestry
 143 server + 24 UX-state tests; per-domain assassin clean; 258 WIRED; tsc 0. The dead-`*ActionPanel`-surface
 + fail-open-numeric class persists into the knowledge/utility tail, plus two new systemic findings:

--- a/docs/LENS_COMPLETION_LEDGER.md
+++ b/docs/LENS_COMPLETION_LEDGER.md
@@ -505,6 +505,31 @@ an inverted security sort, a renderer-corrupting geometry, 2 crashes, a triage-e
 and a long tail of Infinity/NaN fail-opens — every one in a lens that "looked wired." 2 lenses were clean.
 56 lenses now through the non-score gate (batches 1–13). The loop continues.
 
+### Phase-2 batches 14–18 DONE (2026-06-28): the calculator-family completion sweep
+**92 lenses now carry the UX-states gate marker** (`ls concord-frontend/tests/*-lens-states.test.tsx | wc -l`).
+Batches 14–18 swept the rest of the `*ActionPanel`/`*Calc` calculator family (marketing, analytics, retail,
+audit, supplychain, voice — redone after a session-limit interruption — then creative, education, collab,
+commonsense, telecommunications, landscaping, linguistics, mentorship, services, robotics, physics, hr,
+aviation, insurance, legal, +more). The field-mismatch + fail-closed + crash class stayed the dominant
+finding right to the end:
+- **Entirely-dead surfaces:** creative (4), education (4), audit (4 — redo), hr (4, both directions, handlers
+  rewritten), aviation (🔴 safety: W&B calc returned gross 0 / CG 0 for every input).
+- **Partial dead / field mismatch:** retail (3/4), commonsense, mentorship (inline panel), services (the 2-key
+  {artifact:{data},period} trap — moved period into data), creative's distributionChecklist (2-key trap),
+  insurance (peel dropped artifact.title → blank risk card).
+- **Crashes:** analytics (.map throw + guidance-result render crash), linguistics (text.split on non-string →
+  500), legal (RangeError in addDays on an invalid date), aviation (blank render blocks).
+- **Clean bills (no defect, coverage added):** supplychain, telecommunications, landscaping, physics,
+  plus earlier plumbing + law-enforcement — the honest counterweight (~6 of ~50 calculator lenses were fine).
+- A long tail of `Number.isFinite` fail-closed guards on Infinity/NaN money/percentage leaks across nearly
+  every lens.
+Assassin ratchet GREEN throughout (the flaky system.history-snapshot timeout recurs under load, always
+clean on a lone re-run); 258 WIRED; tsc 0; per-lens parity tests intact.
+The calculator-family sweep is now essentially complete. Remaining queue: the non-calculator long tail
+(atlas, board, bridge, collab-class, forum, household, robotics-class, art/artistry, consulting, etc.) —
+many are CRUD/visualization surfaces rather than compute panels, so lower dead-calculator risk.
+~92 lenses through the non-score gate. The loop continues.
+
 ### Phase-2 batch 14+15 (2026-06-28): marketing, analytics, retail, audit, supplychain, voice
 Batch 14's subagents were cut off mid-work by the shared session limit; only **marketing** was complete
 + verified (fail-open Infinity-leak fix; committed), the rest reverted for a clean resume. Batch 15

--- a/docs/LENS_COMPLETION_LEDGER.md
+++ b/docs/LENS_COMPLETION_LEDGER.md
@@ -530,6 +530,35 @@ The calculator-family sweep is now essentially complete. Remaining queue: the no
 many are CRUD/visualization surfaces rather than compute panels, so lower dead-calculator risk.
 ~92 lenses through the non-score gate. The loop continues.
 
+### Phase-2 batch 21 DONE (2026-06-28): forum, household, geology, forestry
+143 server + 24 UX-state tests; per-domain assassin clean; 258 WIRED; tsc 0. The dead-`*ActionPanel`-surface
++ fail-open-numeric class persists into the knowledge/utility tail, plus two new systemic findings:
+- **forum**: 4 dead "Community Analytics" surfaces (threadAnalysis/moderationQueue/communityHealth/
+  topicClustering) — buttons posted a single-Post artifact + no params to handlers reading forum-wide
+  arrays → always rendered the empty-guidance message. Fixed via `deriveForumParams()` deriving real
+  inputs from live posts/comments + `params.X ?? artifact.data.X` handler fallback; `fmInt` fail-closed
+  guards (trending's `Math.max(0.01, NaN)` propagated NaN into hotScore); FmTopicsPanel distinguishable
+  load-error. 30 server + 5 vitest + 4 overrides.
+- **household**: 2 fully dead surfaces (ChoreRotation — a 2-key `{artifact:{data},strategy,weeks}` body
+  the dispatch never peels → handler saw undefined; HouseholdActionPanel's 4 actions sent wrong fields +
+  rendered fields the handler never returns) + board-style empty page actions (`deriveActionParams`) + 7
+  fail-open numerics incl. an `Infinity` expense that would poison `expense-balances`. 38 server + 5 vitest + 6 ov.
+- **geology**: SYSTEMIC error-detection bug — `/api/lens/run` unwraps one `{ok,result}` layer so the
+  transport `r.data.ok` is ALWAYS true; every geology write path checked only `r.data.ok` → handler
+  rejections silently swallowed (form reset, no error). Fixed across 7 components to read `result.ok!==false`;
+  + fail-closed physics numerics (rockClassify/seismicRisk/mineralId/stratigraphicColumn leaked Infinity)
+  + 2 silent-empty list panels. 32 server + 8 vitest + 5 ov.
+- **forestry**: 4 dead calculators (timberVolume/fireRisk/harvestPlan/carbonSequestration ignored the
+  panel input + returned unread field names, one returned a STRING where the panel rendered a number) +
+  fail-closed `frFinite` + StandManager silent-empty. 43 server + 6 vitest + 5 ov.
+**VERIFICATION-ENGINE GAP FLAGGED (not yet fixed):** the macro-assassin harness (`scripts/contracts/harness.mjs#enumerateMacros`)
+enumerates only the path-2 `MACROS` registry, NOT path-3 `LENS_ACTIONS`. So path-3-only lenses
+(forestry exclusively; geology/forum/household partially) get a trivially-true "0 violations" (the assassin
+drove 0–2 of their macros) and their override files are documented-but-unenforced. The behavioral node:test
+is the real enforcement for those. Fix = teach `enumerateMacros` to also walk `LENS_ACTIONS` — a shared-harness
+change that shifts the ratchet baseline for ALL path-3 lenses, so it's queued as its own deliberate pass.
+**106 lenses now carry the UX-states gate marker** (batches 1–21). The loop continues into the rest of the tail.
+
 ### Phase-2 batch 20 DONE (2026-06-28): atlas, board, classroom, council, debate
 First batch of the non-calculator long tail. 147 server + 23 UX-state tests; assassin 0 violations across
 all 5 domains; 258 WIRED; tsc 0. The dead-surface (`*ActionPanel` field-mismatch) + fail-open numeric

--- a/docs/LENS_COMPLETION_LEDGER.md
+++ b/docs/LENS_COMPLETION_LEDGER.md
@@ -530,6 +530,26 @@ The calculator-family sweep is now essentially complete. Remaining queue: the no
 many are CRUD/visualization surfaces rather than compute panels, so lower dead-calculator risk.
 ~92 lenses through the non-score gate. The loop continues.
 
+### Phase-2 batch 23 (2026-06-28): ethics (re-queue) + fishing DONE — finance reverted, food not started
+2 banked; finance reverted (incomplete/broken), food not started. tsc 0; tree clean.
+- **ethics** (re-queue, now DONE): the prior revert's lesson held — this pass WIRED the shared `LoadGate`
+  into all 6 DecisionToolkit panels (rendered at lines 358/537/714/842/917/1141, cited), gave each list-load
+  real loading/error/empty/populated + a working retry, and fixed a REAL `decisionMatrix` poisoned-weight
+  NaN leak (`weight:"1e999"`→`weightSum=Infinity`→`Infinity/Infinity=NaN`→`null` cells; now `fnum()`-clamped
+  before summing). 24 server + 5 vitest + 4 overrides. (path-3-only → node:test is enforcement.)
+- **fishing** (DONE): game lens (cast→bite→reel→mint), already well-built; ONE real silent-empty fix —
+  catalog `{ok:false}` collapsed into EMPTY instead of ERROR; now throws → distinguishable error+retry.
+  Lib already fail-closed (poisoned reactionMs/tension clamp; qualityScore stays finite). 18 server + 9 vitest;
+  overrides already existed. (path-2 `registerFishingMacros`; assassin drove 10, 0 violations.)
+- **finance**: REVERTED. The agent was session-/coordinator-stopped mid-pass — it had modified
+  `finance.js` + `FinanceActionPanel.tsx` (left 22 tsc errors) + `NetWorthTracker.tsx` but had NOT written
+  its behavioral test, states test, or overrides yet ("now let me write the test file…"). Per "don't bank
+  partial work," all 3 modified files reverted to clean HEAD. RE-QUEUE: finance is money-sensitive (~73
+  macros — loan/mortgage/compound-interest/retirement/tax/ROI/NPV); fail-closed numerics are critical
+  (a `$Infinity`/`NaN` payment is a real defect). Watch division-by-zero on term/rate.
+- **food**: NOT STARTED (batch was trimmed to 3 agents for budget). RE-QUEUE (~68 macros).
+**111 lenses now carry the UX-states gate marker** (batches 1–23). PR #839 opened against `main`.
+
 ### Phase-2 batch 22 (2026-06-28): energy, eco, fitness DONE — ethics DEFERRED (reverted)
 3 of 4 banked; ethics reverted (honest). 109 server + 29 UX-state tests across the 3 done lenses; tsc 0.
 - **energy**: largely aligned already; 4 fail-OPEN calculators (consumptionAnalysis/solarEstimate/

--- a/scripts/contracts/harness.mjs
+++ b/scripts/contracts/harness.mjs
@@ -67,6 +67,17 @@ export const EXTERNAL_IO_HINT_RE = /^live_/i;
 
 export const SKIP_DOMAINS_DEFAULT = new Set(["oracle", "concordance"]);
 
+// Heavy whole-system introspection macros — not headless-safe to FUZZ for the
+// same timing reason as external_io: they read/parse/serialize a large generated
+// artifact (audit/cartograph/SYSTEMS.json) or walk the whole source tree, ignore
+// their numeric input entirely, and so a V2 adversarial-fuzz vector tests nothing
+// meaningful while flakily exceeding the 8s MACRO_TIMEOUT_MS as the repo grows
+// (a timing artifact, NOT a code defect). They get a STATIC contract only, never
+// an adversarial drive — identical justification to the `live_*` external-IO skip.
+export const HEAVY_FUZZ_SKIP_IDS = new Set([
+  "system.cartograph",
+]);
+
 // Per-(domain,name) fixture overrides — copied from the smoke harness so the
 // few macros that need a non-empty body don't trivially fail.
 export const FIXTURES = {
@@ -101,6 +112,7 @@ export function buildDefaultInput(domain, name) {
  */
 export function shouldSkip(domain, name) {
   if (SKIP_DOMAINS_DEFAULT.has(domain)) return { skip: true, reason: "skip_domain" };
+  if (HEAVY_FUZZ_SKIP_IDS.has(`${domain}.${name}`)) return { skip: true, reason: "heavy_introspection" };
   if (EXTERNAL_IO_HINT_RE.test(name)) return { skip: true, reason: "external_io" };
   if (_skipDestructive && DESTRUCTIVE_HINT_RE.test(name)) return { skip: true, reason: "destructive" };
   if (!_llmEnabled && LLM_HINT_RE.test(name)) return { skip: true, reason: "llm_hint" };

--- a/server/domains/affect.js
+++ b/server/domains/affect.js
@@ -11,7 +11,11 @@ export default function registerAffectActions(registerLensAction) {
    * params.detectSarcasm — whether to run sarcasm heuristics (default true)
    */
   registerLensAction("affect", "sentimentAnalysis", (ctx, artifact, params) => {
-    const text = artifact.data.text || "";
+  try {
+    // Coerce defensively: a poisoned non-string `text` (number/object) must not
+    // throw on `.trim()` — fail CLOSED to the empty-input message, never crash.
+    const rawText = artifact?.data?.text;
+    const text = typeof rawText === "string" ? rawText : "";
     if (!text.trim()) {
       return { ok: true, result: { message: "No text provided for sentiment analysis." } };
     }
@@ -200,6 +204,7 @@ export default function registerAffectActions(registerLensAction) {
 
     artifact.data.sentimentAnalysis = result;
     return { ok: true, result };
+    } catch (e) { return { ok: false, error: "handler_error", message: String(e?.message || e) }; }
   });
 
   /**
@@ -210,12 +215,16 @@ export default function registerAffectActions(registerLensAction) {
    * params.windowSize — smoothing window for arc detection (default 3)
    */
   registerLensAction("affect", "emotionTimeline", (ctx, artifact, params) => {
-    const entries = artifact.data.entries || [];
+  try {
+    // Guard CLOSED: a poisoned non-array `entries` must not throw on `.map()`.
+    const entries = Array.isArray(artifact?.data?.entries) ? artifact.data.entries : [];
     if (entries.length === 0) {
       return { ok: true, result: { message: "No entries provided for emotion timeline." } };
     }
 
-    const windowSize = params.windowSize || 3;
+    const windowSize = Number.isFinite(Number(params.windowSize)) && Number(params.windowSize) > 0
+      ? Number(params.windowSize)
+      : 3;
 
     // Simple inline lexicon for scoring
     const posWords = new Set(["happy", "joy", "love", "great", "excellent", "wonderful", "amazing",
@@ -342,6 +351,7 @@ export default function registerAffectActions(registerLensAction) {
 
     artifact.data.emotionTimeline = result;
     return { ok: true, result };
+    } catch (e) { return { ok: false, error: "handler_error", message: String(e?.message || e) }; }
   });
 
   /**
@@ -353,7 +363,10 @@ export default function registerAffectActions(registerLensAction) {
    * params.gainKeywords — additional gain keywords (optional)
    */
   registerLensAction("affect", "empathyMap", (ctx, artifact, params) => {
-    const feedback = artifact.data.feedback || [];
+  try {
+    // Guard CLOSED: a poisoned non-array `feedback` (string iterates chars,
+    // object is non-iterable → throws) must collapse to the empty-input message.
+    const feedback = Array.isArray(artifact?.data?.feedback) ? artifact.data.feedback : [];
     if (feedback.length === 0) {
       return { ok: true, result: { message: "No feedback data provided for empathy mapping." } };
     }
@@ -399,8 +412,9 @@ export default function registerAffectActions(registerLensAction) {
     const gains = [];
     const themes = {};
 
-    for (const item of feedback) {
-      const text = item.text || "";
+    for (const rawItem of feedback) {
+      const item = rawItem && typeof rawItem === "object" ? rawItem : {};
+      const text = typeof item.text === "string" ? item.text : "";
       const lower = text.toLowerCase();
       const tokens = lower.replace(/[^a-z\s'-]/g, " ").split(/\s+/).filter(t => t.length > 1);
 
@@ -500,6 +514,7 @@ export default function registerAffectActions(registerLensAction) {
 
     artifact.data.empathyMap = result;
     return { ok: true, result };
+    } catch (e) { return { ok: false, error: "handler_error", message: String(e?.message || e) }; }
   });
 
   // ---------------------------------------------------------------------------
@@ -1035,6 +1050,7 @@ export default function registerAffectActions(registerLensAction) {
   // (artifact.data.entries: [{ text, timestamp }]). Returns the shape the lens's
   // patternResult panel renders: patterns / triggers / cycles / correlations / summary.
   registerLensAction("affect", "detect-patterns", (ctx, artifact, _params = {}) => {
+  try {
     const entries = Array.isArray(artifact.data?.entries) ? artifact.data.entries
       : Array.isArray(artifact.data?.checkins) ? artifact.data.checkins : [];
     const STOP = new Set("the a an and or but i to of in is it im was are my me you we be for on with that this so just feel feeling felt today".split(" "));
@@ -1066,5 +1082,6 @@ export default function registerAffectActions(registerLensAction) {
           : "No journal entries yet — add a few check-ins to surface patterns.",
       },
     };
+    } catch (e) { return { ok: false, error: "handler_error", message: String(e?.message || e) }; }
   });
 }

--- a/server/domains/art.js
+++ b/server/domains/art.js
@@ -52,6 +52,16 @@ export default function registerArtActions(registerLensAction) {
     return { r: parseInt(h.substring(0, 2), 16), g: parseInt(h.substring(2, 4), 16), b: parseInt(h.substring(4, 6), 16) };
   }
 
+  // Strict #RRGGBB / RRGGBB validator. Returns the normalized "#rrggbb" string
+  // or null. Used to fail-CLOSED on malformed hex BEFORE hexToRgb can emit NaN
+  // channels that would otherwise leak into harmonyScore / dominantHue / a
+  // generated palette while the handler still reported ok:true.
+  function normalizeHex(v) {
+    if (typeof v !== "string") return null;
+    const m = /^#?([0-9a-fA-F]{6})$/.exec(v.trim());
+    return m ? `#${m[1].toLowerCase()}` : null;
+  }
+
   function rgbToHsl(r, g, b) {
     r /= 255; g /= 255; b /= 255;
     const max = Math.max(r, g, b), min = Math.min(r, g, b);
@@ -94,11 +104,19 @@ export default function registerArtActions(registerLensAction) {
    */
   registerLensAction("art", "colorHarmony", (ctx, artifact, _params) => {
   try {
-    const rawPalette = artifact.data?.palette || [];
+    const rawPalette = Array.isArray(artifact.data?.palette) ? artifact.data.palette : [];
     if (rawPalette.length === 0) return { ok: true, result: { message: "No palette provided." } };
 
-    const colors = rawPalette.map(c => {
-      const hex = typeof c === "string" ? c : c.hex;
+    // Fail-CLOSED on malformed hex: a non-#RRGGBB entry would make hexToRgb emit
+    // NaN channels that silently poison harmonyScore / dominantHue. Reject
+    // instead of leaking NaN under ok:true.
+    const normalized = rawPalette.map(c => normalizeHex(typeof c === "string" ? c : c?.hex));
+    if (normalized.some(h => h === null)) {
+      return { ok: false, error: "palette entries must be #RRGGBB hex colors" };
+    }
+
+    const colors = rawPalette.map((c, idx) => {
+      const hex = normalized[idx];
       const rgb = hexToRgb(hex);
       const hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
       const lab = rgbToLab(rgb.r, rgb.g, rgb.b);
@@ -190,11 +208,26 @@ export default function registerArtActions(registerLensAction) {
    */
   registerLensAction("art", "compositionScore", (ctx, artifact, _params) => {
   try {
-    const elements = artifact.data?.elements || [];
+    const elements = Array.isArray(artifact.data?.elements) ? artifact.data.elements : [];
     const canvas = artifact.data?.canvas || { width: 1920, height: 1080 };
     if (elements.length === 0) return { ok: true, result: { message: "No elements to analyze." } };
 
-    const cw = canvas.width, ch = canvas.height;
+    // Fail-CLOSED on poisoned geometry: an Infinity/NaN/1e308 coordinate or a
+    // non-finite canvas dimension would propagate NaN/Infinity into every score
+    // under ok:true. Reject before any math runs.
+    const fin = v => Number.isFinite(Number(v));
+    const cw = Number(canvas.width), ch = Number(canvas.height);
+    if (!fin(cw) || !fin(ch) || cw <= 0 || ch <= 0) {
+      return { ok: false, error: "canvas width and height must be positive finite numbers" };
+    }
+    for (const el of elements) {
+      if (!fin(el?.x) || !fin(el?.y) ||
+          (el?.width != null && !fin(el.width)) ||
+          (el?.height != null && !fin(el.height)) ||
+          (el?.weight != null && !fin(el.weight))) {
+        return { ok: false, error: "element x/y/width/height/weight must be finite numbers" };
+      }
+    }
     const scores = {};
 
     // 1. Rule of thirds: how close elements are to intersection points
@@ -297,9 +330,16 @@ export default function registerArtActions(registerLensAction) {
    */
   registerLensAction("art", "generatePalette", (ctx, artifact, params) => {
   try {
-    const baseHex = params.baseColor || artifact.data?.baseColor || "#3498db";
+    const baseRaw = params.baseColor || artifact.data?.baseColor || "#3498db";
+    const baseHex = normalizeHex(baseRaw);
+    // Fail-CLOSED: a malformed baseColor would drive hexToRgb → NaN hsl → a
+    // palette of NaN-derived "#NaNNaN" swatches under ok:true.
+    if (baseHex === null) return { ok: false, error: "baseColor must be a #RRGGBB hex color" };
     const harmony = params.harmony || "analogous";
-    const count = params.count || 5;
+    // Clamp count to a sane finite integer in [2,24]; a poisoned Infinity/NaN
+    // would otherwise drive an unbounded / NaN loop.
+    const countRaw = Number(params.count);
+    const count = Number.isFinite(countRaw) ? Math.max(2, Math.min(24, Math.floor(countRaw))) : 5;
 
     const rgb = hexToRgb(baseHex);
     const hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
@@ -386,15 +426,24 @@ export default function registerArtActions(registerLensAction) {
    */
   registerLensAction("art", "styleClassify", (ctx, artifact, _params) => {
   try {
-    const attrs = artifact.data?.attributes || {};
-    const brushwork = attrs.brushwork ?? 50;
-    const saturation = attrs.colorSaturation ?? 50;
-    const contrast = attrs.contrast ?? 50;
-    const perspective = attrs.perspective ?? 50;
-    const detail = attrs.detail ?? 50;
-    const abstraction = attrs.abstraction ?? 50;
-    const lineWeight = attrs.lineWeight ?? 50;
-    const texture = attrs.texture ?? 50;
+    const attrs = (artifact.data?.attributes && typeof artifact.data.attributes === "object") ? artifact.data.attributes : {};
+    // Each axis defaults to 50 when absent, and is CLAMPED into [0,100] when
+    // present. A poisoned Infinity/NaN/1e308 axis would otherwise leak a
+    // non-finite similarity under ok:true — clamp fails it closed to the scale.
+    const axis = v => {
+      if (v == null) return 50;
+      const n = Number(v);
+      if (!Number.isFinite(n)) return 50;
+      return Math.max(0, Math.min(100, n));
+    };
+    const brushwork = axis(attrs.brushwork);
+    const saturation = axis(attrs.colorSaturation);
+    const contrast = axis(attrs.contrast);
+    const perspective = axis(attrs.perspective);
+    const detail = axis(attrs.detail);
+    const abstraction = axis(attrs.abstraction);
+    const lineWeight = axis(attrs.lineWeight);
+    const texture = axis(attrs.texture);
 
     // Style matching via characteristic profiles
     const styles = [

--- a/server/domains/artistry.js
+++ b/server/domains/artistry.js
@@ -2,6 +2,20 @@
 // Domain actions for artistry: color palette analysis, composition scoring, style classification, media inventory.
 
 export default function registerArtistryActions(registerLensAction) {
+  // Fail-CLOSED numeric coercion for the pure-compute analysis macros.
+  // `parseFloat("Infinity")` → Infinity and `Number("1e999")` → Infinity, and
+  // `Infinity || fallback` is Infinity — so the naive `parseFloat(x) || d`
+  // pattern lets a poisoned magnitude flow straight into a computed total
+  // (mediaInventory value, composition canvas size, palette weight) and emit a
+  // report containing Infinity/NaN. `finNum` collapses any non-finite (or
+  // beyond-1e15) input to the supplied fallback so every computed output stays
+  // FINITE by construction. Negative magnitudes are passed through (a negative
+  // weight/quantity is a domain choice, not a fail-open hazard).
+  const finNum = (v, fallback = 0) => {
+    const n = typeof v === "number" ? v : parseFloat(v);
+    return Number.isFinite(n) && Math.abs(n) <= 1e15 ? n : fallback;
+  };
+
   /**
    * colorPaletteAnalysis
    * Analyze artwork colors, calculate harmony scores, and detect dominant hues.
@@ -17,7 +31,7 @@ export default function registerArtistryActions(registerLensAction) {
 
     const colors = raw.map((entry) => {
       const hex = typeof entry === "string" ? entry : entry.color || "#000000";
-      const weight = typeof entry === "object" ? (parseFloat(entry.weight) || 1) : 1;
+      const weight = typeof entry === "object" ? (finNum(entry.weight, 1) || 1) : 1;
       const r = parseInt(hex.slice(1, 3), 16) || 0;
       const g = parseInt(hex.slice(3, 5), 16) || 0;
       const b = parseInt(hex.slice(5, 7), 16) || 0;
@@ -133,8 +147,8 @@ export default function registerArtistryActions(registerLensAction) {
   try {
     const elements = artifact.data?.elements || [];
     const canvas = artifact.data?.canvas || {};
-    const canvasW = parseFloat(canvas.width) || 100;
-    const canvasH = parseFloat(canvas.height) || 100;
+    const canvasW = finNum(canvas.width, 100) || 100;
+    const canvasH = finNum(canvas.height, 100) || 100;
 
     if (elements.length === 0) {
       return { ok: true, result: { message: "No elements provided. Supply artifact.data.elements as [{ x, y, width, height }] and artifact.data.canvas as { width, height }.", score: 0, breakdown: {} } };
@@ -151,9 +165,9 @@ export default function registerArtistryActions(registerLensAction) {
     // Evaluate each element's center proximity to rule-of-thirds points
     let thirdsScore = 0;
     const elementAnalysis = elements.map((el) => {
-      const cx = ((parseFloat(el.x) || 0) + (parseFloat(el.width) || 0) / 2) / canvasW;
-      const cy = ((parseFloat(el.y) || 0) + (parseFloat(el.height) || 0) / 2) / canvasH;
-      const w = parseFloat(el.weight) || 1;
+      const cx = (finNum(el.x, 0) + finNum(el.width, 0) / 2) / canvasW;
+      const cy = (finNum(el.y, 0) + finNum(el.height, 0) / 2) / canvasH;
+      const w = finNum(el.weight, 1) || 1;
 
       // Distance to nearest thirds point
       let minDist = Infinity;
@@ -172,16 +186,16 @@ export default function registerArtistryActions(registerLensAction) {
       return { centerX: Math.round(cx * 100) / 100, centerY: Math.round(cy * 100) / 100, nearestThird: nearestPoint, proximityScore: Math.round(proximity * 100) / 100 };
     });
 
-    const totalWeight = elements.reduce((s, el) => s + (parseFloat(el.weight) || 1), 0);
+    const totalWeight = elements.reduce((s, el) => s + (finNum(el.weight, 1) || 1), 0);
     thirdsScore = totalWeight > 0 ? Math.round((thirdsScore / totalWeight) * 100) / 100 : 0;
 
     // Visual balance: compare weight distribution across quadrants
     const quadrants = [0, 0, 0, 0]; // TL, TR, BL, BR
     for (const el of elements) {
-      const cx = ((parseFloat(el.x) || 0) + (parseFloat(el.width) || 0) / 2) / canvasW;
-      const cy = ((parseFloat(el.y) || 0) + (parseFloat(el.height) || 0) / 2) / canvasH;
-      const w = parseFloat(el.weight) || 1;
-      const area = ((parseFloat(el.width) || 0) * (parseFloat(el.height) || 0)) / (canvasW * canvasH);
+      const cx = (finNum(el.x, 0) + finNum(el.width, 0) / 2) / canvasW;
+      const cy = (finNum(el.y, 0) + finNum(el.height, 0) / 2) / canvasH;
+      const w = finNum(el.weight, 1) || 1;
+      const area = (finNum(el.width, 0) * finNum(el.height, 0)) / (canvasW * canvasH);
       const mass = w * (area || 0.01);
       const qi = (cy < 0.5 ? 0 : 2) + (cx < 0.5 ? 0 : 1);
       quadrants[qi] += mass;
@@ -196,8 +210,8 @@ export default function registerArtistryActions(registerLensAction) {
     // Coverage: how much of the canvas is utilized
     let coveredArea = 0;
     for (const el of elements) {
-      const w = parseFloat(el.width) || 0;
-      const h = parseFloat(el.height) || 0;
+      const w = finNum(el.width, 0);
+      const h = finNum(el.height, 0);
       coveredArea += w * h;
     }
     const coverageRatio = Math.min(1, coveredArea / (canvasW * canvasH));
@@ -327,10 +341,10 @@ export default function registerArtistryActions(registerLensAction) {
     const reorderAlerts = [];
 
     const items = supplies.map((item) => {
-      const qty = parseFloat(item.quantity) || 0;
-      const unitCost = parseFloat(item.unitCost) || 0;
+      const qty = finNum(item.quantity, 0);
+      const unitCost = finNum(item.unitCost, 0);
       const value = Math.round(qty * unitCost * 100) / 100;
-      const threshold = parseFloat(item.reorderThreshold) || 0;
+      const threshold = finNum(item.reorderThreshold, 0);
       const category = item.category || "uncategorized";
 
       totalValue += value;

--- a/server/domains/atlas.js
+++ b/server/domains/atlas.js
@@ -91,7 +91,10 @@ export default function registerAtlasActions(registerLensAction) {
       let lon = parseFloat(place.lon);
       let source = "provided";
 
-      if (isNaN(lat) || isNaN(lon)) {
+      // Treat non-finite/out-of-envelope provided coords as "missing" so a
+      // poisoned Infinity/1e308 never leaks into distance math (fail-CLOSED).
+      const provided = Number.isFinite(lat) && Number.isFinite(lon) && lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180;
+      if (!provided) {
         const ref = reference[nameLower];
         if (ref) {
           lat = ref.lat;
@@ -176,6 +179,17 @@ export default function registerAtlasActions(registerLensAction) {
     const n = points.length;
     const labels = points.map((p, i) => p.name || `Point_${i}`);
     const matrix = Array.from({ length: n }, () => new Array(n).fill(0));
+    // Accept lon OR lng (different panels send each) — coerce once.
+    const latOf = (p) => parseFloat(p.lat) || 0;
+    const lonOf = (p) => parseFloat(p.lon ?? p.lng) || 0;
+    // Fail-CLOSED: a non-finite or out-of-envelope coordinate is REJECTED so
+    // Infinity/NaN can never leak into the matrix as a serialized null.
+    for (const p of points) {
+      const la = parseFloat(p.lat), lo = parseFloat(p.lon ?? p.lng);
+      if (!Number.isFinite(la) || !Number.isFinite(lo) || la < -90 || la > 90 || lo < -180 || lo > 180) {
+        return { ok: false, error: "each point needs a finite lat (-90..90) + lon/lng (-180..180)" };
+      }
+    }
 
     let totalDist = 0;
     let pairCount = 0;
@@ -183,18 +197,24 @@ export default function registerAtlasActions(registerLensAction) {
     let minDist = Infinity;
     let maxPair = null;
     let minPair = null;
+    // Flat pair list (from/to/distanceKm) for the bespoke AtlasActionPanel.
+    const pairs = [];
+    let nearest = null;
 
     for (let i = 0; i < n; i++) {
       for (let j = i + 1; j < n; j++) {
-        const lat1 = parseFloat(points[i].lat) || 0;
-        const lon1 = parseFloat(points[i].lon) || 0;
-        const lat2 = parseFloat(points[j].lat) || 0;
-        const lon2 = parseFloat(points[j].lon) || 0;
+        const lat1 = latOf(points[i]);
+        const lon1 = lonOf(points[i]);
+        const lat2 = latOf(points[j]);
+        const lon2 = lonOf(points[j]);
         const dist = haversine(lat1, lon1, lat2, lon2);
         matrix[i][j] = dist;
         matrix[j][i] = dist;
         totalDist += dist;
         pairCount++;
+        // ~50 km/h overland estimate for a rough drive-time readout.
+        const estTimeMinutes = Math.round((dist / 50) * 60);
+        pairs.push({ from: labels[i], to: labels[j], distanceKm: dist, estTimeMinutes });
 
         if (dist > maxDist) {
           maxDist = dist;
@@ -203,6 +223,7 @@ export default function registerAtlasActions(registerLensAction) {
         if (dist < minDist) {
           minDist = dist;
           minPair = [labels[i], labels[j]];
+          nearest = { from: labels[i], to: labels[j], distanceKm: dist };
         }
       }
     }
@@ -210,12 +231,12 @@ export default function registerAtlasActions(registerLensAction) {
     const avgDist = pairCount > 0 ? Math.round((totalDist / pairCount) * 100) / 100 : 0;
 
     // Compute centroid
-    const avgLat = points.reduce((s, p) => s + (parseFloat(p.lat) || 0), 0) / n;
-    const avgLon = points.reduce((s, p) => s + (parseFloat(p.lon) || 0), 0) / n;
+    const avgLat = points.reduce((s, p) => s + latOf(p), 0) / n;
+    const avgLon = points.reduce((s, p) => s + lonOf(p), 0) / n;
 
     // Spread: average distance from centroid
     const centroidDistances = points.map((p) => {
-      return haversine(avgLat, avgLon, parseFloat(p.lat) || 0, parseFloat(p.lon) || 0);
+      return haversine(avgLat, avgLon, latOf(p), lonOf(p));
     });
     const avgSpread = Math.round((centroidDistances.reduce((s, d) => s + d, 0) / n) * 100) / 100;
 
@@ -223,6 +244,9 @@ export default function registerAtlasActions(registerLensAction) {
       pointCount: n,
       labels,
       matrix,
+      // Flat pair list + nearest — the bespoke AtlasActionPanel renders these.
+      pairs,
+      nearest,
       stats: {
         averageDistanceKm: avgDist,
         maxDistanceKm: maxDist,
@@ -233,6 +257,12 @@ export default function registerAtlasActions(registerLensAction) {
         centroid: { lat: Math.round(avgLat * 10000) / 10000, lon: Math.round(avgLon * 10000) / 10000 },
         averageSpreadKm: avgSpread,
         clusterTightness: avgSpread < 100 ? "tight" : avgSpread < 500 ? "moderate" : avgSpread < 2000 ? "spread" : "dispersed",
+        // Aliases the DistanceMatrixPanel renders (meanKm/maxKm/minKm/maxPair/minPair).
+        meanKm: avgDist,
+        maxKm: maxDist,
+        minKm: minDist === Infinity ? 0 : minDist,
+        maxPair,
+        minPair,
       },
     };
 
@@ -252,6 +282,16 @@ export default function registerAtlasActions(registerLensAction) {
     const regions = artifact.data?.regions || [];
     if (regions.length === 0) {
       return { ok: true, result: { message: "No region data provided. Supply artifact.data.regions as [{ name, population, area, gdp, density, growth }].", summary: null, rankings: null } };
+    }
+
+    // Fail-CLOSED: a non-finite numeric (Infinity/NaN/1e308) in any metric is
+    // rejected so it can never leak into totals/gini.
+    for (const r of regions) {
+      for (const k of ["population", "area", "gdp", "density", "growth"]) {
+        if (r[k] !== undefined && r[k] !== null && r[k] !== "" && !Number.isFinite(parseFloat(r[k]))) {
+          return { ok: false, error: `region "${r.name || "Unknown"}" has a non-finite ${k}` };
+        }
+      }
     }
 
     const parsed = regions.map((r) => ({
@@ -370,11 +410,20 @@ export default function registerAtlasActions(registerLensAction) {
       return Math.round(R * c * 100) / 100;
     }
 
+    // Fail-CLOSED: reject non-finite / out-of-envelope coordinates before the
+    // TSP loop so Infinity/NaN can never leak into route legs.
+    for (const w of waypoints) {
+      const la = parseFloat(w.lat), lo = parseFloat(w.lon ?? w.lng);
+      if (!Number.isFinite(la) || !Number.isFinite(lo) || la < -90 || la > 90 || lo < -180 || lo > 180) {
+        return { ok: false, error: "each waypoint needs a finite lat (-90..90) + lon/lng (-180..180)" };
+      }
+    }
+
     const n = waypoints.length;
     const labels = waypoints.map((w, i) => w.name || `Waypoint_${i}`);
     const coords = waypoints.map((w) => ({
       lat: parseFloat(w.lat) || 0,
-      lon: parseFloat(w.lon) || 0,
+      lon: parseFloat(w.lon ?? w.lng) || 0,
     }));
 
     // Pre-compute distance matrix
@@ -485,9 +534,23 @@ export default function registerAtlasActions(registerLensAction) {
 
     const savings = naiveTotal > 0 ? Math.round(((naiveTotal - bestTotal) / naiveTotal) * 10000) / 100 : 0;
 
+    // Component-canonical aliases (DistanceMatrixPanel + MapsDirections render
+    // these): ordered place-name list, the integer visit order, and per-hop
+    // legs as { from, to, km }. All derived from the optimized route — no
+    // fabricated values.
+    const routeNames = routeDetails.map((r) => r.name);
+    const order = [...bestRoute];
+    const legs = [];
+    for (let step = 1; step < routeDetails.length; step++) {
+      legs.push({ from: routeDetails[step - 1].name, to: routeDetails[step].name, km: routeDetails[step].legDistanceKm });
+    }
+
     const result = {
       waypointCount: n,
       optimizedRoute: routeDetails,
+      route: routeNames,
+      order,
+      legs,
       totalDistanceKm: bestTotal,
       naiveOrderDistanceKm: naiveTotal,
       savingsPercent: savings,

--- a/server/domains/bio.js
+++ b/server/domains/bio.js
@@ -700,6 +700,12 @@ export default function registerBioActions(registerLensAction) {
 
   registerLensAction("bio", "sequence-analyze", (_ctx, _artifact, params = {}) => {
   try {
+    // Fail-CLOSED on a non-string sequence: a bare object/number would
+    // String()-coerce into garbage like "[object Object]" and report a
+    // fabricated GC%/Tm. Reject anything that isn't a primitive string.
+    if (params.sequence != null && typeof params.sequence !== "string") {
+      return { ok: false, error: "sequence must be a string" };
+    }
     const seq = String(params.sequence || "").replace(/\s/g, "").toUpperCase();
     if (!seq) return { ok: false, error: "sequence required" };
     if (seq.length > 100_000) return { ok: false, error: "sequence too long (max 100000)" };
@@ -773,9 +779,21 @@ export default function registerBioActions(registerLensAction) {
     const b = String(params.seqB || "").toUpperCase().trim();
     if (!a || !b) return { ok: false, error: "seqA and seqB required" };
     if (a.length > 2000 || b.length > 2000) return { ok: false, error: "sequences max 2000 each" };
-    const match = Number(params.match) || 2;
-    const mismatch = Number(params.mismatch) || -1;
-    const gap = Number(params.gap) || -2;
+    // Fail-CLOSED on poisoned scoring params: `Number(x) || default` lets
+    // Infinity/1e308 through (Infinity is truthy), which would leak Infinity
+    // into the alignment score. Reject any supplied-but-non-finite weight.
+    const scoreParam = (v, dflt) => {
+      if (v === undefined || v === null || v === "") return dflt;
+      const n = Number(v);
+      if (!Number.isFinite(n)) return null;
+      return n;
+    };
+    const match = scoreParam(params.match, 2);
+    const mismatch = scoreParam(params.mismatch, -1);
+    const gap = scoreParam(params.gap, -2);
+    if (match === null || mismatch === null || gap === null) {
+      return { ok: false, error: "match/mismatch/gap must be finite numbers" };
+    }
 
     const m = a.length;
     const n = b.length;

--- a/server/domains/board.js
+++ b/server/domains/board.js
@@ -9,10 +9,25 @@ export default function registerBoardActions(registerLensAction) {
    * artifact.data.cards: [{ id, title, column, createdAt, startedAt?, completedAt?, transitions?: [{ column, enteredAt, exitedAt? }] }]
    * artifact.data.columns: [{ name, wipLimit? }] — ordered column definitions
    */
-  registerLensAction("board", "workflowAnalysis", (ctx, artifact, params) => {
+  // Finite-number coercion helpers shared by the three analytics calculators.
+  // parseFloat("Infinity") / parseFloat("1e999") both yield a non-finite value
+  // that flows through `x || 0` (Infinity || 0 === Infinity) and JSON-serialises
+  // to null → blank in the UI. finNum/finInt force every numeric output FINITE.
+  const finNum = (v, dflt = 0) => {
+    const n = typeof v === "number" ? v : parseFloat(v);
+    return Number.isFinite(n) ? n : dflt;
+  };
+  const finInt = (v, dflt = 0) => Math.round(finNum(v, dflt));
+  const safeArr = (v) => (Array.isArray(v) ? v : []);
+
+  registerLensAction("board", "workflowAnalysis", (ctx, artifact, params = {}) => {
   try {
-    const cards = artifact.data.cards || [];
-    const columns = artifact.data.columns || [];
+    // Component-exact contract: the board page derives `cards`/`columns` from
+    // its live tasks and passes them as params (the persisted task artifact's
+    // .data has no cards/columns of its own). Fall back to artifact.data for any
+    // caller that pre-stamps the board snapshot onto the artifact.
+    const cards = safeArr(params.cards ?? artifact?.data?.cards);
+    const columns = safeArr(params.columns ?? artifact?.data?.columns);
 
     if (cards.length === 0) {
       return { ok: true, result: { message: "No cards provided for workflow analysis." } };
@@ -189,9 +204,9 @@ export default function registerBoardActions(registerLensAction) {
    * with urgency and risk adjustment.
    * artifact.data.cards: [{ id, title, businessValue: 1-10, timeCriticality: 1-10, riskReduction: 1-10, effort: 1-10, deadline? }]
    */
-  registerLensAction("board", "cardPrioritization", (ctx, artifact, params) => {
+  registerLensAction("board", "cardPrioritization", (ctx, artifact, params = {}) => {
   try {
-    const cards = artifact.data.cards || [];
+    const cards = safeArr(params.cards ?? artifact?.data?.cards);
     if (cards.length === 0) {
       return { ok: true, result: { message: "No cards provided for prioritization." } };
     }
@@ -241,7 +256,9 @@ export default function registerBoardActions(registerLensAction) {
         normalizedScore: Math.min(100, normalizedScore),
         deadline: card.deadline || null,
         daysUntilDeadline: card.deadline
-          ? Math.round((new Date(card.deadline) - now) / 86400000)
+          ? (Number.isFinite(new Date(card.deadline).getTime())
+              ? Math.round((new Date(card.deadline).getTime() - now.getTime()) / 86400000)
+              : null)
           : null,
       };
     });
@@ -308,22 +325,27 @@ export default function registerBoardActions(registerLensAction) {
    * params.simulations — number of Monte Carlo runs (default 1000)
    * params.sprintLengthDays — sprint duration in days (default 14)
    */
-  registerLensAction("board", "burndownForecast", (ctx, artifact, params) => {
+  registerLensAction("board", "burndownForecast", (ctx, artifact, params = {}) => {
   try {
-    const sprints = artifact.data.sprints || [];
-    const remainingPoints = parseFloat(artifact.data.remainingPoints) || 0;
-    const simulations = params.simulations || 1000;
-    const sprintLengthDays = params.sprintLengthDays || 14;
+    const sprints = safeArr(params.sprints ?? artifact?.data?.sprints);
+    // finNum: a poisoned remainingPoints ("Infinity"/"1e999") must NOT pass the
+    // > 0 gate and seed an infinite Monte-Carlo loop / non-finite output.
+    const remainingPoints = finNum(params.remainingPoints ?? artifact?.data?.remainingPoints, 0);
+    // Clamp the simulation knobs FINITE + bounded so a poisoned/huge value can't
+    // hang the loop. 1..50_000 sims, 1..365-day sprints.
+    const simulations = Math.max(1, Math.min(50000, finInt(params.simulations, 1000)));
+    const sprintLengthDays = Math.max(1, Math.min(365, finInt(params.sprintLengthDays, 14)));
 
     if (sprints.length === 0) {
       return { ok: true, result: { message: "No sprint history provided for forecasting." } };
     }
-    if (remainingPoints <= 0) {
+    if (!(remainingPoints > 0)) {
       return { ok: true, result: { message: "No remaining points to forecast.", completionDate: new Date().toISOString() } };
     }
 
-    // Extract historical velocities
-    const velocities = sprints.map(s => parseFloat(s.completedPoints) || 0).filter(v => v > 0);
+    // Extract historical velocities — finNum so "1e999"/Infinity do not survive
+    // the > 0 filter and poison avgVelocity / stdDev downstream.
+    const velocities = sprints.map(s => finNum(s.completedPoints, 0)).filter(v => v > 0);
     if (velocities.length === 0) {
       return { ok: true, result: { message: "No positive velocity data in sprint history." } };
     }

--- a/server/domains/consulting.js
+++ b/server/domains/consulting.js
@@ -1,20 +1,41 @@
 // server/domains/consulting.js
 export default function registerConsultingActions(registerLensAction) {
+  // Fail-CLOSED numeric coercion for the pure-compute money macros below.
+  // `parseFloat("1e999")`/`parseFloat("Infinity")` both yield Infinity, and
+  // `Infinity || fallback` is Infinity — so the old `parseFloat(x) || d` pattern
+  // let a poisoned rate/hours flow straight into a fee/utilization total and emit
+  // a money field rendering Infinity/NaN. `finPos` collapses any non-finite (or
+  // negative) value to the supplied finite default, guaranteeing FINITE output.
+  // SANE_MAX caps a single finite-but-absurd input (e.g. 1e308 from the assassin)
+  // so the PRODUCT of rate × hours can never overflow to Infinity. 1e12 is far
+  // above any real consulting rate/hour, so realistic values pass untouched.
+  const SANE_MAX = 1e12;
+  const finPos = (v, fallback = 0) => {
+    const n = typeof v === "number" ? v : parseFloat(v);
+    if (!Number.isFinite(n) || n < 0) return fallback;
+    return Math.min(n, SANE_MAX);
+  };
+  // Finite signed coercion (NPS spans -100..+100), clamped to a sane band.
+  const finSigned = (v, lo, hi, fallback = 0) => {
+    const n = typeof v === "number" ? v : parseFloat(v);
+    return Number.isFinite(n) ? Math.max(lo, Math.min(hi, n)) : fallback;
+  };
   registerLensAction("consulting", "engagementScope", (ctx, artifact, _params) => {
     const data = artifact.data || {};
-    const deliverables = data.deliverables || [];
-    const rate = parseFloat(data.hourlyRate) || 200;
-    const hours = deliverables.reduce((s, d) => s + (parseFloat(d.hours) || 8), 0);
+    const deliverables = Array.isArray(data.deliverables) ? data.deliverables : [];
+    const rate = finPos(data.hourlyRate, 200) || 200;
+    const hours = deliverables.reduce((s, d) => s + (finPos(d && d.hours, 8) || 8), 0);
     const totalFee = Math.round(hours * rate * 100) / 100;
     const contingency = Math.round(totalFee * 0.15 * 100) / 100;
-    return { ok: true, result: { client: data.client || artifact.title, deliverables: deliverables.map(d => ({ name: d.name, hours: parseFloat(d.hours) || 8, fee: Math.round((parseFloat(d.hours) || 8) * rate * 100) / 100 })), totalHours: hours, hourlyRate: rate, subtotal: totalFee, contingency, grandTotal: Math.round((totalFee + contingency) * 100) / 100, timeline: `${Math.ceil(hours / 40)} weeks at full-time` } };
+    return { ok: true, result: { client: data.client || artifact.title, deliverables: deliverables.map(d => { const h = finPos(d && d.hours, 8) || 8; return { name: d && d.name, hours: h, fee: Math.round(h * rate * 100) / 100 }; }), totalHours: hours, hourlyRate: rate, subtotal: totalFee, contingency, grandTotal: Math.round((totalFee + contingency) * 100) / 100, timeline: `${Math.ceil(hours / 40)} weeks at full-time` } };
   });
   registerLensAction("consulting", "utilizationRate", (ctx, artifact, _params) => {
     const data = artifact.data || {};
-    const billableHours = parseFloat(data.billableHours) || 0;
-    const totalHours = parseFloat(data.totalHours) || 40;
+    const billableHours = finPos(data.billableHours, 0);
+    const totalHours = finPos(data.totalHours, 40) || 40; // guard divide-by-zero
     const rate = billableHours / totalHours;
-    return { ok: true, result: { billableHours, totalHours, utilizationRate: Math.round(rate * 100), target: 75, variance: Math.round(rate * 100) - 75, status: rate >= 0.8 ? "excellent" : rate >= 0.65 ? "on-target" : rate >= 0.5 ? "below-target" : "critical" } };
+    const ratePct = Math.round(rate * 100);
+    return { ok: true, result: { billableHours, totalHours, utilizationRate: ratePct, target: 75, variance: ratePct - 75, status: rate >= 0.8 ? "excellent" : rate >= 0.65 ? "on-target" : rate >= 0.5 ? "below-target" : "critical" } };
   });
   registerLensAction("consulting", "proposalScore", (ctx, artifact, _params) => {
     const data = artifact.data || {};
@@ -25,10 +46,10 @@ export default function registerConsultingActions(registerLensAction) {
   });
   registerLensAction("consulting", "clientHealth", (ctx, artifact, _params) => {
     const data = artifact.data || {};
-    const nps = parseInt(data.nps) || 0;
-    const invoicesPaid = parseInt(data.invoicesPaid) || 0;
-    const invoicesTotal = parseInt(data.invoicesTotal) || 1;
-    const responseTime = parseFloat(data.avgResponseDays) || 3;
+    const nps = finSigned(data.nps, -100, 100, 0);
+    const invoicesPaid = finPos(data.invoicesPaid, 0);
+    const invoicesTotal = finPos(data.invoicesTotal, 1) || 1; // guard divide-by-zero
+    const responseTime = finPos(data.avgResponseDays, 3);
     const paymentRate = Math.round((invoicesPaid / invoicesTotal) * 100);
     const health = Math.round((Math.min(nps + 100, 200) / 200 * 30 + paymentRate / 100 * 40 + Math.max(0, 1 - responseTime / 14) * 30));
     return { ok: true, result: { client: data.client || artifact.title, nps, paymentRate, avgResponseDays: responseTime, healthScore: health, risk: health >= 70 ? "low" : health >= 40 ? "medium" : "high" } };

--- a/server/domains/council.js
+++ b/server/domains/council.js
@@ -18,8 +18,10 @@ function _voiceScoreFromLens(proposalText, lens) {
 
 export default function registerCouncilActions(registerLensAction) {
   registerLensAction("council", "deliberate", (ctx, artifact, _params) => {
-    const proposal = artifact.data?.proposal || artifact.data?.description || "";
-    const voices = artifact.data?.voices || [];
+    // String()-coerce at the read site: a poisoned non-string proposal (number,
+    // Infinity-ish) must not reach proposal.slice(...) and throw uncaught.
+    const proposal = String(artifact.data?.proposal ?? artifact.data?.description ?? "");
+    const voices = Array.isArray(artifact.data?.voices) ? artifact.data.voices : [];
     if (!proposal) return { ok: true, result: { message: "Submit a proposal for council deliberation." } };
     const perspectives = [
       { voice: "Pragmatist", weight: 0.3, lens: "feasibility and resource cost" },
@@ -36,24 +38,32 @@ export default function registerCouncilActions(registerLensAction) {
     return { ok: true, result: { proposal: proposal.slice(0, 200), evaluations, weightedScore, recommendation: weightedScore >= 60 ? "Proceed" : weightedScore >= 40 ? "Revise and resubmit" : "Reject", consensus: evaluations.every(e => e.position === "support") ? "unanimous" : evaluations.filter(e => e.position === "support").length > evaluations.length / 2 ? "majority" : "no-consensus" } };
   });
   registerLensAction("council", "voteCount", (ctx, artifact, _params) => {
-    const votes = artifact.data?.votes || [];
+    const votes = Array.isArray(artifact.data?.votes) ? artifact.data.votes : [];
     const tally = { for: 0, against: 0, abstain: 0 };
-    for (const v of votes) { const pos = (v.vote || v.position || "abstain").toLowerCase(); if (pos === "for" || pos === "yes" || pos === "support") tally.for++; else if (pos === "against" || pos === "no" || pos === "oppose") tally.against++; else tally.abstain++; }
+    // String()-coerce the vote value: a poisoned non-string vote (number) must
+    // not reach .toLowerCase() and throw uncaught.
+    for (const v of votes) { const pos = String((v && (v.vote ?? v.position)) ?? "abstain").toLowerCase(); if (pos === "for" || pos === "yes" || pos === "support") tally.for++; else if (pos === "against" || pos === "no" || pos === "oppose") tally.against++; else tally.abstain++; }
     const total = votes.length;
     const forPercent = total > 0 ? Math.round((tally.for / total) * 100) : 0;
     return { ok: true, result: { tally, total, forPercent, passed: forPercent >= 67, passThreshold: "67% supermajority", quorumMet: total >= (parseInt(artifact.data?.quorum) || 3) } };
   });
   registerLensAction("council", "generateMinutes", (ctx, artifact, _params) => {
     const data = artifact.data || {};
-    const agenda = data.agenda || [];
-    const attendees = data.attendees || [];
-    const decisions = data.decisions || [];
-    return { ok: true, result: { title: data.title || "Council Meeting Minutes", date: data.date || new Date().toISOString().split("T")[0], attendees: attendees.length, agendaItems: agenda.map((a, i) => ({ item: i + 1, topic: a.topic || a, status: a.status || "discussed" })), decisions: decisions.map(d => ({ decision: d.text || d, votedBy: d.votedBy || "council", passed: d.passed !== false })), actionItems: (data.actionItems || []).map(a => ({ task: a.task || a, assignee: a.assignee || "unassigned", dueDate: a.dueDate || "TBD" })) } };
+    // Array-guard list inputs (a poisoned non-array string must not reach .map()
+    // and throw uncaught) and String()-coerce title/date so the RETURN shape is
+    // stable regardless of input poisoning.
+    const agenda = Array.isArray(data.agenda) ? data.agenda : [];
+    const attendees = Array.isArray(data.attendees) ? data.attendees : [];
+    const decisions = Array.isArray(data.decisions) ? data.decisions : [];
+    const actionItems = Array.isArray(data.actionItems) ? data.actionItems : [];
+    return { ok: true, result: { title: String(data.title || "Council Meeting Minutes"), date: String(data.date || new Date().toISOString().split("T")[0]), attendees: attendees.length, agendaItems: agenda.map((a, i) => ({ item: i + 1, topic: (a && a.topic) || a, status: (a && a.status) || "discussed" })), decisions: decisions.map(d => ({ decision: (d && d.text) || d, votedBy: (d && d.votedBy) || "council", passed: !d || d.passed !== false })), actionItems: actionItems.map(a => ({ task: (a && a.task) || a, assignee: (a && a.assignee) || "unassigned", dueDate: (a && a.dueDate) || "TBD" })) } };
   });
   registerLensAction("council", "conflictResolution", (ctx, artifact, _params) => {
-    const parties = artifact.data?.parties || [];
-    const issue = artifact.data?.issue || artifact.data?.description || "";
-    const positions = parties.map(p => ({ party: p.name || p, position: p.position || "unstated", priority: p.priority || "medium" }));
+    // Array-guard parties + String()-coerce issue so poisoned input degrades
+    // instead of throwing on parties.map() / issue.slice().
+    const parties = Array.isArray(artifact.data?.parties) ? artifact.data.parties : [];
+    const issue = String(artifact.data?.issue ?? artifact.data?.description ?? "");
+    const positions = parties.map(p => ({ party: (p && p.name) || p, position: (p && p.position) || "unstated", priority: (p && p.priority) || "medium" }));
     const commonGround = positions.filter(p => p.priority === "high").length > positions.length / 2 ? "shared-urgency" : "divergent-priorities";
     return { ok: true, result: { issue: issue.slice(0, 200), parties: positions, commonGround, suggestedApproach: commonGround === "shared-urgency" ? "Mediated negotiation — both sides want resolution" : "Structured dialogue — find common interests first", steps: ["Identify shared interests", "Map each party's needs vs wants", "Generate options that satisfy core needs", "Evaluate options against criteria", "Build agreement incrementally"] } };
   });

--- a/server/domains/debate.js
+++ b/server/domains/debate.js
@@ -1,11 +1,44 @@
 // server/domains/debate.js
 export default function registerDebateActions(registerLensAction) {
-  registerLensAction("debate", "evaluateArgument", (ctx, artifact, _params) => {
-    const data = artifact.data || {};
-    const claim = data.claim || data.thesis || "";
-    const evidence = data.evidence || [];
-    const reasoning = data.reasoning || "";
-    if (!claim) return { ok: true, result: { message: "State a claim to evaluate the argument." } };
+  // ─── Shared helpers ─────────────────────────────────────────────────────
+  // The AI-analysis actions are reached from TWO surfaces:
+  //   1. page.tsx "AI Analysis Actions" → /api/lens/:domain/:id/run with
+  //      {action} and NO params → handler(ctx, artifact, {}). artifact.data is
+  //      the live debate created via useLensData (shape:
+  //      {topic, proArguments[], conArguments[], proVotes, conVotes, ...}).
+  //   2. DebateActionPanel → same route WITH {action, params} → the params land
+  //      as the 3rd arg. params carry {text} / {side,arguments} for the chosen
+  //      argument(s).
+  // Both surfaces must produce a live result, so every handler honors explicit
+  // params FIRST, then falls back to deriving its input from the real debate
+  // artifact shape. Nothing is fabricated — derivations only read fields the
+  // debate genuinely carries.
+  const asArray = (v) => (Array.isArray(v) ? v : []);
+  const argText = (a) => (a && typeof a === "object" ? String(a.text ?? a.claim ?? a.point ?? "") : typeof a === "string" ? a : "");
+  // Collapse a debate artifact's pro/con argument lists into a single text blob
+  // for fallacy/claim analysis, preferring an explicit side when given.
+  function debateText(data, params) {
+    if (params && typeof params.text === "string" && params.text.trim()) return params.text;
+    if (params && typeof params.argument === "string" && params.argument.trim()) return params.argument;
+    const d = data || {};
+    if (typeof d.text === "string" && d.text.trim()) return d.text;
+    if (typeof d.argument === "string" && d.argument.trim()) return d.argument;
+    const pro = asArray(d.proArguments).map(argText);
+    const con = asArray(d.conArguments).map(argText);
+    return [...pro, ...con].filter(Boolean).join(". ");
+  }
+
+  registerLensAction("debate", "evaluateArgument", (ctx, artifact, params = {}) => {
+   try {
+    const data = artifact?.data || {};
+    const p = params || {};
+    const claimRaw = p.claim ?? p.text ?? data.claim ?? data.thesis ?? data.topic
+      ?? argText(asArray(data.proArguments)[0]) ?? argText(asArray(data.conArguments)[0]) ?? "";
+    const claim = typeof claimRaw === "string" ? claimRaw : (claimRaw == null ? "" : String(claimRaw));
+    const evidence = asArray(p.evidence ?? data.evidence);
+    const reasoningRaw = p.reasoning ?? data.reasoning ?? debateText(data, p) ?? "";
+    const reasoning = typeof reasoningRaw === "string" ? reasoningRaw : String(reasoningRaw || "");
+    if (!claim.trim()) return { ok: true, result: { message: "State a claim to evaluate the argument." } };
     const evidenceScore = Math.min(100, evidence.length * 20);
     const reasoningScore = reasoning.length > 200 ? 80 : reasoning.length > 50 ? 50 : reasoning.length > 0 ? 25 : 0;
     const hasCounterpoint = !!(data.counterpoint || data.rebuttal);
@@ -16,11 +49,29 @@ export default function registerDebateActions(registerLensAction) {
     if (lowerClaim.includes("always") || lowerClaim.includes("never")) fallacies.push("Overgeneralization");
     if (lowerClaim.match(/if .* then .* therefore/)) fallacies.push("Possible slippery slope");
     return { ok: true, result: { claim: claim.slice(0, 200), evidenceCount: evidence.length, evidenceScore, reasoningScore, addressesCounterpoints: hasCounterpoint, overallScore, fallaciesDetected: fallacies, strength: overallScore >= 70 ? "strong" : overallScore >= 40 ? "moderate" : "weak" } };
+   } catch (e) { return { ok: false, error: "handler_error", message: String(e?.message || e) }; }
   });
-  registerLensAction("debate", "steelmanPosition", (ctx, artifact, _params) => {
-    const position = artifact.data?.position || artifact.data?.argument || "";
+  registerLensAction("debate", "steelmanPosition", (ctx, artifact, params = {}) => {
+   try {
+    const data = artifact?.data || {};
+    const p = params || {};
+    const side = p.side === "con" ? "con" : p.side === "pro" ? "pro" : null;
+    // Explicit position string > explicit arguments[] > the chosen-side args from
+    // the live debate > whichever side has arguments.
+    let position = "";
+    if (typeof p.position === "string" && p.position.trim()) position = p.position;
+    else if (typeof p.argument === "string" && p.argument.trim()) position = p.argument;
+    else if (Array.isArray(p.arguments) && p.arguments.length) position = p.arguments.map(argText).filter(Boolean).join(". ");
+    else if (typeof data.position === "string" && data.position.trim()) position = data.position;
+    else if (typeof data.argument === "string" && data.argument.trim()) position = data.argument;
+    else {
+      const proTxt = asArray(data.proArguments).map(argText).filter(Boolean);
+      const conTxt = asArray(data.conArguments).map(argText).filter(Boolean);
+      const chosen = side === "con" ? conTxt : side === "pro" ? proTxt : (proTxt.length ? proTxt : conTxt);
+      position = chosen.join(". ");
+    }
     if (!position) return { ok: true, result: { message: "State a position to steelman." } };
-    const words = position.split(/\s+/);
+    const words = position.split(/\s+/).filter(Boolean);
     const strengthened = {
       originalLength: words.length,
       improvements: [
@@ -32,22 +83,43 @@ export default function registerDebateActions(registerLensAction) {
       ],
       framework: { premise: "If we grant the strongest interpretation...", evidence: "The best evidence shows...", conclusion: "Therefore, the most defensible version is..." },
     };
-    return { ok: true, result: { originalPosition: position.slice(0, 300), steelmanSteps: strengthened.improvements, framework: strengthened.framework, note: "Steelmanning means presenting the strongest possible version of an opponent's argument" } };
+    return { ok: true, result: { side: side || undefined, originalPosition: position.slice(0, 300), originalLength: words.length, steelmanSteps: strengthened.improvements, framework: strengthened.framework, note: "Steelmanning means presenting the strongest possible version of an opponent's argument" } };
+   } catch (e) { return { ok: false, error: "handler_error", message: String(e?.message || e) }; }
   });
-  registerLensAction("debate", "scoreDebate", (ctx, artifact, _params) => {
-    const sides = artifact.data?.sides || [];
+  registerLensAction("debate", "scoreDebate", (ctx, artifact, params = {}) => {
+   try {
+    const data = artifact?.data || {};
+    const p = params || {};
+    // Explicit {sides:[{name,arguments:[...]}]} > derive two sides from the live
+    // debate's proArguments / conArguments + proVotes / conVotes.
+    let sides = Array.isArray(p.sides) ? p.sides : Array.isArray(data.sides) ? data.sides : null;
+    if (!sides) {
+      const pro = asArray(data.proArguments);
+      const con = asArray(data.conArguments);
+      if (pro.length || con.length) {
+        sides = [
+          { name: "Pro", arguments: pro, votes: Number(data.proVotes) || 0 },
+          { name: "Con", arguments: con, votes: Number(data.conVotes) || 0 },
+        ];
+      } else {
+        sides = [];
+      }
+    }
     if (sides.length < 2) return { ok: true, result: { message: "Add at least 2 debate sides with arguments." } };
     const scored = sides.map(s => {
-      const args = s.arguments || [];
-      const evidenceCount = args.reduce((sum, a) => sum + ((a.evidence || []).length), 0);
-      const rebuttals = args.filter(a => a.rebuttal || a.counters).length;
-      const score = Math.round(args.length * 15 + evidenceCount * 10 + rebuttals * 20);
-      return { side: s.name || s.position, arguments: args.length, evidencePoints: evidenceCount, rebuttals, score, highlights: args.slice(0, 2).map(a => a.claim || a.point || "").filter(Boolean) };
+      const args = asArray(s.arguments);
+      const evidenceCount = args.reduce((sum, a) => sum + asArray(a && a.evidence).length, 0);
+      const rebuttals = args.filter(a => a && (a.rebuttal || a.counters)).length;
+      const votes = Number(s.votes) || 0;
+      const score = Math.round(args.length * 15 + evidenceCount * 10 + rebuttals * 20 + votes * 2);
+      return { side: s.name || s.position || "—", arguments: args.length, evidencePoints: evidenceCount, rebuttals, score, votes, highlights: args.slice(0, 2).map(argText).filter(Boolean) };
     }).sort((a, b) => b.score - a.score);
     return { ok: true, result: { sides: scored, winner: scored[0]?.side, margin: scored.length >= 2 ? scored[0].score - scored[1].score : 0, close: scored.length >= 2 && Math.abs(scored[0].score - scored[1].score) < 20 } };
+   } catch (e) { return { ok: false, error: "handler_error", message: String(e?.message || e) }; }
   });
-  registerLensAction("debate", "fallacyCheck", (ctx, artifact, _params) => {
-    const text = artifact.data?.text || artifact.data?.argument || "";
+  registerLensAction("debate", "fallacyCheck", (ctx, artifact, params = {}) => {
+   try {
+    const text = debateText(artifact?.data || {}, params || {});
     if (!text) return { ok: true, result: { message: "Provide text to check for logical fallacies." } };
     const lower = text.toLowerCase();
     const checks = [
@@ -62,6 +134,7 @@ export default function registerDebateActions(registerLensAction) {
     ];
     const detected = checks.filter(c => c.pattern.test(text)).map(c => ({ fallacy: c.name, description: c.desc }));
     return { ok: true, result: { textLength: text.length, fallaciesDetected: detected, count: detected.length, logicalSoundness: detected.length === 0 ? "appears-sound" : detected.length <= 2 ? "minor-issues" : "significant-issues" } };
+   } catch (e) { return { ok: false, error: "handler_error", message: String(e?.message || e) }; }
   });
 
   // ─── Kialo-shape argument-tree substrate (per-user, STATE-backed) ────

--- a/server/domains/eco.js
+++ b/server/domains/eco.js
@@ -89,8 +89,10 @@ export default function registerEcoActions(registerLensAction) {
 
     for (const activity of activities) {
       const key = `${activity.category}_${activity.type}`.toLowerCase().replace(/\s+/g, "_");
-      const factor = emissionFactors[key] || activity.emissionFactor || 0;
-      const quantity = activity.quantity || 0;
+      // Fail-CLOSED: a poisoned Infinity/NaN/1e999 factor or quantity must never
+      // leak into the totals. Coerce both to finite, non-negative numbers.
+      const factor = finiteNum(emissionFactors[key] ?? activity.emissionFactor, 0, { min: 0 });
+      const quantity = finiteNum(activity.quantity, 0, { min: 0 });
       const emissions = quantity * factor;
       const scope = activity.scope || inferScope(activity.category, activity.type);
 
@@ -126,8 +128,8 @@ export default function registerEcoActions(registerLensAction) {
     let totalOffsets = 0;
     const processedOffsets = offsets.map(o => {
       const key = `${o.type}_${o.unit}`.toLowerCase().replace(/\s+/g, "_");
-      const factor = offsetFactors[key] || o.offsetFactor || 0;
-      const offsetAmount = (o.quantity || 0) * factor;
+      const factor = finiteNum(offsetFactors[key] ?? o.offsetFactor, 0, { min: 0 });
+      const offsetAmount = finiteNum(o.quantity, 0, { min: 0 }) * factor;
       totalOffsets += offsetAmount;
       return {
         type: o.type,
@@ -193,10 +195,15 @@ export default function registerEcoActions(registerLensAction) {
     if (Array.isArray(artifact.data?.observations)) {
       for (const obs of artifact.data.observations) {
         const name = obs.species || obs.name || "unknown";
-        speciesCounts[name] = (speciesCounts[name] || 0) + (obs.count || 1);
+        // Fail-CLOSED: a poisoned Infinity/NaN/1e999 count is clamped to a
+        // finite, non-negative integer so the diversity indices never go NaN.
+        const c = finiteNum(obs.count, 1, { min: 0, integer: true });
+        speciesCounts[name] = (speciesCounts[name] || 0) + c;
       }
     } else if (artifact.data?.species) {
-      speciesCounts = { ...artifact.data.species };
+      for (const [k, v] of Object.entries(artifact.data.species)) {
+        speciesCounts[k] = finiteNum(v, 0, { min: 0, integer: true });
+      }
     } else {
       return { ok: true, result: { message: "No species data provided." } };
     }
@@ -597,16 +604,10 @@ export default function registerEcoActions(registerLensAction) {
         },
       };
     } catch (e) {
-      const fallback = 42;
-      return {
-        ok: true,
-        result: {
-          aqi: fallback, pm25: 8, pm10: 14, o3: 60, no2: 12, co: 0.4, so2: 2,
-          category: 'good', recommendation: "Air quality good (fallback estimate).",
-          source: `fallback (${e?.message || 'network unavailable'})`,
-          lat, lng,
-        },
-      };
+      // Per "everything must be real": Open-Meteo is the real source; a network
+      // failure surfaces honestly rather than fabricating a plausible AQI. The
+      // AQIPanel renders this as an error, not a silent fake reading.
+      return { ok: false, error: `Open-Meteo air-quality unreachable: ${e instanceof Error ? e.message : String(e)}` };
     }
   });
 
@@ -710,11 +711,13 @@ If unsure, fall back to coarser ranks. Always include at least one suggestion ev
    */
   registerLensAction("eco", "energy-estimate", (_ctx, _artifact, params = {}) => {
   try {
-    const lat = Number(params.lat) || 0;
-    const lng = Number(params.lng) || 0;
-    const systemKw = Math.max(0.1, Number(params.systemKw) || 5);
-    const tilt = Math.min(89, Math.max(0, Number(params.tilt) || 30));
-    const azimuth = params.azimuth != null ? Number(params.azimuth) : 180;
+    // Fail-CLOSED: every numeric is coerced to a finite value within physical
+    // bounds, so a poisoned Infinity/NaN/1e999 never leaks into the kWh totals.
+    const lat = finiteNum(params.lat, 0, { min: -90, max: 90 });
+    const lng = finiteNum(params.lng, 0, { min: -180, max: 180 });
+    const systemKw = finiteNum(params.systemKw, 5, { min: 0.1, max: 1e6 });
+    const tilt = finiteNum(params.tilt, 30, { min: 0, max: 89 });
+    const azimuth = params.azimuth != null ? finiteNum(params.azimuth, 180, { min: 0, max: 360 }) : 180;
 
     // Baseline daily insolation (kWh/m²/day) — NREL average for the US is
     // ~4.5; we modulate by absolute latitude (higher = lower) and seasonal
@@ -1320,6 +1323,20 @@ function categoriseAqi(aqi) {
 }
 
 function clamp01(n) { return Math.max(0, Math.min(1, n)); }
+
+// finiteNum — the fail-CLOSED numeric coercion every eco calc routes user
+// numbers through. parseFloat/Number admit Infinity (from "1e999") and NaN
+// (from "not-a-number") silently; this rejects both, falls back to `fallback`,
+// then clamps into [min, max]. With `integer:true` the result is floored.
+// Guarantees a finite return for ALL inputs so no calc can leak Infinity/NaN.
+function finiteNum(v, fallback = 0, { min = -Infinity, max = Infinity, integer = false } = {}) {
+  let n = typeof v === "number" ? v : Number(v);
+  if (!Number.isFinite(n)) n = fallback;
+  if (n < min) n = min;
+  if (n > max) n = max;
+  if (integer) n = Math.floor(n);
+  return n;
+}
 
 function extractJson(text) {
   if (!text) return null;

--- a/server/domains/energy.js
+++ b/server/domains/energy.js
@@ -7,22 +7,42 @@
 
 const EIA_BASE = "https://api.eia.gov/v2";
 
+// Fail-CLOSED numeric parse: returns a FINITE number or the fallback. Unlike
+// `parseFloat(x) || d`, this never lets Infinity / -Infinity / NaN through
+// (parseFloat("1e999") === Infinity, parseFloat("Infinity") === Infinity, and
+// `Infinity || d` keeps Infinity because it is truthy), which would otherwise
+// cascade into the output and serialize to JSON `null` — a blank calculator in
+// production. Optional [min,max] clamp keeps physically-meaningful bounds.
+function finiteNum(v, fallback = 0, min, max) {
+  const n = typeof v === "number" ? v : parseFloat(v);
+  if (!Number.isFinite(n)) return fallback;
+  let out = n;
+  if (typeof min === "number" && out < min) out = min;
+  if (typeof max === "number" && out > max) out = max;
+  return out;
+}
+
 export default function registerEnergyActions(registerLensAction) {
   registerLensAction("energy", "consumptionAnalysis", (ctx, artifact, _params) => {
-    const readings = artifact.data?.readings || [];
+    const readings = Array.isArray(artifact.data?.readings) ? artifact.data.readings : [];
     if (readings.length === 0) return { ok: true, result: { message: "Add energy readings (kWh) to analyze consumption." } };
-    const values = readings.map(r => parseFloat(r.kWh || r.value) || 0);
+    // Clamp each reading to a finite, non-negative kWh. Poisoned entries
+    // (Infinity / NaN / "1e999") collapse to 0 rather than corrupting the sum.
+    const values = readings.map((r) => finiteNum(r?.kWh ?? r?.value, 0, 0));
     const total = values.reduce((s, v) => s + v, 0);
-    const avg = total / values.length;
-    const peak = Math.max(...values);
-    const costPerKWh = parseFloat(artifact.data?.costPerKWh) || 0.12;
-    return { ok: true, result: { totalKWh: Math.round(total * 10) / 10, avgKWh: Math.round(avg * 10) / 10, peakKWh: Math.round(peak * 10) / 10, readingCount: values.length, estimatedCost: Math.round(total * costPerKWh * 100) / 100, costPerKWh, peakToAvgRatio: Math.round((peak / avg) * 100) / 100, savingsOpportunity: peak > avg * 2 ? "Significant peak reduction possible" : "Consumption is relatively stable" } };
+    const avg = values.length > 0 ? total / values.length : 0;
+    const peak = values.length > 0 ? Math.max(...values) : 0;
+    const costPerKWh = finiteNum(artifact.data?.costPerKWh, 0.12, 0);
+    const peakToAvgRatio = avg > 0 ? Math.round((peak / avg) * 100) / 100 : 0;
+    return { ok: true, result: { totalKWh: Math.round(total * 10) / 10, avgKWh: Math.round(avg * 10) / 10, peakKWh: Math.round(peak * 10) / 10, readingCount: values.length, estimatedCost: Math.round(total * costPerKWh * 100) / 100, costPerKWh, peakToAvgRatio, savingsOpportunity: peak > avg * 2 ? "Significant peak reduction possible" : "Consumption is relatively stable" } };
   });
   registerLensAction("energy", "solarEstimate", (ctx, artifact, _params) => {
     const data = artifact.data || {};
-    const roofSqFt = parseFloat(data.roofAreaSqFt) || 1000;
-    const sunHours = parseFloat(data.peakSunHours) || 5;
-    const usageKWh = parseFloat(data.monthlyUsageKWh) || 900;
+    // Clamp to physically-sane bounds so a poisoned ("1e999"/"Infinity") or
+    // absurd input never cascades into Infinity panels/cost/payback.
+    const roofSqFt = finiteNum(data.roofAreaSqFt, 1000, 100, 1_000_000);
+    const sunHours = finiteNum(data.peakSunHours, 5, 0.1, 24);
+    const usageKWh = finiteNum(data.monthlyUsageKWh, 900, 1, 10_000_000);
     const panelWatts = 400;
     const panelSqFt = 18;
     const maxPanels = Math.floor(roofSqFt * 0.7 / panelSqFt);
@@ -36,10 +56,12 @@ export default function registerEnergyActions(registerLensAction) {
   });
   registerLensAction("energy", "carbonFootprint", (ctx, artifact, _params) => {
     const data = artifact.data || {};
-    const electricityKWh = parseFloat(data.electricityKWh) || 0;
-    const naturalGasTherms = parseFloat(data.naturalGasTherms) || 0;
-    const gasolineGallons = parseFloat(data.gasolineGallons) || 0;
-    const flightMiles = parseFloat(data.flightMiles) || 0;
+    // Fail-closed, non-negative finite inputs. Poison collapses to 0 so the
+    // CO2 totals stay finite (an Infinity here would render as null in the UI).
+    const electricityKWh = finiteNum(data.electricityKWh, 0, 0);
+    const naturalGasTherms = finiteNum(data.naturalGasTherms, 0, 0);
+    const gasolineGallons = finiteNum(data.gasolineGallons, 0, 0);
+    const flightMiles = finiteNum(data.flightMiles, 0, 0);
     // EPA emission factors
     const co2Electricity = electricityKWh * 0.000417; // metric tons per kWh
     const co2Gas = naturalGasTherms * 0.0053;
@@ -164,10 +186,12 @@ export default function registerEnergyActions(registerLensAction) {
 
   registerLensAction("energy", "gridStatus", (ctx, artifact, _params) => {
     const data = artifact.data || {};
-    const demandMW = parseFloat(data.currentDemandMW) || 0;
-    const capacityMW = parseFloat(data.totalCapacityMW) || 0;
-    const renewablePercent = parseFloat(data.renewablePercent) || 0;
-    const frequency = parseFloat(data.gridFrequencyHz) || 60;
+    // Fail-closed finite parse with sane bounds; these values are also echoed
+    // into output strings, so an unguarded Infinity would render "Infinity MW".
+    const demandMW = finiteNum(data.currentDemandMW, 0, 0, 100_000_000);
+    const capacityMW = finiteNum(data.totalCapacityMW, 0, 0, 100_000_000);
+    const renewablePercent = finiteNum(data.renewablePercent, 0, 0, 100);
+    const frequency = finiteNum(data.gridFrequencyHz, 60, 0, 1000);
     const utilization = capacityMW > 0 ? Math.round((demandMW / capacityMW) * 100) : 0;
     const frequencyDeviation = Math.abs(frequency - 60);
     return { ok: true, result: { currentDemand: `${demandMW} MW`, totalCapacity: `${capacityMW} MW`, utilization, renewableShare: `${renewablePercent}%`, gridFrequency: `${frequency} Hz`, frequencyStable: frequencyDeviation < 0.05, status: utilization > 90 ? "critical-load" : utilization > 75 ? "high-load" : utilization > 50 ? "normal" : "low-load", reserves: `${Math.round(capacityMW - demandMW)} MW available` } };

--- a/server/domains/ethics.js
+++ b/server/domains/ethics.js
@@ -400,6 +400,15 @@ export default function registerEthicsActions(registerLensAction) {
     return { pos, neg };
   }
 
+  // Coerce any value to a finite number, falling back to `dflt` for
+  // NaN/Infinity/-Infinity/"1e999"/"Infinity"/non-numeric. The scoring math
+  // below MUST never emit NaN/Infinity into a record — poisoned numeric input
+  // ("1e999", "Infinity", NaN) is a real attack surface for the lens.
+  function fnum(v, dflt = 0) {
+    const n = typeof v === "number" ? v : Number(v);
+    return Number.isFinite(n) ? n : dflt;
+  }
+
   /**
    * multiFrameworkDilemma — run a single dilemma + options through
    * utilitarian / deontological / virtue lenses side by side.
@@ -473,11 +482,11 @@ export default function registerEthicsActions(registerLensAction) {
     if (stakeholders.length === 0) return { ok: false, error: "at least one stakeholder required" };
 
     const rows = stakeholders.map((s) => {
-      const vuln = Math.max(0, Math.min(100, Number(s.vulnerability) || 0));
+      const vuln = Math.max(0, Math.min(100, fnum(s.vulnerability, 0)));
       const impacts = {};
       let totalWeighted = 0;
       for (const opt of options) {
-        const raw = Number(s.impacts?.[opt]) || 0;
+        const raw = fnum(s.impacts?.[opt], 0);
         const clamped = Math.max(-100, Math.min(100, raw));
         // Vulnerability amplifies negative impact.
         const weighted = clamped < 0 ? clamped * (1 + vuln / 100) : clamped;
@@ -536,15 +545,20 @@ export default function registerEthicsActions(registerLensAction) {
     if (criteria.length === 0) return { ok: false, error: "at least one criterion required" };
     if (options.length === 0) return { ok: false, error: "at least one option required" };
 
-    const weightSum = criteria.reduce((s, c) => s + (Number(c.weight) || 0), 0) || 1;
-    const normCriteria = criteria.map((c) => ({
-      name: c.name || "Criterion",
-      weight: (Number(c.weight) || 0) / weightSum,
+    // Clamp each weight to a finite, non-negative value BEFORE summing — a
+    // poisoned "1e999"/Infinity weight would otherwise make weightSum Infinity
+    // and every normalized weight NaN (Infinity/Infinity), leaking NaN/percent
+    // into the rendered record.
+    const rawWeights = criteria.map((c) => Math.max(0, fnum(c.weight, 0)));
+    const weightSum = rawWeights.reduce((s, w) => s + w, 0) || 1;
+    const normCriteria = criteria.map((c, i) => ({
+      name: typeof c.name === "string" && c.name.trim() ? c.name : "Criterion",
+      weight: rawWeights[i] / weightSum,
     }));
 
     const scored = options.map((o) => {
       const breakdown = normCriteria.map((c) => {
-        const raw = Math.max(0, Math.min(10, Number(o.scores?.[c.name]) || 0));
+        const raw = Math.max(0, Math.min(10, fnum(o.scores?.[c.name], 0)));
         return { criterion: c.name, raw, weighted: Math.round(raw * c.weight * 100) / 100 };
       });
       const total = Math.round(breakdown.reduce((s, b) => s + b.weighted, 0) * 100) / 100;

--- a/server/domains/fitness.js
+++ b/server/domains/fitness.js
@@ -1,20 +1,32 @@
 export default function registerFitnessActions(registerLensAction) {
+  // Fail-CLOSED numeric coercion for the legacy calc surfaces (progression /
+  // body-comp / periodization / class-utilization) which predate the `fnum`
+  // helper below and used `parseFloat(x) || 0` — a fail-OPEN pattern that lets
+  // Infinity ("1e999"/"Infinity") leak straight through into the output. A
+  // lying calorie / 1RM / progression number is a real safety harm, so every
+  // numeric input is coerced through `Number.isFinite` with a finite default
+  // and (optionally) clamped to a sane domain. NaN/Infinity NEVER reach output.
+  const ffnum = (v, d = 0) => { const n = Number(v); return Number.isFinite(n) ? n : d; };
+  const fclampN = (v, lo, hi, d = lo) => { const n = ffnum(v, d); return Math.max(lo, Math.min(hi, n)); };
+
   registerLensAction("fitness", "progressionCalc", (ctx, artifact, _params) => {
-    const exercises = artifact.data?.exercises || [];
+    const exercises = Array.isArray(artifact.data?.exercises) ? artifact.data.exercises : [];
     const recommendations = exercises.map(ex => {
-      const weight = ex.weight || 0;
-      const reps = ex.reps || 0;
-      const rpe = ex.rpe || 7;
+      // Weights/reps/RPE are clamped to physically-sane finite domains so a
+      // poisoned "1e999" weight can never produce an Infinity recommendation.
+      const weight = fclampN(ex?.weight, 0, 100000, 0);
+      const reps = fclampN(ex?.reps, 0, 1000, 0);
+      const rpe = ex?.rpe == null ? 7 : fclampN(ex?.rpe, 1, 10, 7);
       let increment = 0;
       if (rpe <= 6) increment = weight * 0.05;
       else if (rpe <= 7) increment = weight * 0.025;
       else if (rpe >= 9) increment = -weight * 0.05;
       return {
-        exercise: ex.name,
+        exercise: String(ex?.name ?? ''),
         currentWeight: weight,
         currentReps: reps,
         currentRPE: rpe,
-        recommendedWeight: Math.round((weight + increment) * 2) / 2,
+        recommendedWeight: Math.max(0, Math.round((weight + increment) * 2) / 2),
         recommendation: rpe <= 6 ? 'increase_weight' : rpe <= 8 ? 'maintain' : 'reduce_weight',
       };
     });
@@ -22,17 +34,18 @@ export default function registerFitnessActions(registerLensAction) {
   });
 
   registerLensAction("fitness", "classUtilization", (ctx, artifact, params) => {
-    const capacity = artifact.data?.capacity || 0;
-    const enrolled = artifact.data?.enrolled || 0;
-    const attendanceLog = artifact.data?.attendanceLog || [];
-    const period = params.period || 30;
+    const capacity = fclampN(artifact.data?.capacity, 0, 1000000, 0);
+    const enrolled = fclampN(artifact.data?.enrolled, 0, 1000000, 0);
+    const attendanceLog = Array.isArray(artifact.data?.attendanceLog) ? artifact.data.attendanceLog : [];
+    const period = fclampN(params?.period, 1, 3650, 30);
     const recentAttendance = attendanceLog.filter(a => {
-      const d = new Date(a.date);
+      const d = new Date(a?.date);
+      if (isNaN(d.getTime())) return false;
       const cutoff = new Date(); cutoff.setDate(cutoff.getDate() - period);
       return d >= cutoff;
     });
     const avgAttendance = recentAttendance.length > 0
-      ? Math.round(recentAttendance.reduce((s, a) => s + (a.count || 0), 0) / recentAttendance.length)
+      ? Math.round(recentAttendance.reduce((s, a) => s + fclampN(a?.count, 0, 1000000, 0), 0) / recentAttendance.length)
       : enrolled;
     const utilization = capacity > 0 ? Math.round((avgAttendance / capacity) * 100) : 0;
     return { ok: true, result: { className: artifact.title, capacity, enrolled, avgAttendance, utilization, period, sessions: recentAttendance.length } };
@@ -41,14 +54,17 @@ export default function registerFitnessActions(registerLensAction) {
   registerLensAction("fitness", "bodyCompReport", (ctx, artifact, _params) => {
   try {
     const data = artifact.data || {};
-    const weight = parseFloat(data.weight) || 0; // in lbs or kg
-    const height = parseFloat(data.height) || 0; // in inches or cm
-    const unit = data.unit || "imperial"; // "imperial" or "metric"
-    const age = parseInt(data.age, 10) || 30;
-    const sex = (data.sex || data.gender || "male").toLowerCase();
-    const waist = parseFloat(data.waist) || 0;
-    const neck = parseFloat(data.neck) || 0;
-    const hip = parseFloat(data.hip) || 0;
+    // Fail-CLOSED + clamped to physiological domains. parseFloat("1e999") is
+    // Infinity and `Infinity || 0` is Infinity, so the old `parseFloat||0` was
+    // fail-OPEN and would emit Infinity BMI / body-fat. ffnum + clamp closes it.
+    const weight = fclampN(data.weight, 0, 2000, 0); // lbs or kg
+    const height = fclampN(data.height, 0, 300, 0);   // inches or cm
+    const unit = data.unit === "metric" ? "metric" : "imperial";
+    const age = fclampN(data.age, 1, 120, 30);
+    const sex = String(data.sex || data.gender || "male").toLowerCase() === "female" ? "female" : "male";
+    const waist = fclampN(data.waist, 0, 500, 0);
+    const neck = fclampN(data.neck, 0, 500, 0);
+    const hip = fclampN(data.hip, 0, 500, 0);
 
     // Convert to metric for BMI
     let weightKg, heightCm;
@@ -81,12 +97,25 @@ export default function registerFitnessActions(registerLensAction) {
         neckCm = neck;
         hipCm = hip;
       }
+      // The Navy formula takes log10 of (waist−neck) / (waist+hip−neck); when
+      // waist ≤ neck (or the sum ≤ neck) that argument is ≤0 → NaN. Guard the
+      // circumference difference so a nonsensical measurement set degrades to
+      // "no estimate" rather than leaking NaN.
       if (sex === "male") {
-        bodyFatPct = 495 / (1.0324 - 0.19077 * Math.log10(waistCm - neckCm) + 0.15456 * Math.log10(heightCm)) - 450;
+        const wn = waistCm - neckCm;
+        if (wn > 0 && heightCm > 0) {
+          bodyFatPct = 495 / (1.0324 - 0.19077 * Math.log10(wn) + 0.15456 * Math.log10(heightCm)) - 450;
+        }
       } else if (hipCm > 0) {
-        bodyFatPct = 495 / (1.29579 - 0.35004 * Math.log10(waistCm + hipCm - neckCm) + 0.22100 * Math.log10(heightCm)) - 450;
+        const whn = waistCm + hipCm - neckCm;
+        if (whn > 0 && heightCm > 0) {
+          bodyFatPct = 495 / (1.29579 - 0.35004 * Math.log10(whn) + 0.22100 * Math.log10(heightCm)) - 450;
+        }
       }
-      if (bodyFatPct != null) bodyFatPct = Math.round(bodyFatPct * 10) / 10;
+      // Clamp to a finite physiological band; drop a non-finite/absurd result.
+      if (bodyFatPct != null) {
+        bodyFatPct = Number.isFinite(bodyFatPct) ? Math.round(fclampN(bodyFatPct, 1, 75, 1) * 10) / 10 : null;
+      }
     }
 
     const fatMass = bodyFatPct != null ? Math.round(weightKg * (bodyFatPct / 100) * 10) / 10 : null;
@@ -148,8 +177,10 @@ export default function registerFitnessActions(registerLensAction) {
   });
 
   registerLensAction("fitness", "periodization", (ctx, artifact, params) => {
-    const weeks = params.weeks || artifact.data?.weeks || 12;
-    const goal = params.goal || artifact.data?.goal || 'general_fitness';
+    // Clamp weeks to a finite, sane macrocycle length so a poisoned "1e999"
+    // can't produce Infinity phase durations.
+    const weeks = fclampN(params?.weeks ?? artifact.data?.weeks, 1, 104, 12);
+    const goal = params?.goal || artifact.data?.goal || 'general_fitness';
     const phases = [];
     if (goal === 'strength') {
       phases.push({ name: 'Hypertrophy', weeks: Math.ceil(weeks * 0.33), sets: '3-4', reps: '8-12', intensity: '65-75%' });
@@ -276,9 +307,36 @@ export default function registerFitnessActions(registerLensAction) {
     const N = Math.max(1, Math.min(90, Number(params.days) || 14));
     const all = state.recoveryEntries?.get(userId) || [];
     const cutoff = Date.now() - N * 86400000;
-    const days = all
-      .filter((d) => new Date(d.date).getTime() >= cutoff)
-      .sort((a, b) => a.date.localeCompare(b.date));
+    // Map each stored device row → the EXACT shape SleepRecovery.tsx renders
+    // (recoveryScore / sleepDurationHours / sleepQualityPct / restingHr / hrv /
+    // strainYesterday). The stored rows carry restingHr / hrv / sleepHours /
+    // recoveryScore (written by wearable-sync); the component reads
+    // sleepDurationHours / sleepQualityPct / strainYesterday, which never
+    // existed on the row → undefined.toFixed() crash in prod. We surface the
+    // real device fields under the rendered names and derive the rest ONLY from
+    // present real values (no fabrication; missing → 0, never invented). The
+    // raw row is preserved under `raw` for callers that want device-native keys.
+    const sorted = all
+      .filter((d) => d && !isNaN(new Date(d.date).getTime()) && new Date(d.date).getTime() >= cutoff)
+      .sort((a, b) => String(a.date).localeCompare(String(b.date)));
+    const days = sorted.map((d, i) => {
+      const sleepHours = fnum(d.sleepHours);
+      const prev = i > 0 ? sorted[i - 1] : null;
+      return {
+        date: d.date,
+        recoveryScore: Math.max(0, Math.min(100, Math.round(fnum(d.recoveryScore)))),
+        sleepDurationHours: Math.max(0, Math.round(sleepHours * 100) / 100),
+        // sleepQualityPct is reported by the device when present; otherwise it
+        // is left at 0 (honest "not reported"), never synthesised.
+        sleepQualityPct: Math.max(0, Math.min(100, Math.round(fnum(d.sleepQualityPct)))),
+        restingHr: Math.max(0, Math.round(fnum(d.restingHr))),
+        hrv: Math.max(0, Math.round(fnum(d.hrv) * 10) / 10),
+        // strain "yesterday" is the prior day's reported strain, if the device
+        // pushed one; 0 when there is no prior reading.
+        strainYesterday: prev ? Math.max(0, Math.min(21, Math.round(fnum(prev.strain ?? prev.strainYesterday) * 10) / 10)) : 0,
+        raw: d,
+      };
+    });
     return {
       ok: true,
       result: {
@@ -303,9 +361,32 @@ export default function registerFitnessActions(registerLensAction) {
     const N = Math.max(1, Math.min(30, Number(params.days) || 7));
     const all = state.activityEntries?.get(userId) || [];
     const cutoff = Date.now() - N * 86400000;
+    // Apple-Fitness ring goals. Standard targets; the device can override any
+    // of them per-row (moveGoal/exerciseGoal/standGoal/stepsGoal). These are
+    // GOALS (a fixed target), not fabricated metric data — the actual progress
+    // values below come only from real stored device readings.
+    const DEFAULT_MOVE_GOAL = 600, DEFAULT_EXERCISE_GOAL = 30, DEFAULT_STAND_GOAL = 12, DEFAULT_STEPS_GOAL = 10000;
+    // Map each stored device row → the EXACT shape ActivityRings.tsx renders.
+    // The stored row carries steps / activeCalories / exerciseMinutes (written
+    // by wearable-sync); the component reads moveCalories / standHours and four
+    // *Goal fields that never existed → undefined.toLocaleString() crash + NaN
+    // ring widths in prod. We surface real values under the rendered names and
+    // default the goals; missing real metrics → 0 (honest), never invented.
     const days = all
-      .filter((d) => new Date(d.date).getTime() >= cutoff)
-      .sort((a, b) => a.date.localeCompare(b.date));
+      .filter((d) => d && !isNaN(new Date(d.date).getTime()) && new Date(d.date).getTime() >= cutoff)
+      .sort((a, b) => String(a.date).localeCompare(String(b.date)))
+      .map((d) => ({
+        date: d.date,
+        moveCalories: Math.max(0, Math.round(fnum(d.moveCalories ?? d.activeCalories))),
+        moveGoal: Math.max(1, Math.round(fnum(d.moveGoal, DEFAULT_MOVE_GOAL))),
+        exerciseMinutes: Math.max(0, Math.round(fnum(d.exerciseMinutes))),
+        exerciseGoal: Math.max(1, Math.round(fnum(d.exerciseGoal, DEFAULT_EXERCISE_GOAL))),
+        standHours: Math.max(0, Math.round(fnum(d.standHours))),
+        standGoal: Math.max(1, Math.round(fnum(d.standGoal, DEFAULT_STAND_GOAL))),
+        steps: Math.max(0, Math.round(fnum(d.steps))),
+        stepsGoal: Math.max(1, Math.round(fnum(d.stepsGoal, DEFAULT_STEPS_GOAL))),
+        raw: d,
+      }));
     return {
       ok: true,
       result: {

--- a/server/domains/forestry.js
+++ b/server/domains/forestry.js
@@ -8,48 +8,178 @@
 const INCIWEB_BASE = "https://inciweb.wildfire.gov/api/v1";
 const NIFC_FIRE_API = "https://services3.arcgis.com/T4QMspbfLg3qTGWY/arcgis/rest/services";
 
+// Fail-closed finite coercion: parseFloat/Number admit Infinity & NaN silently,
+// which would poison every downstream board-feet / risk / carbon number and
+// render blank (NaN) or impossible (Infinity) tiles in the workbench. Coerce to
+// a finite number, falling back to `fallback` for anything non-finite.
+function frFinite(v, fallback = 0) {
+  if (typeof v === "number") return Number.isFinite(v) ? v : fallback;
+  if (v == null || v === "") return fallback;
+  const n = Number(String(v).trim());
+  return Number.isFinite(n) ? n : fallback;
+}
+// Per-species board-foot density factor (≈ taper/form relative to a generic
+// mixed stand at 1.0) so timberVolume reflects the chosen species, not just a
+// flat formula. Conifers yield more usable sawtimber per cubic foot than the
+// hardwoods at the same age/acre.
+const VOLUME_SPECIES_FACTOR = {
+  "douglas-fir": 1.25, douglas_fir: 1.25,
+  "ponderosa-pine": 1.1, ponderosa_pine: 1.1,
+  "loblolly-pine": 1.15, loblolly_pine: 1.15,
+  redwood: 1.4, hemlock: 1.05, cedar: 1.0, spruce: 1.1,
+  oak: 0.85, maple: 0.8, aspen: 0.7, mixed: 1.0, other: 0.9,
+};
+
 export default function registerForestryActions(registerLensAction) {
-  registerLensAction("forestry", "timberVolume", (ctx, artifact, _params) => {
-    const trees = artifact.data?.trees || [];
-    if (trees.length === 0) return { ok: true, result: { message: "Add tree measurements (DBH, height) to estimate timber volume." } };
-    const estimated = trees.map(t => { const dbh = parseFloat(t.dbhInches || t.diameter) || 12; const height = parseFloat(t.heightFeet || t.height) || 60; const species = t.species || "mixed"; const bf = 0.00545415 * Math.pow(dbh, 2) * height * 0.5; return { species, dbhInches: dbh, heightFeet: height, boardFeet: Math.round(bf), logs: Math.floor(height / 16) }; });
-    const totalBF = estimated.reduce((s, t) => s + t.boardFeet, 0);
-    const pricePerMBF = parseFloat(artifact.data?.pricePerMBF) || 400;
-    return { ok: true, result: { trees: estimated, totalTrees: trees.length, totalBoardFeet: totalBF, totalMBF: Math.round(totalBF / 1000 * 10) / 10, estimatedValue: Math.round(totalBF / 1000 * pricePerMBF), avgBFPerTree: Math.round(totalBF / trees.length), pricePerMBF } };
+  // timberVolume — the ForestryActionPanel sends { species, acres, avgAgeYears,
+  // treeCount } (NOT a `trees` array). Estimate per-tree board feet from a
+  // species×age yield model, scale by tree count, and return the fields the
+  // panel renders: boardFeet, cubicFeet, valuation. Fail-closed on poison input.
+  registerLensAction("forestry", "timberVolume", (ctx, artifact, params = {}) => {
+    try {
+      const src = (params && Object.keys(params).length ? params : artifact?.data) || {};
+      const species = String(src.species || "mixed");
+      const acres = Math.max(0, frFinite(src.acres, 0));
+      const ageYears = Math.max(0, frFinite(src.avgAgeYears ?? src.ageYears, 0));
+      const treeCount = Math.max(0, Math.round(frFinite(src.treeCount, 0)));
+      if (treeCount <= 0 || acres <= 0) {
+        return { ok: true, result: { message: "Enter species + acres + average age + tree count to estimate timber volume." } };
+      }
+      const factor = VOLUME_SPECIES_FACTOR[species] ?? 1.0;
+      // Mean board feet per tree rises with stand age toward a ~mature plateau.
+      // (deterministic, monotone, finite for any finite age)
+      const ageMaturity = 1 - Math.exp(-ageYears / 35); // 0..~1
+      const bfPerTree = Math.round(220 * factor * (0.15 + 0.85 * ageMaturity));
+      const boardFeet = Math.round(bfPerTree * treeCount);
+      const cubicFeet = Math.round(boardFeet / 6); // ≈6 bf per cubic foot (Int'l ¼")
+      const pricePerMBF = Math.max(0, frFinite(src.pricePerMBF, 400));
+      const valuation = Math.round((boardFeet / 1000) * pricePerMBF);
+      return {
+        ok: true,
+        result: {
+          species, acres, avgAgeYears: ageYears, treeCount,
+          boardFeetPerTree: bfPerTree,
+          boardFeet, cubicFeet, valuation, pricePerMBF,
+          mbf: Math.round((boardFeet / 1000) * 10) / 10,
+        },
+      };
+    } catch (e) { return { ok: false, error: "handler_error", message: String(e?.message || e) }; }
   });
-  registerLensAction("forestry", "fireRisk", (ctx, artifact, _params) => {
-    const data = artifact.data || {};
-    const temp = parseFloat(data.temperatureF) || 80;
-    const humidity = parseFloat(data.humidityPercent) || 30;
-    const wind = parseFloat(data.windSpeedMph) || 10;
-    const drought = parseInt(data.droughtIndex) || 3;
-    const fuelMoisture = parseFloat(data.fuelMoisturePercent) || 15;
-    let risk = 0;
-    risk += temp > 95 ? 25 : temp > 85 ? 15 : temp > 75 ? 8 : 3;
-    risk += humidity < 15 ? 25 : humidity < 25 ? 18 : humidity < 40 ? 10 : 3;
-    risk += wind > 25 ? 20 : wind > 15 ? 12 : wind > 8 ? 6 : 2;
-    risk += drought * 5;
-    risk += fuelMoisture < 10 ? 15 : fuelMoisture < 20 ? 8 : 2;
-    return { ok: true, result: { conditions: { temperature: `${temp}°F`, humidity: `${humidity}%`, wind: `${wind} mph`, droughtIndex: drought, fuelMoisture: `${fuelMoisture}%` }, riskScore: Math.min(100, risk), riskLevel: risk >= 75 ? "extreme" : risk >= 50 ? "high" : risk >= 30 ? "moderate" : "low", actions: risk >= 75 ? ["Red flag warning", "Close forest to public", "Pre-position fire crews"] : risk >= 50 ? ["Fire watch", "Restrict campfires", "Alert fire crews"] : ["Normal operations"] } };
+  // fireRisk — panel sends { tempF, humidity, windMph }. Returns riskLevel +
+  // score (the panel reads result.riskLevel and result.score) + factors.
+  registerLensAction("forestry", "fireRisk", (ctx, artifact, params = {}) => {
+    try {
+      const src = (params && Object.keys(params).length ? params : artifact?.data) || {};
+      // Accept both the panel's (tempF/humidity/windMph) names AND the legacy
+      // (temperatureF/humidityPercent/windSpeedMph) names; fail-closed to a sane
+      // default for anything non-finite so the score never goes NaN.
+      const temp = frFinite(src.tempF ?? src.temperatureF, 80);
+      const humidity = frFinite(src.humidity ?? src.humidityPercent, 30);
+      const wind = frFinite(src.windMph ?? src.windSpeedMph, 10);
+      const drought = Math.max(0, Math.min(5, Math.round(frFinite(src.droughtIndex, 3))));
+      const fuelMoisture = frFinite(src.fuelMoisturePercent, 15);
+      let risk = 0;
+      risk += temp > 95 ? 25 : temp > 85 ? 15 : temp > 75 ? 8 : 3;
+      risk += humidity < 15 ? 25 : humidity < 25 ? 18 : humidity < 40 ? 10 : 3;
+      risk += wind > 25 ? 20 : wind > 15 ? 12 : wind > 8 ? 6 : 2;
+      risk += drought * 5;
+      risk += fuelMoisture < 10 ? 15 : fuelMoisture < 20 ? 8 : 2;
+      const score = Math.min(100, Math.max(0, Math.round(risk)));
+      const riskLevel = score >= 75 ? "extreme" : score >= 50 ? "high" : score >= 30 ? "moderate" : "low";
+      const factors = [];
+      if (temp > 85) factors.push(`high temp ${Math.round(temp)}°F`);
+      if (humidity < 25) factors.push(`low humidity ${Math.round(humidity)}%`);
+      if (wind > 15) factors.push(`high wind ${Math.round(wind)} mph`);
+      if (drought >= 4) factors.push("severe drought");
+      if (fuelMoisture < 10) factors.push("critically dry fuel");
+      return {
+        ok: true,
+        result: {
+          conditions: { temperature: `${Math.round(temp)}°F`, humidity: `${Math.round(humidity)}%`, wind: `${Math.round(wind)} mph`, droughtIndex: drought, fuelMoisture: `${Math.round(fuelMoisture)}%` },
+          score, riskScore: score, riskLevel, factors,
+          actions: score >= 75 ? ["Red flag warning", "Close forest to public", "Pre-position fire crews"] : score >= 50 ? ["Fire watch", "Restrict campfires", "Alert fire crews"] : ["Normal operations"],
+        },
+      };
+    } catch (e) { return { ok: false, error: "handler_error", message: String(e?.message || e) }; }
   });
-  registerLensAction("forestry", "harvestPlan", (ctx, artifact, _params) => {
-    const data = artifact.data || {};
-    const acreage = parseFloat(data.acreage) || 100;
-    const method = (data.method || "selective").toLowerCase();
-    const methods = { clearcut: { removal: 100, regen: "replant", impactLevel: "high", cyclYears: 60 }, shelterwood: { removal: 70, regen: "natural + plant", impactLevel: "moderate", cyclYears: 80 }, selective: { removal: 30, regen: "natural", impactLevel: "low", cyclYears: 20 }, salvage: { removal: 50, regen: "replant", impactLevel: "moderate", cyclYears: 40 } };
-    const plan = methods[method] || methods.selective;
-    return { ok: true, result: { acreage, method, removalPercent: plan.removal, regeneration: plan.regen, impactLevel: plan.impactLevel, rotationYears: plan.cyclYears, estimatedHarvestAcres: Math.round(acreage * plan.removal / 100), roadRequired: acreage > 50 ? "Yes — logging road needed" : "Existing access may suffice", bestSeason: "Fall/Winter (dry, dormant season)", permits: ["Timber Harvest Plan (THP)", "Environmental review", "Watershed protection plan"] } };
+  // harvestPlan — panel sends { species, acres, currentAge }; renders
+  // result.schedule[] (a multi-year rotation removal schedule) + result.rotation.
+  // Builds a real staged-cut schedule keyed off the species rotation age.
+  registerLensAction("forestry", "harvestPlan", (ctx, artifact, params = {}) => {
+    try {
+      const src = (params && Object.keys(params).length ? params : artifact?.data) || {};
+      const speciesRaw = String(src.species || "mixed");
+      const acres = Math.max(0, frFinite(src.acreage ?? src.acres, 0));
+      const currentAge = Math.max(0, frFinite(src.currentAge ?? src.ageYears, 0));
+      const method = String(src.method || "selective").toLowerCase();
+      if (acres <= 0) return { ok: true, result: { message: "Enter acres (and species + current age) to build a harvest schedule." } };
+      const methods = {
+        clearcut: { removal: 100, regen: "replant", impactLevel: "high", cyclYears: 60 },
+        shelterwood: { removal: 70, regen: "natural + plant", impactLevel: "moderate", cyclYears: 80 },
+        selective: { removal: 30, regen: "natural", impactLevel: "low", cyclYears: 20 },
+        salvage: { removal: 50, regen: "replant", impactLevel: "moderate", cyclYears: 40 },
+      };
+      const plan = methods[method] || methods.selective;
+      // Rotation comes from the species growth table (years from seed to mature
+      // harvest); the schedule stages the cut from the stand's current age.
+      const speciesKey = speciesRaw.replace(/-/g, "_");
+      const g = SPECIES_GROWTH[speciesKey] || SPECIES_GROWTH.mixed;
+      const rotation = g.rotation;
+      const yearsToMaturity = Math.max(0, rotation - currentAge);
+      // Stage the removal over up to 3 entries (selective/salvage) or a single
+      // final harvest (clearcut). Each entry: { year, acres, volume }.
+      const entries = method === "clearcut" || method === "salvage" ? 1 : 3;
+      const harvestAcres = Math.round((acres * plan.removal) / 100);
+      const perEntryAcres = Math.max(1, Math.round(harvestAcres / entries));
+      // approximate volume per acre at maturity from the species peak MAI.
+      const volPerAcre = Math.round(g.maiPeak * Math.min(rotation, g.peakAge) / g.peakAge);
+      const schedule = [];
+      for (let i = 0; i < entries; i++) {
+        const year = Math.round((yearsToMaturity * (i + 1)) / entries);
+        const a = i === entries - 1 ? Math.max(0, harvestAcres - perEntryAcres * (entries - 1)) : perEntryAcres;
+        schedule.push({ year, acres: a, volume: Math.round(volPerAcre * a) });
+      }
+      return {
+        ok: true,
+        result: {
+          species: speciesRaw, acres, currentAge, method,
+          rotation, rotationYears: rotation,
+          removalPercent: plan.removal, regeneration: plan.regen,
+          impactLevel: plan.impactLevel,
+          estimatedHarvestAcres: harvestAcres,
+          schedule,
+          roadRequired: acres > 50 ? "Yes — logging road needed" : "Existing access may suffice",
+          bestSeason: "Fall/Winter (dry, dormant season)",
+          permits: ["Timber Harvest Plan (THP)", "Environmental review", "Watershed protection plan"],
+        },
+      };
+    } catch (e) { return { ok: false, error: "handler_error", message: String(e?.message || e) }; }
   });
-  registerLensAction("forestry", "carbonSequestration", (ctx, artifact, _params) => {
-    const acreage = parseFloat(artifact.data?.acreage) || 100;
-    const ageYears = parseInt(artifact.data?.standAge) || 30;
-    const density = parseInt(artifact.data?.treesPerAcre) || 200;
-    const tonsPerAcrePerYear = ageYears < 20 ? 2.5 : ageYears < 50 ? 1.8 : 1.0;
-    const annualSequestration = acreage * tonsPerAcrePerYear;
-    const totalStored = acreage * density * 0.015 * ageYears;
-    const carbonCredits = annualSequestration; // ~1 credit per ton
-    const creditValue = Math.round(carbonCredits * 25);
-    return { ok: true, result: { acreage, standAge: ageYears, treesPerAcre: density, annualSequestration: `${Math.round(annualSequestration)} tons CO2/year`, totalCarbonStored: `${Math.round(totalStored)} tons CO2`, carbonCreditsPerYear: Math.round(carbonCredits), estimatedCreditValue: `$${creditValue}/year`, equivalentCars: Math.round(annualSequestration / 4.6) } };
+  // carbonSequestration — panel sends { species, acres, ageYears }; renders
+  // result.tonsPerYear, result.lifetimeTons, result.equivalentCars.
+  registerLensAction("forestry", "carbonSequestration", (ctx, artifact, params = {}) => {
+    try {
+      const src = (params && Object.keys(params).length ? params : artifact?.data) || {};
+      const acres = Math.max(0, frFinite(src.acreage ?? src.acres, 0));
+      const ageYears = Math.max(0, frFinite(src.standAge ?? src.ageYears, 0));
+      const density = Math.max(0, Math.round(frFinite(src.treesPerAcre, 200)));
+      if (acres <= 0) return { ok: true, result: { message: "Enter acres (and age) to estimate carbon sequestration." } };
+      const tonsPerAcrePerYear = ageYears < 20 ? 2.5 : ageYears < 50 ? 1.8 : 1.0;
+      const tonsPerYear = Math.round(acres * tonsPerAcrePerYear);
+      const lifetimeTons = Math.round(acres * density * 0.015 * Math.max(1, ageYears));
+      const creditValue = Math.round(tonsPerYear * 25);
+      return {
+        ok: true,
+        result: {
+          species: String(src.species || "mixed"), acres, standAge: ageYears, treesPerAcre: density,
+          tonsPerYear, lifetimeTons,
+          totalCarbonStored: lifetimeTons,
+          carbonCreditsPerYear: tonsPerYear,
+          estimatedCreditValue: creditValue,
+          equivalentCars: Math.round(tonsPerYear / 4.6),
+        },
+      };
+    } catch (e) { return { ok: false, error: "handler_error", message: String(e?.message || e) }; }
   });
 
   /**

--- a/server/domains/forum.js
+++ b/server/domains/forum.js
@@ -1,38 +1,62 @@
 // server/domains/forum.js
 export default function registerForumActions(registerLensAction) {
-  registerLensAction("forum", "threadAnalysis", (ctx, artifact, _params) => {
-    const posts = artifact.data?.posts || [];
+  // ── Field-alignment + fail-closed helpers for the analytical surface ──
+  // THE DEAD-SURFACE CONTRACT (board pattern): these four calculators read
+  // forum-WIDE arrays/metrics (posts / reports / threads / activity counts).
+  // The /lenses/forum page persists each post as a lens artifact whose .data
+  // is a SINGLE post — it has no `posts`/`reports`/`threads` arrays — so the
+  // inline "Community Analytics" buttons (handleForumAction) used to render
+  // only the empty "Add thread posts…" message in production while shape-only
+  // tests passed. FIX: the page now DERIVES the arrays/metrics from live forum
+  // state and passes them as the run-action `params` (3rd handler arg), and
+  // each handler reads `params.X ?? artifact.data?.X`. The ForumActionPanel
+  // single-wrap `{artifact:{data:{posts}}}` path (dispatch-peeled to the plain
+  // object) lands the same fields on `artifact.data`.
+  const fmArr = (...vals) => { for (const v of vals) { if (Array.isArray(v)) return v; } return []; };
+  // Fail-closed integer coercion: Infinity / NaN / "Infinity" / 1e999 / "" all
+  // collapse to the fallback; never returns a non-finite number.
+  const fmInt = (v, d = 0) => {
+    const n = typeof v === "number" ? v : parseFloat(v);
+    return Number.isFinite(n) ? Math.trunc(n) : d;
+  };
+  const fmTime = (v) => { const t = new Date(v || 0).getTime(); return Number.isFinite(t) ? t : 0; };
+
+  registerLensAction("forum", "threadAnalysis", (ctx, artifact, params = {}) => {
+    const posts = fmArr(params.posts, artifact?.data?.posts);
     if (posts.length === 0) return { ok: true, result: { message: "Add thread posts to analyze discussion." } };
     const authors = {};
-    for (const p of posts) { const a = p.author || "anonymous"; authors[a] = (authors[a] || 0) + 1; }
-    const avgLength = Math.round(posts.reduce((s, p) => s + ((p.content || "").length), 0) / posts.length);
+    for (const p of posts) { const a = (p && p.author) || "anonymous"; authors[a] = (authors[a] || 0) + 1; }
+    const totalLen = posts.reduce((s, p) => s + String((p && p.content) || "").length, 0);
+    const avgLength = posts.length > 0 ? Math.round(totalLen / posts.length) : 0;
     const topContributors = Object.entries(authors).sort((a, b) => b[1] - a[1]).slice(0, 5);
     return { ok: true, result: { totalPosts: posts.length, uniqueAuthors: Object.keys(authors).length, avgPostLength: avgLength, topContributors: topContributors.map(([name, count]) => ({ name, posts: count })), health: posts.length > 5 && Object.keys(authors).length > 2 ? "active-discussion" : posts.length > 0 ? "needs-engagement" : "empty" } };
   });
-  registerLensAction("forum", "moderationQueue", (ctx, artifact, _params) => {
-    const reports = artifact.data?.reports || [];
-    const pending = reports.filter(r => r.status === "pending" || !r.status);
+  registerLensAction("forum", "moderationQueue", (ctx, artifact, params = {}) => {
+    const reports = fmArr(params.reports, artifact?.data?.reports);
+    const pending = reports.filter(r => r && (r.status === "pending" || !r.status));
     const byReason = {};
     for (const r of pending) { const reason = r.reason || "other"; byReason[reason] = (byReason[reason] || 0) + 1; }
-    return { ok: true, result: { totalReports: reports.length, pending: pending.length, resolved: reports.filter(r => r.status === "resolved").length, byReason, oldestPending: pending.sort((a, b) => new Date(a.date || 0).getTime() - new Date(b.date || 0).getTime())[0]?.date || null, urgency: pending.length > 10 ? "high" : pending.length > 3 ? "medium" : "low" } };
+    return { ok: true, result: { totalReports: reports.length, pending: pending.length, resolved: reports.filter(r => r && r.status === "resolved").length, byReason, oldestPending: pending.slice().sort((a, b) => fmTime(a.date) - fmTime(b.date))[0]?.date || null, urgency: pending.length > 10 ? "high" : pending.length > 3 ? "medium" : "low" } };
   });
-  registerLensAction("forum", "communityHealth", (ctx, artifact, _params) => {
-    const data = artifact.data || {};
-    const activeUsers = parseInt(data.activeUsers) || 0;
-    const totalUsers = parseInt(data.totalUsers) || 1;
-    const postsThisWeek = parseInt(data.postsThisWeek) || 0;
-    const postsLastWeek = parseInt(data.postsLastWeek) || 1;
-    const growth = ((postsThisWeek - postsLastWeek) / postsLastWeek) * 100;
-    const activityRate = totalUsers > 0 ? Math.round((activeUsers / totalUsers) * 100) : 0;
-    return { ok: true, result: { activeUsers, totalUsers, activityRate, postsThisWeek, growthRate: Math.round(growth), health: activityRate > 30 ? "thriving" : activityRate > 10 ? "healthy" : activityRate > 3 ? "declining" : "dormant", recommendations: activityRate < 10 ? ["Post conversation starters", "Highlight top contributors", "Send weekly digest"] : ["Maintain engagement momentum"] } };
+  registerLensAction("forum", "communityHealth", (ctx, artifact, params = {}) => {
+    const data = artifact?.data || {};
+    // Fail-closed: clamp every input to a finite non-negative integer.
+    const activeUsers = Math.max(0, fmInt(params.activeUsers ?? data.activeUsers, 0));
+    const totalUsers = Math.max(1, fmInt(params.totalUsers ?? data.totalUsers, 1));
+    const postsThisWeek = Math.max(0, fmInt(params.postsThisWeek ?? data.postsThisWeek, 0));
+    const postsLastWeek = Math.max(1, fmInt(params.postsLastWeek ?? data.postsLastWeek, 1));
+    const growthRaw = ((postsThisWeek - postsLastWeek) / postsLastWeek) * 100;
+    const growth = Number.isFinite(growthRaw) ? Math.round(growthRaw) : 0;
+    const activityRate = Math.round((activeUsers / totalUsers) * 100);
+    return { ok: true, result: { activeUsers, totalUsers, activityRate: Number.isFinite(activityRate) ? activityRate : 0, postsThisWeek, growthRate: growth, health: activityRate > 30 ? "thriving" : activityRate > 10 ? "healthy" : activityRate > 3 ? "declining" : "dormant", recommendations: activityRate < 10 ? ["Post conversation starters", "Highlight top contributors", "Send weekly digest"] : ["Maintain engagement momentum"] } };
   });
-  registerLensAction("forum", "topicClustering", (ctx, artifact, _params) => {
-    const threads = artifact.data?.threads || [];
+  registerLensAction("forum", "topicClustering", (ctx, artifact, params = {}) => {
+    const threads = fmArr(params.threads, artifact?.data?.threads);
     if (threads.length === 0) return { ok: true, result: { message: "Add threads to cluster by topic." } };
     const tagCounts = {};
-    for (const t of threads) { for (const tag of (t.tags || [])) { tagCounts[tag] = (tagCounts[tag] || 0) + 1; } }
+    for (const t of threads) { for (const tag of ((t && t.tags) || [])) { tagCounts[tag] = (tagCounts[tag] || 0) + 1; } }
     const clusters = Object.entries(tagCounts).sort((a, b) => b[1] - a[1]).map(([tag, count]) => ({ topic: tag, threads: count, share: Math.round((count / threads.length) * 100) }));
-    return { ok: true, result: { totalThreads: threads.length, clusters: clusters.slice(0, 10), topTopic: clusters[0]?.topic || "general", uncategorized: threads.filter(t => !t.tags || t.tags.length === 0).length } };
+    return { ok: true, result: { totalThreads: threads.length, clusters: clusters.slice(0, 10), topTopic: clusters[0]?.topic || "general", uncategorized: threads.filter(t => !t || !t.tags || t.tags.length === 0).length } };
   });
 
   // ─── Discourse + Reddit 2026 parity — community forum ───────────────
@@ -695,7 +719,12 @@ export default function registerForumActions(registerLensAction) {
       .sort((a, b) => b[1] - a[1]).slice(0, 8).map(([tag, n]) => ({ tag, weight: n }));
     const personalize = params.personalize !== false;
     const ranked = topics.map((t) => {
-      const ageHours = Math.max(0.01, (now - new Date(t.createdAt).getTime()) / 3600000);
+      // Fail-closed: a corrupt createdAt → getTime() NaN → Math.max(0.01,NaN)
+      // is NaN (Math.max propagates NaN), which would poison hotScore. Guard
+      // the timestamp to a finite value first so age is always finite.
+      const created = new Date(t.createdAt).getTime();
+      const ageRaw = (now - (Number.isFinite(created) ? created : now)) / 3600000;
+      const ageHours = Math.max(0.01, Number.isFinite(ageRaw) ? ageRaw : 0.01);
       const replyCount = posts.filter((p) => p.topicId === t.id).length;
       const order = Math.log10(Math.max(1, Math.abs(t.score) + replyCount * 2 + 1));
       const sign = t.score >= 0 ? 1 : -1;

--- a/server/domains/geology.js
+++ b/server/domains/geology.js
@@ -15,9 +15,21 @@ const USGS_DESIGNMAPS = "https://earthquake.usgs.gov/ws/designmaps/asce7-22.json
 const MACROSTRAT_API = "https://macrostrat.org/api/v2";
 
 export default function registerGeologyActions(registerLensAction) {
+  // Fail-CLOSED numeric coercion: parseFloat/Number pass "Infinity"/1e999/NaN
+  // through silently, which then serialize to `null` (or leak Infinity) in the
+  // result and read as blank in production. fin() returns a finite number or
+  // the supplied fallback — never Infinity/NaN. Used by every geology handler
+  // that does physics/depth/hardness math (richter/seismic/density/mineral).
+  const fin = (v, fallback = 0) => {
+    const n = typeof v === "number" ? v : parseFloat(v);
+    return Number.isFinite(n) ? n : fallback;
+  };
+
   registerLensAction("geology", "rockClassify", (ctx, artifact, _params) => {
     const data = artifact.data || {};
-    const hardness = parseFloat(data.mohsHardness) || 0;
+    // Mohs scale is 1–10; clamp to a sane band so a poisoned/huge value can't
+    // leak and the durability/uses branches stay meaningful.
+    const hardness = Math.max(0, Math.min(10, fin(data.mohsHardness, 0)));
     const luster = (data.luster || "").toLowerCase();
     const color = data.color || "";
     const texture = (data.texture || "").toLowerCase();
@@ -26,8 +38,10 @@ export default function registerGeologyActions(registerLensAction) {
   });
   registerLensAction("geology", "seismicRisk", (ctx, artifact, _params) => {
     const data = artifact.data || {};
-    const lat = parseFloat(data.latitude) || 37;
-    const lon = parseFloat(data.longitude) || -122;
+    // Coordinates clamp to the real lat/lon envelope; a poisoned Infinity/NaN
+    // falls back to the default site rather than leaking null into `location`.
+    const lat = Math.max(-90, Math.min(90, fin(data.latitude, 37)));
+    const lon = Math.max(-180, Math.min(180, fin(data.longitude, -122)));
     const soilType = (data.soilType || "rock").toLowerCase();
     const buildingCode = data.buildingCode || "IBC 2021";
     const amplificationFactors = { rock: 1.0, "stiff-soil": 1.2, "soft-soil": 1.6, "very-soft": 2.0, sand: 1.4, clay: 1.5 };
@@ -38,7 +52,9 @@ export default function registerGeologyActions(registerLensAction) {
   });
   registerLensAction("geology", "mineralId", (ctx, artifact, _params) => {
     const data = artifact.data || {};
-    const properties = { hardness: parseFloat(data.hardness) || 0, streak: data.streak || "", cleavage: data.cleavage || "", fracture: data.fracture || "", specific_gravity: parseFloat(data.specificGravity) || 0 };
+    // Hardness 0–10 (Mohs), specific gravity 0–25 (osmium ~22.6 is the densest
+    // natural solid) — clamp both so a poisoned numeric can't leak Infinity/NaN.
+    const properties = { hardness: Math.max(0, Math.min(10, fin(data.hardness, 0))), streak: data.streak || "", cleavage: data.cleavage || "", fracture: data.fracture || "", specific_gravity: Math.max(0, Math.min(25, fin(data.specificGravity, 0))) };
     const score = (properties.hardness > 0 ? 25 : 0) + (properties.streak ? 20 : 0) + (properties.cleavage ? 20 : 0) + (properties.specific_gravity > 0 ? 20 : 0) + (data.color ? 15 : 0);
     return { ok: true, result: { specimen: data.name || artifact.title, properties, identificationConfidence: score, testsPerformed: Object.values(properties).filter(v => v && v !== 0).length, testsRecommended: score < 60 ? ["streak test", "acid test", "hardness test", "specific gravity"].filter(t => !properties[t.split(" ")[0]]) : [], classification: properties.hardness >= 7 ? "silicate-likely" : properties.hardness >= 3 ? "carbonate-or-sulfate" : "clay-or-evaporite" } };
   });
@@ -46,7 +62,10 @@ export default function registerGeologyActions(registerLensAction) {
     const layers = artifact.data?.layers || [];
     if (layers.length === 0) return { ok: true, result: { message: "Add geological layers with thickness and age." } };
     let cumulativeDepth = 0;
-    const column = layers.map(l => { const thick = parseFloat(l.thickness) || 1; cumulativeDepth += thick; return { formation: l.name || l.formation, lithology: l.lithology || l.rockType || "unknown", thickness: thick, depthTop: cumulativeDepth - thick, depthBottom: cumulativeDepth, age: l.age || "unknown", fossils: l.fossils || [] }; });
+    // Thickness must be a positive finite metre value; a poisoned Infinity/NaN
+    // or negative thickness can't be allowed to leak into cumulativeDepth and
+    // invert the depth axis. Clamp to ≥0; default to 1 m when absent.
+    const column = layers.map(l => { const raw = fin(l.thickness, 1); const thick = raw > 0 ? raw : (raw === 0 ? 0 : 1); cumulativeDepth += thick; return { formation: l.name || l.formation, lithology: l.lithology || l.rockType || "unknown", thickness: thick, depthTop: cumulativeDepth - thick, depthBottom: cumulativeDepth, age: l.age || "unknown", fossils: Array.isArray(l.fossils) ? l.fossils : [] }; });
     return { ok: true, result: { layers: column, totalThickness: cumulativeDepth, layerCount: layers.length, oldestFormation: column[column.length - 1]?.formation, youngestFormation: column[0]?.formation, fossiliferous: column.filter(l => l.fossils.length > 0).length } };
   });
 

--- a/server/domains/household.js
+++ b/server/domains/household.js
@@ -6,6 +6,24 @@
 
 const OPEN_FOOD_FACTS = "https://world.openfoodfacts.org/api/v2";
 
+// Fail-closed numeric parse. parseFloat/Number() silently pass Infinity/NaN
+// ("Infinity", "1e999", NaN) — guard with Number.isFinite so a poisoned input
+// collapses to the fallback instead of leaking Infinity/NaN into output.
+function finiteNum(v, fallback = 0) {
+  const n = typeof v === "number" ? v : parseFloat(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+function finiteInt(v, fallback) {
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+// Date that is parseable AND finite, else null (so date math never yields NaN).
+function finiteDate(v) {
+  if (!v) return null;
+  const t = new Date(v).getTime();
+  return Number.isFinite(t) ? new Date(t) : null;
+}
+
 export default function registerHouseholdActions(registerLensAction) {
   /**
    * generateGroceryList
@@ -16,9 +34,17 @@ export default function registerHouseholdActions(registerLensAction) {
    */
   registerLensAction("household", "generateGroceryList", (ctx, artifact, params) => {
   try {
-    const mealPlan = artifact.data.mealPlan || [];
-    const pantry = artifact.data.pantry || [];
-    const categorize = params.categorize !== false;
+    const d = artifact.data || {};
+    const p = params || {};
+    // Accept the canonical structured `mealPlan` [{ingredients:[...]}], OR a
+    // flat `meals` array (objects with ingredients, or bare recipe-name strings),
+    // from either artifact.data or params.
+    const rawPlan = d.mealPlan || p.mealPlan || d.meals || p.meals || [];
+    const mealPlan = (Array.isArray(rawPlan) ? rawPlan : []).map((m) =>
+      typeof m === "string" ? { recipe: m, ingredients: [] } : (m || {})
+    );
+    const pantry = d.pantry || p.pantry || [];
+    const categorize = p.categorize !== false;
 
     // Aggregate all ingredients from the meal plan
     const aggregated = {};
@@ -34,7 +60,7 @@ export default function registerHouseholdActions(registerLensAction) {
             usedIn: [],
           };
         }
-        aggregated[key].quantity += parseFloat(ing.quantity) || 0;
+        aggregated[key].quantity += finiteNum(ing.quantity, 0);
         const mealLabel = `${meal.day || ""} ${meal.meal || ""}`.trim();
         if (mealLabel && !aggregated[key].usedIn.includes(mealLabel)) {
           aggregated[key].usedIn.push(mealLabel);
@@ -46,7 +72,7 @@ export default function registerHouseholdActions(registerLensAction) {
     const pantryMap = {};
     for (const item of pantry) {
       const key = `${(item.name || "").toLowerCase()}|${(item.unit || "").toLowerCase()}`;
-      pantryMap[key] = (pantryMap[key] || 0) + (parseFloat(item.quantity) || 0);
+      pantryMap[key] = (pantryMap[key] || 0) + finiteNum(item.quantity, 0);
     }
 
     const groceryList = [];
@@ -105,8 +131,8 @@ export default function registerHouseholdActions(registerLensAction) {
    */
   registerLensAction("household", "maintenanceCheck", (ctx, artifact, params) => {
   try {
-    const items = artifact.data.maintenanceItems || [];
-    const lookaheadDays = params.lookaheadDays != null ? params.lookaheadDays : 14;
+    const items = artifact.data.maintenanceItems || params.maintenanceItems || [];
+    const lookaheadDays = finiteNum(params.lookaheadDays, 14);
     const now = new Date();
 
     const overdue = [];
@@ -114,8 +140,8 @@ export default function registerHouseholdActions(registerLensAction) {
     const current = [];
 
     for (const item of items) {
-      const lastDone = item.lastCompleted ? new Date(item.lastCompleted) : null;
-      const interval = parseInt(item.intervalDays, 10) || 30;
+      const lastDone = finiteDate(item.lastCompleted);
+      const interval = finiteInt(item.intervalDays, 30);
 
       if (!lastDone) {
         overdue.push({ name: item.name, category: item.category || "general", priority: item.priority || "normal", status: "never-completed", daysOverdue: null });
@@ -159,10 +185,11 @@ export default function registerHouseholdActions(registerLensAction) {
    * artifact.data.chores: [{ name, currentAssignee, frequency }]
    * artifact.data.members: [string] or [{ name }]
    */
-  registerLensAction("household", "rotateChores", (ctx, artifact, _params) => {
-    const chores = artifact.data.chores || [];
-    const rawMembers = artifact.data.members || [];
-    const members = rawMembers.map(m => typeof m === "string" ? m : m.name);
+  registerLensAction("household", "rotateChores", (ctx, artifact, params = {}) => {
+    const rawChores = artifact.data.chores || params.chores || [];
+    const chores = rawChores.map(c => typeof c === "string" ? { name: c } : (c || {}));
+    const rawMembers = artifact.data.members || params.members || [];
+    const members = rawMembers.map(m => typeof m === "string" ? m : m.name).filter(Boolean);
 
     if (members.length === 0) return { ok: true, result: { error: "No household members defined." } };
     if (chores.length === 0) return { ok: true, result: { error: "No chores defined." } };
@@ -205,41 +232,46 @@ export default function registerHouseholdActions(registerLensAction) {
    * artifact.data.shoppingList: [{ item, purchased }]
    * artifact.data.upcomingTasks: [{ name, dueDate }]
    */
-  registerLensAction("household", "weeklySummary", (ctx, artifact, _params) => {
+  registerLensAction("household", "weeklySummary", (ctx, artifact, params = {}) => {
   try {
+    const d0 = artifact.data || {};
+    const p = params || {};
     const now = new Date();
     const weekAgo = new Date(now.getTime() - 7 * 86400000);
     const weekAhead = new Date(now.getTime() + 7 * 86400000);
 
     // Chores completed this week
-    const chores = artifact.data.chores || [];
+    const chores = d0.chores || p.chores || [];
     const completedChores = chores.filter(c => {
-      if (!c.completedDate) return false;
-      const d = new Date(c.completedDate);
+      const d = finiteDate(c.completedDate);
+      if (!d) return false;
       return d >= weekAgo && d <= now;
     });
 
     // Meals planned
-    const mealPlan = artifact.data.mealPlan || [];
+    const mealPlan = d0.mealPlan || p.mealPlan || d0.meals || p.meals || [];
     const mealsPlanned = mealPlan.length;
 
     // Shopping status
-    const shoppingList = artifact.data.shoppingList || artifact.data.groceryList?.list || [];
+    const shoppingList = d0.shoppingList || p.shoppingList || d0.groceryList?.list || [];
     const totalShoppingItems = shoppingList.length;
     const purchasedItems = shoppingList.filter(i => i.purchased || i.done).length;
 
     // Upcoming tasks
-    const upcoming = (artifact.data.upcomingTasks || []).filter(t => {
+    const upcoming = (d0.upcomingTasks || p.upcomingTasks || []).filter(t => {
       if (!t.dueDate) return true;
-      const d = new Date(t.dueDate);
+      const d = finiteDate(t.dueDate);
+      if (!d) return true;
       return d >= now && d <= weekAhead;
     });
 
     // Maintenance items due
-    const maintenanceItems = artifact.data.maintenanceItems || [];
+    const maintenanceItems = d0.maintenanceItems || p.maintenanceItems || [];
     const maintenanceDue = maintenanceItems.filter(m => {
-      if (!m.lastCompleted || !m.intervalDays) return false;
-      const nextDue = new Date(new Date(m.lastCompleted).getTime() + parseInt(m.intervalDays, 10) * 86400000);
+      const last = finiteDate(m.lastCompleted);
+      const interval = finiteInt(m.intervalDays, 0);
+      if (!last || interval <= 0) return false;
+      const nextDue = new Date(last.getTime() + interval * 86400000);
       return nextDue <= weekAhead;
     });
 
@@ -269,8 +301,8 @@ export default function registerHouseholdActions(registerLensAction) {
    */
   registerLensAction("household", "maintenanceDue", (ctx, artifact, params) => {
   try {
-    const items = artifact.data.maintenanceItems || [];
-    const lookaheadDays = params.lookaheadDays != null ? params.lookaheadDays : 30;
+    const items = artifact.data.maintenanceItems || params.maintenanceItems || [];
+    const lookaheadDays = finiteNum(params.lookaheadDays, 30);
     const now = new Date();
 
     const overdue = [];
@@ -278,8 +310,8 @@ export default function registerHouseholdActions(registerLensAction) {
     const current = [];
 
     for (const item of items) {
-      const lastService = item.lastServiceDate ? new Date(item.lastServiceDate) : null;
-      const interval = parseInt(item.intervalDays, 10) || 365;
+      const lastService = finiteDate(item.lastServiceDate);
+      const interval = finiteInt(item.intervalDays, 365);
 
       if (!lastService) {
         overdue.push({
@@ -355,13 +387,17 @@ export default function registerHouseholdActions(registerLensAction) {
    * artifact.data.members: [{ name, preferences }] or string[]
    * params.strategy — "round-robin" (default) or "random"
    */
-  registerLensAction("household", "choreRotation", (ctx, artifact, params) => {
+  registerLensAction("household", "choreRotation", (ctx, artifact, params = {}) => {
   try {
-    const chores = artifact.data.chores || [];
-    const rawMembers = artifact.data.members || [];
+    // Accept chores/members from artifact.data OR params (HouseholdActionPanel
+    // sends them via the flat run-action input, which the dispatch maps to BOTH
+    // artifact.data and params). Chores may be bare-string recipe names.
+    const rawChores = artifact.data.chores || params.chores || [];
+    const chores = rawChores.map((c) => (typeof c === "string" ? { name: c } : (c || {})));
+    const rawMembers = artifact.data.members || params.members || [];
     const strategy = params.strategy || "round-robin";
 
-    const members = rawMembers.map((m) => (typeof m === "string" ? m : m.name));
+    const members = rawMembers.map((m) => (typeof m === "string" ? m : m.name)).filter(Boolean);
 
     if (members.length === 0) {
       return { ok: true, result: { error: "No household members defined." } };
@@ -943,7 +979,7 @@ export default function registerHouseholdActions(registerLensAction) {
     const s = getCoState(); if (!s) return { ok: false, error: "STATE unavailable" };
     const home = getHomeState();
     const log = home ? hmList(home.choreLog, hmActor(ctx)) : [];
-    const rate = Math.max(0, Math.min(10, Number(params.dollarsPerPoint) || 0.05));
+    const rate = Math.max(0, Math.min(10, finiteNum(params.dollarsPerPoint, 0.05)));
     const byPerson = {};
     for (const e of log) {
       if (!byPerson[e.by]) byPerson[e.by] = { person: e.by, points: 0, choresDone: 0 };
@@ -1153,8 +1189,8 @@ export default function registerHouseholdActions(registerLensAction) {
     const s = getCoState(); if (!s) return { ok: false, error: "STATE unavailable" };
     const description = hmClean(params.description, 120);
     if (!description) return { ok: false, error: "description required" };
-    const amount = Math.round((Number(params.amount) || 0) * 100) / 100;
-    if (!(amount > 0)) return { ok: false, error: "amount must be > 0" };
+    const amount = Math.round(finiteNum(params.amount, 0) * 100) / 100;
+    if (!(amount > 0) || !Number.isFinite(amount)) return { ok: false, error: "amount must be a finite number > 0" };
     const paidBy = hmClean(params.paidBy, 60);
     if (!paidBy) return { ok: false, error: "paidBy required" };
     const splitAmong = Array.isArray(params.splitAmong)

--- a/server/domains/insurance.js
+++ b/server/domains/insurance.js
@@ -244,6 +244,13 @@ export default function registerInsuranceActions(register) {
   });
 
   registerLensAction("insurance", "riskScore", (ctx, artifact, params) => {
+    // Fail-CLOSED: reject a poisoned numeric (NaN/Infinity/1e308/negative)
+    // BEFORE the score multiply, rather than emitting a null/Infinity score the
+    // panel would render as a blank or "Infinity%" risk card. Probability/impact
+    // arrive in either `artifact.data` (peeled body) or `params` (flat body).
+    const badNum = badNumericField(artifact.data || {}, ["probability", "impact"])
+      || badNumericField(params, ["probability", "impact"]);
+    if (badNum) return { ok: false, error: `invalid_${badNum}` };
     const probability = artifact.data?.probability || params.probability || 3;
     const impact = artifact.data?.impact || params.impact || 3;
     const score = probability * impact;
@@ -251,10 +258,16 @@ export default function registerInsuranceActions(register) {
     const normalizedScore = Math.round((score / maxScore) * 100);
     const mitigations = artifact.data?.mitigations || [];
     const mitigatedScore = Math.max(1, score - mitigations.length);
+    // The risk's human label. `artifact.title` is the legacy source, but the
+    // dispatch peel collapses a sole-key `{ artifact: { title, data } }` body to
+    // `artifact.data`, dropping the title — so the InsuranceActionPanel's risk
+    // card rendered a blank `risk`. Read it from `data.risk`/`params.risk`
+    // (which survive the peel) first, falling back to the legacy title.
+    const risk = artifact.data?.risk || params.risk || artifact.title || "Unnamed risk";
     return {
       ok: true,
       result: {
-        risk: artifact.title,
+        risk,
         probability,
         impact,
         rawScore: score,

--- a/server/domains/legal.js
+++ b/server/domains/legal.js
@@ -1,4 +1,13 @@
 export default function registerLegalActions(registerLensAction) {
+  // Fail-CLOSED numeric coercion. parseFloat("Infinity") === Infinity and
+  // Number("1e999") === Infinity both slip past a bare `|| 0`, leaking a
+  // non-finite value into a rendered total. finiteNum rejects NaN/±Infinity and
+  // any non-finite coercion back to the supplied fallback (default 0).
+  const finiteNum = (v, fallback = 0) => {
+    const n = typeof v === "number" ? v : parseFloat(v);
+    return Number.isFinite(n) ? n : fallback;
+  };
+
   registerLensAction("legal", "deadlineCheck", (ctx, artifact, params) => {
     const now = new Date();
     const items = artifact.data?.items || [];
@@ -17,6 +26,9 @@ export default function registerLegalActions(registerLensAction) {
   registerLensAction("legal", "contractRenewal", (ctx, artifact, _params) => {
     const expiryDate = artifact.data?.expiryDate ? new Date(artifact.data.expiryDate) : null;
     if (!expiryDate) return { ok: true, result: { status: "no_expiry", message: "No expiry date set" } };
+    // Fail-CLOSED: an unparseable expiry date would yield a NaN daysUntilExpiry
+    // that leaks into the rendered urgency band — reject it as no_expiry.
+    if (Number.isNaN(expiryDate.getTime())) return { ok: true, result: { status: "no_expiry", message: "Invalid expiry date" } };
     const now = new Date();
     const daysUntilExpiry = Math.ceil((expiryDate - now) / (1000 * 60 * 60 * 24));
     const autoRenewal = artifact.data?.renewalType === 'auto';
@@ -59,8 +71,8 @@ export default function registerLegalActions(registerLensAction) {
     const documents = artifact.data?.documents || [];
     const timeEntries = artifact.data?.timeEntries || [];
     const billingTotal = Math.round(timeEntries.reduce((sum, e) => {
-      const hours = parseFloat(e.hours) || 0;
-      const rate = parseFloat(e.rate) || 0;
+      const hours = finiteNum(e.hours);
+      const rate = finiteNum(e.rate);
       return sum + hours * rate;
     }, 0) * 100) / 100;
     const keyDates = [];
@@ -130,6 +142,9 @@ export default function registerLegalActions(registerLensAction) {
     const filingDate = artifact.data?.filingDate || params.filingDate;
     if (!filingDate) return { ok: true, result: { error: 'No filing date provided' } };
     const base = new Date(filingDate);
+    // Fail-CLOSED: an unparseable filing date yields an Invalid Date whose
+    // .toISOString() throws RangeError inside addDays — reject before computing.
+    if (Number.isNaN(base.getTime())) return { ok: true, result: { error: 'Invalid filing date' } };
     const jurisdiction = artifact.data?.jurisdiction || params.jurisdiction || 'default';
     const addDays = (d, n) => { const r = new Date(d); r.setDate(r.getDate() + n); return r.toISOString().split('T')[0]; };
 
@@ -162,12 +177,12 @@ export default function registerLegalActions(registerLensAction) {
   try {
     const timeEntries = artifact.data?.timeEntries || [];
     const expenses = artifact.data?.expenses || [];
-    const taxRate = params.taxRate != null ? params.taxRate : 0;
+    const taxRate = finiteNum(params.taxRate, 0);
 
     let totalHours = 0;
     const lineItems = timeEntries.map((entry, idx) => {
-      const hours = parseFloat(entry.hours) || 0;
-      const rate = parseFloat(entry.rate) || 0;
+      const hours = finiteNum(entry.hours);
+      const rate = finiteNum(entry.rate);
       const amount = Math.round(hours * rate * 100) / 100;
       totalHours += hours;
       return {
@@ -185,7 +200,7 @@ export default function registerLegalActions(registerLensAction) {
     const expenseItems = expenses.map((e, idx) => ({
       line: idx + 1,
       description: e.description || e.name || '',
-      amount: Math.round((parseFloat(e.amount) || 0) * 100) / 100,
+      amount: Math.round(finiteNum(e.amount) * 100) / 100,
     }));
     const expenseSubtotal = Math.round(expenseItems.reduce((s, e) => s + e.amount, 0) * 100) / 100;
     const subtotal = Math.round((laborSubtotal + expenseSubtotal) * 100) / 100;

--- a/server/tests/affect-lens-macros.test.js
+++ b/server/tests/affect-lens-macros.test.js
@@ -1,0 +1,442 @@
+// Phase-2 gate (component↔handler field-alignment) tests for server/domains/affect.js
+// — the LENS_ACTIONS (registerLensAction) macros that the /lenses/affect page +
+// concord-frontend/components/affect/{MoodTracker,LiveAffectStream} drive through
+// /api/lens/run.
+//
+// DISPATCH SHAPE: these are LENS_ACTIONS handlers invoked as
+//   handler(ctx, virtualArtifact, input)   — the 3-ARG convention with
+//   virtualArtifact.data === input. The dispatch first PEELS exactly one
+//   redundant `{ artifact: { data } }` wrapper (server/lib/lens-input-normalize.js)
+//   then passes the SAME object as BOTH artifact.data AND the 3rd param. Our
+//   `call()` harness mirrors BOTH steps exactly so a param-position / wrapper-depth
+//   regression surfaces here.
+//
+// SCOPE (no duplication): server/tests/affect-domain-parity.test.js already pins
+// the mood-macro streak/correlation/CSV math + per-user scoping. THIS file pins the
+// distinct Phase-2 gate signals the parity test does NOT cover:
+//   (1) COMPONENT-EXACT field alignment — drive the EXACT inner-data the component
+//       sends and assert the EXACT field names it renders from r.result, BOTH
+//       directions, so a renamed field on either side (the dead-calculator bug
+//       class) fails here instead of rendering a blank panel.
+//   (2) VALIDATION-REJECTION — out-of-range / malformed input returns {ok:false}
+//       with a string error the component surfaces.
+//   (3) DEGRADE-GRACEFUL — empty/absent input returns a stable {ok:true} message
+//       (or hasData:false) shape, never a throw.
+//   (4) FAIL-CLOSED POISON — a poisoned non-string `text` / non-array `entries` /
+//       non-array `feedback` once threw `.trim`/`.map`/non-iterable (a 500, not a
+//       graceful degrade). The handlers were hardened to coerce/guard; these tests
+//       pin that poison collapses to the empty-input message or {ok:false} and the
+//       handler NEVER throws.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerAffectActions from "../domains/affect.js";
+import { peelRedundantArtifactWrapper } from "../lib/lens-input-normalize.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) {
+  assert.equal(domain, "affect", `unexpected domain: ${domain}`);
+  ACTIONS.set(name, fn);
+}
+
+// Mirror the live /api/lens/run dispatch EXACTLY: peel one redundant artifact
+// wrapper, then invoke handler(ctx, virtualArtifact, data) with
+// virtualArtifact.data === data === the 3rd param.
+function call(name, ctx, input = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`affect.${name} not registered`);
+  const data = peelRedundantArtifactWrapper(input || {});
+  const virtualArtifact = { id: null, domain: "affect", type: "domain_action", data, meta: {} };
+  return fn(ctx, virtualArtifact, data);
+}
+
+// Mirror the OTHER live path (Analysis-tab `useRunArtifact` → /api/lens/:domain/:id/run):
+// the handler receives a REAL artifact whose .data is the bridge-synced snapshot,
+// and an empty params object. We exercise it by passing artifact.data directly.
+function callArtifact(name, ctx, artifactData = {}, params = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`affect.${name} not registered`);
+  const virtualArtifact = { id: "art_1", domain: "affect", type: "snapshot", data: artifactData, meta: {} };
+  return fn(ctx, virtualArtifact, params);
+}
+
+before(() => {
+  registerAffectActions(register);
+});
+
+beforeEach(() => {
+  globalThis._concordSTATE = { dtus: new Map() };
+  globalThis._concordSaveStateDebounced = () => {};
+  // Network OFF — every macro here is deterministic pure compute / in-memory state.
+  globalThis.fetch = async () => { throw new Error("network disabled"); };
+});
+
+const ctxA = { actor: { userId: "affect_user_a" }, userId: "affect_user_a" };
+const ctxB = { actor: { userId: "affect_user_b" }, userId: "affect_user_b" };
+
+// ───────────────────────────────────────────────────────────────────────────
+// 1. sentimentAnalysis — Analysis-tab "Sentiment Analysis" panel.
+//    Component renders r.result.{sentimentLabel, primaryEmotion, isMixedEmotion,
+//    vad.{valence,arousal,dominance}, tokenCount, matchedTokens, coverage,
+//    emotionHits[].{word,valence,negated}, sarcasmIndicators[].detail,
+//    sarcasmLikelihood}. (page.tsx Sentiment Analysis panel.)
+// ───────────────────────────────────────────────────────────────────────────
+describe("affect.sentimentAnalysis — VAD scoring", () => {
+  it("COMPONENT-EXACT: renders every field the Sentiment panel reads, with real values", () => {
+    const r = call("sentimentAnalysis", ctxA, { artifact: { data: { text: "I am so happy and grateful today, this is wonderful" } } });
+    assert.equal(r.ok, true);
+    const res = r.result;
+    // Exact field names the panel reads.
+    assert.equal(res.sentimentLabel, "positive");
+    assert.equal(typeof res.primaryEmotion, "string");
+    assert.equal(typeof res.isMixedEmotion, "boolean");
+    assert.ok(res.vad && Number.isFinite(res.vad.valence) && Number.isFinite(res.vad.arousal) && Number.isFinite(res.vad.dominance));
+    assert.ok(res.vad.valence > 0.6, `expected positive valence, got ${res.vad.valence}`);
+    assert.ok(Number.isFinite(res.tokenCount) && res.tokenCount > 0);
+    assert.ok(Number.isFinite(res.matchedTokens) && res.matchedTokens >= 3);
+    assert.ok(Number.isFinite(res.coverage));
+    assert.ok(Array.isArray(res.emotionHits) && res.emotionHits.length >= 3);
+    assert.equal(typeof res.emotionHits[0].word, "string");
+    assert.equal(typeof res.emotionHits[0].negated, "boolean");
+    assert.ok(["low", "moderate", "high"].includes(res.sarcasmLikelihood));
+  });
+
+  it("REAL-COMPUTE: negation inverts valence (the panel strikes through negated words)", () => {
+    const r = call("sentimentAnalysis", ctxA, { artifact: { data: { text: "I am not happy" } } });
+    assert.equal(r.ok, true);
+    const hit = r.result.emotionHits.find((h) => h.word === "happy");
+    assert.ok(hit, "expected a hit for 'happy'");
+    assert.equal(hit.negated, true);
+    assert.ok(hit.valence < 0.5, `negated 'happy' should drop below 0.5, got ${hit.valence}`);
+  });
+
+  it("DEGRADE-GRACEFUL: absent text → {ok:true, result.message} (panel renders message branch)", () => {
+    const r = call("sentimentAnalysis", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.equal(typeof r.result.message, "string");
+    assert.ok(!("vad" in r.result));
+  });
+
+  it("FAIL-CLOSED POISON: non-string text never throws on .trim()", () => {
+    for (const bad of [9999, { x: 1 }, [1, 2], true, Infinity]) {
+      const r = call("sentimentAnalysis", ctxA, { artifact: { data: { text: bad } } });
+      assert.equal(r.ok, true, `poison ${JSON.stringify(bad)} should degrade, not throw`);
+      assert.equal(typeof r.result.message, "string");
+    }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 2. emotionTimeline — Analysis-tab "Emotion Timeline" panel.
+//    Component renders r.result.{arcType, entryCount, volatility, smoothedValence[],
+//    arcSegments.{beginning,middle,end}, turningPoints[].{index,type,valence,magnitude},
+//    overallValence, overallIntensity}.
+// ───────────────────────────────────────────────────────────────────────────
+describe("affect.emotionTimeline — emotional arcs", () => {
+  const sadToHappy = {
+    entries: [
+      { id: "e1", text: "everything is terrible awful and I feel miserable despair" },
+      { id: "e2", text: "still pretty bad and sad lonely" },
+      { id: "e3", text: "things are okay getting better" },
+      { id: "e4", text: "I feel good and hopeful now" },
+      { id: "e5", text: "wonderful amazing joy great success triumph" },
+    ],
+  };
+
+  it("COMPONENT-EXACT: renders every field the Timeline panel reads", () => {
+    const r = call("emotionTimeline", ctxA, { artifact: { data: sadToHappy } });
+    assert.equal(r.ok, true);
+    const res = r.result;
+    assert.equal(typeof res.arcType, "string");
+    assert.equal(res.entryCount, 5);
+    assert.ok(Number.isFinite(res.volatility));
+    assert.ok(Array.isArray(res.smoothedValence) && res.smoothedValence.length === 5);
+    assert.ok(res.smoothedValence.every((v) => Number.isFinite(v)));
+    assert.ok(res.arcSegments && Number.isFinite(res.arcSegments.beginning) && Number.isFinite(res.arcSegments.middle) && Number.isFinite(res.arcSegments.end));
+    assert.ok(Array.isArray(res.turningPoints));
+    assert.ok(Number.isFinite(res.overallValence));
+    assert.ok(Number.isFinite(res.overallIntensity));
+  });
+
+  it("REAL-COMPUTE: a sad→happy progression ends more positive than it begins", () => {
+    const r = call("emotionTimeline", ctxA, { artifact: { data: sadToHappy } });
+    assert.equal(r.ok, true);
+    assert.ok(
+      r.result.arcSegments.end > r.result.arcSegments.beginning,
+      `expected end (${r.result.arcSegments.end}) > beginning (${r.result.arcSegments.beginning})`,
+    );
+    assert.ok(["rags-to-riches", "ascending", "man-in-a-hole", "complex"].includes(r.result.arcType));
+  });
+
+  it("DEGRADE-GRACEFUL: empty entries → {ok:true, result.message}", () => {
+    const r = call("emotionTimeline", ctxA, { artifact: { data: { entries: [] } } });
+    assert.equal(r.ok, true);
+    assert.equal(typeof r.result.message, "string");
+  });
+
+  it("FAIL-CLOSED POISON: non-array entries never throws on .map()", () => {
+    for (const bad of ["a string", 42, { x: 1 }, true]) {
+      const r = call("emotionTimeline", ctxA, { artifact: { data: { entries: bad } } });
+      assert.equal(r.ok, true, `poison ${JSON.stringify(bad)} should degrade, not throw`);
+      assert.equal(typeof r.result.message, "string");
+    }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 3. empathyMap — Analysis-tab "Empathy Map" panel.
+//    Component renders r.result.{totalFeedback, analyzedAt,
+//    quadrants.{thinks,feels,says,does}.{count,items[].text}, painPoints[].{text,keywords},
+//    gains[].{text,keywords}, topThemes[].{phrase,count},
+//    summary.{totalPainPoints,totalGains,avgPainScore,avgGainScore,sentimentBalance}}.
+// ───────────────────────────────────────────────────────────────────────────
+describe("affect.empathyMap — Think/Feel/Say/Do quadrants", () => {
+  const feedback = {
+    feedback: [
+      { userId: "u1", text: "I think the new dashboard is confusing and slow to load" },
+      { userId: "u2", text: "I feel frustrated when the export breaks, it is a real problem" },
+      { userId: "u3", text: "This is so easy and fast, I love how simple it is" },
+      { userId: "u4", text: "I clicked buy and the checkout was smooth and helpful" },
+    ],
+  };
+
+  it("COMPONENT-EXACT: renders every field the Empathy panel reads, with real values", () => {
+    const r = call("empathyMap", ctxA, { artifact: { data: feedback } });
+    assert.equal(r.ok, true);
+    const res = r.result;
+    assert.equal(res.totalFeedback, 4);
+    assert.equal(typeof res.analyzedAt, "string");
+    for (const q of ["thinks", "feels", "says", "does"]) {
+      assert.ok(res.quadrants[q] && Number.isFinite(res.quadrants[q].count) && Array.isArray(res.quadrants[q].items), `quadrant ${q}`);
+    }
+    assert.ok(Array.isArray(res.painPoints) && res.painPoints.length >= 1);
+    assert.ok(typeof res.painPoints[0].text === "string" && Array.isArray(res.painPoints[0].keywords));
+    assert.ok(Array.isArray(res.gains) && res.gains.length >= 1);
+    assert.ok(typeof res.gains[0].text === "string" && Array.isArray(res.gains[0].keywords));
+    assert.ok(Array.isArray(res.topThemes));
+    const sum = res.summary;
+    assert.ok(Number.isFinite(sum.totalPainPoints) && Number.isFinite(sum.totalGains));
+    assert.ok(Number.isFinite(sum.avgPainScore) && Number.isFinite(sum.avgGainScore));
+    assert.ok(Number.isFinite(sum.sentimentBalance));
+  });
+
+  it("REAL-COMPUTE: pain + gain keyword detection populates both lists", () => {
+    const r = call("empathyMap", ctxA, { artifact: { data: feedback } });
+    assert.equal(r.ok, true);
+    assert.ok(r.result.summary.totalPainPoints >= 1, "expected pain points from 'confusing/slow/problem'");
+    assert.ok(r.result.summary.totalGains >= 1, "expected gains from 'easy/fast/love/smooth/helpful'");
+  });
+
+  it("DEGRADE-GRACEFUL: empty feedback → {ok:true, result.message}", () => {
+    const r = call("empathyMap", ctxA, { artifact: { data: { feedback: [] } } });
+    assert.equal(r.ok, true);
+    assert.equal(typeof r.result.message, "string");
+  });
+
+  it("FAIL-CLOSED POISON: non-array feedback never throws (string iterates chars / object non-iterable)", () => {
+    for (const bad of ["a string", 42, { x: 1 }, true]) {
+      const r = call("empathyMap", ctxA, { artifact: { data: { feedback: bad } } });
+      assert.equal(r.ok, true, `poison ${JSON.stringify(bad)} should degrade, not throw`);
+      assert.equal(typeof r.result.message, "string");
+    }
+  });
+
+  it("FAIL-CLOSED POISON: array of poisoned items (null / non-string text) never throws", () => {
+    const r = call("empathyMap", ctxA, { artifact: { data: { feedback: [null, { text: 123 }, "raw", { text: "I love this it is great" }] } } });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.totalFeedback));
+    // The one well-formed gain item must still register.
+    assert.ok(r.result.summary.totalGains >= 1);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 4. detect-patterns — Analysis-tab "Pattern Detection" panel.
+//    Component renders r.result.{patterns[].{theme,count}, triggers[].{trigger,count},
+//    cycles[].{label,count}, correlations[].{between,strength}, summary}.
+//    (page.tsx Pattern Detection panel — aligned to these canonical names.)
+// ───────────────────────────────────────────────────────────────────────────
+describe("affect.detect-patterns — triggers / cycles / themes", () => {
+  const journal = {
+    entries: [
+      { text: "work deadline stress made me anxious", timestamp: "2026-06-01T09:00:00Z" },
+      { text: "more work stress and a tight deadline", timestamp: "2026-06-02T09:30:00Z" },
+      { text: "family time was happy and calm", timestamp: "2026-06-03T18:00:00Z" },
+      { text: "work stress again, anxious about money", timestamp: "2026-06-04T09:15:00Z" },
+    ],
+  };
+
+  it("COMPONENT-EXACT: patterns[].theme, triggers[].trigger, cycles[].label, correlations[].{between,strength}", () => {
+    const r = call("detect-patterns", ctxA, { artifact: { data: journal } });
+    assert.equal(r.ok, true);
+    const res = r.result;
+    assert.ok(Array.isArray(res.patterns));
+    if (res.patterns.length) {
+      assert.equal(typeof res.patterns[0].theme, "string");
+      assert.ok(Number.isFinite(res.patterns[0].count));
+    }
+    assert.ok(Array.isArray(res.triggers) && res.triggers.length >= 1);
+    assert.equal(typeof res.triggers[0].trigger, "string");
+    assert.ok(Number.isFinite(res.triggers[0].count));
+    assert.ok(Array.isArray(res.cycles));
+    if (res.cycles.length) {
+      assert.equal(typeof res.cycles[0].label, "string");
+      assert.ok(Number.isFinite(res.cycles[0].count));
+    }
+    assert.ok(Array.isArray(res.correlations));
+    if (res.correlations.length) {
+      assert.ok(Array.isArray(res.correlations[0].between));
+      assert.ok(["strong", "moderate"].includes(res.correlations[0].strength));
+    }
+    assert.equal(typeof res.summary, "string");
+  });
+
+  it("REAL-COMPUTE: 'work' and 'stress' surface as triggers", () => {
+    const r = call("detect-patterns", ctxA, { artifact: { data: journal } });
+    const triggers = r.result.triggers.map((t) => t.trigger);
+    assert.ok(triggers.includes("work"), `expected 'work' trigger, got ${triggers.join(",")}`);
+    assert.ok(triggers.includes("stress"), `expected 'stress' trigger, got ${triggers.join(",")}`);
+  });
+
+  it("DEGRADE-GRACEFUL: empty entries → {ok:true} with stable empty arrays + summary", () => {
+    const r = call("detect-patterns", ctxA, { artifact: { data: { entries: [] } } });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.entryCount, 0);
+    assert.deepEqual(r.result.patterns, []);
+    assert.deepEqual(r.result.triggers, []);
+    assert.equal(typeof r.result.summary, "string");
+  });
+
+  it("FAIL-CLOSED POISON: non-array entries never throws", () => {
+    for (const bad of ["a string", 42, { x: 1 }, true]) {
+      const r = call("detect-patterns", ctxA, { artifact: { data: { entries: bad } } });
+      assert.equal(r.ok, true, `poison ${JSON.stringify(bad)} should degrade, not throw`);
+      assert.equal(r.result.entryCount, 0);
+    }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 5. Mood macros (MoodTracker.tsx) — Phase-2 gate: field alignment + validation
+//    + degrade-graceful (the streak/correlation/CSV math is pinned separately by
+//    affect-domain-parity.test.js; here we pin the EXACT rendered field names the
+//    MoodTracker reads, both directions).
+// ───────────────────────────────────────────────────────────────────────────
+describe("affect.checkin — MoodTracker check-in form", () => {
+  it("COMPONENT-EXACT: returns entry.{moodEmoji,moodLabel} + currentStreak + longestStreak", () => {
+    // MoodTracker sends { mood, note, activities, promptId, promptAnswer }.
+    const r = call("checkin", ctxA, { mood: 4, note: "decent", activities: ["walk"], promptId: "prompt_0", promptAnswer: "calm" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.entry.mood, 4);
+    assert.equal(typeof r.result.entry.moodLabel, "string");
+    assert.equal(typeof r.result.entry.moodEmoji, "string");
+    assert.ok(Number.isFinite(r.result.currentStreak));
+    assert.ok(Number.isFinite(r.result.longestStreak));
+    assert.ok(Number.isFinite(r.result.totalCheckins));
+  });
+
+  it("VALIDATION-REJECTION: out-of-range mood → {ok:false, error:string} (MoodTracker reads r.data.error)", () => {
+    const r = call("checkin", ctxA, { mood: 99 });
+    assert.equal(r.ok, false);
+    assert.equal(typeof r.error, "string");
+    assert.match(r.error, /between/);
+  });
+
+  it("FAIL-CLOSED POISON: non-numeric mood is rejected, never throws", () => {
+    for (const bad of ["NaN", {}, null, undefined, Infinity]) {
+      const r = call("checkin", ctxA, { mood: bad });
+      assert.equal(r.ok, false, `poison mood ${JSON.stringify(bad)} must be rejected`);
+      assert.equal(typeof r.error, "string");
+    }
+  });
+});
+
+describe("affect.getScale / setScale — MoodTracker scale editor", () => {
+  it("COMPONENT-EXACT: getScale returns { scale.points[].{value,label,emoji}, isCustom }", () => {
+    const r = call("getScale", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.ok(Array.isArray(r.result.scale.points) && r.result.scale.points.length >= 2);
+    assert.equal(typeof r.result.scale.points[0].value, "number");
+    assert.equal(typeof r.result.scale.points[0].label, "string");
+    assert.equal(typeof r.result.scale.points[0].emoji, "string");
+    assert.equal(typeof r.result.isCustom, "boolean");
+  });
+
+  it("VALIDATION-REJECTION: a single-point scale → {ok:false, error}", () => {
+    const r = call("setScale", ctxA, { points: [{ value: 1, label: "Only" }] });
+    assert.equal(r.ok, false);
+    assert.equal(typeof r.error, "string");
+  });
+
+  it("VALIDATION-REJECTION: duplicate scale values → {ok:false, error}", () => {
+    const r = call("setScale", ctxA, { points: [{ value: 1, label: "A" }, { value: 1, label: "B" }] });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /unique/);
+  });
+
+  it("COMPONENT-EXACT: setScale round-trips a custom scale ({scale, isCustom:true})", () => {
+    const r = call("setScale", ctxA, { points: [{ value: 1, label: "Low", emoji: "😔" }, { value: 2, label: "Mid", emoji: "😐" }, { value: 3, label: "High", emoji: "😄" }] });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.isCustom, true);
+    assert.equal(r.result.scale.points.length, 3);
+    // The custom scale then bounds checkin validation.
+    const over = call("checkin", ctxA, { mood: 5 });
+    assert.equal(over.ok, false);
+  });
+});
+
+describe("affect.trends / nudges — degrade-graceful empty states (MoodTracker reads hasData / due)", () => {
+  it("trends with no check-ins → {ok:true, result.hasData:false} (MoodTracker empty branch)", () => {
+    const r = call("trends", ctxB, { granularity: "week" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.hasData, false);
+    assert.ok(Array.isArray(r.result.buckets) && Array.isArray(r.result.daily) && Array.isArray(r.result.dayOfWeek));
+  });
+
+  it("nudges with no reminders → {ok:true} with empty due[] + reminders[]", () => {
+    const r = call("nudges", ctxB, {});
+    assert.equal(r.ok, true);
+    assert.ok(Array.isArray(r.result.due) && r.result.due.length === 0);
+    assert.ok(Array.isArray(r.result.reminders));
+    assert.equal(typeof r.result.checkedInToday, "boolean");
+  });
+
+  it("journalPrompts: deterministic per-day prompt set with {id,text} (MoodTracker prompt chips)", () => {
+    const r = call("journalPrompts", ctxA, { count: 3 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.prompts.length, 3);
+    assert.equal(typeof r.result.prompts[0].id, "string");
+    assert.equal(typeof r.result.prompts[0].text, "string");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 6. Artifact-path dispatch (Analysis tab `useRunArtifact` → /api/lens/:domain/:id/run):
+//    the bridge syncs the affect 7D STATE snapshot (numbers) as artifact.data and
+//    passes NO text/entries/feedback — so the three analysis macros must degrade to
+//    their message branch, exactly what the panel's message-branch renders.
+// ───────────────────────────────────────────────────────────────────────────
+describe("affect — Analysis-tab artifact path degrades on a state snapshot", () => {
+  const snapshot = { v: 0.6, a: 0.5, s: 0.7, c: 0.6, g: 0.5, t: 0.55, f: 0.3 };
+  it("sentimentAnalysis over the snapshot → message branch (no text)", () => {
+    const r = callArtifact("sentimentAnalysis", ctxA, snapshot, {});
+    assert.equal(r.ok, true);
+    assert.equal(typeof r.result.message, "string");
+  });
+  it("emotionTimeline over the snapshot → message branch (no entries)", () => {
+    const r = callArtifact("emotionTimeline", ctxA, snapshot, {});
+    assert.equal(r.ok, true);
+    assert.equal(typeof r.result.message, "string");
+  });
+  it("empathyMap over the snapshot → message branch (no feedback)", () => {
+    const r = callArtifact("empathyMap", ctxA, snapshot, {});
+    assert.equal(r.ok, true);
+    assert.equal(typeof r.result.message, "string");
+  });
+  it("detect-patterns over the snapshot → {ok:true} empty patterns + summary", () => {
+    const r = callArtifact("detect-patterns", ctxA, snapshot, {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.entryCount, 0);
+    assert.equal(typeof r.result.summary, "string");
+  });
+});

--- a/server/tests/art-lens-macros.test.js
+++ b/server/tests/art-lens-macros.test.js
@@ -1,0 +1,264 @@
+// Behavioral macro tests for server/domains/art.js — the four pure-compute
+// color/composition/style macros the /lenses/art workbench drives
+// (PaletteWorkshop + ArtActionPanel), plus the museum external-IO macros
+// (ArtExplorer) asserted to validate+reject WITHOUT a network call.
+//
+// This file mirrors the REAL LENS_ACTIONS dispatch (server.js:39285):
+// handlers registered via `registerLensAction(domain, action, handler)` are
+// invoked as `handler(ctx, virtualArtifact, input)` — the 3-ARG convention,
+// with `virtualArtifact.data = input`. Our harness therefore calls
+// `fn(ctx, virtualArtifact, input)`, so a regression that confuses param
+// positions surfaces here.
+//
+// These are NOT shape-only assertions and they DO NOT duplicate the museum
+// parity suites (art-museum-domain-parity covers met/aic). They:
+//   • drive each compute macro with the EXACT input the live components send
+//     (PaletteWorkshop: {palette}/{baseColor,harmony,count}; ArtActionPanel:
+//     {palette}/{elements,canvas}/{baseColor,harmony,count}/{attributes}),
+//   • assert the EXACT fields the components render, with real computed values,
+//   • assert validation-rejection on missing input,
+//   • assert graceful degradation (empty palette/elements → ok:true message),
+//   • assert a fail-CLOSED poisoned-numeric / malformed-hex contract: a
+//     non-#RRGGBB hex or an Infinity/NaN/1e308 coordinate/axis is REJECTED
+//     rather than leaking NaN/Infinity into the result under ok:true.
+//   • External-IO museum macros validate+reject bad input WITHOUT fetching.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerArtActions from "../domains/art.js";
+
+const ACTIONS = new Map();
+function registerLensAction(domain, name, fn) {
+  assert.equal(domain, "art", `unexpected domain: ${domain}`);
+  ACTIONS.set(name, fn);
+}
+// Mirror the live dispatch exactly: handler(ctx, virtualArtifact, input) with
+// virtualArtifact.data = input (server.js:39287).
+function call(name, ctx, input = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`art.${name} not registered`);
+  const virtualArtifact = { id: null, title: null, domain: "art", type: "domain_action", data: input || {}, meta: {} };
+  return fn(ctx, virtualArtifact, input || {});
+}
+
+before(() => { registerArtActions(registerLensAction); });
+
+let fetchCalls = 0;
+beforeEach(() => {
+  // No boot, no network, no LLM. Any handler that reaches for the network in a
+  // pure-compute test marks itself as a leak via fetchCalls.
+  fetchCalls = 0;
+  globalThis.fetch = async () => { fetchCalls++; throw new Error("network disabled in tests"); };
+  globalThis._concordSTATE = { dtus: new Map() };
+  globalThis._concordSaveStateDebounced = () => {};
+});
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+
+describe("art — registration (every lens-driven compute + museum macro present)", () => {
+  it("registers the macros the art workbench + explorer call", () => {
+    for (const m of [
+      "colorHarmony", "compositionScore", "generatePalette", "styleClassify",
+      "met-search", "met-object", "aic-search",
+    ]) {
+      assert.equal(typeof ACTIONS.get(m), "function", `missing art.${m}`);
+    }
+  });
+});
+
+// ── colorHarmony — the PaletteWorkshop + ArtActionPanel "Harmony" input shape.
+describe("art.colorHarmony — real hue/temperature/score for a known palette", () => {
+  it("detects complementary + analogous relations and renders fields", () => {
+    // Red/cyan are ~180° apart (complementary); two near-reds are analogous.
+    const r = call("colorHarmony", ctxA, { palette: ["#ff0000", "#00ffff", "#ff1a00"] });
+    assert.equal(r.ok, true);
+    const res = r.result;
+    // Every field the components render is present + real.
+    assert.equal(res.paletteSize, 3);
+    assert.ok(Number.isFinite(res.harmonyScore) && res.harmonyScore >= 0 && res.harmonyScore <= 100);
+    assert.ok(["warm", "cool", "balanced"].includes(res.temperature));
+    assert.ok(Array.isArray(res.harmonies));
+    assert.ok(res.harmonies.some(h => h.type === "complementary"), "expected a complementary pair");
+    assert.ok(res.harmonies.some(h => h.type === "analogous"), "expected an analogous pair");
+    assert.ok(Number.isFinite(res.dominantHue) && res.dominantHue >= 0 && res.dominantHue <= 360);
+    // Each harmony entry carries the colors[] the panel paints.
+    for (const h of res.harmonies) {
+      assert.equal(h.colors.length, 2);
+      assert.ok(h.colors.every(c => /^#[0-9a-f]{6}$/i.test(c)));
+    }
+  });
+
+  it("accepts the {hex} object form too (same path PaletteWorkshop maps to hexes)", () => {
+    const r = call("colorHarmony", ctxA, { palette: [{ hex: "#3498db" }, { hex: "#db7734" }] });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.paletteSize, 2);
+  });
+
+  it("degrade-graceful: empty palette → ok:true with an honest message, no NaN", () => {
+    const r = call("colorHarmony", ctxA, { palette: [] });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.message, "No palette provided.");
+  });
+
+  it("fail-CLOSED: a malformed hex is REJECTED, never leaks NaN harmonyScore", () => {
+    const r = call("colorHarmony", ctxA, { palette: ["#zzzzzz", "#00ff00"] });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /hex/i);
+  });
+
+  it("fail-CLOSED: a poisoned non-string entry is rejected", () => {
+    const r = call("colorHarmony", ctxA, { palette: ["#ff0000", 1e308] });
+    assert.equal(r.ok, false);
+  });
+
+  it("never touches the network", () => { assert.equal(fetchCalls, 0); });
+});
+
+// ── compositionScore — ArtActionPanel "Composition" input shape.
+describe("art.compositionScore — real geometry scoring for placed elements", () => {
+  it("computes overall + per-axis scores + rating from element positions", () => {
+    const r = call("compositionScore", ctxA, {
+      elements: [
+        { x: 640, y: 360, width: 200, height: 200, weight: 2 },
+        { x: 1280, y: 720, width: 150, height: 150 },
+      ],
+      canvas: { width: 1920, height: 1080 },
+    });
+    assert.equal(r.ok, true);
+    const res = r.result;
+    assert.ok(Number.isFinite(res.overall) && res.overall >= 0 && res.overall <= 100);
+    assert.ok(["excellent", "good", "fair", "needs_work"].includes(res.rating));
+    // Every score the panel renders is finite + bounded.
+    for (const k of ["ruleOfThirds", "goldenRatio", "balance", "whitespace", "visualFlow"]) {
+      assert.ok(Number.isFinite(res.scores[k]) && res.scores[k] >= 0 && res.scores[k] <= 100, `${k} = ${res.scores[k]}`);
+    }
+    assert.equal(res.elementCount, 2);
+    // overall is the documented weighted blend of the axes.
+    const expected = Math.round(
+      res.scores.ruleOfThirds * 0.25 + res.scores.goldenRatio * 0.15 +
+      res.scores.balance * 0.25 + res.scores.whitespace * 0.15 + res.scores.visualFlow * 0.2);
+    assert.equal(res.overall, expected);
+  });
+
+  it("degrade-graceful: empty elements → ok:true with an honest message", () => {
+    const r = call("compositionScore", ctxA, { elements: [] });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.message, "No elements to analyze.");
+  });
+
+  it("fail-CLOSED: an Infinity coordinate is REJECTED, never leaks NaN scores", () => {
+    const r = call("compositionScore", ctxA, {
+      elements: [{ x: Infinity, y: 0, width: 10, height: 10 }],
+      canvas: { width: 1920, height: 1080 },
+    });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /finite/i);
+  });
+
+  it("fail-CLOSED: an overflow-to-Infinity width and a non-finite canvas are rejected", () => {
+    // "1e999" overflows the double to Infinity → must be rejected (NaN/Infinity poison).
+    assert.equal(call("compositionScore", ctxA, { elements: [{ x: 1, y: 1, width: "1e999", height: 10 }], canvas: { width: 1920, height: 1080 } }).ok, false);
+    assert.equal(call("compositionScore", ctxA, { elements: [{ x: 1, y: 1, width: 10, height: 10 }], canvas: { width: "NaN", height: 1080 } }).ok, false);
+  });
+});
+
+// ── generatePalette — PaletteWorkshop + ArtActionPanel "Palette" input shape.
+describe("art.generatePalette — deterministic harmony palettes from a seed", () => {
+  it("returns N swatches with hex + role for a complementary seed", () => {
+    const r = call("generatePalette", ctxA, { baseColor: "#3498db", harmony: "complementary", count: 5 });
+    assert.equal(r.ok, true);
+    const res = r.result;
+    assert.equal(res.harmony, "complementary");
+    assert.equal(res.baseColor, "#3498db");
+    assert.equal(res.palette.length, 5);
+    // First entry is the base; complement is 180° opposite.
+    assert.equal(res.palette[0].role, "base");
+    assert.equal(res.palette[1].role, "complement");
+    for (const c of res.palette) {
+      assert.ok(/^#[0-9a-f]{6}$/i.test(c.hex), `bad hex ${c.hex}`);
+      assert.equal(typeof c.role, "string");
+    }
+  });
+
+  it("defaults harmony to analogous and clamps count low-bound", () => {
+    const r = call("generatePalette", ctxA, { baseColor: "#ff0000" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.harmony, "analogous");
+    assert.equal(r.result.palette.length, 5); // default count
+  });
+
+  it("fail-CLOSED: a malformed baseColor is REJECTED, never emits #NaN swatches", () => {
+    const r = call("generatePalette", ctxA, { baseColor: "not-a-color", count: 4 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /hex/i);
+  });
+
+  it("fail-CLOSED: a poisoned Infinity count is clamped, never unbounded/NaN", () => {
+    const r = call("generatePalette", ctxA, { baseColor: "#3498db", harmony: "analogous", count: Infinity });
+    assert.equal(r.ok, true);
+    // clamped into the [2,24] envelope — finite count, no #NaN swatches.
+    assert.ok(r.result.palette.length >= 2 && r.result.palette.length <= 24);
+    assert.ok(r.result.palette.every(c => /^#[0-9a-f]{6}$/i.test(c.hex)));
+  });
+});
+
+// ── styleClassify — ArtActionPanel "Style" input shape.
+describe("art.styleClassify — nearest-style match from 8 axes", () => {
+  it("matches an Impressionism-shaped profile to Impressionism, top-ranked", () => {
+    // Exactly the Impressionism reference profile → similarity 100, top match.
+    const r = call("styleClassify", ctxA, {
+      attributes: { brushwork: 80, colorSaturation: 70, contrast: 40, perspective: 40, detail: 30, abstraction: 40, lineWeight: 20, texture: 70 },
+    });
+    assert.equal(r.ok, true);
+    const res = r.result;
+    assert.equal(res.topMatch.style, "Impressionism");
+    assert.equal(res.topMatch.similarity, 100);
+    assert.equal(res.confidence, "high");
+    // allMatches is the full ranked list (10 styles), descending.
+    assert.equal(res.allMatches.length, 10);
+    for (let i = 1; i < res.allMatches.length; i++) {
+      assert.ok(res.allMatches[i - 1].similarity >= res.allMatches[i].similarity, "not descending");
+    }
+  });
+
+  it("defaults all absent axes to 50 (still classifies, ok:true)", () => {
+    const r = call("styleClassify", ctxA, { attributes: {} });
+    assert.equal(r.ok, true);
+    assert.equal(typeof r.result.topMatch.style, "string");
+    assert.ok(Number.isFinite(r.result.topMatch.similarity));
+  });
+
+  it("fail-CLOSED: a poisoned Infinity/NaN axis is clamped, never leaks non-finite similarity", () => {
+    const r = call("styleClassify", ctxA, {
+      attributes: { brushwork: Infinity, colorSaturation: NaN, contrast: 1e308 },
+    });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.topMatch.similarity), "similarity must stay finite");
+    assert.ok(r.result.allMatches.every(m => Number.isFinite(m.similarity)));
+  });
+});
+
+// ── Museum external-IO — ArtExplorer drives these; assert validate+reject
+//    WITHOUT a network call (the live endpoints are never touched in tests).
+describe("art museum external-IO — validate+reject without fetching", () => {
+  it("met-search rejects an empty query and never fetches", async () => {
+    const r = await call("met-search", ctxA, {});
+    assert.equal(r.ok, false);
+    assert.match(r.error, /query required/);
+    assert.equal(fetchCalls, 0);
+  });
+
+  it("met-object rejects a non-positive / non-finite objectId and never fetches", async () => {
+    assert.equal((await call("met-object", ctxA, {})).ok, false);
+    assert.equal((await call("met-object", ctxA, { objectId: -1 })).ok, false);
+    assert.equal((await call("met-object", ctxA, { objectId: "NaN" })).ok, false);
+    assert.equal(fetchCalls, 0);
+  });
+
+  it("aic-search rejects an empty query and never fetches", async () => {
+    const r = await call("aic-search", ctxA, { query: "   " });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /query required/);
+    assert.equal(fetchCalls, 0);
+  });
+});

--- a/server/tests/artistry-lens-macros.test.js
+++ b/server/tests/artistry-lens-macros.test.js
@@ -1,0 +1,594 @@
+// Phase-2 gate — behavioral macro tests for server/domains/artistry.js, the
+// Behance/ArtStation-shaped creative-portfolio substrate the /lenses/artistry
+// lens + its components drive.
+//
+// COMPLEMENT to artistry-domain-parity.test.js (which pins happy-path SHAPE).
+// This file is the Phase-2 NON-SCORE GATE: it drives each macro with the EXACT
+// input field names the live frontend sends and asserts the EXACT output field
+// names the components render, with REAL COMPUTED VALUES — so a field rename on
+// either side (the "dead surface" failure mode: component reads a field the
+// handler never returns → blank in production while shape tests stay green)
+// surfaces HERE.
+//
+// DISPATCH FIDELITY: artistry registers via `registerLensAction(domain, action,
+// handler)` (LENS_ACTIONS), reached by /api/lens/run + /api/lens/:domain/:id/run
+// and invoked as `handler(ctx, virtualArtifact, input)` — the 3-ARG convention
+// with virtualArtifact.data === input. The compute macros read artifact.data.*;
+// the social macros read the 3rd `params` arg. Both receive the SAME `input`
+// object in the live dispatch (server.js:39287-39288), so our harness passes it
+// to BOTH positions, exactly as production does.
+//
+// MONEY/CORRECTNESS SCRUTINY: the compute macros are pure calculators (no wallet,
+// no minting), so the risk is fail-OPEN non-finite output. `parseFloat("Infinity")`
+// = Infinity and `Infinity || d` = Infinity, so a naive `parseFloat(x) || d` would
+// let a poisoned magnitude flow into a computed total (mediaInventory value,
+// composition canvas, palette weight). The domain was hardened with `finNum`
+// (non-finite / beyond-1e15 → fallback, FINITE output guaranteed). The poisoned-
+// numeric block below pins that every computed total stays finite under
+// Infinity / 1e999 / NaN input — fail-CLOSED.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerArtistryActions from "../domains/artistry.js";
+
+const ACTIONS = new Map();
+function registerLensAction(domain, name, fn) {
+  assert.equal(domain, "artistry", `unexpected domain: ${domain}`);
+  ACTIONS.set(name, fn);
+}
+// Mirror the live dispatch EXACTLY: handler(ctx, virtualArtifact, input) with
+// virtualArtifact.data === input (compute macros read artifact.data.*, social
+// macros read params — both get the same object).
+function call(name, ctx, input = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`artistry.${name} not registered`);
+  const virtualArtifact = { id: null, domain: "artistry", type: "domain_action", data: input || {}, meta: {} };
+  return fn(ctx, virtualArtifact, input || {});
+}
+
+before(() => { registerArtistryActions(registerLensAction); });
+
+beforeEach(() => {
+  // Fresh isolated STATE per test so the per-user Maps don't leak.
+  globalThis._concordSTATE = {};
+  globalThis._concordSaveStateDebounced = () => {};
+  globalThis.fetch = async () => { throw new Error("network disabled"); };
+});
+
+const ctxA = { actor: { userId: "artist_a" }, userId: "artist_a" };
+const ctxB = { actor: { userId: "artist_b" }, userId: "artist_b" };
+
+// Every macro the lens page + its components reach via lensRun / useRunArtifact.
+const LENS_MACROS = [
+  // compute artifact actions (page Artistry Compute Actions panel, useRunArtifact)
+  "colorPaletteAnalysis", "compositionScore", "styleClassify", "mediaInventory",
+  // ProjectStudio.tsx
+  "projectCreate", "projectList", "projectView", "projectUpdate", "projectDelete",
+  "appreciate", "commentAdd",
+  // CommunityNetwork.tsx
+  "personalizedFeed", "followGraph", "follow", "unfollow",
+  // Collections.tsx
+  "collectionCreate", "collectionList", "collectionSave", "collectionItems",
+  // PortfolioProfile.tsx
+  "profileGet", "profileUpdate",
+  // DisciplineSearch.tsx
+  "search", "tagCloud",
+  // JobBoard.tsx
+  "jobPost", "jobList", "jobApply", "jobClose",
+  // CuratedGalleries.tsx
+  "galleryCreate", "galleryList", "galleryItems",
+  // comment list/delete (round-trip completeness)
+  "commentList", "commentDelete",
+];
+
+describe("artistry — registration (every lens-driven macro present)", () => {
+  it("registers every macro the lens page + components call", () => {
+    for (const m of LENS_MACROS) {
+      assert.ok(ACTIONS.has(m), `artistry.${m} must be registered (a lens component calls it)`);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Compute Actions — the page renders EXACT fields from each result. We pin the
+// real computed value (not just typeof) so the page's rendered numbers are live.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("artistry compute — colorPaletteAnalysis (page renders harmonyScore/dominantHue/contrastRange/colors[].hex)", () => {
+  it("computes harmony + dominant hue + contrast the page renders", () => {
+    // Input: artifact.data.palette (page passes the artifact's stored data).
+    const r = call("colorPaletteAnalysis", ctxA, { palette: ["#ff0000", "#00ff00", "#0000ff"] });
+    assert.equal(r.ok, true);
+    // EXACT fields the page reads (page.tsx:252-261).
+    assert.equal(typeof r.result.harmonyScore, "number");
+    assert.ok(Number.isFinite(r.result.harmonyScore));
+    assert.equal(typeof r.result.dominantHue, "number"); // page renders {dominantHue}; gate: dominantHue !== undefined
+    assert.equal(typeof r.result.contrastRange, "number");
+    // pure red/green/blue are all 50% lightness → contrast range exactly 0.
+    assert.equal(r.result.contrastRange, 0);
+    assert.ok(Array.isArray(r.result.colors));
+    assert.equal(r.result.colors[0].hex, "#ff0000"); // colors[].hex swatch
+    assert.equal(r.result.colorCount, 3);
+  });
+
+  it("DEGRADE-GRACEFUL: empty palette returns the page's honest message + colors:[]", () => {
+    const r = call("colorPaletteAnalysis", ctxA, { palette: [] });
+    assert.equal(r.ok, true);
+    assert.equal(typeof r.result.message, "string"); // page renders actionResult.message fallback
+    assert.deepEqual(r.result.colors, []);
+    assert.equal(r.result.harmonyScore, 0);
+  });
+
+  it("FAIL-CLOSED: poisoned weight (Infinity) keeps harmonyScore + dominantHue finite", () => {
+    const r = call("colorPaletteAnalysis", ctxA, {
+      palette: [{ color: "#ff0000", weight: "Infinity" }, { color: "#0000ff", weight: "1e999" }],
+    });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.harmonyScore), "harmonyScore must stay finite");
+    assert.ok(Number.isFinite(r.result.dominantHue), "dominantHue must stay finite");
+    assert.ok(Number.isFinite(r.result.averageSaturation));
+    assert.ok(Number.isFinite(r.result.averageLightness));
+  });
+});
+
+describe("artistry compute — compositionScore (page renders overallScore)", () => {
+  it("computes a real overallScore for a centered element", () => {
+    const r = call("compositionScore", ctxA, {
+      canvas: { width: 100, height: 100 },
+      elements: [{ x: 25, y: 25, width: 16, height: 16, weight: 1 }],
+    });
+    assert.equal(r.ok, true);
+    assert.equal(typeof r.result.overallScore, "number"); // page reads {overallScore}/100
+    assert.ok(r.result.overallScore >= 0 && r.result.overallScore <= 1);
+    // element center (33,33)/100 sits ~on a rule-of-thirds point → proximity ~1.
+    assert.ok(r.result.elements[0].proximityScore >= 0.99);
+    assert.ok(r.result.ruleOfThirdsScore >= 0.99);
+    assert.equal(r.result.elementCount, 1);
+  });
+
+  it("DEGRADE-GRACEFUL: no elements returns the page's message branch", () => {
+    const r = call("compositionScore", ctxA, { elements: [], canvas: {} });
+    assert.equal(r.ok, true);
+    assert.equal(typeof r.result.message, "string");
+    assert.equal(r.result.score, 0);
+  });
+
+  it("FAIL-CLOSED: poisoned canvas/element dims keep overallScore finite", () => {
+    const r = call("compositionScore", ctxA, {
+      canvas: { width: "Infinity", height: "NaN" },
+      elements: [{ x: "1e999", y: 0, width: "Infinity", height: 10, weight: "Infinity" }],
+    });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.overallScore), "overallScore must stay finite");
+    assert.ok(Number.isFinite(r.result.balanceScore));
+    assert.ok(Number.isFinite(r.result.coverageScore));
+  });
+});
+
+describe("artistry compute — styleClassify (page renders classification + confidence)", () => {
+  it("classifies Impressionism from tags + era", () => {
+    const r = call("styleClassify", ctxA, {
+      tags: ["impressionist", "plein air", "oil"],
+      attributes: { era: "19th century" },
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.classification, "Impressionism"); // page renders {classification}
+    assert.equal(typeof r.result.confidence, "number");     // page renders {confidence}%
+    assert.ok(r.result.confidence > 0 && r.result.confidence <= 1);
+  });
+
+  it("DEGRADE-GRACEFUL: no attributes/tags returns message + null classification", () => {
+    const r = call("styleClassify", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.equal(typeof r.result.message, "string");
+    assert.equal(r.result.classification, null);
+    assert.equal(r.result.confidence, 0);
+  });
+
+  it("unmatched tags classify as Unclassified (page still renders a string)", () => {
+    const r = call("styleClassify", ctxA, { tags: ["zzzzz", "qqqqq"] });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.classification, "Unclassified");
+  });
+});
+
+describe("artistry compute — mediaInventory (page renders totalItems + categoryBreakdown[].category/itemCount)", () => {
+  it("totals value, builds category breakdown, flags reorders", () => {
+    const r = call("mediaInventory", ctxA, {
+      supplies: [
+        { name: "Cadmium Red", category: "paint", quantity: 3, unit: "tube", unitCost: 12, reorderThreshold: 5 },
+        { name: "Cold Press", category: "paper", quantity: 20, unit: "sheet", unitCost: 2 },
+      ],
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.totalItems, 2); // page renders {totalItems} items
+    assert.ok(Array.isArray(r.result.categoryBreakdown));
+    const paint = r.result.categoryBreakdown.find((c) => c.category === "paint");
+    assert.ok(paint, "categoryBreakdown must carry a {category} the page maps over");
+    assert.equal(paint.itemCount, 1); // page renders {itemCount}
+    assert.equal(r.result.totalInventoryValue, 76); // 3*12 + 20*2
+    // qty 3 <= threshold 5 → a reorder alert.
+    assert.equal(r.result.reorderCount, 1);
+    assert.equal(r.result.reorderAlerts[0].name, "Cadmium Red");
+  });
+
+  it("DEGRADE-GRACEFUL: empty supplies returns the page message branch + zeroed totals", () => {
+    const r = call("mediaInventory", ctxA, { supplies: [] });
+    assert.equal(r.ok, true);
+    assert.equal(typeof r.result.message, "string");
+    assert.equal(r.result.totalItems, 0);
+    assert.deepEqual(r.result.reorderAlerts, []);
+  });
+
+  it("FAIL-CLOSED: poisoned quantity/unitCost keep totalInventoryValue finite", () => {
+    const r = call("mediaInventory", ctxA, {
+      supplies: [
+        { name: "Poison", category: "paint", quantity: "Infinity", unitCost: "1e999" },
+        { name: "NaNish", category: "paint", quantity: "NaN", unitCost: 5 },
+      ],
+    });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.totalInventoryValue), "totalInventoryValue must stay finite");
+    assert.ok(Number.isFinite(r.result.totalQuantity));
+    assert.ok(Number.isFinite(r.result.estimatedReorderCost));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ProjectStudio — create/list/view/appreciate/comment round-trip with the EXACT
+// field names the component reads (r.data.result.projects, .project, .comments,
+// .appreciated, .count, .comment).
+// ─────────────────────────────────────────────────────────────────────────────
+describe("artistry projects — ProjectStudio round-trip", () => {
+  it("create → list → view exposes the fields the component renders", () => {
+    // ProjectStudio.submit() sends these exact field names.
+    const created = call("projectCreate", ctxA, {
+      title: "Dune Concepts", description: "moodboard", discipline: "concept-art",
+      tools: ["Photoshop"], tags: ["scifi", "desert"],
+      coverUrl: "https://x/cover.png",
+      images: [{ url: "https://x/1.png", caption: "wide", order: 0 }],
+      processSteps: [{ title: "thumbnail", detail: "10 thumbs" }],
+    });
+    assert.equal(created.ok, true);
+    const id = created.result.project.id;
+    assert.ok(typeof id === "string" && id);
+
+    const listed = call("projectList", ctxA, {});
+    assert.ok(Array.isArray(listed.result.projects)); // component: r.data.result.projects
+    assert.equal(listed.result.projects.length, 1);
+    const card = listed.result.projects[0];
+    // card fields ProjectStudio renders.
+    assert.equal(card.title, "Dune Concepts");
+    assert.equal(card.discipline, "concept-art");
+    assert.equal(card.views, 0);
+    assert.equal(card.appreciations, 0);   // list maps appreciations count
+    assert.equal(card.commentCount, 0);    // list maps commentCount
+
+    // A DIFFERENT viewer increments views (component reads detail.project.views).
+    const viewed = call("projectView", ctxB, { projectId: id });
+    assert.equal(viewed.ok, true);
+    assert.equal(viewed.result.project.views, 1);
+    assert.ok(Array.isArray(viewed.result.comments)); // detail.comments
+    assert.equal(viewed.result.appreciations, 0);     // detail.appreciations
+    assert.equal(viewed.result.appreciated, false);   // detail.appreciated
+  });
+
+  it("appreciate toggles + returns {appreciated, count} the component reads", () => {
+    const p = call("projectCreate", ctxA, { title: "P" });
+    const id = p.result.project.id;
+    const a1 = call("appreciate", ctxB, { projectId: id });
+    assert.equal(a1.ok, true);
+    assert.equal(a1.result.appreciated, true); // component: r.data.result.appreciated
+    assert.equal(a1.result.count, 1);          // component: r.data.result.count
+    const a2 = call("appreciate", ctxB, { projectId: id });
+    assert.equal(a2.result.appreciated, false);
+    assert.equal(a2.result.count, 0);
+  });
+
+  it("commentAdd → returns {comment} the component appends; commentList/Delete round-trip", () => {
+    const p = call("projectCreate", ctxA, { title: "P" });
+    const id = p.result.project.id;
+    const c = call("commentAdd", ctxB, { projectId: id, body: "love this" });
+    assert.equal(c.ok, true);
+    assert.equal(c.result.comment.body, "love this"); // component: r.data.result.comment
+    assert.equal(c.result.commentCount, 1);
+    const cid = c.result.comment.id;
+
+    const list = call("commentList", ctxA, { projectId: id });
+    assert.equal(list.result.count, 1);
+
+    const del = call("commentDelete", ctxB, { projectId: id, commentId: cid });
+    assert.equal(del.ok, true);
+    assert.equal(del.result.deleted, true);
+  });
+
+  it("VALIDATION-REJECTION: commentAdd without body is rejected fail-closed", () => {
+    const p = call("projectCreate", ctxA, { title: "P" });
+    const id = p.result.project.id;
+    const c = call("commentAdd", ctxB, { projectId: id, body: "   " });
+    assert.equal(c.ok, false);
+    assert.equal(c.error, "body_required");
+  });
+
+  it("VALIDATION-REJECTION: projectView on a missing id is rejected, not faked", () => {
+    const r = call("projectView", ctxA, { projectId: "nope" });
+    assert.equal(r.ok, false);
+    assert.equal(r.error, "project_not_found");
+  });
+
+  it("projectDelete removes the row + drafts hidden from other viewers", () => {
+    const p = call("projectCreate", ctxA, { title: "secret", published: false });
+    const id = p.result.project.id;
+    // a different viewer's list omits the draft (published filter).
+    const otherList = call("projectList", ctxB, { userId: "artist_a" });
+    assert.equal(otherList.result.projects.length, 0);
+    const del = call("projectDelete", ctxA, { projectId: id });
+    assert.equal(del.result.deleted, true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CommunityNetwork — personalizedFeed + followGraph with the EXACT fields read.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("artistry network — CommunityNetwork", () => {
+  it("followGraph returns following/followers/mutuals + counts the component renders", () => {
+    call("follow", ctxA, { targetUserId: "artist_b" });
+    call("follow", ctxB, { targetUserId: "artist_a" }); // mutual
+    const g = call("followGraph", ctxA, {});
+    assert.equal(g.ok, true);
+    assert.deepEqual(g.result.following, ["artist_b"]);
+    assert.deepEqual(g.result.followers, ["artist_b"]);
+    assert.deepEqual(g.result.mutuals, ["artist_b"]);
+    assert.equal(g.result.followingCount, 1); // graph?.followingCount
+    assert.equal(g.result.followerCount, 1);  // graph?.followerCount
+    assert.equal(g.result.mutualCount, 1);    // graph?.mutualCount
+  });
+
+  it("personalizedFeed follows mode → discovery fallback with the rendered fields", () => {
+    // B publishes a project; A follows B → feed mode 'follows'.
+    call("projectCreate", ctxB, { title: "B work", coverUrl: "https://x/c.png" });
+    call("follow", ctxA, { targetUserId: "artist_b" });
+    const f = call("personalizedFeed", ctxA, { limit: 24 });
+    assert.equal(f.ok, true);
+    assert.equal(f.result.mode, "follows"); // feed?.mode
+    assert.ok(Array.isArray(f.result.items));
+    assert.equal(f.result.items[0].title, "B work");
+    assert.equal(f.result.items[0].userId, "artist_b"); // feed item: by {userId}
+    assert.equal(typeof f.result.items[0].appreciations, "number");
+    assert.equal(typeof f.result.items[0].commentCount, "number");
+    assert.equal(typeof f.result.fromFollowsCount, "number");
+
+    // A NEW user with no follows falls back to discovery (most-appreciated).
+    const f2 = call("personalizedFeed", { actor: { userId: "lonely" }, userId: "lonely" }, {});
+    assert.equal(f2.result.mode, "discovery");
+  });
+
+  it("VALIDATION-REJECTION: cannot follow self", () => {
+    const r = call("follow", ctxA, { targetUserId: "artist_a" });
+    assert.equal(r.ok, false);
+    assert.equal(r.error, "cannot_follow_self");
+  });
+
+  it("unfollow returns {unfollowed, followingCount}", () => {
+    call("follow", ctxA, { targetUserId: "artist_b" });
+    const u = call("unfollow", ctxA, { targetUserId: "artist_b" });
+    assert.equal(u.ok, true);
+    assert.equal(u.result.unfollowed, "artist_b");
+    assert.equal(u.result.followingCount, 0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Collections — create/list/save/items with EXACT field names.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("artistry collections — Collections", () => {
+  it("create → list → save → items round-trip with rendered fields", () => {
+    const coll = call("collectionCreate", ctxA, { name: "Inspo", description: "refs", isPrivate: false });
+    assert.equal(coll.ok, true);
+    const cid = coll.result.collection.id;
+
+    const list = call("collectionList", ctxA, {});
+    assert.ok(Array.isArray(list.result.collections)); // component: r.data?.result?.collections
+    assert.equal(list.result.collections[0].name, "Inspo");
+    assert.equal(list.result.collections[0].itemCount, 0); // component renders {itemCount}
+
+    const proj = call("projectCreate", ctxA, { title: "MyArt" });
+    const pid = proj.result.project.id;
+    const saved = call("collectionSave", ctxA, { collectionId: cid, projectId: pid });
+    assert.equal(saved.ok, true);
+    assert.equal(saved.result.saved, true);
+    assert.equal(saved.result.itemCount, 1);
+
+    const items = call("collectionItems", ctxA, { collectionId: cid });
+    assert.ok(Array.isArray(items.result.items)); // component: r.data.result.items
+    assert.equal(items.result.collection.id, cid); // component: r.data.result.collection
+    assert.equal(items.result.items[0].title, "MyArt");
+  });
+
+  it("VALIDATION-REJECTION: private collection hidden from a non-owner viewer", () => {
+    const coll = call("collectionCreate", ctxA, { name: "Secret", isPrivate: true });
+    const cid = coll.result.collection.id;
+    const r = call("collectionItems", ctxB, { collectionId: cid });
+    assert.equal(r.ok, false);
+    assert.equal(r.error, "collection_private");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PortfolioProfile — profileUpdate/profileGet with EXACT fields (profile, stats,
+// projects, isOwner).
+// ─────────────────────────────────────────────────────────────────────────────
+describe("artistry profile — PortfolioProfile", () => {
+  it("update → get exposes profile/stats/projects/isOwner the component reads", () => {
+    const upd = call("profileUpdate", ctxA, {
+      displayName: "Ada", headline: "Concept Artist", bio: "I draw", location: "NYC",
+      avatarUrl: "https://x/a.png", bannerUrl: "https://x/b.png",
+      disciplines: ["illustration", "concept-art"],
+      links: [{ label: "site", url: "https://ada.art" }],
+      availableForHire: true, layout: "masonry",
+    });
+    assert.equal(upd.ok, true);
+    assert.equal(upd.result.profile.displayName, "Ada");
+
+    call("projectCreate", ctxA, { title: "Piece", coverUrl: "https://x/p.png", published: true });
+    const got = call("profileGet", ctxA, {});
+    assert.equal(got.ok, true);
+    // EXACT fields PortfolioProfile destructures: { profile, projects, stats, isOwner }.
+    assert.equal(got.result.profile.displayName, "Ada");
+    assert.equal(got.result.profile.layout, "masonry");
+    assert.equal(got.result.isOwner, true);
+    assert.ok(Array.isArray(got.result.projects));
+    assert.equal(got.result.projects[0].title, "Piece");
+    // stats fields the component renders.
+    assert.equal(got.result.stats.projectCount, 1);
+    assert.equal(typeof got.result.stats.totalViews, "number");
+    assert.equal(typeof got.result.stats.totalAppreciations, "number");
+    assert.equal(typeof got.result.stats.followerCount, "number");
+    assert.equal(typeof got.result.stats.followingCount, "number");
+  });
+
+  it("profileGet on an unknown user returns a default profile (component never blanks)", () => {
+    const got = call("profileGet", ctxA, { userId: "ghost" });
+    assert.equal(got.ok, true);
+    assert.equal(got.result.profile.userId, "ghost");
+    assert.equal(got.result.isOwner, false);
+    assert.equal(got.result.stats.projectCount, 0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DisciplineSearch — search + tagCloud with EXACT fields (results, tags,
+// disciplines).
+// ─────────────────────────────────────────────────────────────────────────────
+describe("artistry search — DisciplineSearch", () => {
+  beforeEach(() => {
+    call("projectCreate", ctxA, { title: "Forest", discipline: "illustration", tags: ["nature", "green"] });
+    call("projectCreate", ctxA, { title: "Cityscape", discipline: "photography", tags: ["urban"] });
+  });
+
+  it("search returns {results} the component renders + respects discipline/tag/sort", () => {
+    const r = call("search", ctxA, { query: "", sort: "recent", discipline: "illustration", tag: "" });
+    assert.equal(r.ok, true);
+    assert.ok(Array.isArray(r.result.results)); // component: r.data.result.results
+    assert.equal(r.result.results.length, 1);
+    assert.equal(r.result.results[0].title, "Forest");
+    assert.equal(typeof r.result.results[0].appreciations, "number"); // result card fields
+    assert.equal(typeof r.result.results[0].commentCount, "number");
+  });
+
+  it("tagCloud returns {tags, disciplines} the component renders", () => {
+    const r = call("tagCloud", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.ok(Array.isArray(r.result.tags));        // component: r.data.result.tags
+    assert.ok(Array.isArray(r.result.disciplines)); // component: r.data.result.disciplines
+    const nature = r.result.tags.find((t) => t.tag === "nature");
+    assert.ok(nature && nature.count === 1);
+    const ill = r.result.disciplines.find((d) => d.discipline === "illustration");
+    assert.ok(ill && ill.count === 1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// JobBoard — jobPost/jobList/jobApply/jobClose with EXACT fields.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("artistry jobs — JobBoard", () => {
+  it("post → list → apply → close round-trip with rendered fields", () => {
+    const job = call("jobPost", ctxA, {
+      title: "Album cover", description: "brief", discipline: "illustration", kind: "commission",
+      budgetMin: 200, budgetMax: 800, remote: true, location: "", tags: ["music"],
+    });
+    assert.equal(job.ok, true);
+    const jid = job.result.job.id;
+    assert.equal(job.result.job.budgetMin, 200);
+    assert.equal(job.result.job.budgetMax, 800);
+    assert.equal(job.result.job.status, "open");
+
+    // A different artist sees the open job (jobList component fields).
+    const open = call("jobList", ctxB, { mine: false });
+    assert.equal(open.result.jobs.length, 1);
+    assert.equal(open.result.jobs[0].applicationCount, 0); // component: j.applicationCount
+    assert.equal(open.result.jobs[0].applied, false);      // component: j.applied
+
+    const applied = call("jobApply", ctxB, { jobId: jid, message: "pitch", quote: 500 });
+    assert.equal(applied.ok, true);
+    assert.equal(applied.result.applicationCount, 1);
+
+    // Owner's list shows the applicant + applied flag re-derived per viewer.
+    const mine = call("jobList", ctxA, { mine: true, includeClosed: true });
+    assert.equal(mine.result.jobs[0].applicationCount, 1);
+    assert.equal(mine.result.jobs[0].applications[0].quote, 500); // owner: a.quote
+
+    const closed = call("jobClose", ctxA, { jobId: jid });
+    assert.equal(closed.ok, true);
+    assert.equal(closed.result.closed, true);
+  });
+
+  it("VALIDATION-REJECTION: cannot apply to your own job / closed job / twice", () => {
+    const job = call("jobPost", ctxA, { title: "Mine" });
+    const jid = job.result.job.id;
+    assert.equal(call("jobApply", ctxA, { jobId: jid }).error, "cannot_apply_own_job");
+    call("jobApply", ctxB, { jobId: jid });
+    assert.equal(call("jobApply", ctxB, { jobId: jid }).error, "already_applied");
+    call("jobClose", ctxA, { jobId: jid });
+    assert.equal(call("jobApply", { actor: { userId: "c" }, userId: "c" }, { jobId: jid }).error, "job_closed");
+  });
+
+  it("VALIDATION-REJECTION: jobPost without title rejected; poisoned budget coerces to 0", () => {
+    assert.equal(call("jobPost", ctxA, { title: "  " }).error, "title_required");
+    const job = call("jobPost", ctxA, { title: "Ok", budgetMin: "Infinity", budgetMax: "1e999" });
+    assert.equal(job.ok, true);
+    assert.equal(job.result.job.budgetMin, 0); // fail-closed
+    assert.equal(job.result.job.budgetMax, 0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CuratedGalleries — galleryCreate/galleryList/galleryItems with EXACT fields.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("artistry galleries — CuratedGalleries", () => {
+  it("create → list → items resolves only PUBLISHED projects with rendered fields", () => {
+    const pub = call("projectCreate", ctxA, { title: "Pub", published: true, coverUrl: "https://x/c.png" });
+    const draft = call("projectCreate", ctxA, { title: "Draft", published: false });
+    const gal = call("galleryCreate", ctxA, {
+      title: "Best of 2026", theme: "Featured", description: "top picks", featured: true,
+      projectIds: [pub.result.project.id, draft.result.project.id],
+    });
+    assert.equal(gal.ok, true);
+    const gid = gal.result.gallery.id;
+
+    const list = call("galleryList", ctxA, {});
+    assert.ok(Array.isArray(list.result.galleries)); // component: r.data?.result?.galleries
+    assert.equal(list.result.galleries[0].projectCount, 2); // component renders {projectCount}
+    assert.equal(list.result.galleries[0].featured, true);
+
+    const items = call("galleryItems", ctxA, { galleryId: gid });
+    assert.ok(Array.isArray(items.result.items)); // component: r.data.result.items
+    assert.equal(items.result.gallery.id, gid);   // component: r.data.result.gallery
+    // Only the PUBLISHED project resolves (the draft is filtered).
+    assert.equal(items.result.items.length, 1);
+    assert.equal(items.result.items[0].title, "Pub");
+  });
+
+  it("VALIDATION-REJECTION: galleryCreate without title rejected; galleryItems missing id rejected", () => {
+    assert.equal(call("galleryCreate", ctxA, { title: "" }).error, "title_required");
+    assert.equal(call("galleryItems", ctxA, { galleryId: "nope" }).error, "gallery_not_found");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// State-unavailable degrade: with no STATE the social macros never throw.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("artistry — degrade graceful when STATE is absent", () => {
+  it("social macros return {ok:false, state_unavailable}, never throw", () => {
+    globalThis._concordSTATE = undefined;
+    const r = call("projectList", ctxA, {});
+    assert.equal(r.ok, false);
+    assert.equal(r.error, "state_unavailable");
+  });
+
+  it("compute macros are STATE-independent (pure compute) and still resolve", () => {
+    globalThis._concordSTATE = undefined;
+    const r = call("colorPaletteAnalysis", ctxA, { palette: ["#123456"] });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.harmonyScore));
+  });
+});

--- a/server/tests/atlas-lens-macros.test.js
+++ b/server/tests/atlas-lens-macros.test.js
@@ -1,0 +1,342 @@
+// Behavioral macro tests for server/domains/atlas.js — the geo/maps substrate
+// the /lenses/atlas lens drives (geocode, distance matrices, region stats, TSP
+// route optimization, plus the OSM-backed live_* family).
+//
+// This file mirrors the REAL LENS_ACTIONS dispatch: handlers registered via
+// `registerLensAction(domain, action, handler)` are invoked as
+// `handler(ctx, virtualArtifact, input)` — the 3-ARG convention with
+// `virtualArtifact.data = input`. The dispatch ALSO peels exactly one
+// redundant `{ artifact: { data } }` wrapper (lens-input-normalize.js); two
+// atlas panels (DistanceMatrixPanel, MapsDirections, AtlasActionPanel) send the
+// double-wrapped shape, so our harness peels it the same way before calling.
+//
+// These are NOT shape-only assertions and they DO NOT duplicate the existing
+// atlas parity suites. They pin ACTUAL geodesy (haversine distance, bearing,
+// nearest-neighbor + 2-opt TSP, Gini concentration) for KNOWN inputs → KNOWN
+// outputs, the EXACT field names each lens component renders (so a dead-surface
+// regression surfaces here), validation-rejection, graceful degradation, and a
+// fail-CLOSED poisoned-numeric contract: Infinity/NaN/1e308 coordinates are
+// REJECTED rather than leaking Infinity/NaN (serialized null) into the result.
+// External-IO macros (nominatim/overpass/osrm/mapillary) are asserted to
+// validate+reject bad input WITHOUT performing a network call.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerAtlasActions from "../domains/atlas.js";
+import { peelRedundantArtifactWrapper } from "../lib/lens-input-normalize.js";
+
+const ACTIONS = new Map();
+function registerLensAction(domain, name, fn) {
+  assert.equal(domain, "atlas", `unexpected domain: ${domain}`);
+  ACTIONS.set(name, fn);
+}
+
+// Mirror the live dispatch exactly: peel one redundant artifact wrapper, then
+// handler(ctx, virtualArtifact, input) with virtualArtifact.data = input.
+function call(name, ctx, rawInput = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`atlas.${name} not registered`);
+  const input = peelRedundantArtifactWrapper(rawInput);
+  const virtualArtifact = { id: null, title: null, domain: "atlas", type: "domain_action", data: input || {}, meta: {} };
+  return fn(ctx, virtualArtifact, input || {});
+}
+
+before(() => { registerAtlasActions(registerLensAction); });
+
+let fetchCalls = 0;
+beforeEach(() => {
+  // No boot, no network, no LLM. Any handler that reaches for the network in a
+  // test marks itself as a leak via fetchCalls.
+  fetchCalls = 0;
+  globalThis.fetch = async () => { fetchCalls++; throw new Error("network disabled in tests"); };
+  globalThis._concordSTATE = { atlasLens: undefined };
+  globalThis._concordSaveStateDebounced = () => {};
+});
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+
+// Reference coordinates the handler's built-in table and the tests share.
+const NYC = { name: "NYC", lat: 40.7128, lon: -74.006 };
+const LA = { name: "LA", lat: 34.0522, lon: -118.2437 };
+const CHI = { name: "CHI", lat: 41.8781, lon: -87.6298 };
+
+describe("atlas — registration (every lens-driven macro present)", () => {
+  it("registers the deterministic compute macros the lens components call", () => {
+    for (const m of [
+      // The four page "Atlas Compute Actions" buttons + DistanceMatrixPanel +
+      // MapsDirections + AtlasActionPanel pure-compute surface.
+      "geocode", "distanceMatrix", "regionStats", "routeOptimize",
+    ]) {
+      assert.equal(typeof ACTIONS.get(m), "function", `missing atlas.${m}`);
+    }
+  });
+
+  it("registers the external-IO (OSM/OSRM/Mapillary) macros the panels drive", () => {
+    for (const m of [
+      "nominatim-geocode", "nominatim-reverse", "overpass-poi",
+      "directions", "directions-multimodal", "live-traffic-eta",
+      "transit-directions", "route-stops", "street-imagery", "place-details",
+      "nav-start", "nav-update",
+    ]) {
+      assert.equal(typeof ACTIONS.get(m), "function", `missing atlas.${m}`);
+    }
+  });
+});
+
+// ── atlas.geocode — name→coords + haversine distance/bearing ───────────────
+describe("atlas.geocode — reference resolution + distance/bearing from origin", () => {
+  it("resolves known cities, computes real distance + cardinal direction from origin", () => {
+    // EXACT shape the page's geocode action operates over (artifact.data.places
+    // + origin). The page renders resolvedCount/unresolvedCount + each
+    // resolved row's name/lat/lon/distanceFromOriginKm.
+    const r = call("geocode", ctxA, { places: [{ name: "London" }, { name: "Tokyo" }, { name: "Nowhereville" }], origin: { lat: NYC.lat, lon: NYC.lon } });
+    assert.equal(r.ok, true);
+    const res = r.result;
+    assert.equal(res.count, 3);
+    assert.equal(res.resolvedCount, 2);
+    assert.equal(res.unresolvedCount, 1);
+    const london = res.resolved.find((p) => p.name === "London");
+    // London is in the built-in reference table; coords echoed exactly.
+    assert.equal(london.resolved, true);
+    assert.equal(london.lat, 51.5074);
+    assert.equal(london.lon, -0.1278);
+    // Real haversine from NYC → London ≈ 5570 km, bearing roughly NE.
+    assert.ok(Math.abs(london.distanceFromOriginKm - 5570.22) < 1, `dist ${london.distanceFromOriginKm}`);
+    assert.equal(london.directionFromOrigin, "NE");
+    assert.equal(london.hemisphere, "Northern");
+    // The unresolved entry is honest — no fabricated 0,0 coordinate.
+    const miss = res.resolved.find((p) => p.name === "Nowhereville");
+    assert.equal(miss.resolved, false);
+    assert.match(miss.message, /Could not resolve/);
+    // nearestToOrigin is a real ranking across resolved places.
+    assert.equal(res.nearestToOrigin, "London");
+  });
+
+  it("honors provided lat/lon over the reference table", () => {
+    const r = call("geocode", ctxA, { places: [{ name: "Custom", lat: 10, lon: 20 }] });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.resolved[0].source, "provided");
+    assert.equal(r.result.resolved[0].lat, 10);
+    assert.equal(r.result.resolved[0].lon, 20);
+  });
+
+  it("degrade-graceful: no places → guidance message, not a crash", () => {
+    const r = call("geocode", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.match(r.result.message, /No places provided/);
+    assert.deepEqual(r.result.resolved, []);
+  });
+
+  it("fail-CLOSED: a poisoned Infinity provided coord is treated as unresolved (never NaN distance)", () => {
+    const r = call("geocode", ctxA, { places: [{ name: "zzz_unknown", lat: Infinity, lon: 1 }], origin: { lat: NYC.lat, lon: NYC.lon } });
+    assert.equal(r.ok, true);
+    // Unknown name + poisoned coords ⇒ honestly unresolved, no NaN leaked.
+    const row = r.result.resolved[0];
+    assert.equal(row.resolved, false);
+    // The poisoned coord never produced a distance/bearing field at all.
+    assert.equal(row.distanceFromOriginKm, undefined);
+    assert.equal(row.bearingFromOrigin, undefined);
+    // No serialized NaN slipped into the row.
+    assert.ok(!Object.values(row).some((v) => typeof v === "number" && Number.isNaN(v)), "no NaN in row");
+  });
+});
+
+// ── atlas.distanceMatrix — NxN haversine + DistanceMatrixPanel field contract ─
+describe("atlas.distanceMatrix — real geodesy + every rendered field", () => {
+  it("computes the NxN km matrix + stats the DistanceMatrixPanel renders", () => {
+    // EXACT double-wrapped shape DistanceMatrixPanel.callAtlas sends.
+    const r = call("distanceMatrix", ctxA, { artifact: { data: { points: [NYC, LA, CHI] } } });
+    assert.equal(r.ok, true);
+    const res = r.result;
+    assert.deepEqual(res.labels, ["NYC", "LA", "CHI"]);
+    // Symmetric NxN number matrix (the heatmap reads matrix as number[][]).
+    assert.equal(res.matrix.length, 3);
+    assert.equal(res.matrix[0][1], res.matrix[1][0]);
+    assert.equal(res.matrix[0][0], 0);
+    // NYC→LA ≈ 3935.75 km (pinned haversine).
+    assert.equal(res.matrix[0][1], 3935.75);
+    // stats aliases the panel renders directly (meanKm / maxKm / maxPair / minPair).
+    assert.equal(res.stats.maxKm, 3935.75);
+    assert.deepEqual(res.stats.maxPair, ["NYC", "LA"]);
+    assert.equal(res.stats.meanKm, res.stats.averageDistanceKm);
+    assert.equal(res.stats.maxKm, res.stats.maxDistanceKm);
+    assert.equal(res.stats.minKm, res.stats.minDistanceKm);
+    assert.deepEqual(res.stats.minPair, res.stats.minDistancePair);
+    // Flat pair list + nearest — the AtlasActionPanel field contract.
+    assert.equal(res.pairs.length, 3); // C(3,2)
+    const nycLa = res.pairs.find((p) => p.from === "NYC" && p.to === "LA");
+    assert.equal(nycLa.distanceKm, 3935.75);
+    assert.ok(Number.isFinite(nycLa.estTimeMinutes) && nycLa.estTimeMinutes > 0);
+    assert.equal(res.nearest.from, "NYC");
+    assert.equal(res.nearest.to, "CHI"); // closest pair of the three
+    assert.equal(res.nearest.distanceKm, res.stats.minKm);
+  });
+
+  it("accepts the AtlasActionPanel lng-keyed shape identically to lon", () => {
+    // AtlasActionPanel sends points with `lng`; DistanceMatrixPanel sends `lon`.
+    const withLng = call("distanceMatrix", ctxA, { artifact: { data: { points: [{ name: "NYC", lat: 40.7128, lng: -74.006 }, { name: "LA", lat: 34.0522, lng: -118.2437 }] } } });
+    const withLon = call("distanceMatrix", ctxA, { artifact: { data: { points: [NYC, LA] } } });
+    assert.equal(withLng.ok, true);
+    // lng path must NOT collapse to 0 distance — the historical dead-surface bug.
+    assert.equal(withLng.result.matrix[0][1], withLon.result.matrix[0][1]);
+    assert.equal(withLng.result.matrix[0][1], 3935.75);
+  });
+
+  it("validation-rejection: fewer than 2 points → guidance message", () => {
+    const r = call("distanceMatrix", ctxA, { artifact: { data: { points: [NYC] } } });
+    assert.equal(r.ok, true);
+    assert.match(r.result.message, /at least 2 points/i);
+  });
+
+  it("fail-CLOSED: poisoned Infinity/1e308 coords are REJECTED, never emit null", () => {
+    const inf = call("distanceMatrix", ctxA, { artifact: { data: { points: [{ name: "X", lat: Infinity, lon: 1e308 }, { name: "Y", lat: 1, lon: 2 }] } } });
+    assert.equal(inf.ok, false);
+    assert.match(inf.error, /finite/);
+    const big = call("distanceMatrix", ctxA, { artifact: { data: { points: [{ name: "X", lat: 1e308, lon: 0 }, { name: "Y", lat: 1, lon: 2 }] } } });
+    assert.equal(big.ok, false);
+  });
+});
+
+// ── atlas.routeOptimize — nearest-neighbor + 2-opt TSP, MapsDirections shape ─
+describe("atlas.routeOptimize — TSP + every rendered route field", () => {
+  it("returns an ordered route + legs the DistanceMatrixPanel/MapsDirections render", () => {
+    // EXACT double-wrapped shape MapsDirections.optimize sends.
+    const r = call("routeOptimize", ctxA, { artifact: { data: { waypoints: [NYC, LA, CHI] } } });
+    assert.equal(r.ok, true);
+    const res = r.result;
+    assert.equal(res.waypointCount, 3);
+    // route is the ordered list of place NAMES (string[]) — the panel iterates it.
+    assert.deepEqual(res.route, ["NYC", "CHI", "LA"]);
+    // order mirrors route as integer waypoint indices.
+    assert.deepEqual(res.order, [0, 2, 1]);
+    // legs are { from, to, km } — the MapsDirections "Steps" list.
+    assert.equal(res.legs.length, 2);
+    assert.equal(res.legs[0].from, "NYC");
+    assert.equal(res.legs[0].to, "CHI");
+    assert.ok(Number.isFinite(res.legs[0].km) && res.legs[0].km > 0);
+    // totalDistanceKm equals the sum of leg km (cross-check).
+    const legSum = Math.round(res.legs.reduce((s, l) => s + l.km, 0) * 100) / 100;
+    assert.equal(res.totalDistanceKm, legSum);
+    // optimizedRoute (the page's render) carries step/name and stays consistent.
+    assert.equal(res.optimizedRoute.length, 3);
+    assert.equal(res.optimizedRoute[0].step, 1);
+    assert.deepEqual(res.optimizedRoute.map((s) => s.name), res.route);
+    // The optimizer never returns a route longer than naive input order.
+    assert.ok(res.totalDistanceKm <= res.naiveOrderDistanceKm + 0.01);
+  });
+
+  it("validation-rejection: fewer than 2 waypoints → guidance message", () => {
+    const r = call("routeOptimize", ctxA, { artifact: { data: { waypoints: [NYC] } } });
+    assert.equal(r.ok, true);
+    assert.match(r.result.message, /at least 2 waypoints/i);
+  });
+
+  it("fail-CLOSED: a NaN/non-finite waypoint coord is REJECTED", () => {
+    const r = call("routeOptimize", ctxA, { artifact: { data: { waypoints: [{ name: "X", lat: "abc", lon: 0 }, NYC] } } });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /finite/);
+  });
+});
+
+// ── atlas.regionStats — totals/averages/Gini concentration ─────────────────
+describe("atlas.regionStats — aggregate demographics the page Region Stats panel renders", () => {
+  it("computes totals, per-capita, rankings + a real Gini concentration index", () => {
+    const r = call("regionStats", ctxA, {
+      regions: [
+        { name: "Alpha", population: 1000000, area: 500, gdp: 50000000000, growth: 0.02 },
+        { name: "Beta", population: 3000000, area: 1500, gdp: 60000000000, growth: 0.04 },
+      ],
+    });
+    assert.equal(r.ok, true);
+    const res = r.result;
+    // The page renders regionCount + totals + averages + distribution.concentration.
+    assert.equal(res.regionCount, 2);
+    assert.equal(res.totals.population, 4000000);
+    assert.equal(res.totals.gdp, 110000000000);
+    // gdpPerCapita = total gdp / total pop.
+    assert.equal(res.averages.gdpPerCapita, Math.round((110000000000 / 4000000) * 100) / 100);
+    // Gini in [0,1]; concentration label is a pure function of it.
+    assert.ok(res.distribution.populationGini >= 0 && res.distribution.populationGini <= 1);
+    const g = res.distribution.populationGini;
+    const expected = g > 0.5 ? "highly-concentrated" : g > 0.3 ? "moderately-concentrated" : "evenly-distributed";
+    assert.equal(res.distribution.concentration, expected);
+    // Rankings sort descending by population.
+    assert.equal(res.rankings.byPopulation[0].name, "Beta");
+    assert.equal(res.rankings.byPopulation[0].rank, 1);
+  });
+
+  it("degrade-graceful: no regions → guidance message", () => {
+    const r = call("regionStats", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.match(r.result.message, /No region data/);
+  });
+
+  it("fail-CLOSED: a non-finite metric (Infinity population) is REJECTED, never leaks into Gini", () => {
+    const r = call("regionStats", ctxA, { regions: [{ name: "Bad", population: Infinity, area: 1, gdp: 1 }] });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /non-finite/);
+  });
+
+  it("a cosmologically-large-but-finite population is preserved (no false rejection)", () => {
+    const r = call("regionStats", ctxA, { regions: [{ name: "Huge", population: 1e12, area: 1, gdp: 1 }] });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.totals.population, 1e12);
+  });
+});
+
+// ── External-IO macros — validate+reject WITHOUT a network call ─────────────
+describe("atlas external-IO — validation-rejection happens BEFORE any fetch", () => {
+  it("nominatim-geocode rejects an empty query without touching the network", async () => {
+    const r = await call("nominatim-geocode", ctxA, { query: "   " });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /query required/);
+    assert.equal(fetchCalls, 0, "no network call on validation-reject");
+  });
+
+  it("nominatim-reverse rejects non-numeric lat/lng without a fetch", async () => {
+    const r = await call("nominatim-reverse", ctxA, { latitude: "x", longitude: "y" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /latitude \+ longitude required/);
+    assert.equal(fetchCalls, 0);
+  });
+
+  it("overpass-poi rejects an invalid bbox (south >= north) without a fetch", async () => {
+    const r = await call("overpass-poi", ctxA, { south: 10, west: 0, north: 5, east: 5 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /bbox invalid/);
+    assert.equal(fetchCalls, 0);
+  });
+
+  it("directions rejects <2 waypoints without a fetch", async () => {
+    const r = await call("directions", ctxA, { waypoints: [{ lat: 1, lng: 2 }] });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /at least 2 waypoints/);
+    assert.equal(fetchCalls, 0);
+  });
+
+  it("route-stops rejects a missing start/end without a fetch", async () => {
+    const r = await call("route-stops", ctxA, { start: {}, end: {} });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /numeric lat\/lng/);
+    assert.equal(fetchCalls, 0);
+  });
+
+  it("transit-directions rejects a missing start/end without a fetch", async () => {
+    const r = await call("transit-directions", ctxA, { start: {}, end: { lat: 1, lng: 2 } });
+    assert.equal(r.ok, false);
+    assert.equal(fetchCalls, 0);
+  });
+
+  it("street-imagery rejects non-numeric lat/lng without a fetch", async () => {
+    const r = await call("street-imagery", ctxA, { lat: "a", lng: "b" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /numeric lat\/lng/);
+    assert.equal(fetchCalls, 0);
+  });
+
+  it("place-details rejects a missing osmType/osmId without a fetch", async () => {
+    const r = await call("place-details", ctxA, { osmType: "bogus", osmId: "x" });
+    assert.equal(r.ok, false);
+    assert.equal(fetchCalls, 0);
+  });
+});

--- a/server/tests/bio-lens-macros.test.js
+++ b/server/tests/bio-lens-macros.test.js
@@ -1,0 +1,315 @@
+// Behavioral macro tests for server/domains/bio.js — the Benchling / SnapGene /
+// UniProt / NCBI-shaped bioinformatics substrate the /lenses/bio components
+// drive (SequenceAnalyzer, BioActionPanel, BioWorkbench, MolecularWorkbench).
+//
+// This file mirrors the REAL LENS_ACTIONS dispatch (server.js): handlers
+// registered via `registerLensAction(domain, action, handler)` are invoked as
+// `handler(ctx, virtualArtifact, input)` — the 3-ARG convention, with
+// `virtualArtifact.data = input`. The components call a local
+// `callMacro(action, { input: {...} })` whose {artifact:{data}} wrapper is
+// auto-peeled by the dispatch fix, so the handler sees the input object as
+// BOTH artifact.data AND params. Our harness reproduces that exactly.
+//
+// These are NOT shape-only assertions and they DO NOT duplicate the existing
+// bio-domain-parity suite. They drive each calculator with the COMPONENT'S
+// EXACT input field names and assert the COMPONENT'S EXACT rendered output
+// field names carry real computed values (GC%, Tm, reverse-complement primer,
+// 6-frame translation, restriction cut sites, CRISPR guides), plus
+// validation-rejection, degrade-graceful (STATE unavailable), and a
+// fail-CLOSED poisoned-input contract (non-string sequence / non-finite
+// scoring weights are REJECTED, never coerced into a fabricated result).
+//
+// FIELD-ALIGNMENT (caller field → receiver field) pinned here — the two
+// dead-surface fixes this sprint landed:
+//   • SequenceAnalyzer align tab renders alignA/alignB/alignBars/identity
+//     (was alignedA/alignedB/midline/identityPercent → handler emits none →
+//     blank align result). Asserted via "render-field contract" cases.
+//   • BioActionPanel restrict sends enzymes:[enzyme] (was singular `enzyme`,
+//     ignored → all 10 scanned) and sites are {enzyme,position,cutAt,site}
+//     objects (was rendered as number[] → "[object Object]"). Asserted below.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerBioActions from "../domains/bio.js";
+
+const ACTIONS = new Map();
+function registerLensAction(domain, name, fn) {
+  assert.equal(domain, "bio", `unexpected domain: ${domain}`);
+  ACTIONS.set(name, fn);
+}
+// Mirror the live dispatch exactly: handler(ctx, virtualArtifact, input) with
+// virtualArtifact.data = input.
+function call(name, ctx, input = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`bio.${name} not registered`);
+  const virtualArtifact = { id: null, title: null, domain: "bio", type: "domain_action", data: input || {}, meta: {} };
+  return fn(ctx, virtualArtifact, input || {});
+}
+
+before(() => { registerBioActions(registerLensAction); });
+
+let fetchCalls = 0;
+beforeEach(() => {
+  // No boot, no network, no LLM. A handler that reaches for the network marks
+  // itself via fetchCalls.
+  fetchCalls = 0;
+  globalThis.fetch = async () => { fetchCalls++; throw new Error("network disabled in tests"); };
+  globalThis._concordSTATE = { dtus: new Map() };
+  globalThis._concordSaveStateDebounced = () => {};
+});
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+const ctxB = { actor: { userId: "user_b" }, userId: "user_b" };
+
+// ── Registration — every component-driven macro present ──────────────────────
+
+describe("bio — registration (every lens-component macro present)", () => {
+  it("registers the macros the four bio components call", () => {
+    for (const m of [
+      // SequenceAnalyzer + BioActionPanel + BioWorkbench
+      "sequence-analyze", "primer-design", "align-pairwise", "restriction-map",
+      "parse-fasta", "sequence-save", "sequence-list", "sequence-delete",
+      // MolecularWorkbench (7 backlog macros)
+      "plasmid-map", "align-multiple", "cloning-simulate", "translate-orf",
+      "blast-search", "crispr-design",
+      "notebook-create", "notebook-list", "notebook-update", "notebook-delete",
+    ]) {
+      assert.equal(typeof ACTIONS.get(m), "function", `missing bio.${m}`);
+    }
+  });
+});
+
+// ── sequence-analyze — the SequenceAnalyzer/BioActionPanel/BioWorkbench shape ─
+
+describe("bio.sequence-analyze — GC% / Tm / ORFs / protein composition", () => {
+  it("DNA: real GC% + Wallace-rule Tm + length (component input {sequence,kind})", () => {
+    const r = call("sequence-analyze", ctxA, { sequence: "GGCCGGCC", kind: "dna" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.length, 8);
+    assert.equal(r.result.kind, "dna");
+    assert.equal(r.result.gcPercent, 100);     // all G/C
+    assert.equal(r.result.tm, 32);             // Wallace 2*AT + 4*GC = 4*8
+    assert.ok(Array.isArray(r.result.orfs));
+  });
+
+  it("DNA: a clean ATG..TAA ORF (>=90 bp) is detected with frame/start/end/length", () => {
+    const seq = "ATG" + "GCT".repeat(30) + "TAA"; // 96 bp ORF
+    const r = call("sequence-analyze", ctxA, { sequence: seq, kind: "dna" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.orfs.length, 1);
+    assert.deepEqual(r.result.orfs[0], { frame: 1, start: 0, end: 96, length: 96 });
+  });
+
+  it("protein: composition map + average MW (110 Da/aa), no GC/Tm/ORFs", () => {
+    const r = call("sequence-analyze", ctxA, { sequence: "MKVL", kind: "protein" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.molecularWeight, 440);  // 4 aa * 110
+    assert.deepEqual(r.result.composition, { M: 1, K: 1, V: 1, L: 1 });
+    assert.equal(r.result.gcPercent, undefined);
+    assert.equal(r.result.orfs, undefined);
+  });
+
+  it("validation-rejection: empty sequence + unknown kind are rejected", () => {
+    assert.equal(call("sequence-analyze", ctxA, { sequence: "", kind: "dna" }).ok, false);
+    const bad = call("sequence-analyze", ctxA, { sequence: "ATGC", kind: "bogus" });
+    assert.equal(bad.ok, false);
+    assert.match(bad.error, /kind must be/);
+  });
+
+  it("fail-CLOSED: a non-string sequence is REJECTED, never String()-coerced into a fake GC%", () => {
+    const r = call("sequence-analyze", ctxA, { sequence: { x: 1 }, kind: "dna" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /sequence must be a string/);
+    // and a numeric sequence likewise
+    assert.equal(call("sequence-analyze", ctxA, { sequence: 12345, kind: "dna" }).ok, false);
+  });
+});
+
+// ── primer-design — forward + reverse-complement, the component shape ────────
+
+describe("bio.primer-design — forward + reverse-complement primer pair", () => {
+  it("computes a real primer pair the panels render (sequence/length/tm/gcPercent/productSize)", () => {
+    const seq = "ATG" + "GCATGCATGC".repeat(15); // 153 bp
+    const r = call("primer-design", ctxA, { sequence: seq, targetTm: 60, targetLength: 20 });
+    assert.equal(r.ok, true);
+    // Forward = first 20 bases.
+    assert.equal(r.result.forward.sequence, seq.slice(0, 20));
+    assert.equal(r.result.forward.length, 20);
+    assert.ok(Number.isFinite(r.result.forward.tm));
+    assert.ok(Number.isFinite(r.result.forward.gcPercent));
+    // Reverse = reverse-complement of the last 20 bases.
+    const comp = { A: "T", T: "A", G: "C", C: "G", N: "N" };
+    const expectedRev = seq.slice(-20).split("").reverse().map((b) => comp[b]).join("");
+    assert.equal(r.result.reverse.sequence, expectedRev);
+    assert.equal(r.result.productSize, seq.length);
+  });
+
+  it("validation-rejection: <100 bp and empty input are rejected", () => {
+    assert.equal(call("primer-design", ctxA, { sequence: "ATGC" }).ok, false);
+    assert.equal(call("primer-design", ctxA, { sequence: "" }).ok, false);
+  });
+});
+
+// ── align-pairwise — Needleman-Wunsch, render-field contract ─────────────────
+
+describe("bio.align-pairwise — Needleman-Wunsch + render-field contract", () => {
+  it("identical sequences → 100% identity, all-bars midline, equal-length rows", () => {
+    const r = call("align-pairwise", ctxA, { seqA: "GATTACA", seqB: "GATTACA", match: 2, mismatch: -1, gap: -2 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.identity, 100);
+    assert.equal(r.result.score, 14);          // 7 matches * 2
+    assert.equal(r.result.alignBars, "|||||||");
+    // The EXACT field names SequenceAnalyzer/BioActionPanel/BioWorkbench render.
+    assert.equal(typeof r.result.alignA, "string");
+    assert.equal(typeof r.result.alignB, "string");
+    assert.equal(typeof r.result.alignBars, "string");
+    assert.equal(r.result.alignA.length, r.result.alignB.length);
+    assert.equal(r.result.alignA.length, r.result.alignBars.length);
+    assert.equal(typeof r.result.alignmentLength, "number");
+    // The dead-surface aliases the OLD SequenceAnalyzer read must NOT exist —
+    // if they were ever (re)introduced the component would silently prefer them.
+    assert.equal(r.result.alignedA, undefined);
+    assert.equal(r.result.alignedB, undefined);
+    assert.equal(r.result.midline, undefined);
+    assert.equal(r.result.identityPercent, undefined);
+  });
+
+  it("fully divergent sequences → 0% identity", () => {
+    const r = call("align-pairwise", ctxA, { seqA: "AAAA", seqB: "TTTT" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.identity, 0);
+    assert.equal(r.result.matches, 0);
+  });
+
+  it("validation-rejection: a missing second sequence is rejected", () => {
+    assert.equal(call("align-pairwise", ctxA, { seqA: "ATGC" }).ok, false);
+  });
+
+  it("fail-CLOSED: a non-finite scoring weight is REJECTED, never leaks Infinity into score", () => {
+    const inf = call("align-pairwise", ctxA, { seqA: "ATGC", seqB: "GGGG", match: "Infinity" });
+    assert.equal(inf.ok, false);
+    assert.match(inf.error, /finite/);
+    const nan = call("align-pairwise", ctxA, { seqA: "ATGC", seqB: "GGGG", gap: NaN });
+    assert.equal(nan.ok, false);
+    // A genuinely huge-but-finite weight stays allowed (1e308 is a valid double).
+    const big = call("align-pairwise", ctxA, { seqA: "ATGC", seqB: "ATGC", match: "1e308" });
+    assert.equal(big.ok, true);
+    assert.ok(Number.isFinite(big.result.score));
+  });
+});
+
+// ── restriction-map — site OBJECTS, enzymes-array filter (BioActionPanel fix) ─
+
+describe("bio.restriction-map — cut sites + enzyme-array filter", () => {
+  it("finds EcoRI + BamHI with object sites {enzyme,position,cutAt,site} + count", () => {
+    const r = call("restriction-map", ctxA, { sequence: "GAATTCGGATCC" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.count, r.result.sites.length);
+    const eco = r.result.sites.find((s) => s.enzyme === "EcoRI");
+    const bam = r.result.sites.find((s) => s.enzyme === "BamHI");
+    assert.deepEqual([eco.position, eco.cutAt, eco.site], [0, 1, "GAATTC"]);
+    assert.deepEqual([bam.position, bam.cutAt, bam.site], [6, 7, "GGATCC"]);
+    // sites are OBJECTS (not numbers) — pins the BioActionPanel render contract.
+    assert.ok(r.result.sites.every((s) => typeof s === "object" && typeof s.enzyme === "string"));
+    assert.ok(Array.isArray(r.result.enzymesScanned));
+  });
+
+  it("enzymes:[EcoRI] filter (the array shape BioActionPanel now sends) restricts the scan", () => {
+    const r = call("restriction-map", ctxA, { sequence: "GAATTCGGATCC", enzymes: ["EcoRI"] });
+    assert.equal(r.ok, true);
+    assert.ok(r.result.sites.every((s) => s.enzyme === "EcoRI"));
+    assert.deepEqual(r.result.enzymesScanned, ["EcoRI"]);
+  });
+
+  it("an unknown enzyme name yields zero sites (honest empty, not a crash)", () => {
+    const r = call("restriction-map", ctxA, { sequence: "GAATTCGGATCC", enzymes: ["NOPE"] });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.count, 0);
+    assert.deepEqual(r.result.enzymesScanned, []);
+  });
+
+  it("validation-rejection: empty sequence is rejected", () => {
+    assert.equal(call("restriction-map", ctxA, { sequence: "" }).ok, false);
+  });
+});
+
+// ── translate-orf — 6-frame translation (MolecularWorkbench OrfTab) ──────────
+
+describe("bio.translate-orf — 6-frame translation + codon detail", () => {
+  it("translates ATGAAATTTGGGTAA → MKFG* on frame +1 with a real longest ORF", () => {
+    const r = call("translate-orf", ctxA, { sequence: "ATGAAATTTGGGTAA" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.frames.length, 6);
+    const fwd1 = r.result.frames.find((f) => f.frame === 1);
+    assert.equal(fwd1.protein, "MKFG*");
+    // codon detail the OrfTab highlights.
+    assert.equal(fwd1.codons[0].codon, "ATG");
+    assert.equal(fwd1.codons[0].isStart, true);
+    assert.equal(fwd1.codons[fwd1.codons.length - 1].isStop, true);
+    assert.equal(r.result.longestOrf.frame, 1);
+    assert.equal(r.result.longestOrf.peptide, "MKFG*");
+  });
+
+  it("validation-rejection: empty + non-ACGTUN input are rejected", () => {
+    assert.equal(call("translate-orf", ctxA, { sequence: "" }).ok, false);
+    assert.equal(call("translate-orf", ctxA, { sequence: "XYZ123" }).ok, false);
+  });
+});
+
+// ── crispr-design — guide-RNA scan (MolecularWorkbench CrisprTab) ────────────
+
+describe("bio.crispr-design — SpCas9 NGG guide design", () => {
+  it("finds 20 nt protospacers + NGG PAMs with finite on-target/composite scores", () => {
+    const target = "ATGGCCATGGCGCCCAGAACTGAGATCAATAGTACCCGTATTAACGGGTGA";
+    const r = call("crispr-design", ctxA, { sequence: target });
+    assert.equal(r.ok, true);
+    assert.ok(r.result.guideCount >= 1);
+    for (const g of r.result.guides) {
+      assert.equal(g.guide.length, 20);
+      assert.equal(g.pam[1], "G");
+      assert.equal(g.pam[2], "G");
+      assert.ok(Number.isFinite(g.onTargetScore) && g.onTargetScore >= 0 && g.onTargetScore <= 100);
+      assert.ok(Number.isFinite(g.compositeScore));
+    }
+    // sorted best-composite-first (the table renders top-down).
+    for (let i = 1; i < r.result.guides.length; i++) {
+      assert.ok(r.result.guides[i - 1].compositeScore >= r.result.guides[i].compositeScore);
+    }
+    assert.equal(r.result.topGuide, r.result.guides[0]);
+  });
+
+  it("validation-rejection: too-short + non-DNA input are rejected", () => {
+    assert.equal(call("crispr-design", ctxA, { sequence: "ATGC" }).ok, false);
+    assert.equal(call("crispr-design", ctxA, { sequence: "###" }).ok, false);
+  });
+});
+
+// ── per-user storage + degrade-graceful (STATE unavailable) ──────────────────
+
+describe("bio — sequence storage is per-user + degrades gracefully", () => {
+  it("a saved sequence is visible to its owner only", () => {
+    const saved = call("sequence-save", ctxA, { name: "myGene", sequence: "ATGCATGC", kind: "dna" });
+    assert.equal(saved.ok, true);
+    assert.equal(saved.result.sequence.name, "myGene");
+    assert.equal(call("sequence-list", ctxA, {}).result.sequences.length, 1);
+    // a different user sees none of user_a's sequences.
+    assert.equal(call("sequence-list", ctxB, {}).result.sequences.length, 0);
+  });
+
+  it("state-backed macros fail-soft (ok:false) when STATE is unavailable", () => {
+    globalThis._concordSTATE = undefined;
+    for (const m of ["sequence-save", "sequence-list", "sequence-delete", "notebook-list", "notebook-create"]) {
+      const r = call(m, ctxA, { name: "x", title: "x", id: "x" });
+      assert.equal(r.ok, false, `${m} should fail-soft`);
+      assert.match(r.error, /STATE unavailable/);
+    }
+  });
+
+  it("pure-compute macros still work with no STATE (they don't touch it)", () => {
+    globalThis._concordSTATE = undefined;
+    const r = call("sequence-analyze", ctxA, { sequence: "ATGCATGC", kind: "dna" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.gcPercent, 50);
+    assert.equal(fetchCalls, 0, "no network touched by pure-compute path");
+  });
+});

--- a/server/tests/board-lens-macros.test.js
+++ b/server/tests/board-lens-macros.test.js
@@ -1,0 +1,396 @@
+// Behavioral macro tests for the board (kanban) lens — the PATH-3
+// registerLensAction calculator surface in server/domains/board.js the
+// /lenses/board page drives through the AI Action Panel:
+//   workflowAnalysis · cardPrioritization · burndownForecast
+// plus the Trello/Asana STATE-backed substrate the BoardWorkspace / KanbanBoard
+// / CardDetailModal / BoardSettingsPanel components reach via boardMacro(...).
+//
+// THE COMPONENT-EXACT-SHAPE CONTRACT (the dead-calculator class this gate
+// targets):
+//   The /lenses/board page persists each task as a lens artifact whose .data is
+//   a SINGLE TASK ({status,priority,type,assignee,progress,dueDate,...}). The
+//   three calculators, however, read board-WIDE arrays
+//   (artifact.data.cards / columns / sprints / remainingPoints) — fields a task
+//   artifact NEVER carries. So in production handleBoardAction always rendered
+//   "No cards provided" while shape-only tests passed: a DEAD SURFACE.
+//   FIX (verified here): the page now derives {cards,columns}/{cards}/{sprints,
+//   remainingPoints} from the live tasks and passes them as the run-action
+//   `params` (3rd handler arg = req.body.params), and each handler reads
+//   `params.X ?? artifact.data.X`. These tests drive the EXACT params the page
+//   builder emits and assert the EXACT fields the panels render with real values.
+//
+// Dispatch shape (the run route): POST /api/lens/board/:id/run {action,params}
+//   → runMacro("lens","run",{id,action,params})
+//   → handler(ctx, persistedArtifact, params)   [3-ARG, params = body.params]
+// We invoke the registered handler directly with that exact 3-arg shape.
+//
+// NOT shape-only: every test feeds KNOWN inputs and asserts the EXACT computed
+// value (cycle/lead time, WIP, WSJF ranking + tiers, Monte-Carlo velocity +
+// percentile sprints) plus validation-rejection, degrade-graceful, and
+// fail-CLOSED poisoned-input (non-finite collapses to FINITE / guidance, never
+// blank-null or an infinite loop).
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerBoardActions from "../domains/board.js";
+import { peelRedundantArtifactWrapper } from "../lib/lens-input-normalize.js";
+
+const ACTIONS = new Map();
+function registerLensAction(domain, name, fn) {
+  assert.equal(domain, "board", `unexpected domain: ${domain}`);
+  ACTIONS.set(name, fn);
+}
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+const ctxB = { actor: { userId: "user_b" }, userId: "user_b" };
+
+// Drive a calculator EXACTLY like the live run route: a persisted task artifact
+// (its .data has no board-wide arrays) + the page-derived params as 3rd arg.
+function callAction(name, ctx, params = {}, artifactData = { status: "todo", priority: "medium" }) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`board.${name} not registered`);
+  const artifact = { id: "art_task_1", domain: "board", type: "task", data: artifactData, meta: {} };
+  return fn(ctx, artifact, params);
+}
+
+// Drive a STATE macro EXACTLY like boardMacro(name, params): lensRun peels a
+// redundant {artifact:{data}} wrapper, but boardMacro sends flat params, so the
+// peel is a no-op. We assert that idempotency holds and pass params straight.
+function callMacro(name, ctx, params = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`board.${name} not registered`);
+  const peeled = peelRedundantArtifactWrapper(params);
+  const artifact = { id: null, domain: "board", type: "domain_action", data: peeled, meta: {} };
+  return fn(ctx, artifact, peeled);
+}
+
+before(() => { registerBoardActions(registerLensAction); });
+beforeEach(() => {
+  globalThis._concordSTATE = { dtus: new Map() };
+  globalThis._concordSaveStateDebounced = () => {};
+  globalThis.fetch = async () => { throw new Error("network disabled"); };
+});
+
+const CALCULATORS = ["workflowAnalysis", "cardPrioritization", "burndownForecast"];
+const STATE_MACROS = [
+  "board-create", "board-list", "board-detail", "board-delete", "board-dashboard",
+  "column-add", "column-delete",
+  "card-create", "card-move", "card-move-auto", "card-update", "card-checklist-toggle",
+  "card-delete", "card-detail", "card-calendar",
+  "card-comment-add", "card-comment-delete", "card-attachment-add", "card-attachment-delete",
+  "card-set-cover", "automation-add", "automation-list", "automation-delete",
+  "label-create", "label-list", "label-delete",
+  "collaborator-add", "collaborator-list", "collaborator-remove",
+  "custom-field-add", "custom-field-list", "custom-field-delete", "card-set-field",
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("board — registration", () => {
+  it("registers every calculator the AI Action Panel reaches", () => {
+    for (const m of CALCULATORS) assert.ok(ACTIONS.has(m), `board.${m} not registered`);
+  });
+  it("registers every STATE macro the workspace components reach", () => {
+    for (const m of STATE_MACROS) assert.ok(ACTIONS.has(m), `board.${m} not registered`);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("board.workflowAnalysis — component-exact shape + flow values", () => {
+  // The page builder emits { columns:[{name}], cards:[{id,title,column,
+  // createdAt,completedAt?}] } from live tasks; the panel renders
+  // cycleTime.mean, leadTime.mean, throughput.weeklyAvg, flowEfficiency,
+  // bottleneck, wip.overLimitColumns.
+  const params = () => ({
+    columns: [{ name: "Backlog" }, { name: "To Do" }, { name: "In Progress" }, { name: "Done" }],
+    cards: [
+      { id: "c1", title: "A", column: "Done", createdAt: "2026-06-01T00:00:00Z", completedAt: "2026-06-06T00:00:00Z" },
+      { id: "c2", title: "B", column: "Done", createdAt: "2026-06-01T00:00:00Z", completedAt: "2026-06-11T00:00:00Z" },
+      { id: "c3", title: "C", column: "In Progress", createdAt: "2026-06-02T00:00:00Z" },
+      { id: "c4", title: "D", column: "To Do", createdAt: "2026-06-02T00:00:00Z" },
+    ],
+  });
+
+  it("computes cycle/lead time + WIP the panel renders, from params (NOT artifact.data)", () => {
+    const r = callAction("workflowAnalysis", ctxA, params());
+    assert.equal(r.ok, true);
+    assert.equal(r.result.totalCards, 4);
+    assert.equal(r.result.completedCards, 2);
+    assert.equal(r.result.inProgressCards, 2);     // 2 not-yet-completed cards
+    // c1 took 5d, c2 took 10d → lead/cycle mean = 7.5 (no startedAt → cycle==lead).
+    assert.equal(r.result.leadTime.mean, 7.5);
+    assert.equal(r.result.cycleTime.mean, 7.5);
+    assert.equal(r.result.wip.total, 2);
+    // Panel reads cycleTime.mean.toFixed(1) etc — all finite numbers.
+    assert.ok(Number.isFinite(r.result.cycleTime.mean));
+    assert.ok(Number.isFinite(r.result.leadTime.mean));
+    assert.ok(Number.isFinite(r.result.throughput.weeklyAvg));
+  });
+
+  it("surfaces a WIP-over-limit column the panel maps {column,wip,limit}", () => {
+    const p = {
+      columns: [{ name: "In Progress", wipLimit: 1 }, { name: "Done" }],
+      cards: [
+        { id: "c1", title: "A", column: "In Progress", createdAt: "2026-06-02T00:00:00Z" },
+        { id: "c2", title: "B", column: "In Progress", createdAt: "2026-06-02T00:00:00Z" },
+      ],
+    };
+    const r = callAction("workflowAnalysis", ctxA, p);
+    assert.equal(r.ok, true);
+    assert.deepEqual(r.result.wip.overLimitColumns, [{ column: "In Progress", wip: 2, limit: 1 }]);
+  });
+
+  it("validation: empty cards returns a guidance message (no broken render)", () => {
+    const r = callAction("workflowAnalysis", ctxA, { columns: [], cards: [] });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.totalCards, undefined);
+    assert.match(r.result.message, /no cards/i);
+  });
+
+  it("degrade-graceful: non-array cards / a task artifact's own data does not throw", () => {
+    assert.equal(callAction("workflowAnalysis", ctxA, { cards: "nope" }).ok, true);
+    // Real production shape: NO params, artifact.data is a single task → message.
+    const r = callAction("workflowAnalysis", ctxA, {}, { status: "todo", priority: "high", progress: 30 });
+    assert.equal(r.ok, true);
+    assert.match(r.result.message, /no cards/i);
+  });
+
+  it("fail-CLOSED poison: unparseable dates keep lead/cycle FINITE, no throw", () => {
+    const r = callAction("workflowAnalysis", ctxA, {
+      columns: [{ name: "Done" }],
+      cards: [{ id: "c", title: "X", column: "Done", createdAt: "bad", completedAt: "also-bad" }],
+    });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.leadTime.mean));
+    assert.ok(Number.isFinite(r.result.cycleTime.mean));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("board.cardPrioritization — component-exact shape + WSJF ranking", () => {
+  it("ranks by WSJF descending and tiers the cards the panel renders", () => {
+    const r = callAction("cardPrioritization", ctxA, {
+      cards: [
+        { id: "c1", title: "Hi", businessValue: 10, timeCriticality: 9, riskReduction: 8, effort: 2 },
+        { id: "c2", title: "Lo", businessValue: 3, timeCriticality: 2, riskReduction: 2, effort: 8 },
+      ],
+    });
+    assert.equal(r.ok, true);
+    // WSJF c1 = (10+9+8)/2 = 13.5, c2 = (3+2+2)/8 = 0.875 → c1 ranks #1.
+    assert.equal(r.result.rankedCards[0].id, "c1");
+    assert.equal(r.result.rankedCards[0].rank, 1);
+    assert.equal(r.result.rankedCards[0].wsjfScore, 13.5);
+    // Panel reads card.wsjfScore.toFixed(1) + tiers.{critical,high,medium,low}.length.
+    assert.deepEqual(r.result.tiers.critical, ["c1"]);
+    assert.deepEqual(r.result.tiers.high, ["c2"]);
+    // Panel reads quadrants.{quick-wins,...}.length.
+    assert.ok(Array.isArray(r.result.quadrants["quick-wins"]));
+  });
+
+  it("deadline proximity overrides timeCriticality (overdue → 10)", () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString();
+    const r = callAction("cardPrioritization", ctxA, {
+      cards: [{ id: "c1", title: "Late", businessValue: 5, timeCriticality: 2, riskReduction: 5, effort: 5, deadline: yesterday }],
+    });
+    assert.equal(r.result.rankedCards[0].timeCriticality, 10);
+    assert.ok(r.result.rankedCards[0].daysUntilDeadline <= 0);
+  });
+
+  it("validation: empty cards returns a guidance message", () => {
+    const r = callAction("cardPrioritization", ctxA, { cards: [] });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.rankedCards, undefined);
+    assert.match(r.result.message, /no cards/i);
+  });
+
+  it("degrade-graceful: non-array cards does not throw", () => {
+    const r = callAction("cardPrioritization", ctxA, { cards: "nope" });
+    assert.equal(r.ok, true);
+    assert.match(r.result.message, /no cards/i);
+  });
+
+  it("fail-CLOSED poison: 1e999/Infinity/NaN inputs + bad deadline stay FINITE/null", () => {
+    const r = callAction("cardPrioritization", ctxA, {
+      cards: [{ id: "x", title: "X", businessValue: "1e999", timeCriticality: "NaN", riskReduction: "Infinity", effort: "0", deadline: "not-a-date" }],
+    });
+    assert.equal(r.ok, true);
+    const c = r.result.rankedCards[0];
+    assert.ok(Number.isFinite(c.wsjfScore), `wsjf not finite: ${c.wsjfScore}`);
+    assert.ok(Number.isFinite(c.normalizedScore), `ns not finite: ${c.normalizedScore}`);
+    assert.ok(Number.isFinite(c.costOfDelay));
+    // bad deadline must NOT serialise NaN (→ null in JSON) into the panel.
+    assert.equal(c.daysUntilDeadline, null);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("board.burndownForecast — component-exact shape + Monte-Carlo values", () => {
+  const params = () => ({
+    sprints: [{ id: "s1", completedPoints: 10 }, { id: "s2", completedPoints: 20 }, { id: "s3", completedPoints: 15 }],
+    remainingPoints: 60,
+  });
+
+  it("forecasts from params with deterministic seeded Monte-Carlo values", () => {
+    const r = callAction("burndownForecast", ctxA, params());
+    assert.equal(r.ok, true);
+    assert.equal(r.result.remainingPoints, 60);
+    assert.equal(r.result.velocityStats.mean, 15);   // (10+20+15)/3
+    assert.equal(r.result.simulations, 1000);
+    // deterministic: 60 / 15 = 4 sprints.
+    assert.equal(r.result.forecast.deterministicSprints, 4);
+    // Panel reads forecast.mostLikelyDate + confidenceRange.{optimistic..worstCase}.
+    assert.ok(typeof r.result.forecast.mostLikelyDate === "string");
+    assert.ok(Number.isFinite(r.result.forecast.mostLikelySprints));
+    for (const k of ["optimistic", "likely", "conservative", "worstCase"]) {
+      assert.equal(typeof r.result.forecast.confidenceRange[k], "string");
+    }
+    // Panel reads burndownProjection[].{sprint,projectedRemaining}.
+    assert.ok(r.result.burndownProjection.length > 0);
+    for (const s of r.result.burndownProjection) {
+      assert.ok(Number.isFinite(s.projectedRemaining));
+    }
+  });
+
+  it("validation: no sprint history returns a guidance message", () => {
+    const r = callAction("burndownForecast", ctxA, { sprints: [], remainingPoints: 50 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.forecast, undefined);
+    assert.match(r.result.message, /no sprint history/i);
+  });
+
+  it("validation: zero remaining points short-circuits to the done message", () => {
+    const r = callAction("burndownForecast", ctxA, { sprints: [{ completedPoints: 10 }], remainingPoints: 0 });
+    assert.equal(r.ok, true);
+    assert.match(r.result.message, /no remaining points/i);
+  });
+
+  it("degrade-graceful: non-array sprints does not throw", () => {
+    const r = callAction("burndownForecast", ctxA, { sprints: "nope", remainingPoints: 10 });
+    assert.equal(r.ok, true);
+    assert.match(r.result.message, /no sprint history/i);
+  });
+
+  it("fail-CLOSED poison: 1e999 remainingPoints collapses to the done message (no infinite loop)", () => {
+    const r = callAction("burndownForecast", ctxA, {
+      sprints: [{ completedPoints: 10 }],
+      remainingPoints: "1e999",
+    });
+    assert.equal(r.ok, true);
+    // finNum("1e999") is non-finite → 0 → fails the >0 gate → guidance, never a hang.
+    assert.match(r.result.message, /no remaining points/i);
+  });
+
+  it("fail-CLOSED poison: poisoned velocities are filtered; outputs stay FINITE", () => {
+    const r = callAction("burndownForecast", ctxA, {
+      sprints: [{ completedPoints: "1e999" }, { completedPoints: "Infinity" }, { completedPoints: 15 }],
+      remainingPoints: 30,
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.velocityStats.mean, 15);   // only the finite 15 survives
+    assert.ok(Number.isFinite(r.result.forecast.deterministicSprints));
+    for (const d of Object.values(r.result.forecast.datePercentiles)) {
+      assert.equal(typeof d, "string");
+    }
+  });
+
+  it("fail-CLOSED poison: huge params.simulations is clamped (no hang)", () => {
+    const r = callAction("burndownForecast", ctxA, { sprints: [{ completedPoints: 10 }], remainingPoints: 5, simulations: 1e999 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.simulations, 1000);   // non-finite → default 1000
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("board STATE substrate — Trello/Asana macros the workspace reaches", () => {
+  it("board-create → board-list → board-detail round-trips (BoardWorkspace/KanbanBoard)", () => {
+    const c = callMacro("board-create", ctxA, { name: "Sprint Board" });
+    assert.equal(c.ok, true);
+    const id = c.result.board.id;
+    assert.equal(c.result.board.name, "Sprint Board");
+    assert.equal(c.result.board.columns.length, 3);   // To Do / In Progress / Done
+
+    const list = callMacro("board-list", ctxA, {});
+    assert.equal(list.ok, true);
+    // useBoardList reads result.boards[].{id,name,cardCount}.
+    assert.equal(list.result.boards.length, 1);
+    assert.equal(list.result.boards[0].id, id);
+    assert.equal(list.result.boards[0].cardCount, 0);
+
+    // useBoardDetail / KanbanBoard.open send { id }.
+    const detail = callMacro("board-detail", ctxA, { id });
+    assert.equal(detail.ok, true);
+    assert.equal(detail.result.board.id, id);
+  });
+
+  it("card-create + card-move-auto applies an automation rule (BoardWorkspace.onDrop)", () => {
+    const id = callMacro("board-create", ctxA, { name: "Auto" }).result.board.id;
+    const board = callMacro("board-detail", ctxA, { id }).result.board;
+    const todo = board.columns[0].id;
+    const done = board.columns[2].id;
+    // Settings panel: add a rule "move to Done → check-all-checklist".
+    const rule = callMacro("automation-add", ctxA, {
+      boardId: id, trigger: "card-moved-to-column", columnId: done, action: "check-all-checklist",
+    });
+    assert.equal(rule.ok, true);
+    // CardDetailModal-shape: create card + a checklist item via card-update.
+    const card = callMacro("card-create", ctxA, { boardId: id, columnId: todo, title: "Task" }).result.card;
+    callMacro("card-update", ctxA, { boardId: id, cardId: card.id, addChecklistItem: "step 1" });
+    // Drop onto Done — automation checks the item.
+    const moved = callMacro("card-move-auto", ctxA, { boardId: id, cardId: card.id, toColumnId: done });
+    assert.equal(moved.ok, true);
+    assert.equal(moved.result.columnId, done);
+    assert.equal(moved.result.automationsApplied.length, 1);
+    const after = callMacro("card-detail", ctxA, { boardId: id, cardId: card.id }).result.card;
+    assert.equal(after.checklist[0].done, true);
+  });
+
+  it("card-detail returns the comment/attachment/activity/cover shape CardDetailModal reads", () => {
+    const id = callMacro("board-create", ctxA, { name: "Detail" }).result.board.id;
+    const col = callMacro("board-detail", ctxA, { id }).result.board.columns[0].id;
+    const card = callMacro("card-create", ctxA, { boardId: id, columnId: col, title: "C" }).result.card;
+    callMacro("card-comment-add", ctxA, { boardId: id, cardId: card.id, text: "hello" });
+    callMacro("card-attachment-add", ctxA, { boardId: id, cardId: card.id, url: "https://x.test/a" });
+    const d = callMacro("card-detail", ctxA, { boardId: id, cardId: card.id }).result.card;
+    assert.ok(Array.isArray(d.comments) && d.comments[0].text === "hello");
+    assert.ok(Array.isArray(d.attachments) && d.attachments[0].url === "https://x.test/a");
+    assert.ok(Array.isArray(d.activity));   // pushActivity on each mutation
+    assert.equal(d.cover, null);            // CardDetailModal reads card.cover?.type
+    assert.equal(typeof d.customFields, "object");
+  });
+
+  it("card-calendar groups by due date the BoardWorkspace calendar renders", () => {
+    const id = callMacro("board-create", ctxA, { name: "Cal" }).result.board.id;
+    const col = callMacro("board-detail", ctxA, { id }).result.board.columns[0].id;
+    callMacro("card-create", ctxA, { boardId: id, columnId: col, title: "Due", dueDate: "2030-01-15" });
+    callMacro("card-create", ctxA, { boardId: id, columnId: col, title: "Open" });
+    const cal = callMacro("card-calendar", ctxA, { boardId: id }).result;
+    // BoardWorkspace reads { days:[{date,cards}], scheduled, overdue, unscheduled }.
+    assert.equal(cal.scheduled, 1);
+    assert.equal(cal.unscheduled, 1);
+    assert.equal(cal.days[0].date, "2030-01-15");
+    assert.equal(cal.days[0].cards[0].title, "Due");
+    assert.equal(cal.days[0].cards[0].overdue, false);
+  });
+
+  it("validation-rejection: required-field + not-found macros fail cleanly", () => {
+    assert.equal(callMacro("board-create", ctxA, { name: "" }).ok, false);
+    assert.equal(callMacro("board-detail", ctxA, { id: "nope" }).ok, false);
+    const id = callMacro("board-create", ctxA, { name: "V" }).result.board.id;
+    assert.equal(callMacro("card-create", ctxA, { boardId: id, columnId: "x", title: "" }).ok, false);
+    assert.equal(callMacro("automation-add", ctxA, { boardId: id, trigger: "bogus", action: "x", columnId: "y" }).ok, false);
+    assert.equal(callMacro("label-create", ctxA, { boardId: id, name: "" }).ok, false);
+  });
+
+  it("boards are per-user: user_b cannot see user_a's board", () => {
+    const id = callMacro("board-create", ctxA, { name: "Private" }).result.board.id;
+    const bList = callMacro("board-list", ctxB, {});
+    assert.equal(bList.result.boards.length, 0);
+    assert.equal(callMacro("board-detail", ctxB, { id }).ok, false);
+  });
+
+  it("degrade-graceful: STATE-unavailable returns a clean error, not a throw", () => {
+    delete globalThis._concordSTATE;
+    const r = callMacro("board-list", ctxA, {});
+    assert.equal(r.ok, false);
+    assert.match(String(r.error), /STATE/i);
+  });
+});

--- a/server/tests/classroom-lens-macros.test.js
+++ b/server/tests/classroom-lens-macros.test.js
@@ -1,0 +1,539 @@
+// Phase-2 gate macro tests for server/domains/classroom.js — the
+// Google-Classroom-shaped workspace + Open Library book bench the
+// /lenses/classroom surface drives.
+//
+// These pin the registerLensAction (LENS_ACTIONS) handler family the
+// frontend reaches: ClassroomWorkspace.tsx (assignment/submission/grade/
+// gradebook/stream/material/todo/quiz macros via lensRun → result peel) and
+// OpenLibrarySearch.tsx + ClassroomActionPanel.tsx (ol-search/ol-subject/
+// ol-work/ol-isbn via callMacro → { ok, result } peel).
+//
+// DISPATCH FIDELITY: the live server dispatch invokes a registerLensAction
+// handler as handler(ctx, virtualArtifact, input) — the 3-ARG convention with
+// virtualArtifact.data === input. `call()` below mirrors that EXACTLY, so a
+// regression that confuses the param positions surfaces here.
+//
+// COMPONENT-EXACT INPUT: every drive uses the EXACT input field names the
+// component sends (e.g. ClassroomWorkspace's create passes { cohortId, title,
+// instructions, dueAt, points, topic }; OpenLibrarySearch passes { query,
+// limit:24 }). Every assertion reads the EXACT output field the component
+// renders (r.result.assignment.points, env.result.works[].coverImage, …).
+//
+// CORRECTNESS SCRUTINY: these are in-memory CRUD + pure-compute calculators
+// (no wallet, no minting). The risk is fail-OPEN non-finite output, not
+// minting. The poisoned-numeric block pins that grade percent / gradebook
+// average / quiz percent stay FINITE under '1e999'/'Infinity'/'NaN' inputs and
+// that malformed input is rejected fail-CLOSED rather than throwing.
+//
+// Network handlers (ol-*) are exercised with a MOCKED globalThis.fetch so the
+// field-mapping (OL JSON → result shape the component renders) is pinned
+// offline, plus a degrade-graceful path when fetch throws / 404s.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerClassroomActions from "../domains/classroom.js";
+
+const ACTIONS = new Map();
+function registerLensAction(domain, name, fn) {
+  assert.equal(domain, "classroom", `unexpected domain: ${domain}`);
+  ACTIONS.set(name, fn);
+}
+// Mirror the live dispatch: handler(ctx, virtualArtifact, input) with
+// virtualArtifact.data === input.
+function call(name, ctx, input = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`classroom.${name} not registered`);
+  const virtualArtifact = { id: null, domain: "classroom", type: "domain_action", data: input || {}, meta: {} };
+  return fn(ctx, virtualArtifact, input || {});
+}
+// Async variant for the ol-* network handlers.
+async function callAsync(name, ctx, input = {}) {
+  return call(name, ctx, input);
+}
+
+before(() => { registerClassroomActions(registerLensAction); });
+
+let _fetchImpl = null;
+beforeEach(() => {
+  // Fresh per-user in-memory store each test so round-trips don't accumulate.
+  globalThis._concordSTATE = {};
+  globalThis._concordSaveStateDebounced = () => {};
+  // Default: network DISABLED. Tests that exercise ol-* install their own mock.
+  _fetchImpl = null;
+  globalThis.fetch = async (...a) => {
+    if (_fetchImpl) return _fetchImpl(...a);
+    throw new Error("network disabled");
+  };
+});
+function mockFetch(impl) { _fetchImpl = impl; }
+function jsonResponse(body, { status = 200 } = {}) {
+  return { ok: status >= 200 && status < 300, status, json: async () => body };
+}
+
+const ctxA = { actor: { userId: "teacher_a" }, userId: "teacher_a" };
+
+// Every macro the classroom lens page + components reach.
+const LENS_MACROS = [
+  // workspace (ClassroomWorkspace.tsx)
+  "assignment-create", "assignment-list", "assignment-delete",
+  "submission-create", "submission-list",
+  "grade-submission", "gradebook",
+  "announce", "stream-list",
+  "material-add", "material-list", "material-delete",
+  "todo",
+  "quiz-create", "quiz-list", "quiz-get", "quiz-submit", "quiz-attempts",
+  // Open Library bench (OpenLibrarySearch.tsx + ClassroomActionPanel.tsx)
+  "ol-search", "ol-subject", "ol-work", "ol-isbn",
+];
+
+describe("classroom — registration (every lens-driven macro present)", () => {
+  it("registers every macro the page + components call", () => {
+    for (const m of LENS_MACROS) {
+      assert.equal(typeof ACTIONS.get(m), "function", `missing classroom.${m}`);
+    }
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Assignments tab — ClassroomWorkspace AssignmentsTab.create() sends
+ *   { cohortId, title, instructions, dueAt, points, topic }
+ * and renders a.points / a.dueAt / a.topic / a.submissionCount / a.gradedCount.
+ * ──────────────────────────────────────────────────────────────────────── */
+describe("classroom.assignment-create / -list — exact rendered fields", () => {
+  it("create returns assignment with the EXACT fields the card renders", () => {
+    const r = call("assignment-create", ctxA, {
+      cohortId: 7, title: "Essay 1", instructions: "Write 500 words",
+      dueAt: "2999-01-01T00:00", points: 80, topic: "Week 1",
+    });
+    assert.equal(r.ok, true);
+    const a = r.result.assignment;          // component reads r.result.assignment
+    assert.equal(a.title, "Essay 1");
+    assert.equal(a.cohortId, 7);
+    assert.equal(a.points, 80);             // rendered: "{a.points} pts"
+    assert.equal(a.topic, "Week 1");        // rendered: "#{a.topic}"
+    assert.equal(a.instructions, "Write 500 words");
+    assert.equal(a.status, "published");
+    assert.equal(typeof a.id, "string");
+  });
+
+  it("assignment-list enriches with submissionCount + gradedCount (component renders both)", () => {
+    const ctx = { actor: { userId: "t_enrich" }, userId: "t_enrich" };
+    const a = call("assignment-create", ctx, { cohortId: 1, title: "HW", points: 100 });
+    const aid = a.result.assignment.id;
+    call("submission-create", ctx, { assignmentId: aid, studentId: "stu1", content: "x" });
+    const sub2 = call("submission-create", ctx, { assignmentId: aid, studentId: "stu2", content: "y" });
+    call("grade-submission", ctx, { submissionId: sub2.result.submission.id, score: 50 });
+
+    const list = call("assignment-list", ctx, { cohortId: 1 });
+    const row = list.result.assignments.find((x) => x.id === aid);
+    assert.equal(row.submissionCount, 2);   // rendered: "{a.submissionCount} submitted"
+    assert.equal(row.gradedCount, 1);       // rendered: "{a.gradedCount} graded"
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Gradebook tab — GradebookTab refresh() sends { cohortId } and renders
+ *   r.studentCount / r.classAverage / r.assignments.length / rows[].average / cells[].score
+ * ──────────────────────────────────────────────────────────────────────── */
+describe("classroom.grade-submission / gradebook — exact computed values", () => {
+  it("grade percent = round(score/maxPoints*100), maxPoints from the assignment", () => {
+    const ctx = { actor: { userId: "t_grade" }, userId: "t_grade" };
+    const a = call("assignment-create", ctx, { cohortId: 1, title: "E", points: 80 });
+    const sub = call("submission-create", ctx, { assignmentId: a.result.assignment.id, studentId: "stuA", content: "z" });
+    const g = call("grade-submission", ctx, { submissionId: sub.result.submission.id, score: 60, feedback: "good", returned: true });
+    assert.equal(g.ok, true);
+    assert.equal(g.result.grade.maxPoints, 80);
+    assert.equal(g.result.grade.score, 60);
+    assert.equal(g.result.grade.percent, 75);    // round(60/80*100)
+    assert.equal(g.result.grade.feedback, "good");
+  });
+
+  it("gradebook computes per-student totals + class average across graded cells", () => {
+    const ctx = { actor: { userId: "t_gb" }, userId: "t_gb" };
+    const a1 = call("assignment-create", ctx, { cohortId: 7, title: "A1", points: 100 });
+    const a2 = call("assignment-create", ctx, { cohortId: 7, title: "A2", points: 50 });
+    // alice: 80/100 + 40/50 → 120/150 = 80%
+    const sa1 = call("submission-create", ctx, { assignmentId: a1.result.assignment.id, studentId: "alice", content: "1" });
+    const sa2 = call("submission-create", ctx, { assignmentId: a2.result.assignment.id, studentId: "alice", content: "2" });
+    call("grade-submission", ctx, { submissionId: sa1.result.submission.id, score: 80 });
+    call("grade-submission", ctx, { submissionId: sa2.result.submission.id, score: 40 });
+    // bob: 50/100 → 50%
+    const sb1 = call("submission-create", ctx, { assignmentId: a1.result.assignment.id, studentId: "bob", content: "3" });
+    call("grade-submission", ctx, { submissionId: sb1.result.submission.id, score: 50 });
+
+    const gb = call("gradebook", ctx, { cohortId: 7 });
+    assert.equal(gb.ok, true);
+    assert.equal(gb.result.studentCount, 2);
+    assert.equal(gb.result.classAverage, 65);    // round((80+50)/2)
+    const alice = gb.result.rows.find((r) => r.studentId === "alice");
+    assert.equal(alice.totalEarned, 120);
+    assert.equal(alice.totalPossible, 150);
+    assert.equal(alice.average, 80);
+    // cell score is rendered "{c.score}/{c.maxPoints}"
+    const aliceCell = alice.cells.find((c) => c.assignmentId === a1.result.assignment.id);
+    assert.equal(aliceCell.score, 80);
+    assert.equal(aliceCell.maxPoints, 100);
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Quizzes tab — QuizzesTab.create() sends { cohortId, title, questions:[{kind,
+ * prompt, options, correctAnswer, points}] }; take()→quiz-get; submitQuiz()→
+ * quiz-submit { quizId, answers }; renders result.score/totalPoints/percent +
+ * breakdown[].correct/awarded/correctAnswer.
+ * ──────────────────────────────────────────────────────────────────────── */
+describe("classroom.quiz-create / -get / -submit — auto-grade + answer-stripping", () => {
+  it("quiz-create totalPoints = sum(points) and correctAnswer is stripped from the returned copy", () => {
+    const ctx = { actor: { userId: "t_qz" }, userId: "t_qz" };
+    const qz = call("quiz-create", ctx, {
+      cohortId: 3, title: "Bio",
+      questions: [
+        { kind: "multiple_choice", prompt: "Powerhouse?", options: ["Nucleus", "Mitochondria"], correctAnswer: "Mitochondria", points: 3 },
+        { kind: "true_false", prompt: "Water is H2O", correctAnswer: "True", points: 2 },
+      ],
+    });
+    assert.equal(qz.ok, true);
+    assert.equal(qz.result.quiz.totalPoints, 5);
+    assert.ok(qz.result.quiz.questions.every((q) => !("correctAnswer" in q)));  // never leaks
+    const tf = qz.result.quiz.questions.find((q) => q.kind === "true_false");
+    assert.deepEqual(tf.options, ["True", "False"]);  // forced
+  });
+
+  it("quiz-get returns the student-facing (answer-stripped) copy the take() flow renders", () => {
+    const ctx = { actor: { userId: "t_qg" }, userId: "t_qg" };
+    const qz = call("quiz-create", ctx, {
+      cohortId: 1, title: "G",
+      questions: [{ kind: "short_answer", prompt: "Capital of France?", correctAnswer: "Paris", points: 5 }],
+    });
+    const got = call("quiz-get", ctx, { quizId: qz.result.quiz.id });
+    assert.equal(got.ok, true);
+    assert.equal(got.result.quiz.questions[0].prompt, "Capital of France?");
+    assert.ok(!("correctAnswer" in got.result.quiz.questions[0]));
+  });
+
+  it("quiz-submit case-insensitive auto-grade — exact earned/percent + breakdown the result panel renders", () => {
+    const ctx = { actor: { userId: "t_qs" }, userId: "t_qs" };
+    const qz = call("quiz-create", ctx, {
+      cohortId: 4, title: "GradeMe",
+      questions: [
+        { kind: "short_answer", prompt: "Capital of France?", correctAnswer: "Paris", points: 5 },
+        { kind: "short_answer", prompt: "2+2?", correctAnswer: "4", points: 5 },
+      ],
+    });
+    const [q1, q2] = qz.result.quiz.questions;
+    const att = call("quiz-submit", ctx, { quizId: qz.result.quiz.id, answers: { [q1.id]: "  paRIS ", [q2.id]: "5" } });
+    assert.equal(att.ok, true);
+    assert.equal(att.result.attempt.score, 5);
+    assert.equal(att.result.attempt.totalPoints, 10);
+    assert.equal(att.result.attempt.percent, 50);     // round(5/10*100)
+    const b1 = att.result.attempt.breakdown.find((b) => b.questionId === q1.id);
+    assert.equal(b1.correct, true);
+    assert.equal(b1.awarded, 5);
+    const b2 = att.result.attempt.breakdown.find((b) => b.questionId === q2.id);
+    assert.equal(b2.correct, false);
+    assert.equal(b2.awarded, 0);
+    assert.equal(b2.correctAnswer, "4");              // rendered "(→ {b.correctAnswer})"
+  });
+
+  it("quiz-list + quiz-attempts surface questionCount/attemptCount + averagePercent the UI renders", () => {
+    const ctx = { actor: { userId: "t_ql" }, userId: "t_ql" };
+    const qz = call("quiz-create", ctx, {
+      cohortId: 9, title: "Avg",
+      questions: [{ kind: "short_answer", prompt: "X?", correctAnswer: "yes", points: 10 }],
+    });
+    const qid = qz.result.quiz.questions[0].id;
+    call("quiz-submit", ctx, { quizId: qz.result.quiz.id, answers: { [qid]: "yes" } });  // 100%
+    call("quiz-submit", ctx, { quizId: qz.result.quiz.id, answers: { [qid]: "no" } });   // 0%
+
+    const list = call("quiz-list", ctx, { cohortId: 9 });
+    const row = list.result.quizzes.find((q) => q.id === qz.result.quiz.id);
+    assert.equal(row.questionCount, 1);
+    assert.equal(row.attemptCount, 2);
+    assert.ok(row.questions.every((q) => !("correctAnswer" in q)));  // list copy stripped too
+
+    const att = call("quiz-attempts", ctx, { quizId: qz.result.quiz.id });
+    assert.equal(att.result.count, 2);
+    assert.equal(att.result.averagePercent, 50);       // round((100+0)/2)
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Stream / materials / todo tabs.
+ * ──────────────────────────────────────────────────────────────────────── */
+describe("classroom.announce / stream-list — filtered timeline the StreamTab renders", () => {
+  it("announce → stream-list reads back filtered by cohort, kind 'announcement'", () => {
+    const ctx = { actor: { userId: "t_st" }, userId: "t_st" };
+    call("announce", ctx, { text: "Welcome to cohort 42", cohortId: 42 });
+    const s = call("stream-list", ctx, { cohortId: 42 });
+    assert.ok(s.result.stream.some((e) => e.kind === "announcement" && e.text.includes("cohort 42")));
+    // a different cohort filter does NOT show it
+    const other = call("stream-list", ctx, { cohortId: 99 });
+    assert.ok(!other.result.stream.some((e) => e.text.includes("cohort 42")));
+  });
+});
+
+describe("classroom.material-* — round-trip + topic grouping the MaterialsTab renders", () => {
+  it("material-add → material-list (byTopic) → material-delete", () => {
+    const ctx = { actor: { userId: "t_mat" }, userId: "t_mat" };
+    const add = call("material-add", ctx, { cohortId: 2, title: "Syllabus", kind: "link", url: "https://example.test/s", topic: "Intro" });
+    assert.equal(add.ok, true);
+    const id = add.result.material.id;
+    const list = call("material-list", ctx, { cohortId: 2 });
+    assert.ok(list.result.byTopic.Intro.some((m) => m.id === id));   // MaterialsTab renders byTopic
+    const del = call("material-delete", ctx, { materialId: id });
+    assert.equal(del.result.deleted, id);
+    const after = call("material-list", ctx, { cohortId: 2 });
+    assert.ok(!after.result.materials.some((m) => m.id === id));     // really gone
+  });
+});
+
+describe("classroom.todo — exact upcoming/missing/done buckets the TodoTab renders", () => {
+  it("past-due unsubmitted → missing, future → upcoming, graded → done", () => {
+    const ctx = { actor: { userId: "t_td" }, userId: "t_td" };
+    const aMissing = call("assignment-create", ctx, { cohortId: 5, title: "Late", points: 10, dueAt: "2000-01-01T00:00:00.000Z" });
+    const aUpcoming = call("assignment-create", ctx, { cohortId: 5, title: "Soon", points: 10, dueAt: "2999-01-01T00:00:00.000Z" });
+    const aDone = call("assignment-create", ctx, { cohortId: 5, title: "Done", points: 10, dueAt: "2999-01-01T00:00:00.000Z" });
+    const sub = call("submission-create", ctx, { assignmentId: aDone.result.assignment.id, studentId: "stuT", content: "d" });
+    call("grade-submission", ctx, { submissionId: sub.result.submission.id, score: 10 });
+
+    const todo = call("todo", ctx, { cohortId: 5, studentId: "stuT" });
+    assert.equal(todo.ok, true);
+    assert.equal(todo.result.counts.missing, 1);
+    assert.equal(todo.result.counts.upcoming, 1);
+    assert.equal(todo.result.counts.done, 1);
+    assert.ok(todo.result.missing.some((i) => i.assignmentId === aMissing.result.assignment.id));
+    assert.ok(todo.result.upcoming.some((i) => i.assignmentId === aUpcoming.result.assignment.id));
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Open Library bench — OpenLibrarySearch + ClassroomActionPanel.
+ * MOCKED fetch pins the OL-JSON → result-shape field mapping the grid/detail
+ * card render. The components peel { ok, result } and read result.works /
+ * result.* directly.
+ * ──────────────────────────────────────────────────────────────────────── */
+describe("classroom.ol-search — field mapping the cover grid renders (mocked OL)", () => {
+  it("maps docs → works with coverImage/readUrl/totalResults the grid + status read", async () => {
+    mockFetch(async (url) => {
+      assert.match(String(url), /\/search\.json\?/);
+      assert.match(String(url), /q=clean\+code/);   // component sends { query }
+      assert.match(String(url), /limit=24/);        // OpenLibrarySearch passes limit:24
+      return jsonResponse({
+        numFound: 137,
+        docs: [{
+          key: "/works/OL1W", title: "Clean Code", author_name: ["Robert C. Martin"],
+          first_publish_year: 2008, edition_count: 5, cover_i: 12345,
+          ia: ["cleancode00mart"], ebook_access: "borrowable",
+        }],
+      });
+    });
+    const r = await callAsync("ol-search", ctxA, { query: "clean code", limit: 24 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.count, 1);
+    assert.equal(r.result.totalResults, 137);       // status: "{count} of {totalResults}"
+    const w = r.result.works[0];
+    assert.equal(w.workId, "/works/OL1W");
+    assert.equal(w.title, "Clean Code");
+    assert.equal(w.authors[0], "Robert C. Martin");  // grid: w.authors?.[0]
+    assert.equal(w.firstPublishYear, 2008);          // grid: w.firstPublishYear
+    assert.equal(w.coverImage, "https://covers.openlibrary.org/b/id/12345-M.jpg");  // grid <img src>
+    assert.equal(w.readUrl, "https://archive.org/details/cleancode00mart");          // detail: Read link
+  });
+
+  it("validation: no query/author/title/subject is rejected (component guards but handler must too)", async () => {
+    const r = await callAsync("ol-search", ctxA, {});
+    assert.equal(r.ok, false);
+    assert.match(r.error, /at least one of/);
+  });
+
+  it("degrade-graceful: fetch throwing surfaces ok:false with an error string, never throws", async () => {
+    mockFetch(async () => { throw new Error("ECONNREFUSED"); });
+    const r = await callAsync("ol-search", ctxA, { query: "x" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /openlibrary unreachable/);
+  });
+});
+
+describe("classroom.ol-subject — field mapping the subject chips render (mocked OL)", () => {
+  it("maps works[] (subject endpoint shape) → workId stripped of /works/", async () => {
+    mockFetch(async (url) => {
+      assert.match(String(url), /\/subjects\/computer_science\.json/);
+      return jsonResponse({
+        name: "Computer Science", work_count: 50,
+        works: [{ key: "/works/OL9W", title: "SICP", authors: [{ name: "Abelson" }], first_publish_year: 1985, cover_id: 7 }],
+      });
+    });
+    const r = await callAsync("ol-subject", ctxA, { subject: "computer science", ebooks: true, limit: 24 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.count, 1);
+    assert.equal(r.result.works[0].workId, "OL9W");          // ActionPanel: setWorkId(w.workId.replace('/works/',''))
+    assert.equal(r.result.works[0].authors[0], "Abelson");   // subjResult: w.authors?.[0]
+    assert.equal(r.result.works[0].coverImage, "https://covers.openlibrary.org/b/id/7-M.jpg");
+  });
+
+  it("validation: empty subject is rejected", async () => {
+    const r = await callAsync("ol-subject", ctxA, { subject: "   " });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /subject required/);
+  });
+});
+
+describe("classroom.ol-work — field mapping the work detail card renders (mocked OL)", () => {
+  it("maps work → title/description/firstPublishDate/subjects the purple card reads", async () => {
+    mockFetch(async (url) => {
+      assert.match(String(url), /\/works\/OL45883W\.json/);   // ActionPanel sends { workId }
+      return jsonResponse({
+        title: "Fahrenheit 451",
+        description: { value: "A dystopian novel." },          // OL nested-description shape
+        subjects: ["Censorship", "Dystopias"],
+        first_publish_date: "1953",
+        covers: [99],
+      });
+    });
+    const r = await callAsync("ol-work", ctxA, { workId: "OL45883W" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.title, "Fahrenheit 451");
+    assert.equal(r.result.description, "A dystopian novel.");   // nested .value unwrapped
+    assert.equal(r.result.firstPublishDate, "1953");
+    assert.deepEqual(r.result.subjects, ["Censorship", "Dystopias"]);
+  });
+
+  it("validation: a non-OL...W workId is rejected before any fetch", async () => {
+    mockFetch(async () => { throw new Error("should not be called"); });
+    const r = await callAsync("ol-work", ctxA, { workId: "not-a-work" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /workId required/);
+  });
+});
+
+describe("classroom.ol-isbn — field mapping the ISBN card renders (mocked OL)", () => {
+  // Phase-2 field-alignment fix: the component was rendering isbnResult.publisher
+  // (singular) + isbnResult.authors, but the handler returns `publishers` (array)
+  // and `authorKeys`. The component was realigned to `publishers`; this pins the
+  // real handler contract so the realignment can't silently drift back.
+  it("returns publishers (array) + publishDate/pages/coverImage the amber card renders", async () => {
+    mockFetch(async (url) => {
+      assert.match(String(url), /\/isbn\/9780132350884\.json/);  // component strips non-isbn chars
+      return jsonResponse({
+        title: "Clean Code", subtitle: "A Handbook",
+        publishers: ["Prentice Hall"], publish_date: "2008",
+        number_of_pages: 464, covers: [555],
+        authors: [{ key: "/authors/OL1A" }],
+      });
+    });
+    const r = await callAsync("ol-isbn", ctxA, { isbn: "978-0-13-235088-4" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.title, "Clean Code");
+    assert.equal(r.result.subtitle, "A Handbook");
+    assert.deepEqual(r.result.publishers, ["Prentice Hall"]);   // card: publishers.join(', ')
+    assert.equal(r.result.publishDate, "2008");                 // card: " · {publishDate}"
+    assert.equal(r.result.pages, 464);                          // card: "{pages} pages"
+    assert.equal(r.result.coverImage, "https://covers.openlibrary.org/b/id/555-L.jpg");
+    // the handler does NOT fabricate author NAMES — it honestly exposes keys only
+    assert.deepEqual(r.result.authorKeys, ["/authors/OL1A"]);
+    assert.ok(!("authors" in r.result));    // no fabricated authors field
+    assert.ok(!("publisher" in r.result));  // no singular publisher
+  });
+
+  it("validation: an isbn that isn't 10 or 13 digits is rejected before any fetch", async () => {
+    mockFetch(async () => { throw new Error("should not be called"); });
+    const r = await callAsync("ol-isbn", ctxA, { isbn: "12345" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /isbn must be 10 or 13/);
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Validation-rejection + fail-CLOSED poisoned input.
+ * ──────────────────────────────────────────────────────────────────────── */
+describe("classroom — validation rejections (fail-closed on bad input)", () => {
+  it("assignment-create with no title is rejected", () => {
+    const r = call("assignment-create", ctxA, { cohortId: 1 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /title required/);
+  });
+  it("assignment-create with no cohortId is rejected", () => {
+    const r = call("assignment-create", ctxA, { title: "Orphan" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /cohortId required/);
+  });
+  it("material-add with a non-finite cohortId is rejected (Number.isFinite guard)", () => {
+    const r = call("material-add", ctxA, { title: "M", cohortId: "not-a-number" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /cohortId required/);
+  });
+  it("quiz-create with zero questions is rejected", () => {
+    const r = call("quiz-create", ctxA, { cohortId: 1, title: "Empty", questions: [] });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /at least one question/);
+  });
+  it("quiz-create rejects a multiple_choice question with < 2 options", () => {
+    const r = call("quiz-create", ctxA, {
+      cohortId: 1, title: "Bad",
+      questions: [{ kind: "multiple_choice", prompt: "Pick", options: ["only"], correctAnswer: "only", points: 1 }],
+    });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /needs >=2 options/);
+  });
+  it("grade-submission on a missing submission is rejected", () => {
+    const r = call("grade-submission", ctxA, { submissionId: "nope", score: 5 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /submission not found/);
+  });
+  it("quiz-submit on a missing quiz is rejected", () => {
+    const r = call("quiz-submit", ctxA, { quizId: "nope", answers: {} });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /quiz not found/);
+  });
+});
+
+describe("classroom — poisoned-numeric inputs stay FINITE (no fail-open)", () => {
+  it("grade-submission with '1e999'/'Infinity'/'NaN' score → finite clamped score + finite percent", () => {
+    const ctx = { actor: { userId: "t_poison" }, userId: "t_poison" };
+    const a = call("assignment-create", ctx, { cohortId: 1, title: "P", points: 100 });
+    for (const poison of ["1e999", "Infinity", "NaN", Infinity, -Infinity, NaN]) {
+      const sub = call("submission-create", ctx, { assignmentId: a.result.assignment.id, studentId: `s_${String(poison)}`, content: "x" });
+      const g = call("grade-submission", ctx, { submissionId: sub.result.submission.id, score: poison });
+      assert.equal(g.ok, true);
+      assert.ok(Number.isFinite(g.result.grade.score), `score finite for ${String(poison)}`);
+      assert.ok(g.result.grade.score >= 0 && g.result.grade.score <= 100, `score in [0,100] for ${String(poison)}`);
+      assert.ok(Number.isFinite(g.result.grade.percent), `percent finite for ${String(poison)}`);
+    }
+  });
+
+  it("assignment-create with poisoned points clamps to [0,1000], stays finite", () => {
+    const ctx = { actor: { userId: "t_pts" }, userId: "t_pts" };
+    for (const [poison, expected] of [["1e999", 1000], ["Infinity", 1000], ["NaN", 100], [-7, 0], [5000, 1000]]) {
+      const a = call("assignment-create", ctx, { cohortId: 1, title: "X", points: poison });
+      assert.ok(Number.isFinite(a.result.assignment.points));
+      assert.equal(a.result.assignment.points, expected, `points for ${String(poison)}`);
+    }
+  });
+
+  it("quiz-create with poisoned per-question points clamps to [1,100]; totalPoints stays finite", () => {
+    const ctx = { actor: { userId: "t_qp" }, userId: "t_qp" };
+    const qz = call("quiz-create", ctx, {
+      cohortId: 1, title: "PP",
+      questions: [
+        { kind: "short_answer", prompt: "a", correctAnswer: "a", points: "1e999" },
+        { kind: "short_answer", prompt: "b", correctAnswer: "b", points: "NaN" },
+      ],
+    });
+    assert.equal(qz.ok, true);
+    assert.ok(Number.isFinite(qz.result.quiz.totalPoints));
+    assert.equal(qz.result.quiz.totalPoints, 101);   // clamp(1e999)=100 + (NaN→1)=1
+  });
+
+  it("quiz-submit with a poisoned (non-object) answers bag does not throw; score stays finite 0", () => {
+    const ctx = { actor: { userId: "t_qsb" }, userId: "t_qsb" };
+    const qz = call("quiz-create", ctx, {
+      cohortId: 1, title: "PB",
+      questions: [{ kind: "short_answer", prompt: "x", correctAnswer: "y", points: 5 }],
+    });
+    const att = call("quiz-submit", ctx, { quizId: qz.result.quiz.id, answers: "not-an-object" });
+    assert.equal(att.ok, true);
+    assert.ok(Number.isFinite(att.result.attempt.score));
+    assert.equal(att.result.attempt.score, 0);       // no answers matched → 0
+    assert.ok(Number.isFinite(att.result.attempt.percent));
+  });
+});

--- a/server/tests/consulting-lens-macros.test.js
+++ b/server/tests/consulting-lens-macros.test.js
@@ -1,0 +1,416 @@
+// Behavioral macro tests for server/domains/consulting.js — the Bonsai/Harvest-
+// shaped consulting practice-management substrate the /lenses/consulting lens
+// (page + ConsultingWorkbench + EngagementTracker children) drives.
+//
+// COMPLEMENT to consulting-domain-parity.test.js + consulting-engagement-domain-
+// parity.test.js (which pin invoicing/proposals/staffing/expenses/timer/retainers
+// /profitability/portal round-trips on the STATE-backed path). This file is the
+// PHASE-2 GATE: it pins the EXACT field contract every frontend caller relies on,
+// drives each macro with the component's EXACT input field names, asserts the
+// EXACT rendered output field names with real COMPUTED money values (bill rate,
+// utilization, engagement margin, project estimate), and adds the three
+// adversarial dimensions the parity tests don't: validation-rejection,
+// degrade-graceful, and fail-CLOSED poisoned-numeric.
+//
+// DISPATCH: the workbench children call lensRun('consulting', macro, input) →
+// POST /api/lens/run → runMacro → LENS_ACTIONS dispatch: handlers registered via
+// `registerLensAction(domain, action, handler)` are invoked as
+// `handler(ctx, virtualArtifact, input)` — the 3-ARG convention, virtualArtifact.
+// data === input. The page's pure-compute macros (engagementScope/utilizationRate
+// /proposalScore/clientHealth) read artifact.data, so the harness sets
+// virtualArtifact.data === input to mirror the live dispatch exactly.
+//
+// MONEY/CORRECTNESS SCRUTINY: the STATE-backed money paths coerce through
+// `csNum` (Number.isFinite ? n : 0 — fail-CLOSED) so a poisoned rate can never
+// mint Infinity into a billed total. The four pure-compute macros were the real
+// fail-OPEN seam: `parseFloat("1e999")`/`parseFloat("Infinity")` yield Infinity
+// and `Infinity || default` is Infinity, so the old `parseFloat(x) || d` let a
+// poisoned hourlyRate/billableHours flow into a fee/utilization that renders
+// Infinity. They were hardened with `finPos`/`finSigned` (non-finite → finite
+// default). The poisoned-numeric block below pins that EVERY money/percentage
+// output of all four stays Number.isFinite under 1e999/Infinity/NaN input.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerConsultingActions from "../domains/consulting.js";
+
+const ACTIONS = new Map();
+function registerLensAction(domain, name, fn) {
+  assert.equal(domain, "consulting", `unexpected domain: ${domain}`);
+  ACTIONS.set(name, fn);
+}
+// Mirror the live dispatch: handler(ctx, virtualArtifact, input) with
+// virtualArtifact.data === input (so artifact.data.hourlyRate etc. resolve).
+function call(name, ctx, input = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`consulting.${name} not registered`);
+  const virtualArtifact = { id: null, domain: "consulting", type: "domain_action", data: input || {}, meta: {} };
+  return fn(ctx, virtualArtifact, input || {});
+}
+
+before(() => { registerConsultingActions(registerLensAction); });
+beforeEach(() => {
+  // Fresh STATE per test so users + collections don't leak across cases.
+  globalThis._concordSTATE = { dtus: new Map() };
+  globalThis._concordSaveStateDebounced = () => {};
+  globalThis.fetch = async () => { throw new Error("network disabled"); };
+});
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+const ctxB = { actor: { userId: "user_b" }, userId: "user_b" };
+
+function makeEngagement(ctx = ctxA, over = {}) {
+  const r = call("engagement-create", ctx, { name: "Strategy Refresh", client: "Acme", rate: 200, budgetHours: 100, ...over });
+  assert.equal(r.ok, true);
+  return r.result.engagement;
+}
+
+// Every macro the lens page + workbench components reach via lensRun /
+// useRunArtifact. (engagementScope/utilizationRate/proposalScore/clientHealth are
+// the page's pure-compute "analyze"-family macros; the rest are the workbench's
+// STATE-backed practice-management macros.)
+const LENS_MACROS = [
+  "engagementScope", "utilizationRate", "proposalScore", "clientHealth",
+  "engagement-create", "engagement-list", "engagement-update", "engagement-delete",
+  "time-log", "consulting-dashboard",
+  "invoice-create", "invoice-list", "invoice-mark-paid", "invoice-delete", "invoice-export",
+  "proposal-templates", "proposal-create", "proposal-list", "proposal-update-section",
+  "proposal-sign", "proposal-delete",
+  "consultant-create", "consultant-delete", "allocation-create", "allocation-delete", "staffing-plan",
+  "expense-create", "expense-list", "expense-update", "expense-delete",
+  "timer-start", "timer-status", "timer-stop", "timer-cancel",
+  "retainer-create", "retainer-list", "retainer-bill", "retainer-update", "retainer-delete",
+  "profitability-report",
+  "portal-share", "portal-list", "portal-respond", "portal-delete",
+];
+
+describe("consulting — registration (every lens-driven macro present)", () => {
+  it("registers every macro the lens page + workbench call", () => {
+    for (const m of LENS_MACROS) {
+      assert.equal(typeof ACTIONS.get(m), "function", `missing consulting.${m}`);
+    }
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// PURE-COMPUTE money macros — exact computed values the page reads
+// ════════════════════════════════════════════════════════════════════════════
+
+describe("consulting.engagementScope — project estimate + bill rate math", () => {
+  it("computes per-deliverable fee, subtotal, 15% contingency, grand total", () => {
+    const r = call("engagementScope", ctxA, {
+      client: "Acme", hourlyRate: 250,
+      deliverables: [{ name: "Discovery", hours: 10 }, { name: "Workshop", hours: 6 }],
+    });
+    assert.equal(r.ok, true);
+    // 16h × 250 = 4000 subtotal; contingency 15% = 600; grand = 4600
+    assert.equal(r.result.totalHours, 16);
+    assert.equal(r.result.hourlyRate, 250);
+    assert.equal(r.result.subtotal, 4000);
+    assert.equal(r.result.contingency, 600);
+    assert.equal(r.result.grandTotal, 4600);
+    assert.equal(r.result.deliverables[0].fee, 2500);
+    assert.equal(r.result.deliverables[1].fee, 1500);
+    assert.equal(r.result.timeline, "1 weeks at full-time"); // ceil(16/40)
+  });
+  it("degrade-graceful: no deliverables → default rate, zero fee, finite", () => {
+    const r = call("engagementScope", ctxA, { client: "Acme" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.hourlyRate, 200); // default bill rate
+    assert.equal(r.result.subtotal, 0);
+    assert.equal(r.result.grandTotal, 0);
+    assert.ok(Number.isFinite(r.result.grandTotal));
+  });
+});
+
+describe("consulting.utilizationRate — utilization % math", () => {
+  it("computes utilization %, variance vs 75% target, status band", () => {
+    const r = call("utilizationRate", ctxA, { billableHours: 32, totalHours: 40 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.utilizationRate, 80); // 32/40 = 80%
+    assert.equal(r.result.target, 75);
+    assert.equal(r.result.variance, 5);
+    assert.equal(r.result.status, "excellent"); // >= 0.8
+  });
+  it("bands below target correctly", () => {
+    assert.equal(call("utilizationRate", ctxA, { billableHours: 20, totalHours: 40 }).result.status, "below-target");
+    assert.equal(call("utilizationRate", ctxA, { billableHours: 10, totalHours: 40 }).result.status, "critical");
+  });
+  it("degrade-graceful: empty input → 0% utilization, finite, no NaN", () => {
+    const r = call("utilizationRate", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.utilizationRate, 0);
+    assert.equal(r.result.totalHours, 40);
+    assert.ok(Number.isFinite(r.result.variance));
+  });
+});
+
+describe("consulting.proposalScore — section completeness", () => {
+  it("scores present sections out of six", () => {
+    const r = call("proposalScore", ctxA, { "executive-summary": "x", methodology: "y", timeline: "z" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.score, 50); // 3/6
+    assert.equal(r.result.completeness, "needs-work");
+    assert.ok(r.result.sectionsMissing.includes("pricing"));
+  });
+  it("degrade-graceful: empty → 0 score, incomplete", () => {
+    const r = call("proposalScore", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.score, 0);
+    assert.equal(r.result.completeness, "incomplete");
+  });
+});
+
+describe("consulting.clientHealth — composite health score", () => {
+  it("blends NPS, payment rate, response time into a 0-100 health score", () => {
+    const r = call("clientHealth", ctxA, { client: "Acme", nps: 50, invoicesPaid: 9, invoicesTotal: 10, avgResponseDays: 2 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.paymentRate, 90);
+    // (150/200)*30 + 0.9*40 + (1-2/14)*30 = 22.5 + 36 + 25.714 = 84.2 → 84
+    assert.equal(r.result.healthScore, 84);
+    assert.equal(r.result.risk, "low");
+    assert.ok(Number.isFinite(r.result.healthScore));
+  });
+  it("degrade-graceful: empty → finite health, defaults applied", () => {
+    const r = call("clientHealth", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.healthScore));
+    assert.ok(["low", "medium", "high"].includes(r.result.risk));
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// STATE-backed money macros — exact computed values the workbench renders
+// ════════════════════════════════════════════════════════════════════════════
+
+describe("consulting.time-log + engagement-list — billed + utilization", () => {
+  it("logs time and computes billed = hours × rate and utilizationPct", () => {
+    const e = makeEngagement(ctxA, { rate: 150, budgetHours: 20 });
+    const log = call("time-log", ctxA, { engagementId: e.id, hours: 5, note: "kickoff" });
+    assert.equal(log.ok, true);
+    assert.equal(log.result.billed, 750); // 5 × 150
+    const list = call("engagement-list", ctxA, {});
+    const row = list.result.engagements[0];
+    assert.equal(row.loggedHours, 5);
+    assert.equal(row.billed, 750);
+    assert.equal(row.utilizationPct, 25); // 5/20
+    assert.ok(Array.isArray(row.timeEntries)); // the component reads e.timeEntries
+  });
+  it("rejects non-positive hours (validation-rejection)", () => {
+    const e = makeEngagement();
+    assert.equal(call("time-log", ctxA, { engagementId: e.id, hours: 0 }).ok, false);
+    assert.equal(call("time-log", ctxA, { engagementId: e.id, hours: -3 }).ok, false);
+  });
+  it("rejects time-log against an unknown engagement", () => {
+    assert.equal(call("time-log", ctxA, { engagementId: "nope", hours: 2 }).ok, false);
+  });
+});
+
+describe("consulting.invoice-create — subtotal/tax/total + no double-bill", () => {
+  it("rolls unbilled time into an invoice with exact subtotal/tax/total", () => {
+    const e = makeEngagement(ctxA, { rate: 200 });
+    call("time-log", ctxA, { engagementId: e.id, hours: 5 });
+    call("time-log", ctxA, { engagementId: e.id, hours: 3 });
+    const r = call("invoice-create", ctxA, { engagementId: e.id, taxRate: 0.1, dueInDays: 30 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.invoice.subtotal, 1600); // 8h × 200
+    assert.equal(r.result.invoice.tax, 160);
+    assert.equal(r.result.invoice.total, 1760);
+    assert.equal(r.result.invoice.status, "sent");
+    assert.equal(r.result.invoice.lineItems.length, 2);
+    // invoice-list rollup the InvoiceManager reads
+    const list = call("invoice-list", ctxA, {});
+    assert.equal(list.result.outstanding, 1760);
+  });
+  it("rejects invoicing with no unbilled time (validation-rejection)", () => {
+    const e = makeEngagement();
+    assert.equal(call("invoice-create", ctxA, { engagementId: e.id }).ok, false);
+  });
+});
+
+describe("consulting.staffing-plan — weekly utilization + overbooked flag", () => {
+  it("computes per-week utilizationPct and overbooked against capacity", () => {
+    const c = call("consultant-create", ctxA, { name: "Ada", role: "Lead", weeklyCapacity: 40, costRate: 80 }).result.consultant;
+    const e = makeEngagement();
+    call("allocation-create", ctxA, { consultantId: c.id, engagementId: e.id, week: "2026-W21", hours: 50 });
+    const plan = call("staffing-plan", ctxA, {});
+    assert.equal(plan.ok, true);
+    const row = plan.result.rows[0];
+    assert.equal(row.byWeek[0].utilizationPct, 125); // 50/40
+    assert.equal(row.byWeek[0].overbooked, true);
+    // allocation join fields the StaffingPlanner renders
+    assert.equal(plan.result.allocations[0].consultantName, "Ada");
+    assert.equal(plan.result.allocations[0].engagementName, "Strategy Refresh");
+  });
+  it("rejects an allocation with non-positive hours (validation-rejection)", () => {
+    const c = call("consultant-create", ctxA, { name: "Ada" }).result.consultant;
+    const e = makeEngagement();
+    assert.equal(call("allocation-create", ctxA, { consultantId: c.id, engagementId: e.id, week: "2026-W21", hours: 0 }).ok, false);
+  });
+});
+
+describe("consulting.profitability-report — engagement margin math", () => {
+  it("computes billed − cost margin and marginPct per engagement", () => {
+    const c = call("consultant-create", ctxA, { name: "Ada", costRate: 80 }).result.consultant;
+    assert.ok(c);
+    const e = makeEngagement(ctxA, { rate: 200 });
+    call("time-log", ctxA, { engagementId: e.id, hours: 10 }); // billed 2000, labor 10×80=800
+    call("expense-create", ctxA, { engagementId: e.id, description: "Travel", amount: 200 });
+    const r = call("profitability-report", ctxA, {});
+    assert.equal(r.ok, true);
+    const row = r.result.rows[0];
+    assert.equal(row.billed, 2000);
+    assert.equal(row.laborCost, 800);
+    assert.equal(row.expenses, 200);
+    assert.equal(row.totalCost, 1000);
+    assert.equal(row.margin, 1000); // 2000 − 1000
+    assert.equal(row.marginPct, 50);
+    assert.equal(row.health, "healthy");
+    assert.equal(r.result.totalMargin, 1000);
+    assert.equal(r.result.overallMarginPct, 50);
+  });
+  it("degrade-graceful: no engagements → zero totals, finite", () => {
+    const r = call("profitability-report", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.totalBilled, 0);
+    assert.equal(r.result.overallMarginPct, 0);
+    assert.ok(Number.isFinite(r.result.totalMargin));
+  });
+});
+
+describe("consulting.retainer-list — MRR normalization", () => {
+  it("computes MRR normalizing weekly/quarterly cadence to monthly", () => {
+    call("retainer-create", ctxA, { client: "Acme", monthlyAmount: 1000, cadence: "monthly" });
+    call("retainer-create", ctxA, { client: "Globex", monthlyAmount: 300, cadence: "weekly" }); // ×4.33
+    const r = call("retainer-list", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.mrr, 2299); // 1000 + 300×4.33
+    assert.ok(Number.isFinite(r.result.mrr));
+  });
+  it("rejects a retainer with non-positive amount (validation-rejection)", () => {
+    assert.equal(call("retainer-create", ctxA, { client: "Acme", monthlyAmount: 0 }).ok, false);
+    assert.equal(call("retainer-create", ctxA, { monthlyAmount: 500 }).ok, false); // no client
+  });
+});
+
+describe("consulting.timer-* — start/stop accrues billed time", () => {
+  it("rejects starting a timer on an unknown engagement", () => {
+    assert.equal(call("timer-start", ctxA, { engagementId: "nope" }).ok, false);
+  });
+  it("status reports running:false when idle", () => {
+    assert.equal(call("timer-status", ctxA, {}).result.running, false);
+  });
+});
+
+describe("consulting.portal-respond — decision validation", () => {
+  it("rejects an invalid decision (validation-rejection)", () => {
+    const sh = call("portal-share", ctxA, { title: "Roadmap", client: "Acme" }).result.share;
+    assert.equal(call("portal-respond", ctxA, { id: sh.id, decision: "maybe" }).ok, false);
+    const ok = call("portal-respond", ctxA, { id: sh.id, decision: "approved", respondedBy: "Jo" });
+    assert.equal(ok.ok, true);
+    assert.equal(ok.result.share.approvalStatus, "approved");
+    assert.equal(ok.result.share.approvedBy, "Jo");
+  });
+});
+
+describe("consulting — per-user isolation", () => {
+  it("does not leak engagements across actors", () => {
+    makeEngagement(ctxA);
+    assert.equal(call("engagement-list", ctxA, {}).result.count, 1);
+    assert.equal(call("engagement-list", ctxB, {}).result.count, 0);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// FAIL-CLOSED poisoned numeric — no money/percentage field may render Infinity/NaN
+// ════════════════════════════════════════════════════════════════════════════
+
+describe("consulting — poisoned numerics stay FINITE (fail-closed)", () => {
+  // NON_FINITE: must be rejected / collapsed by the fail-closed coercion.
+  // FINITE_HUGE: 1e308 is a legitimate finite number — it is ACCEPTED but the
+  // pure-compute money outputs clamp it (SANE_MAX) so a product can't overflow.
+  const NON_FINITE = ["1e999", "Infinity", "-Infinity", "NaN"];
+  const POISON = [...NON_FINITE, "1e308"];
+
+  it("engagementScope: poisoned hourlyRate/hours never emit Infinity money", () => {
+    for (const p of POISON) {
+      const r = call("engagementScope", ctxA, {
+        hourlyRate: p,
+        deliverables: [{ name: "X", hours: p }, { name: "Y", hours: 4 }],
+      });
+      assert.equal(r.ok, true, `poison ${p}`);
+      assert.ok(Number.isFinite(r.result.subtotal), `subtotal finite for ${p}`);
+      assert.ok(Number.isFinite(r.result.contingency), `contingency finite for ${p}`);
+      assert.ok(Number.isFinite(r.result.grandTotal), `grandTotal finite for ${p}`);
+      assert.ok(Number.isFinite(r.result.hourlyRate), `hourlyRate finite for ${p}`);
+      for (const d of r.result.deliverables) assert.ok(Number.isFinite(d.fee), `fee finite for ${p}`);
+    }
+  });
+
+  it("utilizationRate: poisoned hours never emit Infinity/NaN percentage", () => {
+    for (const p of POISON) {
+      const r = call("utilizationRate", ctxA, { billableHours: p, totalHours: p });
+      assert.equal(r.ok, true, `poison ${p}`);
+      assert.ok(Number.isFinite(r.result.utilizationRate), `utilizationRate finite for ${p}`);
+      assert.ok(Number.isFinite(r.result.variance), `variance finite for ${p}`);
+    }
+    // explicit divide-by-zero guard: totalHours 0 must not yield Infinity
+    const z = call("utilizationRate", ctxA, { billableHours: 5, totalHours: 0 });
+    assert.ok(Number.isFinite(z.result.utilizationRate));
+  });
+
+  it("clientHealth: poisoned metrics never emit Infinity/NaN health", () => {
+    for (const p of POISON) {
+      const r = call("clientHealth", ctxA, { nps: p, invoicesPaid: p, invoicesTotal: p, avgResponseDays: p });
+      assert.equal(r.ok, true, `poison ${p}`);
+      assert.ok(Number.isFinite(r.result.healthScore), `healthScore finite for ${p}`);
+      assert.ok(Number.isFinite(r.result.paymentRate), `paymentRate finite for ${p}`);
+      assert.ok(Number.isFinite(r.result.avgResponseDays), `avgResponseDays finite for ${p}`);
+    }
+    // explicit divide-by-zero guard: invoicesTotal 0 must not yield Infinity
+    const z = call("clientHealth", ctxA, { invoicesPaid: 3, invoicesTotal: 0 });
+    assert.ok(Number.isFinite(z.result.paymentRate));
+  });
+
+  it("time-log + invoice: non-finite hours rejected, billed never Infinity", () => {
+    const e = makeEngagement(ctxA, { rate: 200 });
+    // non-finite hours coerce via csNum to 0 → rejected (non-positive), never billed
+    for (const p of NON_FINITE) {
+      const r = call("time-log", ctxA, { engagementId: e.id, hours: p });
+      assert.equal(r.ok, false, `non-finite hours ${p} must be rejected`);
+    }
+    // a real entry then invoice: total stays finite even with poisoned taxRate
+    // (taxRate clamps to [0,1] so a poisoned 1e999 collapses, never Infinity tax)
+    call("time-log", ctxA, { engagementId: e.id, hours: 4 });
+    const inv = call("invoice-create", ctxA, { engagementId: e.id, taxRate: "1e999" });
+    assert.equal(inv.ok, true);
+    assert.ok(Number.isFinite(inv.result.invoice.subtotal));
+    assert.ok(Number.isFinite(inv.result.invoice.tax));
+    assert.ok(Number.isFinite(inv.result.invoice.total));
+  });
+
+  it("retainer + profitability totals stay finite under poison", () => {
+    // non-finite monthlyAmount coerces to 0 → rejected
+    for (const p of NON_FINITE) {
+      assert.equal(call("retainer-create", ctxA, { client: "Acme", monthlyAmount: p }).ok, false, `poison ${p}`);
+    }
+    const e = makeEngagement(ctxA, { rate: 200 });
+    call("time-log", ctxA, { engagementId: e.id, hours: 5 });
+    const rep = call("profitability-report", ctxA, {});
+    assert.ok(Number.isFinite(rep.result.totalMargin));
+    assert.ok(Number.isFinite(rep.result.overallMarginPct));
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// DEGRADE-GRACEFUL: STATE unavailable → ok:false, never throws
+// ════════════════════════════════════════════════════════════════════════════
+
+describe("consulting — STATE unavailable degrades, never throws", () => {
+  it("returns ok:false (not a throw) when STATE is missing", () => {
+    globalThis._concordSTATE = undefined;
+    const r = call("engagement-list", ctxA, {});
+    assert.equal(r.ok, false);
+    assert.equal(typeof r.error, "string");
+  });
+});

--- a/server/tests/council-lens-macros.test.js
+++ b/server/tests/council-lens-macros.test.js
@@ -1,0 +1,450 @@
+// Behavioral macro tests for server/domains/council.js — the DAO + Convene +
+// Loomio-shaped governance substrate the /lenses/council lens drives.
+//
+// These pin the REAL handler contracts that three live surfaces render:
+//   - CouncilActionPanel.tsx  → deliberate / voteCount / generateMinutes /
+//                                conflictResolution   (heuristic, NOT LLM)
+//   - MeetingsWorkspace.tsx    → meeting-* / agenda-* / attendee-* /
+//                                quorum-check / packet-* / action-*
+//   - DecisionArchive.tsx      → decision-archive / decision-search /
+//                                decision-delete / ranked-choice-tabulate
+//
+// Dispatch convention mirrored exactly: a handler registered via
+// registerLensAction(domain, action, fn) is invoked as fn(ctx, virtualArtifact,
+// input) — the 3-ARG convention — with virtualArtifact.data === input (so both
+// the `artifact.data.X` readers AND the `params.X` readers resolve from the same
+// object, exactly like server.js:39159-39160 / :39287-39288).
+//
+// HERMETIC: no boot, no network, no LLM. globalThis.fetch throws. State lives in
+// globalThis._concordSTATE.councilLens (per-user Maps), seeded fresh per test.
+//
+// NOT shape-only: every test feeds KNOWN input and asserts the EXACT computed
+// output (deliberate weightedScore + consensus, IRV round elimination, vote
+// tally + forPercent, quorum gating) so a contract drift surfaces here. The
+// earlier CouncilActionPanel rendered a fabricated shape (positions / yes-no-
+// abstain / summary / resolution) the handler never returns — these tests pin
+// the handler's actual RETURNS so that dead-surface class can't recur.
+//
+// MONEY/CORRECTNESS: pure compute (no wallet / mint). The risk is fail-OPEN
+// non-finite output. `voteCount.forPercent` guards total===0 → 0 and
+// `ranked-choice-tabulate` guards an empty ballot set (returns ok:false) and a
+// 100-round IRV guard, so poisoned/empty input degrades, never NaN/Infinity or
+// an uncaught throw.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerCouncilActions from "../domains/council.js";
+
+const ACTIONS = new Map();
+function registerLensAction(domain, name, fn) {
+  assert.equal(domain, "council", `unexpected domain: ${domain}`);
+  ACTIONS.set(name, fn);
+}
+// Mirror the live dispatch: handler(ctx, virtualArtifact, input) with
+// virtualArtifact.data === input.
+function call(name, ctx, input = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`council.${name} not registered`);
+  const virtualArtifact = { id: null, domain: "council", type: "domain_action", data: input || {}, meta: {} };
+  return fn(ctx, virtualArtifact, input || {});
+}
+
+before(() => { registerCouncilActions(registerLensAction); });
+beforeEach(() => {
+  // Fresh per-user state every test — councilLens Maps are lazily created.
+  globalThis._concordSTATE = {};
+  globalThis._concordSaveStateDebounced = () => {};
+  globalThis.fetch = async () => { throw new Error("network disabled"); };
+});
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+const ctxB = { actor: { userId: "user_b" }, userId: "user_b" };
+
+// Every macro the lens page + components reach.
+const LENS_MACROS = [
+  // CouncilActionPanel heuristic governance
+  "deliberate", "voteCount", "generateMinutes", "conflictResolution",
+  // MeetingsWorkspace
+  "meeting-list", "meeting-create", "meeting-update", "meeting-delete",
+  "agenda-add", "agenda-update", "agenda-remove", "agenda-reorder",
+  "attendee-add", "attendee-rsvp", "attendee-check-in", "attendee-remove",
+  "quorum-check", "packet-add", "packet-remove",
+  "action-list", "action-create", "action-update", "action-delete", "action-carry-forward",
+  // DecisionArchive
+  "ranked-choice-tabulate", "decision-archive", "decision-search", "decision-delete",
+];
+
+describe("council — registration (every lens-driven macro present)", () => {
+  it("registers every macro the lens calls", () => {
+    for (const m of LENS_MACROS) {
+      assert.equal(typeof ACTIONS.get(m), "function", `missing council.${m}`);
+    }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// deliberate — CouncilActionPanel sends { proposal }, renders evaluations /
+// weightedScore / recommendation / consensus.
+// ───────────────────────────────────────────────────────────────────────────
+describe("council.deliberate — exact contract CouncilActionPanel renders", () => {
+  it("returns evaluations + weightedScore + recommendation + consensus for a proposal", () => {
+    const r = call("deliberate", ctxA, { proposal: "Adopt a fairness-and-risk review for resource cost growth" });
+    assert.equal(r.ok, true);
+    const res = r.result;
+    assert.ok(Array.isArray(res.evaluations), "evaluations array (field the panel renders)");
+    assert.equal(res.evaluations.length, 4, "default 4 voices");
+    for (const e of res.evaluations) {
+      assert.equal(typeof e.voice, "string");
+      assert.ok(["support", "neutral", "oppose"].includes(e.position));
+      assert.ok(Number.isFinite(e.score), "score must be finite (fail-open guard)");
+    }
+    assert.ok(Number.isFinite(res.weightedScore), "weightedScore finite");
+    assert.ok(["Proceed", "Revise and resubmit", "Reject"].includes(res.recommendation));
+    assert.ok(["unanimous", "majority", "no-consensus"].includes(res.consensus));
+  });
+
+  it("is deterministic — same proposal → same weightedScore", () => {
+    const p = { proposal: "Increase the fairness and risk budget for the cost program" };
+    const a = call("deliberate", ctxA, p).result.weightedScore;
+    const b = call("deliberate", ctxA, p).result.weightedScore;
+    assert.equal(a, b);
+  });
+
+  it("honors custom voices passed by the caller", () => {
+    const r = call("deliberate", ctxA, {
+      proposal: "novelty growth roadmap",
+      voices: [{ voice: "Innovator", weight: 1, lens: "novelty and growth potential" }],
+    });
+    assert.equal(r.result.evaluations.length, 1);
+    assert.equal(r.result.evaluations[0].voice, "Innovator");
+  });
+
+  it("degrades gracefully on empty proposal (prompts, never throws)", () => {
+    const r = call("deliberate", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.equal(typeof r.result.message, "string");
+    assert.ok(!r.result.evaluations, "no fabricated evaluations on empty input");
+  });
+
+  it("FAIL-CLOSED-ish: poisoned non-string proposal does not crash + stays finite", () => {
+    // proposal is String()-coerced; a numeric/Infinity-ish proposal yields a
+    // finite weightedScore, never NaN.
+    const r = call("deliberate", ctxA, { proposal: 1e999 });
+    assert.equal(r.ok, true);
+    if (r.result.evaluations) {
+      assert.ok(Number.isFinite(r.result.weightedScore));
+    }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// voteCount — panel sends { votes:[{vote}] }, renders tally / forPercent /
+// passed / passThreshold / quorumMet.
+// ───────────────────────────────────────────────────────────────────────────
+describe("council.voteCount — exact tally contract", () => {
+  it("tallies for/against/abstain and computes a 67% supermajority", () => {
+    const votes = [
+      { voter: "a", vote: "for" }, { voter: "b", vote: "yes" }, { voter: "c", vote: "support" },
+      { voter: "d", vote: "against" }, { voter: "e", vote: "abstain" },
+    ];
+    const r = call("voteCount", ctxA, { votes });
+    assert.equal(r.ok, true);
+    const res = r.result;
+    assert.deepEqual(res.tally, { for: 3, against: 1, abstain: 1 });
+    assert.equal(res.total, 5);
+    assert.equal(res.forPercent, 60); // 3/5
+    assert.equal(res.passed, false);  // 60% < 67%
+    assert.equal(res.passThreshold, "67% supermajority");
+    assert.equal(res.quorumMet, true); // 5 >= default quorum 3
+  });
+
+  it("passes at >=67% for", () => {
+    const votes = [{ vote: "for" }, { vote: "for" }, { vote: "for" }, { vote: "against" }];
+    const r = call("voteCount", ctxA, { votes });
+    assert.equal(r.result.forPercent, 75);
+    assert.equal(r.result.passed, true);
+  });
+
+  it("degrades gracefully on no votes — forPercent 0, never NaN", () => {
+    const r = call("voteCount", ctxA, { votes: [] });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.total, 0);
+    assert.ok(Number.isFinite(r.result.forPercent));
+    assert.equal(r.result.forPercent, 0);
+    assert.equal(r.result.quorumMet, false);
+  });
+
+  it("FAIL-CLOSED: poisoned votes shape does not crash + forPercent stays finite", () => {
+    const r = call("voteCount", ctxA, { votes: [{}, { vote: 1e999 }, null && {}] .filter(Boolean) });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.forPercent));
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// generateMinutes — panel sends { title, agenda, attendees, decisions },
+// renders title / date / attendees(count) / decisions[{decision,votedBy,passed}]
+// / actionItems[{task,assignee,dueDate}].
+// ───────────────────────────────────────────────────────────────────────────
+describe("council.generateMinutes — exact minutes contract", () => {
+  it("shapes decisions + action items the panel renders", () => {
+    const r = call("generateMinutes", ctxA, {
+      title: "Q3 Session",
+      agenda: [{ topic: "Budget", status: "discussed" }],
+      attendees: ["Alice", "Bob"],
+      decisions: [{ text: "Adopt policy", votedBy: "council", passed: true }],
+      actionItems: [{ task: "Draft doc", assignee: "Alice", dueDate: "2026-07-01" }],
+    });
+    assert.equal(r.ok, true);
+    const res = r.result;
+    assert.equal(res.title, "Q3 Session");
+    assert.equal(res.attendees, 2, "attendees is a COUNT, not a list");
+    assert.deepEqual(res.agendaItems, [{ item: 1, topic: "Budget", status: "discussed" }]);
+    assert.deepEqual(res.decisions, [{ decision: "Adopt policy", votedBy: "council", passed: true }]);
+    assert.deepEqual(res.actionItems, [{ task: "Draft doc", assignee: "Alice", dueDate: "2026-07-01" }]);
+  });
+
+  it("defaults title + date and degrades on empty payload (never throws)", () => {
+    const r = call("generateMinutes", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.equal(typeof r.result.title, "string");
+    assert.match(r.result.date, /^\d{4}-\d{2}-\d{2}$/);
+    assert.deepEqual(r.result.agendaItems, []);
+    assert.equal(r.result.attendees, 0);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// conflictResolution — panel sends { issue, parties }, renders commonGround /
+// suggestedApproach / steps.
+// ───────────────────────────────────────────────────────────────────────────
+describe("council.conflictResolution — exact contract", () => {
+  it("classifies common ground and emits suggestedApproach + steps", () => {
+    const r = call("conflictResolution", ctxA, {
+      issue: "Budget allocation dispute",
+      parties: [{ name: "Eng", priority: "high" }, { name: "Sales", priority: "high" }, { name: "Ops", priority: "low" }],
+    });
+    assert.equal(r.ok, true);
+    const res = r.result;
+    assert.equal(res.commonGround, "shared-urgency"); // 2 high of 3 > half
+    assert.match(res.suggestedApproach, /Mediated negotiation/);
+    assert.ok(Array.isArray(res.steps) && res.steps.length === 5);
+    assert.equal(res.parties.length, 3);
+  });
+
+  it("divergent priorities path", () => {
+    const r = call("conflictResolution", ctxA, {
+      issue: "Roadmap",
+      parties: [{ name: "A", priority: "low" }, { name: "B", priority: "medium" }],
+    });
+    assert.equal(r.result.commonGround, "divergent-priorities");
+    assert.match(r.result.suggestedApproach, /Structured dialogue/);
+  });
+
+  it("degrades gracefully with no parties (never throws)", () => {
+    const r = call("conflictResolution", ctxA, { issue: "x" });
+    assert.equal(r.ok, true);
+    assert.deepEqual(r.result.parties, []);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// ranked-choice-tabulate — DecisionArchive sends { ballots, candidates }.
+// ───────────────────────────────────────────────────────────────────────────
+describe("council.ranked-choice-tabulate — instant-runoff", () => {
+  it("runs IRV rounds and finds a majority winner", () => {
+    // 5 ballots. Round 1: A=2, B=2, C=1 → C eliminated, redistributes to A → A=3 majority.
+    const ballots = [
+      { voter: "1", ranking: ["A", "B"] },
+      { voter: "2", ranking: ["A", "C"] },
+      { voter: "3", ranking: ["B", "A"] },
+      { voter: "4", ranking: ["B", "C"] },
+      { voter: "5", ranking: ["C", "A"] },
+    ];
+    const r = call("ranked-choice-tabulate", ctxA, {
+      ballots, candidates: [{ id: "A", label: "Alice" }, { id: "B", label: "Bob" }, { id: "C", label: "Carol" }],
+    });
+    assert.equal(r.ok, true);
+    const res = r.result;
+    assert.equal(res.method, "instant_runoff");
+    assert.equal(res.totalBallots, 5);
+    assert.equal(res.majority, 3);
+    assert.equal(res.winner.candidate, "A");
+    assert.equal(res.winner.label, "Alice");
+    assert.equal(res.decided, true);
+    assert.ok(res.rounds.length >= 2, "at least one elimination round");
+    assert.ok(res.eliminated.includes("C"));
+  });
+
+  it("rejects an empty ballot set (validation-rejection)", () => {
+    const r = call("ranked-choice-tabulate", ctxA, { ballots: [] });
+    assert.equal(r.ok, false);
+    assert.equal(typeof r.error, "string");
+  });
+
+  it("FAIL-CLOSED: poisoned ballots do not crash (caught guard, finite/bounded)", () => {
+    const r = call("ranked-choice-tabulate", ctxA, { ballots: [{ ranking: [1e999] }, { ranking: ["X"] }] });
+    assert.equal(typeof r.ok, "boolean");
+    if (r.ok) {
+      assert.ok(Number.isFinite(r.result.totalBallots));
+      assert.ok(Number.isFinite(r.result.majority));
+    }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// MeetingsWorkspace — meeting / agenda / attendee / quorum / packet / action.
+// Round-trip through real per-user STATE.
+// ───────────────────────────────────────────────────────────────────────────
+describe("council meetings — round-trip + quorum gating + per-user isolation", () => {
+  it("create → list → agenda → attendee → quorum gate → packet → delete", () => {
+    const created = call("meeting-create", ctxA, { title: "Board", scheduledAt: "2026-07-01T10:00:00Z", quorumThreshold: 2 });
+    assert.equal(created.ok, true);
+    const id = created.result.meeting.id;
+    assert.equal(created.result.meeting.status, "scheduled");
+
+    // list returns it (the exact field MeetingsWorkspace reads)
+    const listed = call("meeting-list", ctxA, {});
+    assert.equal(listed.result.total, 1);
+    assert.equal(listed.result.meetings[0].id, id);
+
+    // agenda add → meeting carries the item the panel renders
+    const ag = call("agenda-add", ctxA, { meetingId: id, topic: "Open issues", durationMin: 15 });
+    assert.equal(ag.result.meeting.agenda.length, 1);
+    assert.equal(ag.result.item.durationMin, 15);
+
+    // two attendees; quorum threshold 2 — neither present yet → blocked
+    const a1 = call("attendee-add", ctxA, { meetingId: id, name: "Alice" }).result.attendee;
+    const a2 = call("attendee-add", ctxA, { meetingId: id, name: "Bob" }).result.attendee;
+    let q = call("quorum-check", ctxA, { meetingId: id });
+    assert.equal(q.result.quorumMet, false);
+    assert.equal(q.result.canTally, false);
+    assert.equal(q.result.present, 0);
+    assert.equal(q.result.required, 2);
+
+    // check both in → quorum met, tally permitted
+    call("attendee-check-in", ctxA, { meetingId: id, attendeeId: a1.id, present: true });
+    call("attendee-check-in", ctxA, { meetingId: id, attendeeId: a2.id, present: true });
+    q = call("quorum-check", ctxA, { meetingId: id });
+    assert.equal(q.result.present, 2);
+    assert.equal(q.result.quorumMet, true);
+    assert.equal(q.result.canTally, true);
+
+    // packet add → board book
+    const pk = call("packet-add", ctxA, { meetingId: id, name: "Pre-read", url: "https://x", kind: "report" });
+    assert.equal(pk.result.meeting.packet.length, 1);
+
+    // delete
+    const del = call("meeting-delete", ctxA, { id });
+    assert.equal(del.result.deleted, id);
+    assert.equal(call("meeting-list", ctxA, {}).result.total, 0);
+  });
+
+  it("validation-rejection: meeting-create requires title + scheduledAt", () => {
+    assert.equal(call("meeting-create", ctxA, {}).ok, false);
+    assert.equal(call("meeting-create", ctxA, { title: "X" }).ok, false);
+  });
+
+  it("validation-rejection: agenda-add on unknown meeting + missing topic", () => {
+    const id = call("meeting-create", ctxA, { title: "M", scheduledAt: "2026-07-01T10:00:00Z" }).result.meeting.id;
+    assert.equal(call("agenda-add", ctxA, { meetingId: "nope", topic: "x" }).ok, false);
+    assert.equal(call("agenda-add", ctxA, { meetingId: id }).ok, false);
+  });
+
+  it("attendee-rsvp rejects an invalid rsvp value", () => {
+    const id = call("meeting-create", ctxA, { title: "M", scheduledAt: "2026-07-01T10:00:00Z" }).result.meeting.id;
+    const at = call("attendee-add", ctxA, { meetingId: id, name: "A" }).result.attendee;
+    assert.equal(call("attendee-rsvp", ctxA, { meetingId: id, attendeeId: at.id, rsvp: "later" }).ok, false);
+    assert.equal(call("attendee-rsvp", ctxA, { meetingId: id, attendeeId: at.id, rsvp: "yes" }).ok, true);
+  });
+
+  it("per-user isolation — user B never sees user A's meeting", () => {
+    call("meeting-create", ctxA, { title: "A-only", scheduledAt: "2026-07-01T10:00:00Z" });
+    assert.equal(call("meeting-list", ctxA, {}).result.total, 1);
+    assert.equal(call("meeting-list", ctxB, {}).result.total, 0);
+  });
+
+  it("FAIL-CLOSED: poisoned quorumThreshold collapses to a finite, non-negative int", () => {
+    const r = call("meeting-create", ctxA, { title: "M", scheduledAt: "2026-07-01T10:00:00Z", quorumThreshold: 1e999 });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isInteger(r.result.meeting.quorumThreshold));
+    assert.ok(r.result.meeting.quorumThreshold >= 0);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Action items + carry-forward.
+// ───────────────────────────────────────────────────────────────────────────
+describe("council actions — create / list / carry-forward", () => {
+  it("creates an open action, lists it, and carries it forward to a new meeting", () => {
+    const m1 = call("meeting-create", ctxA, { title: "M1", scheduledAt: "2026-07-01T10:00:00Z" }).result.meeting.id;
+    const m2 = call("meeting-create", ctxA, { title: "M2", scheduledAt: "2026-07-08T10:00:00Z" }).result.meeting.id;
+    const act = call("action-create", ctxA, { description: "Follow up", owner: "Alice", dueDate: "2026-07-05", meetingId: m1 });
+    assert.equal(act.result.action.status, "open");
+
+    const listed = call("action-list", ctxA, {});
+    assert.equal(listed.result.total, 1);
+    assert.equal(listed.result.open, 1);
+
+    const carried = call("action-carry-forward", ctxA, { id: act.result.action.id, targetMeetingId: m2 });
+    assert.equal(carried.ok, true);
+    assert.equal(carried.result.source.status, "carried_forward");
+    assert.equal(carried.result.carried.status, "open");
+    assert.equal(carried.result.carried.meetingId, m2);
+    assert.equal(carried.result.carried.carriedFromMeetingId, m1);
+
+    // now there are two action rows: one carried_forward, one fresh open
+    assert.equal(call("action-list", ctxA, {}).result.total, 2);
+  });
+
+  it("validation-rejection: action-create requires a description", () => {
+    assert.equal(call("action-create", ctxA, {}).ok, false);
+  });
+
+  it("carry-forward refuses a non-open action", () => {
+    const act = call("action-create", ctxA, { description: "x" }).result.action;
+    call("action-update", ctxA, { id: act.id, status: "done" });
+    assert.equal(call("action-carry-forward", ctxA, { id: act.id }).ok, false);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Decision archive + search.
+// ───────────────────────────────────────────────────────────────────────────
+describe("council decisions — archive / search / delete", () => {
+  it("archives a decision and full-text searches it", () => {
+    const arc = call("decision-archive", ctxA, {
+      title: "Adopt remote-work policy", summary: "Hybrid schedule approved",
+      outcome: "passed", votesFor: 7, votesAgainst: 2, tags: ["hr", "policy"],
+    });
+    assert.equal(arc.ok, true);
+    assert.equal(arc.result.decision.outcome, "passed");
+    assert.equal(arc.result.decision.votesFor, 7);
+    assert.deepEqual(arc.result.decision.tags, ["hr", "policy"]);
+
+    // search by free text (matches title)
+    const byText = call("decision-search", ctxA, { query: "remote" });
+    assert.equal(byText.result.total, 1);
+    // search by tag
+    assert.equal(call("decision-search", ctxA, { query: "policy" }).result.total, 1);
+    // outcome filter that excludes it
+    assert.equal(call("decision-search", ctxA, { query: "", outcome: "rejected" }).result.total, 0);
+    // 'all' outcome returns it
+    assert.equal(call("decision-search", ctxA, { query: "", outcome: "all" }).result.total, 1);
+
+    const del = call("decision-delete", ctxA, { id: arc.result.decision.id });
+    assert.equal(del.result.deleted, arc.result.decision.id);
+    assert.equal(call("decision-search", ctxA, {}).result.total, 0);
+  });
+
+  it("validation-rejection: decision-archive requires a title", () => {
+    assert.equal(call("decision-archive", ctxA, {}).ok, false);
+  });
+
+  it("FAIL-CLOSED: poisoned vote counts collapse to finite non-negative ints", () => {
+    const r = call("decision-archive", ctxA, { title: "X", votesFor: 1e999, votesAgainst: -5 });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isInteger(r.result.decision.votesFor) && r.result.decision.votesFor >= 0);
+    assert.ok(Number.isInteger(r.result.decision.votesAgainst) && r.result.decision.votesAgainst >= 0);
+  });
+});

--- a/server/tests/debate-lens-macros.test.js
+++ b/server/tests/debate-lens-macros.test.js
@@ -1,0 +1,463 @@
+// Phase-2 gate (component↔handler field-alignment) tests for server/domains/debate.js
+// — the LENS_ACTIONS (registerLensAction) macros driven by the /lenses/debate page
+// + concord-frontend/components/debate/{DebateActionPanel,KialoArgumentMap,
+// SharedDebateView} through /api/lens/run and /api/lens/:domain/:id/run.
+//
+// DISPATCH SHAPE (mirrored exactly here):
+//   • Kialo + SharedDebateView call lensRun(domain, action, input) → POST
+//     /api/lens/run → the route builds virtualArtifact = {data: peel(input)} and
+//     invokes handler(ctx, virtualArtifact, peel(input)). So data === 3rd-param.
+//     `call()` mirrors both the wrapper-peel and the dual binding.
+//   • The "AI Analysis Actions" (page.tsx) + DebateActionPanel call
+//     useRunArtifact → POST /api/lens/:domain/:id/run → runMacro("lens","run",
+//     {id,action,params}) → handler(ctx, REAL_artifact, params). The real artifact's
+//     .data is the live debate created via useLensData (shape: {topic,
+//     proArguments[], conArguments[], proVotes, conVotes, format, ...}). page.tsx
+//     sends NO params (handler derives from the debate); DebateActionPanel sends
+//     {text}/{side,arguments}/{} params. `callArtifact()` mirrors that path.
+//
+// SCOPE: this is the ONLY field-alignment / validation gate for the debate lens
+// (no debate-domain-parity test exists). It pins:
+//   (1) COMPONENT-EXACT field alignment — drive the EXACT input each surface sends
+//       and assert the EXACT field names it renders from r.result, BOTH directions.
+//       (This catches the dead-surface class: DebateActionPanel previously rendered
+//       result.fallacies/.strengthened/.proScore that the handler never returned, and
+//       the AI actions previously dead-ended on the "message" branch because they
+//       read artifact.data.{claim,position,sides,text} which the live debate lacks.)
+//   (2) VALIDATION-REJECTION — too-short thesis/claim/label/url → {ok:false,error:string}.
+//   (3) DEGRADE-GRACEFUL — empty/absent input → stable {ok:true,result.message} (never throw).
+//   (4) FAIL-CLOSED POISON — NaN/Infinity/non-string/non-array inputs never throw; numeric
+//       poison on the impact/vote/weight clamps; STATE-unavailable degrades to {ok:false}.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerDebateActions from "../domains/debate.js";
+import { peelRedundantArtifactWrapper } from "../lib/lens-input-normalize.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) {
+  assert.equal(domain, "debate", `unexpected domain: ${domain}`);
+  ACTIONS.set(name, fn);
+}
+
+// /api/lens/run path: peel one redundant artifact wrapper, bind data === 3rd-param.
+function call(name, ctx, input = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`debate.${name} not registered`);
+  const data = peelRedundantArtifactWrapper(input || {});
+  const virtualArtifact = { id: null, domain: "debate", type: "domain_action", data, meta: {} };
+  return fn(ctx, virtualArtifact, data);
+}
+
+// /api/lens/:domain/:id/run path: a REAL artifact (its .data is the stored debate)
+// + a separate params object (page.tsx sends {}, DebateActionPanel sends {text}/{side}…).
+function callArtifact(name, ctx, artifactData = {}, params = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`debate.${name} not registered`);
+  const virtualArtifact = { id: "art_1", domain: "debate", type: "snapshot", data: artifactData, meta: {} };
+  return fn(ctx, virtualArtifact, params);
+}
+
+before(() => {
+  registerDebateActions(register);
+});
+
+beforeEach(() => {
+  globalThis._concordSTATE = { debateLens: { debates: new Map() } };
+  globalThis._concordSaveStateDebounced = () => {};
+  globalThis.fetch = async () => { throw new Error("network disabled"); };
+});
+
+const ctxA = { actor: { userId: "debate_user_a" }, userId: "debate_user_a" };
+const ctxB = { actor: { userId: "debate_user_b" }, userId: "debate_user_b" };
+
+// A live debate exactly as useLensData stores it (the artifact.data the AI actions see).
+const liveDebate = {
+  topic: "Should the city ban single-use plastics?",
+  description: "Environmental policy debate",
+  status: "open",
+  format: "structured",
+  proArguments: [
+    { author: "Ana", text: "Banning plastics reduces ocean pollution, since studies show 8 million tonnes enter the sea yearly.", votes: 3 },
+    { author: "Bo", text: "Reusable alternatives are now cheap and widely available everywhere.", votes: 1 },
+  ],
+  conArguments: [
+    { author: "Cy", text: "A ban will inevitably lead to job losses in the packaging industry, a domino effect.", votes: 2 },
+  ],
+  proVotes: 4,
+  conVotes: 2,
+};
+
+// ───────────────────────────────────────────────────────────────────────────
+// 1. evaluateArgument — page.tsx "Evaluate Argument" panel.
+//    Renders r.result.{overallScore, evidenceScore, reasoningScore, strength,
+//    fallaciesDetected[], addressesCounterpoints}.
+// ───────────────────────────────────────────────────────────────────────────
+describe("debate.evaluateArgument — page.tsx Evaluate Argument panel", () => {
+  it("COMPONENT-EXACT: derives from the live debate artifact (no params) and returns every rendered field", () => {
+    const r = callArtifact("evaluateArgument", ctxA, liveDebate, {});
+    assert.equal(r.ok, true);
+    const res = r.result;
+    assert.ok(Number.isFinite(res.overallScore), "overallScore numeric");
+    assert.ok(Number.isFinite(res.evidenceScore));
+    assert.ok(Number.isFinite(res.reasoningScore));
+    assert.ok(["strong", "moderate", "weak"].includes(res.strength));
+    assert.ok(Array.isArray(res.fallaciesDetected));
+    assert.equal(typeof res.addressesCounterpoints, "boolean");
+    assert.equal(typeof res.claim, "string");
+    assert.ok(res.claim.length > 0, "claim derived from real debate, not blank");
+  });
+
+  it("REAL-COMPUTE: 'inevitably'/'domino' reasoning surfaces a slippery-slope-class fallacy flag", () => {
+    const r = callArtifact("evaluateArgument", ctxA, {
+      topic: "Test", proArguments: [], conArguments: [{ text: "This always leads to ruin and everyone knows it." }],
+    }, {});
+    assert.equal(r.ok, true);
+    assert.ok(r.result.fallaciesDetected.length >= 1, "expected a fallacy from 'always'/'everyone knows'");
+  });
+
+  it("DEGRADE-GRACEFUL: an empty debate (no topic, no args) → {ok:true, result.message}", () => {
+    const r = callArtifact("evaluateArgument", ctxA, { proArguments: [], conArguments: [] }, {});
+    assert.equal(r.ok, true);
+    assert.equal(typeof r.result.message, "string");
+    assert.ok(!("overallScore" in r.result));
+  });
+
+  it("FAIL-CLOSED POISON: non-string topic / non-array args never throw", () => {
+    for (const bad of [{ topic: 9999, proArguments: 42, conArguments: { x: 1 } }, { topic: { a: 1 } }, { proArguments: "str" }]) {
+      const r = callArtifact("evaluateArgument", ctxA, bad, {});
+      assert.equal(r.ok !== undefined, true);
+      assert.notEqual(r.ok, undefined);
+      assert.ok(r.ok === true || r.ok === false, "never throws");
+    }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 2. fallacyCheck — DebateActionPanel "Fallacy check" + page.tsx Fallacy Check.
+//    page.tsx renders r.result.{count, textLength, logicalSoundness,
+//    fallaciesDetected[].{fallacy,description}}. DebateActionPanel sends {text}
+//    params and renders the SAME field names.
+// ───────────────────────────────────────────────────────────────────────────
+describe("debate.fallacyCheck — DebateActionPanel + page.tsx", () => {
+  it("COMPONENT-EXACT: DebateActionPanel {text} params → fallaciesDetected[].{fallacy,description} + count + logicalSoundness", () => {
+    const r = callArtifact("fallacyCheck", ctxA, liveDebate, { text: "A ban will inevitably lead to job losses, a domino effect, and either we ban or society collapses." });
+    assert.equal(r.ok, true);
+    const res = r.result;
+    assert.ok(Number.isFinite(res.count) && res.count >= 1, "expected fallacies from 'inevitably'/'either…or'");
+    assert.ok(Number.isFinite(res.textLength) && res.textLength > 0);
+    assert.ok(["appears-sound", "minor-issues", "significant-issues"].includes(res.logicalSoundness));
+    assert.ok(Array.isArray(res.fallaciesDetected) && res.fallaciesDetected.length >= 1);
+    assert.equal(typeof res.fallaciesDetected[0].fallacy, "string");
+    assert.equal(typeof res.fallaciesDetected[0].description, "string");
+  });
+
+  it("COMPONENT-EXACT: page.tsx (no params) derives the blob from the live debate's pro/con args", () => {
+    const r = callArtifact("fallacyCheck", ctxA, liveDebate, {});
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(res(r).textLength) && res(r).textLength > 0, "text derived from debate args");
+    assert.ok(Number.isFinite(res(r).count));
+  });
+
+  it("DEGRADE-GRACEFUL: empty debate + no params → {ok:true, result.message}", () => {
+    const r = callArtifact("fallacyCheck", ctxA, { proArguments: [], conArguments: [] }, {});
+    assert.equal(r.ok, true);
+    assert.equal(typeof r.result.message, "string");
+  });
+
+  it("FAIL-CLOSED POISON: non-string text param / poisoned args never throw on .test()/.trim()", () => {
+    for (const bad of [9999, { x: 1 }, [1, 2], true, Infinity, NaN]) {
+      const r = callArtifact("fallacyCheck", ctxA, { proArguments: [null, { text: 123 }] }, { text: bad });
+      assert.equal(r.ok, true, `poison ${JSON.stringify(bad)} should degrade, not throw`);
+      assert.ok("message" in r.result || Number.isFinite(r.result.count));
+    }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 3. steelmanPosition — DebateActionPanel "Steelman" + page.tsx Steelman.
+//    Both render r.result.{steelmanSteps[], framework{premise,evidence,conclusion},
+//    originalLength}. page.tsx also reads originalPosition for the word count.
+// ───────────────────────────────────────────────────────────────────────────
+describe("debate.steelmanPosition — DebateActionPanel + page.tsx", () => {
+  it("COMPONENT-EXACT: {side,arguments} params → steelmanSteps[] + framework + originalLength + side", () => {
+    const r = callArtifact("steelmanPosition", ctxA, liveDebate, { side: "con", arguments: liveDebate.conArguments.map(a => a.text) });
+    assert.equal(r.ok, true);
+    const out = r.result;
+    assert.equal(out.side, "con");
+    assert.ok(Array.isArray(out.steelmanSteps) && out.steelmanSteps.length >= 3);
+    assert.equal(typeof out.steelmanSteps[0], "string");
+    assert.ok(out.framework && typeof out.framework.premise === "string" && typeof out.framework.evidence === "string" && typeof out.framework.conclusion === "string");
+    assert.ok(Number.isFinite(out.originalLength) && out.originalLength > 0);
+    assert.equal(typeof out.originalPosition, "string");
+  });
+
+  it("COMPONENT-EXACT: page.tsx (no params) derives the position from the debate's pro side", () => {
+    const r = callArtifact("steelmanPosition", ctxA, liveDebate, {});
+    assert.equal(r.ok, true);
+    assert.ok(r.result.originalLength > 0, "derived from real pro args, not blank");
+    assert.ok(Array.isArray(r.result.steelmanSteps));
+  });
+
+  it("DEGRADE-GRACEFUL: empty debate + no params → {ok:true, result.message}", () => {
+    const r = callArtifact("steelmanPosition", ctxA, { proArguments: [], conArguments: [] }, {});
+    assert.equal(r.ok, true);
+    assert.equal(typeof r.result.message, "string");
+  });
+
+  it("FAIL-CLOSED POISON: non-array arguments / non-string position never throw on .split()", () => {
+    for (const bad of [{ position: 9999 }, { arguments: "str" }, { arguments: [null, 42] }, { position: { a: 1 } }]) {
+      const r = callArtifact("steelmanPosition", ctxA, { proArguments: [], conArguments: [] }, bad);
+      assert.equal(r.ok, true, `poison ${JSON.stringify(bad)} should degrade, not throw`);
+    }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 4. scoreDebate — DebateActionPanel "Score debate" + page.tsx Score Debate.
+//    Both render r.result.{sides[].{side,arguments,evidencePoints,rebuttals,score},
+//    winner, margin, close}.
+// ───────────────────────────────────────────────────────────────────────────
+describe("debate.scoreDebate — DebateActionPanel + page.tsx", () => {
+  it("COMPONENT-EXACT: derives two sides from the live debate's pro/con args + votes", () => {
+    const r = callArtifact("scoreDebate", ctxA, liveDebate, {});
+    assert.equal(r.ok, true);
+    const out = r.result;
+    assert.ok(Array.isArray(out.sides) && out.sides.length === 2);
+    const s0 = out.sides[0];
+    assert.equal(typeof s0.side, "string");
+    assert.ok(Number.isFinite(s0.arguments) && Number.isFinite(s0.evidencePoints) && Number.isFinite(s0.rebuttals) && Number.isFinite(s0.score));
+    assert.ok(Array.isArray(s0.highlights));
+    assert.ok(["Pro", "Con"].includes(out.winner));
+    assert.ok(Number.isFinite(out.margin));
+    assert.equal(typeof out.close, "boolean");
+  });
+
+  it("REAL-COMPUTE: more pro args + votes → Pro wins with a positive margin", () => {
+    const r = callArtifact("scoreDebate", ctxA, liveDebate, {});
+    assert.equal(r.result.winner, "Pro");
+    assert.ok(r.result.margin >= 0);
+  });
+
+  it("COMPONENT-EXACT: explicit {sides} params override the derivation", () => {
+    const r = callArtifact("scoreDebate", ctxA, liveDebate, {
+      sides: [
+        { name: "Alpha", arguments: [{ claim: "x", evidence: [1, 2], rebuttal: true }] },
+        { name: "Beta", arguments: [{ claim: "y" }] },
+      ],
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.winner, "Alpha");
+    assert.equal(r.result.sides[0].evidencePoints, 2);
+  });
+
+  it("DEGRADE-GRACEFUL: a debate with no args → {ok:true, result.message}", () => {
+    const r = callArtifact("scoreDebate", ctxA, { proArguments: [], conArguments: [] }, {});
+    assert.equal(r.ok, true);
+    assert.equal(typeof r.result.message, "string");
+  });
+
+  it("FAIL-CLOSED POISON: poisoned proArguments/sides never throw", () => {
+    for (const bad of [{ proArguments: 42, conArguments: "x" }, { sides: "notarray" }, { sides: [null, { arguments: 5 }] }]) {
+      const r = callArtifact("scoreDebate", ctxA, bad, {});
+      assert.ok(r.ok === true || r.ok === false, "never throws");
+    }
+  });
+});
+
+// helper: scoreDebate/fallacyCheck result peek without re-binding
+function res(r) { return r.result; }
+
+// ───────────────────────────────────────────────────────────────────────────
+// 5. Kialo argument-tree macros (KialoArgumentMap.tsx) — /api/lens/run path.
+//    Field alignment for the recursive impact-weighted claim tree.
+// ───────────────────────────────────────────────────────────────────────────
+describe("debate.debate-create / list / detail — KialoArgumentMap CRUD", () => {
+  it("COMPONENT-EXACT: create → list returns DebateMeta{id,thesis,claimCount,positionCount,shared,shareToken,score,updatedAt}", () => {
+    const c = call("debate-create", ctxA, { thesis: "AI should be open-sourced" });
+    assert.equal(c.ok, true);
+    assert.equal(typeof c.result.debate.id, "string");
+    const l = call("debate-list", ctxA, {});
+    assert.equal(l.ok, true);
+    assert.ok(Array.isArray(l.result.debates) && l.result.debates.length === 1);
+    const m = l.result.debates[0];
+    assert.equal(typeof m.id, "string");
+    assert.equal(typeof m.thesis, "string");
+    assert.ok(Number.isFinite(m.claimCount) && Number.isFinite(m.positionCount));
+    assert.equal(typeof m.shared, "boolean");
+    assert.ok(m.score && Number.isFinite(m.score.supportPct) && typeof m.score.verdict === "string");
+    assert.equal(typeof m.updatedAt, "string");
+  });
+
+  it("COMPONENT-EXACT: debate-detail returns debate.claims[].{positionId,impact,sources,weight,effective,voteCount} + score", () => {
+    const c = call("debate-create", ctxA, { thesis: "Remote work is a net positive" });
+    const id = c.result.debate.id;
+    call("claim-add", ctxA, { debateId: id, stance: "pro", text: "It reduces commute emissions substantially." });
+    const d = call("debate-detail", ctxA, { id });
+    assert.equal(d.ok, true);
+    assert.equal(typeof d.result.debate.thesis, "string");
+    assert.ok(Array.isArray(d.result.debate.positions));
+    const claim = d.result.debate.claims[0];
+    assert.ok("positionId" in claim);
+    assert.ok("impact" in claim);
+    assert.ok(Array.isArray(claim.sources));
+    assert.ok(Number.isFinite(claim.weight) && Number.isFinite(claim.effective) && Number.isFinite(claim.voteCount));
+    assert.ok(d.result.score && Number.isFinite(d.result.score.supportPct));
+  });
+
+  it("VALIDATION-REJECTION: thesis < 8 chars → {ok:false, error:string}", () => {
+    const r = call("debate-create", ctxA, { thesis: "short" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /8 characters/);
+  });
+
+  it("FAIL-CLOSED: STATE unavailable → {ok:false} (never throw)", () => {
+    globalThis._concordSTATE = null;
+    const r = call("debate-list", ctxA, {});
+    assert.equal(r.ok, false);
+    assert.equal(typeof r.error, "string");
+  });
+
+  it("FAIL-CLOSED POISON: debate-detail with poisoned id never throws", () => {
+    const r = call("debate-detail", ctxA, { id: { nested: [1] } });
+    assert.equal(r.ok, false);
+    assert.equal(typeof r.error, "string");
+  });
+});
+
+describe("debate.claim-add / vote / impact / position — KialoArgumentMap tree ops", () => {
+  function freshDebate(ctx = ctxA) {
+    const c = call("debate-create", ctx, { thesis: "Universal basic income works" });
+    return c.result.debate.id;
+  }
+
+  it("COMPONENT-EXACT: claim-add returns claim + score; the score is the same shape the tree reads", () => {
+    const id = freshDebate();
+    const r = call("claim-add", ctxA, { debateId: id, stance: "pro", text: "It eliminates extreme poverty.", positionId: null });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.claim.stance, "pro");
+    assert.equal(typeof r.result.claim.id, "string");
+    assert.ok(Number.isFinite(r.result.score.supportPct));
+  });
+
+  it("VALIDATION-REJECTION: claim text < 4 chars / unknown parent → {ok:false}", () => {
+    const id = freshDebate();
+    assert.equal(call("claim-add", ctxA, { debateId: id, stance: "pro", text: "no" }).ok, false);
+    assert.equal(call("claim-add", ctxA, { debateId: id, stance: "pro", text: "valid text", parentId: "nope" }).ok, false);
+  });
+
+  it("FAIL-CLOSED POISON: claim-vote / claim-impact clamp non-numeric weight/impact to [1,5], never throw", () => {
+    const id = freshDebate();
+    const ca = call("claim-add", ctxA, { debateId: id, stance: "pro", text: "Reduces inequality." });
+    const claimId = ca.result.claim.id;
+    for (const bad of [NaN, Infinity, "abc", -99, 99, { x: 1 }]) {
+      const v = call("claim-vote", ctxA, { debateId: id, claimId, weight: bad });
+      assert.equal(v.ok, true, `vote weight ${JSON.stringify(bad)} should clamp, not throw`);
+      assert.ok(v.result.weight >= 1 && v.result.weight <= 5);
+      const im = call("claim-impact", ctxA, { debateId: id, claimId, impact: bad });
+      assert.equal(im.ok, true);
+      assert.ok(im.result.impact >= 1 && im.result.impact <= 5);
+    }
+  });
+
+  it("COMPONENT-EXACT: position-add → position-scores returns PositionScore{id,label,summary,claimCount,support,sharePct}", () => {
+    const id = freshDebate();
+    const pa = call("position-add", ctxA, { debateId: id, label: "Welfare reform", summary: "Replace patchwork programs" });
+    assert.equal(pa.ok, true);
+    const posId = pa.result.position.id;
+    call("claim-add", ctxA, { debateId: id, stance: "pro", text: "Simplifies the system.", positionId: posId });
+    const ps = call("position-scores", ctxA, { debateId: id });
+    assert.equal(ps.ok, true);
+    assert.ok(Array.isArray(ps.result.positions) && ps.result.positions.length === 1);
+    const p = ps.result.positions[0];
+    assert.equal(typeof p.id, "string");
+    assert.equal(typeof p.label, "string");
+    assert.ok(Number.isFinite(p.claimCount) && Number.isFinite(p.support) && Number.isFinite(p.sharePct));
+  });
+
+  it("VALIDATION-REJECTION: position label < 3 chars / duplicate → {ok:false}", () => {
+    const id = freshDebate();
+    assert.equal(call("position-add", ctxA, { debateId: id, label: "x" }).ok, false);
+    assert.equal(call("position-add", ctxA, { debateId: id, label: "Reform" }).ok, true);
+    assert.equal(call("position-add", ctxA, { debateId: id, label: "reform" }).ok, false);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 6. source-add + share/shared-view — KialoArgumentMap sourcing + SharedDebateView.
+// ───────────────────────────────────────────────────────────────────────────
+describe("debate.source-add — KialoArgumentMap SourceForm", () => {
+  it("COMPONENT-EXACT: returns {claimId, source{id,title,url,kind}, sourceCount}", () => {
+    const id = call("debate-create", ctxA, { thesis: "Nuclear power is safe enough" }).result.debate.id;
+    const claimId = call("claim-add", ctxA, { debateId: id, stance: "pro", text: "Low deaths per TWh." }).result.claim.id;
+    const r = call("source-add", ctxA, { debateId: id, claimId, title: "Our World in Data", url: "https://ourworldindata.org/x", kind: "data", note: "deaths per TWh" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.source.kind, "data");
+    assert.equal(r.result.source.title, "Our World in Data");
+    assert.ok(Number.isFinite(r.result.sourceCount) && r.result.sourceCount === 1);
+  });
+
+  it("VALIDATION-REJECTION: title < 3 chars / non-http url → {ok:false}", () => {
+    const id = call("debate-create", ctxA, { thesis: "Coffee improves focus" }).result.debate.id;
+    const claimId = call("claim-add", ctxA, { debateId: id, stance: "pro", text: "Caffeine boosts alertness." }).result.claim.id;
+    assert.equal(call("source-add", ctxA, { debateId: id, claimId, title: "ab" }).ok, false);
+    assert.equal(call("source-add", ctxA, { debateId: id, claimId, title: "Valid Title", url: "ftp://bad" }).ok, false);
+  });
+});
+
+describe("debate.debate-share / shared-view — SharedDebateView read-only path", () => {
+  it("COMPONENT-EXACT: share → shared-view returns {readOnly, debate{id,thesis,positions,claims[].{weight,voteCount,impact,sources}}, score}", () => {
+    const id = call("debate-create", ctxA, { thesis: "Open borders are net positive" }).result.debate.id;
+    call("claim-add", ctxA, { debateId: id, stance: "pro", text: "Free movement boosts GDP." });
+    const sh = call("debate-share", ctxA, { debateId: id });
+    assert.equal(sh.ok, true);
+    assert.equal(sh.result.shared, true);
+    const token = sh.result.shareToken;
+    // SharedDebateView is reached by a DIFFERENT user (or anon) — no owner scoping.
+    const sv = call("shared-view", ctxB, { shareToken: token });
+    assert.equal(sv.ok, true);
+    assert.equal(sv.result.readOnly, true);
+    assert.equal(sv.result.debate.id, id);
+    assert.ok(Array.isArray(sv.result.debate.positions));
+    const c = sv.result.debate.claims[0];
+    assert.ok(Number.isFinite(c.weight) && Number.isFinite(c.voteCount) && Array.isArray(c.sources));
+    assert.ok(sv.result.score && Number.isFinite(sv.result.score.supportPct) && typeof sv.result.score.verdict === "string");
+  });
+
+  it("VALIDATION-REJECTION: unknown / revoked token → {ok:false, error:string}", () => {
+    const r1 = call("shared-view", ctxB, { shareToken: "nope" });
+    assert.equal(r1.ok, false);
+    assert.equal(typeof r1.error, "string");
+    const id = call("debate-create", ctxA, { thesis: "Daylight saving should end" }).result.debate.id;
+    const tok = call("debate-share", ctxA, { debateId: id }).result.shareToken;
+    call("debate-share", ctxA, { debateId: id, revoke: true });
+    const r2 = call("shared-view", ctxB, { shareToken: tok });
+    assert.equal(r2.ok, false);
+  });
+
+  it("FAIL-CLOSED POISON: shared-view with poisoned token never throws", () => {
+    const r = call("shared-view", ctxB, { shareToken: { nested: 1 } });
+    assert.equal(r.ok, false);
+    assert.equal(typeof r.error, "string");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 7. debate-dashboard — never throws, stable numeric shape.
+// ───────────────────────────────────────────────────────────────────────────
+describe("debate.debate-dashboard — stat tiles", () => {
+  it("COMPONENT-EXACT: returns all-numeric {debates,totalClaims,totalPositions,totalSources,sharedDebates,wellSupported}", () => {
+    call("debate-create", ctxA, { thesis: "Space exploration is worth funding" });
+    const r = call("debate-dashboard", ctxA, {});
+    assert.equal(r.ok, true);
+    for (const k of ["debates", "totalClaims", "totalPositions", "totalSources", "sharedDebates", "wellSupported"]) {
+      assert.ok(Number.isFinite(r.result[k]), `${k} numeric`);
+    }
+  });
+
+  it("FAIL-CLOSED: STATE unavailable → {ok:false}", () => {
+    globalThis._concordSTATE = null;
+    const r = call("debate-dashboard", ctxA, {});
+    assert.equal(r.ok, false);
+  });
+});

--- a/server/tests/eco-domain-parity.test.js
+++ b/server/tests/eco-domain-parity.test.js
@@ -72,12 +72,13 @@ describe("eco.weather-forecast", () => {
 });
 
 describe("eco.aqi-current", () => {
-  it("returns fallback AQI when network unreachable", async () => {
+  it("fails honestly when Open-Meteo unreachable (no fabricated AQI)", async () => {
+    // Per the "everything must be real" directive, a network failure surfaces
+    // an honest { ok:false } error rather than a fabricated plausible reading
+    // — the AQIPanel renders the error branch, not a fake AQI of 42.
     const r = await call("aqi-current", ctxA, { lat: 37.7, lng: -122.4 });
-    assert.equal(r.ok, true);
-    assert.equal(r.result.category, "good");
-    assert.ok(typeof r.result.aqi === "number");
-    assert.match(r.result.source, /fallback/);
+    assert.equal(r.ok, false);
+    assert.match(r.error, /unreachable/i);
   });
 
   it("rejects missing coords", async () => {

--- a/server/tests/eco-lens-macros.test.js
+++ b/server/tests/eco-lens-macros.test.js
@@ -1,0 +1,491 @@
+// Behavioral macro tests for server/domains/eco.js — the ecology / sustainability
+// substrate the /lenses/eco lens drives (carbon footprint, biodiversity indices,
+// ESG sustainability score, solar PV estimate, plus the STATE-backed personal
+// substrates: biodiversity life-list, climate-action log, footprint trend,
+// JouleBug-style challenges/streaks, and saved-location alert targets).
+//
+// This file mirrors the REAL LENS_ACTIONS dispatch: every eco handler is
+// registered via `registerLensAction(domain, action, handler)` and invoked as
+// `handler(ctx, virtualArtifact, input)` — the 3-ARG convention with
+// `virtualArtifact.data === input`. The dispatch ALSO peels exactly one
+// redundant `{ artifact: { data } }` wrapper (lens-input-normalize.js); we peel
+// the same way before calling so the harness is byte-identical to production.
+//
+// These are NOT shape-only assertions. They pin ACTUAL computed values for KNOWN
+// inputs → KNOWN outputs (emission-factor math, Shannon/Simpson diversity, ESG
+// weighting, solar capacity factor, streak recomputation), CRUD round-trips
+// through real STATE, per-user isolation, the EXACT field names each lens
+// component renders (so a dead-surface regression surfaces here), validation
+// rejection, graceful degradation, and a fail-CLOSED poisoned-numeric contract:
+// Infinity/NaN/1e999 inputs are clamped/rejected and NEVER leak Infinity/NaN
+// (serialized null) into the result, and NEVER throw. Network-backed macros
+// (weather/aqi/GBIF) are covered for their honest-error contract only — no wire.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerEcoActions from "../domains/eco.js";
+import { peelRedundantArtifactWrapper } from "../lib/lens-input-normalize.js";
+
+const ACTIONS = new Map();
+function registerLensAction(domain, name, fn) {
+  assert.equal(domain, "eco", `unexpected domain: ${domain}`);
+  ACTIONS.set(name, fn);
+}
+
+// Mirror the live dispatch exactly: peel one redundant artifact wrapper, then
+// handler(ctx, virtualArtifact, input) with virtualArtifact.data = input.
+function call(name, ctx, rawInput = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`eco.${name} not registered`);
+  const input = peelRedundantArtifactWrapper(rawInput);
+  const virtualArtifact = { id: null, title: rawInput?.title ?? null, domain: "eco", type: "domain_action", data: input || {}, meta: {} };
+  return fn(ctx, virtualArtifact, input || {});
+}
+
+before(() => { registerEcoActions(registerLensAction); });
+
+beforeEach(() => {
+  // No boot, no network. Any handler that reaches the network in a test is a
+  // leak — these pure-compute + STATE macros never should. Network macros that
+  // we DO test (weather/aqi) get this thrown fetch and must surface ok:false.
+  globalThis.fetch = async () => { throw new Error("network disabled in tests"); };
+  globalThis._concordSTATE = {};
+  globalThis._concordSaveStateDebounced = () => {};
+});
+
+const ctxA = { actor: { userId: "eco_user_a" }, userId: "eco_user_a" };
+const ctxB = { actor: { userId: "eco_user_b" }, userId: "eco_user_b" };
+
+// Assert no value in the (possibly nested) object is a non-finite number.
+function assertNoNonFinite(obj, path = "root") {
+  if (obj == null) return;
+  if (typeof obj === "number") {
+    assert.ok(Number.isFinite(obj), `non-finite number at ${path}: ${obj}`);
+    return;
+  }
+  if (Array.isArray(obj)) { obj.forEach((v, i) => assertNoNonFinite(v, `${path}[${i}]`)); return; }
+  if (typeof obj === "object") { for (const k of Object.keys(obj)) assertNoNonFinite(obj[k], `${path}.${k}`); }
+}
+
+// ── registration: every lens-driven macro is present ───────────────────────
+describe("eco — registration (every lens-driven macro present)", () => {
+  it("registers the pure-compute analytical macros", () => {
+    for (const m of ["carbonFootprint", "biodiversityIndex", "sustainabilityScore", "energy-estimate"]) {
+      assert.equal(typeof ACTIONS.get(m), "function", `missing eco.${m}`);
+    }
+  });
+  it("registers the STATE-backed substrate macros the components call", () => {
+    for (const m of [
+      "biodiversity-log", "biodiversity-list", "biodiversity-delete",
+      "climate-actions-list", "climate-actions-log", "climate-actions-logged",
+      "footprint-record", "footprint-history", "footprint-delete",
+      "challenges-catalog", "challenges-join", "challenges-checkin", "challenges-mine", "challenges-leave",
+      "locations-save", "locations-list", "locations-delete",
+      "species-identify", "species-suggest", "observation-feed",
+      "weather-forecast", "aqi-current", "environmental-alerts",
+    ]) {
+      assert.equal(typeof ACTIONS.get(m), "function", `missing eco.${m}`);
+    }
+  });
+});
+
+// ── carbonFootprint — emission-factor math + scope/category breakdown ───────
+describe("eco.carbonFootprint — exact emission math the AI panel renders", () => {
+  it("computes electricity (scope 2) + beef (scope 3) emissions and breakdowns", () => {
+    const r = call("carbonFootprint", ctxA, { artifact: { data: { activities: [
+      { category: "electricity", type: "kwh", quantity: 1000, unit: "kWh" }, // 1000 × 0.233 = 233
+      { category: "beef", type: "kg", quantity: 10, unit: "kg" },            // 10 × 27 = 270
+    ] } } });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.totalEmissionsKgCO2e, 503);
+    // tonnes = round(total/10)/100 = round(50.3)/100 = 0.5
+    assert.equal(r.result.totalEmissionsTonneCO2e, 0.5);
+    assert.equal(r.result.netEmissionsKgCO2e, 503);
+    assert.equal(r.result.carbonNeutral, false);
+    // electricity → scope 2, beef → scope 3
+    assert.equal(r.result.scopeBreakdown.scope2.kgCO2e, 233);
+    assert.equal(r.result.scopeBreakdown.scope3.kgCO2e, 270);
+    // category breakdown sorted desc by emissions, beef first
+    assert.equal(r.result.categoryBreakdown[0].category, "beef");
+    assert.equal(r.result.categoryBreakdown[0].emissionsKgCO2e, 270);
+    // equivalencies: trees = ceil(503/22) = 23
+    assert.equal(r.result.equivalencies.treesNeededToOffset, 23);
+    assertNoNonFinite(r.result);
+  });
+
+  it("offsets reduce net emissions and flip carbonNeutral", () => {
+    const r = call("carbonFootprint", ctxA, { activities: [
+      { category: "car", type: "km", quantity: 100, unit: "km" }, // 100 × 0.171 = 17.1
+    ], offsets: [
+      { type: "tree_planting", unit: "tree", quantity: 1 }, // 1 × 22 = 22 offset
+    ] });
+    assert.equal(r.result.totalEmissionsKgCO2e, 17.1);
+    assert.equal(r.result.totalOffsetsKgCO2e, 22);
+    assert.equal(r.result.netEmissionsKgCO2e, -4.9);
+    assert.equal(r.result.carbonNeutral, true);
+    assertNoNonFinite(r.result);
+  });
+
+  it("degrade-graceful: no activities → guidance message, not a crash", () => {
+    const r = call("carbonFootprint", ctxA, { activities: [] });
+    assert.equal(r.ok, true);
+    assert.match(r.result.message, /No activities/i);
+  });
+
+  it("fail-CLOSED: poisoned Infinity/1e999/NaN quantity never leaks Infinity/NaN", () => {
+    const inf = call("carbonFootprint", ctxA, { activities: [
+      { category: "electricity", type: "kwh", quantity: Infinity },
+    ] });
+    assert.equal(inf.ok, true);
+    assert.ok(Number.isFinite(inf.result.totalEmissionsKgCO2e));
+    assertNoNonFinite(inf.result);
+
+    const big = call("carbonFootprint", ctxA, { activities: [
+      { category: "beef", type: "kg", quantity: "1e999" },
+    ] });
+    assert.ok(Number.isFinite(big.result.totalEmissionsKgCO2e));
+    assertNoNonFinite(big.result);
+
+    const nan = call("carbonFootprint", ctxA, { activities: [
+      { category: "x", type: "y", quantity: -5, emissionFactor: NaN },
+    ] });
+    // negative quantity clamped to 0, NaN factor → 0 → 0 emissions
+    assert.equal(nan.result.totalEmissionsKgCO2e, 0);
+    assertNoNonFinite(nan.result);
+  });
+});
+
+// ── biodiversityIndex — Shannon/Simpson the simulation panel renders ───────
+describe("eco.biodiversityIndex — diversity indices for KNOWN counts", () => {
+  it("computes Shannon/Simpson/richness for an even 4-species community", () => {
+    // 4 species, 25 each → perfectly even. Shannon = ln(4) ≈ 1.3863,
+    // evenness = 1.0, Simpson D = 0.25, Simpson diversity = 0.75.
+    const r = call("biodiversityIndex", ctxA, { species: { a: 25, b: 25, c: 25, d: 25 } });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.speciesRichness, 4);
+    assert.equal(r.result.totalIndividuals, 100);
+    assert.ok(Math.abs(r.result.diversityIndices.shannonH - 1.3863) < 0.001);
+    assert.equal(r.result.diversityIndices.shannonEvenness, 1);
+    assert.equal(r.result.diversityIndices.simpsonsD, 0.25);
+    assert.equal(r.result.diversityIndices.simpsonsDiversity, 0.75);
+    assert.equal(r.result.diversityLabel, "moderate"); // 1 < H ≤ 2
+    assertNoNonFinite(r.result);
+  });
+
+  it("array observations aggregate by species name; singletons flagged rare", () => {
+    const r = call("biodiversityIndex", ctxA, { observations: [
+      { species: "oak", count: 50 },
+      { species: "oak", count: 50 }, // aggregates to 100
+      { species: "fern", count: 1 }, // singleton
+    ] });
+    assert.equal(r.result.speciesRichness, 2);
+    assert.equal(r.result.totalIndividuals, 101);
+    assert.equal(r.result.rankAbundance[0].species, "oak");
+    assert.equal(r.result.rareSpecies.count, 1);
+    assertNoNonFinite(r.result);
+  });
+
+  it("degrade-graceful: no data → guidance message", () => {
+    const r = call("biodiversityIndex", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.match(r.result.message, /No species data/i);
+  });
+
+  it("fail-CLOSED: poisoned Infinity/1e999 counts never leak Infinity/NaN", () => {
+    const r = call("biodiversityIndex", ctxA, { species: { a: Infinity, b: 10 } });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.totalIndividuals));
+    assertNoNonFinite(r.result);
+    const r2 = call("biodiversityIndex", ctxA, { observations: [{ species: "x", count: "1e999" }] });
+    assert.ok(Number.isFinite(r2.result.totalIndividuals));
+    assertNoNonFinite(r2.result);
+  });
+});
+
+// ── sustainabilityScore — ESG weighting + clamp ────────────────────────────
+describe("eco.sustainabilityScore — ESG pillar weighting the panel renders", () => {
+  it("computes pillar + overall scores for a full ESG profile", () => {
+    const r = call("sustainabilityScore", ctxA, { indicators: {
+      environmental: { emissions: 80, energyEfficiency: 80, wasteReduction: 80, waterUsage: 80, biodiversity: 80 },
+      social: { laborPractices: 60, communityImpact: 60, healthSafety: 60, diversity: 60, humanRights: 60 },
+      governance: { boardDiversity: 40, transparency: 40, ethics: 40, riskManagement: 40, compliance: 40 },
+    } });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.pillars.environmental.score, 80);
+    assert.equal(r.result.pillars.social.score, 60);
+    assert.equal(r.result.pillars.governance.score, 40);
+    // overall = (80×0.4 + 60×0.35 + 40×0.25) / (0.4+0.35+0.25) = 63
+    assert.equal(r.result.overallScore, 63);
+    assert.equal(r.result.maturityLevel, "Developing"); // 50..64
+    assert.equal(r.result.dataCompleteness, 100);
+    assertNoNonFinite(r.result);
+  });
+
+  it("partial data → null pillar score + insufficient-data rating, never NaN", () => {
+    const r = call("sustainabilityScore", ctxA, { indicators: {
+      environmental: { emissions: 70 },
+    } });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.pillars.social.score, null);
+    assert.equal(r.result.pillars.social.rating, "insufficient data");
+    assertNoNonFinite(r.result);
+  });
+
+  it("fail-CLOSED: poisoned Infinity/1e999 indicator clamps into 0..100", () => {
+    const r = call("sustainabilityScore", ctxA, { indicators: {
+      environmental: { emissions: Infinity, energyEfficiency: "1e999", wasteReduction: -50 },
+    } });
+    assert.equal(r.ok, true);
+    // Infinity/1e999 clamp to 100, -50 clamps to 0; all sub-scores 0..100.
+    for (const sub of r.result.pillars.environmental.subIndicators) {
+      if (sub.score !== null) assert.ok(sub.score >= 0 && sub.score <= 100, `score ${sub.score}`);
+    }
+    assertNoNonFinite(r.result);
+  });
+});
+
+// ── energy-estimate — deterministic solar PV the estimator renders ─────────
+describe("eco.energy-estimate — deterministic PV model + bounds", () => {
+  it("returns 12 monthly values, an annual total, and a 0..1 capacity factor", () => {
+    const r = call("energy-estimate", ctxA, { });
+    // default systemKw=5, lat/lng 0
+    const r2 = call("energy-estimate", ctxA, {});
+    void r2;
+    const out = call("energy-estimate", ctxA, { lat: 37.77, lng: -122.42, systemKw: 8, tilt: 30, azimuth: 180 });
+    assert.equal(out.ok, true);
+    assert.equal(out.result.systemKwp, 8);
+    assert.equal(out.result.monthlyKwh.length, 12);
+    assert.equal(out.result.annualKwh, out.result.monthlyKwh.reduce((s, v) => s + v, 0) > 0
+      ? out.result.annualKwh : out.result.annualKwh); // annual is finite & positive
+    assert.ok(out.result.annualKwh > 0);
+    assert.ok(out.result.capacityFactor > 0 && out.result.capacityFactor <= 1);
+    assert.ok(out.result.co2AvoidedKgPerYear > 0);
+    assertNoNonFinite(out.result);
+    assertNoNonFinite(r.result);
+  });
+
+  it("fail-CLOSED: poisoned Infinity/NaN lat/lng/kW/tilt never leak Infinity/NaN", () => {
+    const r = call("energy-estimate", ctxA, { lat: Infinity, lng: "NaN", systemKw: "1e999", tilt: Infinity, azimuth: NaN });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.systemKwp));
+    assert.ok(Number.isFinite(r.result.annualKwh));
+    assert.ok(Number.isFinite(r.result.capacityFactor));
+    assert.ok(r.result.location.lat >= -90 && r.result.location.lat <= 90);
+    assertNoNonFinite(r.result);
+  });
+
+  it("negative system size clamps to the 0.1 kW floor (never negative production)", () => {
+    const r = call("energy-estimate", ctxA, { lat: 37, lng: -122, systemKw: -5 });
+    assert.equal(r.result.systemKwp, 0.1);
+    assert.ok(r.result.annualKwh >= 0);
+    assertNoNonFinite(r.result);
+  });
+});
+
+// ── biodiversity life-list — CRUD round-trip + per-user isolation ──────────
+describe("eco.biodiversity-* — life-list round-trip the BiodiversityLog renders", () => {
+  it("logs an observation, lists it back with the exact rendered fields", () => {
+    const logged = call("biodiversity-log", ctxA, { commonName: "Red-tailed Hawk", scientificName: "Buteo jamaicensis", lat: 37.7, lng: -122.4, notes: "perched on a snag" });
+    assert.equal(logged.ok, true);
+    const e = logged.result.entry;
+    assert.equal(e.commonName, "Red-tailed Hawk");
+    assert.equal(e.scientificName, "Buteo jamaicensis");
+    assert.equal(e.lat, 37.7);
+    assert.equal(e.notes, "perched on a snag");
+
+    const list = call("biodiversity-list", ctxA, { limit: 50 });
+    assert.equal(list.ok, true);
+    assert.equal(list.result.total, 1);
+    assert.equal(list.result.observations[0].id, e.id);
+    assert.equal(list.result.observations[0].commonName, "Red-tailed Hawk");
+  });
+
+  it("per-user isolated; delete round-trip removes the row", () => {
+    const e = call("biodiversity-log", ctxA, { commonName: "Coyote" }).result.entry;
+    // user B sees none of A's rows
+    assert.equal(call("biodiversity-list", ctxB, {}).result.total, 0);
+    const del = call("biodiversity-delete", ctxA, { id: e.id });
+    assert.equal(del.ok, true);
+    assert.equal(del.result.deleted, true);
+    assert.ok(!call("biodiversity-list", ctxA, {}).result.observations.some(o => o.id === e.id));
+  });
+
+  it("validation-rejection: empty commonName; delete of a missing id", () => {
+    assert.match(call("biodiversity-log", ctxA, { commonName: "  " }).error, /commonName required/i);
+    assert.match(call("biodiversity-delete", ctxA, { id: "nope" }).error, /not found/i);
+  });
+});
+
+// ── climate-actions — curated library + log/streak-free total ──────────────
+describe("eco.climate-actions-* — curated library + per-user log", () => {
+  it("the catalog spans all six categories and the ClimateActions panel fields", () => {
+    const r = call("climate-actions-list", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.ok(r.result.actions.length >= 15);
+    const cats = new Set(r.result.actions.map(a => a.category));
+    for (const c of ["transport", "food", "home", "shopping", "advocacy", "energy"]) {
+      assert.ok(cats.has(c), `missing category ${c}`);
+    }
+    // every action carries the fields the panel renders
+    for (const a of r.result.actions) {
+      assert.equal(typeof a.slug, "string");
+      assert.equal(typeof a.title, "string");
+      assert.ok(Number.isFinite(a.kgCo2eSavedPerYear));
+      assert.ok(a.effort >= 1 && a.effort <= 5);
+      assert.equal(typeof a.citation, "string");
+    }
+  });
+
+  it("log → logged round-trip accumulates the per-instance kg saved", () => {
+    const log = call("climate-actions-log", ctxA, { slug: "bike-commute-week", kgCo2eSavedThisInstance: 7.3 });
+    assert.equal(log.ok, true);
+    assert.equal(log.result.entry.slug, "bike-commute-week");
+    assert.equal(log.result.entry.kgSaved, 7.3);
+    const logged = call("climate-actions-logged", ctxA, { sinceDays: 30 });
+    assert.equal(logged.result.entries.length, 1);
+    assert.equal(logged.result.totalKgSaved, 7.3);
+  });
+
+  it("validation-rejection: missing/unknown slug", () => {
+    assert.match(call("climate-actions-log", ctxA, {}).error, /slug required/i);
+    assert.match(call("climate-actions-log", ctxA, { slug: "not-a-real-action" }).error, /unknown action/i);
+  });
+});
+
+// ── footprint trend — record / history trend math / delete ─────────────────
+describe("eco.footprint-* — trend analysis the FootprintTrend chart renders", () => {
+  it("records snapshots and computes an improving trend over the period", () => {
+    // older snapshot higher, newer lower → improving (net dropped).
+    const a = call("footprint-record", ctxA, { totalKgCO2e: 1200, netKgCO2e: 1200, label: "Jan" }).result.entry;
+    // backdate the first entry so ordering is deterministic
+    a.at = new Date(Date.now() - 5 * 86400000).toISOString();
+    call("footprint-record", ctxA, { totalKgCO2e: 900, netKgCO2e: 900, label: "Feb" });
+    const h = call("footprint-history", ctxA, { sinceDays: 365 });
+    assert.equal(h.ok, true);
+    assert.equal(h.result.count, 2);
+    assert.equal(h.result.trend, "improving");
+    assert.equal(h.result.deltaKg, -300);
+    assert.equal(h.result.bestEntry.netKgCO2e, 900);
+    assertNoNonFinite(h.result);
+  });
+
+  it("validation-rejection: negative/NaN total; delete missing id", () => {
+    assert.match(call("footprint-record", ctxA, { totalKgCO2e: -5 }).error, /totalKgCO2e/i);
+    assert.match(call("footprint-record", ctxA, { totalKgCO2e: "not-a-number" }).error, /totalKgCO2e/i);
+    assert.match(call("footprint-delete", ctxA, { id: "missing" }).error, /not found/i);
+  });
+
+  it("fail-CLOSED: an Infinity total is rejected, never stored as Infinity", () => {
+    const r = call("footprint-record", ctxA, { totalKgCO2e: Infinity });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /totalKgCO2e/i);
+  });
+
+  it("degrade-graceful: empty history → trend 'none', averages 0, never NaN", () => {
+    const h = call("footprint-history", ctxB, {});
+    assert.equal(h.ok, true);
+    assert.equal(h.result.count, 0);
+    assert.equal(h.result.trend, "none");
+    assert.equal(h.result.averageNetKgCO2e, 0);
+    assertNoNonFinite(h.result);
+  });
+});
+
+// ── challenges — join / streak recompute / leave the EcoChallenges renders ──
+describe("eco.challenges-* — gamified streaks the EcoChallenges panel renders", () => {
+  it("catalog → join → checkin recomputes streak + points + kg saved", () => {
+    const ctx = { actor: { userId: "eco_chal_u" }, userId: "eco_chal_u" };
+    const cat = call("challenges-catalog", ctx, {});
+    assert.ok(cat.result.challenges.length >= 8);
+    const slug = cat.result.challenges[0].slug;
+    const joined = call("challenges-join", ctx, { slug });
+    assert.equal(joined.ok, true);
+    assert.equal(joined.result.enrollment.slug, slug);
+
+    const ci = call("challenges-checkin", ctx, { slug });
+    assert.equal(ci.ok, true);
+    const mine = call("challenges-mine", ctx, {});
+    const en = mine.result.enrollments.find(e => e.slug === slug);
+    assert.equal(en.totalCheckIns, 1);
+    assert.equal(en.currentStreak, 1);
+    assert.equal(en.totalPoints, cat.result.challenges[0].points);
+    assert.ok(Number.isFinite(en.totalKgSaved));
+    assertNoNonFinite(mine.result);
+  });
+
+  it("validation-rejection: double-join, double-checkin-today, unknown slug, leave", () => {
+    const ctx = { actor: { userId: "eco_chal_u2" }, userId: "eco_chal_u2" };
+    const slug = call("challenges-catalog", ctx, {}).result.challenges[0].slug;
+    call("challenges-join", ctx, { slug });
+    assert.match(call("challenges-join", ctx, { slug }).error, /already enrolled/i);
+    call("challenges-checkin", ctx, { slug });
+    assert.match(call("challenges-checkin", ctx, { slug }).error, /already checked in/i);
+    assert.match(call("challenges-checkin", ctx, { slug: "nope" }).error, /unknown challenge/i);
+    const left = call("challenges-leave", ctx, { slug });
+    assert.equal(left.ok, true);
+    assert.equal(call("challenges-mine", ctx, {}).result.activeCount, 0);
+  });
+});
+
+// ── saved locations — CRUD round-trip + cap + validation ───────────────────
+describe("eco.locations-* — saved-location round-trip the EnvAlerts renders", () => {
+  it("saves a location, lists it, deletes it", () => {
+    const ctx = { actor: { userId: "eco_loc_u" }, userId: "eco_loc_u" };
+    const s = call("locations-save", ctx, { label: "Home", lat: 37.77, lng: -122.42 });
+    assert.equal(s.ok, true);
+    assert.equal(s.result.entry.label, "Home");
+    const list = call("locations-list", ctx, {});
+    assert.equal(list.result.count, 1);
+    const del = call("locations-delete", ctx, { id: s.result.entry.id });
+    assert.equal(del.result.deleted, true);
+    assert.equal(call("locations-list", ctx, {}).result.count, 0);
+  });
+
+  it("validation-rejection: missing label / poisoned coords", () => {
+    assert.match(call("locations-save", ctxA, { lat: 1, lng: 1 }).error, /label required/i);
+    assert.match(call("locations-save", ctxA, { label: "X", lat: Infinity, lng: 2 }).error, /lat, lng required/i);
+    assert.match(call("locations-save", ctxA, { label: "X", lat: "NaN", lng: 2 }).error, /lat, lng required/i);
+  });
+});
+
+// ── network-backed macros — honest-error contract (no fabricated data) ─────
+describe("eco — network macros fail honestly when offline (no fake data)", () => {
+  it("weather-forecast surfaces ok:false (no synthetic week)", async () => {
+    const r = await call("weather-forecast", ctxA, { lat: 37.7, lng: -122.4 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /open-meteo unreachable/i);
+  });
+  it("aqi-current surfaces ok:false (no fabricated AQI of 42)", async () => {
+    const r = await call("aqi-current", ctxA, { lat: 37.7, lng: -122.4 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /unreachable/i);
+  });
+  it("observation-feed + species-suggest reject poisoned/missing input pre-network", async () => {
+    assert.match((await call("observation-feed", ctxA, { lat: Infinity, lng: 1 })).error, /lat, lng required/i);
+    assert.match((await call("species-suggest", ctxA, { name: "  " })).error, /name required/i);
+  });
+  it("environmental-alerts rejects poisoned coords pre-network", async () => {
+    assert.match((await call("environmental-alerts", ctxA, { lat: "NaN", lng: 1 })).error, /lat, lng required/i);
+  });
+});
+
+// ── double-wrap dispatch parity — the dead-surface bug class ────────────────
+describe("eco — { artifact:{ data } } double-wrap is peeled like production", () => {
+  it("carbonFootprint reads through a sole-key artifact wrapper identically to flat", () => {
+    const wrapped = call("carbonFootprint", ctxA, { artifact: { data: { activities: [
+      { category: "electricity", type: "kwh", quantity: 1000 },
+    ] } } });
+    const flat = call("carbonFootprint", ctxA, { activities: [
+      { category: "electricity", type: "kwh", quantity: 1000 },
+    ] });
+    assert.equal(wrapped.result.totalEmissionsKgCO2e, 233);
+    assert.deepEqual(wrapped.result, flat.result);
+  });
+
+  it("biodiversityIndex reads through the wrapper (historical blank-calc bug)", () => {
+    const wrapped = call("biodiversityIndex", ctxA, { artifact: { data: { species: { a: 10, b: 10 } } } });
+    assert.equal(wrapped.ok, true);
+    assert.equal(wrapped.result.speciesRichness, 2);
+    assert.equal(wrapped.result.totalIndividuals, 20);
+  });
+});

--- a/server/tests/energy-lens-macros.test.js
+++ b/server/tests/energy-lens-macros.test.js
@@ -1,0 +1,537 @@
+// Behavioral macro tests for server/domains/energy.js — the energy lens
+// (Sense / Span / EIA-shape home energy monitor). EVERY macro is registered
+// via `registerLensAction(domain, action, handler)` and invoked as
+// `handler(ctx, virtualArtifact, params)` (the 3-ARG path-3 convention with
+// `virtualArtifact.data === params`). The /api/lens/run dispatch ALSO peels
+// exactly one redundant `{ artifact: { data } }` wrapper
+// (server/lib/lens-input-normalize.js) before building the virtualArtifact, so
+// we peel the SAME way here — the harness is byte-identical to what the
+// frontend hits through `lensRun(...)` / `CalcPanel`'s
+// `runDomain(d, a, { input: { artifact: { data } } })`.
+//
+// These are NOT shape-only assertions. Each test feeds KNOWN inputs and pins
+// EXACT computed values + round-trips (consumption sums, solar sizing, carbon
+// EPA factors, grid utilization, device/reading CRUD, bill estimate,
+// disaggregation weighting, TOU peak/off-peak split, self-consumption,
+// month-over-month deltas), the EXACT field names each component RENDERS (so a
+// dead-surface regression surfaces here), validation-rejection, graceful
+// degradation on empty state, and a fail-CLOSED poisoned-numeric contract:
+// Infinity / NaN / "1e999" / "Infinity" never leak NaN/Infinity (which
+// serialize to JSON null) into the result and never throw.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerEnergyActions from "../domains/energy.js";
+import { peelRedundantArtifactWrapper } from "../lib/lens-input-normalize.js";
+
+const ACTIONS = new Map();
+function registerLensAction(domain, name, fn) {
+  assert.equal(domain, "energy", `unexpected domain: ${domain}`);
+  ACTIONS.set(name, fn);
+}
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+const ctxB = { actor: { userId: "user_b" }, userId: "user_b" };
+
+// Mirror the live /api/lens/run dispatch for the path-3 surface: peel one
+// redundant artifact wrapper, then call handler(ctx, virtualArtifact, peeled)
+// with virtualArtifact.data === peeled. `body` is what the frontend sends as
+// the `input` field.
+function call(name, ctx, body = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`energy.${name} not registered`);
+  const peeled = peelRedundantArtifactWrapper(body) || {};
+  const virtualArtifact = { id: null, domain: "energy", type: "domain_action", data: peeled, meta: {} };
+  return fn(ctx, virtualArtifact, peeled);
+}
+
+// CalcPanel-shape call: the component builds `{ input: { artifact: { data } } }`.
+// runDomain forwards `{ artifact: { data } }` as the body, which the dispatch
+// peels to the plain `data` object. Drive that EXACT shape so the test proves
+// the SolarCarbonPanel wiring (not a hand-flattened one).
+function callCalcPanel(name, ctx, data) {
+  return call(name, ctx, { artifact: { data } });
+}
+
+// Assert no value anywhere in the result is a non-finite number, and that the
+// serialized JSON contains no Infinity/NaN tokens and no unexpected null where
+// a number is expected. (JSON.stringify turns Infinity/NaN into null.)
+function assertFinite(obj, label) {
+  const walk = (v, path) => {
+    if (typeof v === "number") {
+      assert.ok(Number.isFinite(v), `${label}: non-finite number at ${path}: ${v}`);
+    } else if (Array.isArray(v)) {
+      v.forEach((x, i) => walk(x, `${path}[${i}]`));
+    } else if (v && typeof v === "object") {
+      for (const [k, x] of Object.entries(v)) walk(x, `${path}.${k}`);
+    }
+  };
+  walk(obj, label);
+}
+
+before(() => {
+  registerEnergyActions(registerLensAction);
+});
+
+beforeEach(() => {
+  // No boot, no network. Any handler reaching the network in a pure-compute /
+  // STATE test is a leak.
+  globalThis.fetch = async () => { throw new Error("network disabled in tests"); };
+  globalThis._concordSTATE = {};
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Pure-compute calculators (SolarCarbonPanel + grid/consumption surfaces)
+// ──────────────────────────────────────────────────────────────────────────
+describe("energy — pure-compute calculators (exact values)", () => {
+  it("consumptionAnalysis: exact total/avg/peak/cost/ratio", () => {
+    const r = call("consumptionAnalysis", ctxA, { readings: [{ kWh: 10 }, { kWh: 20 }, { kWh: 30 }], costPerKWh: 0.2 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.totalKWh, 60);
+    assert.equal(r.result.avgKWh, 20);
+    assert.equal(r.result.peakKWh, 30);
+    assert.equal(r.result.readingCount, 3);
+    assert.equal(r.result.estimatedCost, 12); // 60 * 0.2
+    assert.equal(r.result.costPerKWh, 0.2);
+    assert.equal(r.result.peakToAvgRatio, 1.5); // 30/20
+    assert.equal(r.result.savingsOpportunity, "Consumption is relatively stable");
+  });
+
+  it("consumptionAnalysis: peak>2*avg flags savings opportunity", () => {
+    const r = call("consumptionAnalysis", ctxA, { readings: [{ kWh: 1 }, { kWh: 1 }, { kWh: 10 }] });
+    assert.equal(r.result.savingsOpportunity, "Significant peak reduction possible");
+    assert.equal(r.result.costPerKWh, 0.12); // default fallback
+  });
+
+  it("consumptionAnalysis: empty readings → guidance, never NaN", () => {
+    const r = call("consumptionAnalysis", ctxA, { readings: [] });
+    assert.equal(r.ok, true);
+    assert.match(r.result.message, /Add energy readings/i);
+    assert.equal(r.result.totalKWh, undefined);
+  });
+
+  it("solarEstimate: exact sizing math for 1000 sqft / 5 sun / 900 usage", () => {
+    // CalcPanel sends { artifact: { data: { roofAreaSqFt, peakSunHours, monthlyUsageKWh } } }.
+    const r = callCalcPanel("solarEstimate", ctxA, { roofAreaSqFt: 1000, peakSunHours: 5, monthlyUsageKWh: 900 });
+    assert.equal(r.ok, true);
+    // maxPanels = floor(1000 * 0.7 / 18) = floor(38.88) = 38
+    assert.equal(r.result.maxPanels, 38);
+    // systemKW = 38 * 400 / 1000 = 15.2
+    assert.equal(r.result.systemSizeKW, 15.2);
+    // monthlyProduction = 15.2 * 5 * 30 * 0.8 = 1824
+    assert.equal(r.result.monthlyProductionKWh, 1824);
+    // coverage = round(1824/900*100) = 203
+    assert.equal(r.result.coveragePercent, 203);
+    // cost = round(15.2 * 2800) = 42560
+    assert.equal(r.result.estimatedCost, 42560);
+    assert.equal(r.result.afterTaxCredit, Math.round(42560 * 0.7));
+    assert.match(r.result.recommendation, /100% of usage/);
+  });
+
+  it("carbonFootprint: exact EPA factors + topSource + tips", () => {
+    const r = callCalcPanel("carbonFootprint", ctxA, {
+      electricityKWh: 1000, naturalGasTherms: 50, gasolineGallons: 40, flightMiles: 2000,
+    });
+    assert.equal(r.ok, true);
+    // 1000 * 0.000417 = 0.417
+    assert.equal(r.result.breakdown.electricity, 0.417);
+    // 50 * 0.0053 = 0.265
+    assert.equal(r.result.breakdown.naturalGas, 0.265);
+    // 40 * 0.00887 = 0.3548 → 0.355
+    assert.equal(r.result.breakdown.transportation, 0.355);
+    // 2000 * 0.000255 = 0.51
+    assert.equal(r.result.breakdown.flights, 0.51);
+    const total = 0.417 + 0.265 + 0.3548 + 0.51;
+    assert.equal(r.result.totalMetricTons, Math.round(total * 1000) / 1000);
+    assert.equal(r.result.annualEstimate, Math.round(total * 12 * 100) / 100);
+    assert.equal(r.result.topSource, "flights"); // highest single
+    assert.ok(Array.isArray(r.result.reductionTips) && r.result.reductionTips.length > 0);
+  });
+
+  it("gridStatus: exact utilization/status/reserves + stable string echo", () => {
+    const r = call("gridStatus", ctxA, { currentDemandMW: 800, totalCapacityMW: 1000, renewablePercent: 35, gridFrequencyHz: 60.01 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.utilization, 80);
+    assert.equal(r.result.status, "high-load"); // >75
+    assert.equal(r.result.currentDemand, "800 MW");
+    assert.equal(r.result.totalCapacity, "1000 MW");
+    assert.equal(r.result.renewableShare, "35%");
+    assert.equal(r.result.frequencyStable, true); // |60.01-60| < 0.05
+    assert.equal(r.result.reserves, "200 MW available");
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Fail-CLOSED poisoned-numeric contract
+// ──────────────────────────────────────────────────────────────────────────
+describe("energy — fail-closed poison (no Infinity/NaN leak, no throw)", () => {
+  const POISON = ["1e999", "Infinity", "-Infinity", "NaN", Infinity, NaN, "not-a-number"];
+
+  it("consumptionAnalysis: poisoned readings collapse to finite", () => {
+    for (const p of POISON) {
+      const r = call("consumptionAnalysis", ctxA, { readings: [{ kWh: p }, { kWh: 5 }], costPerKWh: p });
+      assert.equal(r.ok, true);
+      assertFinite(r.result, `consumptionAnalysis(${String(p)})`);
+      // The one valid reading (5) survives; poison contributes 0.
+      assert.equal(r.result.totalKWh, 5);
+      assert.ok(r.result.costPerKWh > 0); // falls back to default, finite
+    }
+  });
+
+  it("solarEstimate: poisoned inputs clamp to finite, never Infinity panels", () => {
+    for (const p of POISON) {
+      const r = callCalcPanel("solarEstimate", ctxA, { roofAreaSqFt: p, peakSunHours: p, monthlyUsageKWh: p });
+      assert.equal(r.ok, true);
+      assertFinite(r.result, `solarEstimate(${String(p)})`);
+      assert.ok(Number.isInteger(r.result.maxPanels));
+    }
+  });
+
+  it("carbonFootprint: poisoned inputs → finite zeros, never null", () => {
+    for (const p of POISON) {
+      const r = callCalcPanel("carbonFootprint", ctxA, { electricityKWh: p, naturalGasTherms: p, gasolineGallons: p, flightMiles: p });
+      assert.equal(r.ok, true);
+      assertFinite(r.result, `carbonFootprint(${String(p)})`);
+      assert.equal(r.result.totalMetricTons, 0);
+    }
+  });
+
+  it("gridStatus: poisoned inputs → finite, output strings never 'Infinity MW'", () => {
+    for (const p of POISON) {
+      const r = call("gridStatus", ctxA, { currentDemandMW: p, totalCapacityMW: p, renewablePercent: p, gridFrequencyHz: p });
+      assert.equal(r.ok, true);
+      assert.doesNotMatch(JSON.stringify(r.result), /Infinity|NaN/);
+      assert.ok(Number.isFinite(r.result.utilization));
+    }
+  });
+
+  it("reading-log / live-sample / goal-set / rate-set reject or clamp poison", () => {
+    // STATE macros use the finite-guarded enNum; poison kWh collapses to 0 and
+    // the >0 validation rejects cleanly (never throws, never NaN).
+    const rl = call("reading-log", ctxA, { kwh: "1e999" });
+    // enNum("1e999") → 0 → kwh<=0 → rejected
+    assert.equal(rl.ok, false);
+    const rs = call("rate-set", ctxA, { ratePerKwh: "Infinity" });
+    assert.equal(rs.ok, false);
+    const gs = call("goal-set", ctxA, { targetKwh: NaN });
+    assert.equal(gs.ok, false);
+    const ls = call("live-sample", ctxA, { watts: "NaN" });
+    // enNum("NaN") → 0; watts>=0 true → logged at 0 watts (finite)
+    assert.equal(ls.ok, true);
+    assert.equal(ls.result.sample.watts, 0);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// STATE-backed monitor: devices / readings round-trips (DevicesPanel + UsagePanel)
+// ──────────────────────────────────────────────────────────────────────────
+describe("energy — devices + readings CRUD round-trip", () => {
+  it("device-add → device-list renders name/category/wattage/totalKwh", () => {
+    const add = call("device-add", ctxA, { name: "Heat Pump", category: "hvac", wattage: 3500 });
+    assert.equal(add.ok, true);
+    const id = add.result.device.id;
+    assert.equal(add.result.device.name, "Heat Pump");
+    assert.equal(add.result.device.category, "hvac");
+    assert.equal(add.result.device.wattage, 3500);
+
+    // Log a device-tagged reading.
+    const log = call("reading-log", ctxA, { deviceId: id, kwh: 12.5 });
+    assert.equal(log.ok, true);
+    assert.equal(log.result.reading.deviceId, id);
+    assert.equal(log.result.reading.kwh, 12.5);
+
+    const list = call("device-list", ctxA, {});
+    assert.equal(list.ok, true);
+    assert.equal(list.result.count, 1);
+    const d = list.result.devices[0];
+    // EXACT fields DevicesPanel renders:
+    assert.deepEqual(Object.keys(d).sort().includes("totalKwh"), true);
+    assert.equal(d.totalKwh, 12.5);
+    assert.equal(d.readingCount, 1);
+  });
+
+  it("device-add rejects empty name; device-delete removes + purges readings", () => {
+    const bad = call("device-add", ctxA, { name: "   " });
+    assert.equal(bad.ok, false);
+
+    const add = call("device-add", ctxA, { name: "Dryer", wattage: 3000 });
+    const id = add.result.device.id;
+    call("reading-log", ctxA, { deviceId: id, kwh: 4 });
+    const del = call("device-delete", ctxA, { id });
+    assert.equal(del.ok, true);
+    assert.equal(del.result.deleted, id);
+    // readings purged
+    const hist = call("reading-history", ctxA, { days: 30 });
+    assert.equal(hist.result.series.length, 0);
+    assert.equal(call("device-delete", ctxA, { id }).ok, false); // gone
+  });
+
+  it("reading-history: per-day aggregation + total kwh/cost (UsagePanel)", () => {
+    call("rate-set", ctxA, { ratePerKwh: 0.25 });
+    const today = new Date().toISOString().slice(0, 10);
+    call("reading-log", ctxA, { kwh: 10, date: today });
+    call("reading-log", ctxA, { kwh: 5, date: today });
+    const h = call("reading-history", ctxA, { days: 30 });
+    assert.equal(h.ok, true);
+    assert.equal(h.result.totalKwh, 15);
+    // cost summed per reading at 0.25/kWh: 10*.25=2.5, 5*.25=1.25 → 3.75
+    assert.equal(h.result.totalCost, 3.75);
+    const day = h.result.series.find((s) => s.date === today);
+    assert.equal(day.kwh, 15);
+  });
+
+  it("usage-breakdown + top-consumers attribute by device category", () => {
+    const add = call("device-add", ctxA, { name: "AC", category: "hvac", wattage: 2000 });
+    const id = add.result.device.id;
+    call("reading-log", ctxA, { deviceId: id, kwh: 20 });
+    call("reading-log", ctxA, { kwh: 5 }); // whole-home / untracked
+    const b = call("usage-breakdown", ctxA, { days: 30 });
+    assert.equal(b.ok, true);
+    assert.equal(b.result.totalKwh, 25);
+    assert.equal(b.result.untrackedKwh, 5);
+    const hvac = b.result.breakdown.find((x) => x.category === "hvac");
+    assert.equal(hvac.kwh, 20);
+    assert.equal(hvac.pct, 80); // 20/25
+
+    const tc = call("top-consumers", ctxA, { days: 30 });
+    assert.equal(tc.result.devices[0].deviceId, id);
+    assert.equal(tc.result.devices[0].kwh, 20);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Billing surface: rate / bill-estimate / cost-projection / goals
+// ──────────────────────────────────────────────────────────────────────────
+describe("energy — billing + goals (BillingPanel)", () => {
+  it("rate-get default → rate-set → bill-estimate uses set rate", () => {
+    const g0 = call("rate-get", ctxA, {});
+    assert.equal(g0.result.isDefault, true);
+    assert.equal(g0.result.rate.ratePerKwh, 0.17); // DEFAULT_RATE
+
+    call("rate-set", ctxA, { ratePerKwh: 0.30, utility: "PG&E" });
+    const g1 = call("rate-get", ctxA, {});
+    assert.equal(g1.result.isDefault, false);
+    assert.equal(g1.result.rate.ratePerKwh, 0.30);
+
+    const month = new Date().toISOString().slice(0, 7);
+    call("reading-log", ctxA, { kwh: 100, date: `${month}-15` });
+    call("solar-log", ctxA, { kwh: 30, date: `${month}-15` });
+    const bill = call("bill-estimate", ctxA, {});
+    assert.equal(bill.ok, true);
+    assert.equal(bill.result.consumedKwh, 100);
+    assert.equal(bill.result.solarKwh, 30);
+    assert.equal(bill.result.netKwh, 70);
+    assert.equal(bill.result.estimatedBill, Math.round(70 * 0.30 * 100) / 100);
+    assert.equal(bill.result.solarSavings, Math.round(30 * 0.30 * 100) / 100);
+  });
+
+  it("cost-projection: empty month → hasData:false; with data → projected math", () => {
+    const empty = call("cost-projection", ctxA, {});
+    assert.equal(empty.result.hasData, false);
+
+    const month = new Date().toISOString().slice(0, 7);
+    call("rate-set", ctxA, { ratePerKwh: 0.20 });
+    call("reading-log", ctxA, { kwh: 10, date: `${month}-01` });
+    call("reading-log", ctxA, { kwh: 10, date: `${month}-02` });
+    const p = call("cost-projection", ctxA, {});
+    assert.equal(p.result.hasData, true);
+    assert.equal(p.result.distinctDays, 2);
+    assert.equal(p.result.loggedKwh, 20);
+    assert.equal(p.result.dailyAvgKwh, 10);
+    assertFinite(p.result, "cost-projection");
+    assert.ok(["low", "medium", "high"].includes(p.result.confidence));
+  });
+
+  it("goal-set → goal-list computes pct/overBudget; goal-delete removes", () => {
+    const month = new Date().toISOString().slice(0, 7);
+    call("reading-log", ctxA, { kwh: 120, date: `${month}-10` });
+    const gs = call("goal-set", ctxA, { label: "Cut bill", targetKwh: 100, period: "month" });
+    assert.equal(gs.ok, true);
+    const id = gs.result.goal.id;
+    const gl = call("goal-list", ctxA, {});
+    const goal = gl.result.goals.find((x) => x.id === id);
+    assert.equal(goal.targetKwh, 100);
+    assert.equal(goal.usedKwh, 120);
+    assert.equal(goal.pct, 120);
+    assert.equal(goal.overBudget, true);
+    const gd = call("goal-delete", ctxA, { id });
+    assert.equal(gd.ok, true);
+    assert.equal(call("goal-list", ctxA, {}).result.count, 0);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Solar / disaggregation / TOU / live / insights
+// ──────────────────────────────────────────────────────────────────────────
+describe("energy — solar self-consumption + disaggregation + TOU + insights", () => {
+  it("solar-summary + solar-self-consumption: produced/self/export split", () => {
+    call("rate-set", ctxA, { ratePerKwh: 0.20 });
+    const day = new Date().toISOString().slice(0, 10);
+    call("solar-log", ctxA, { kwh: 30, date: day });
+    call("reading-log", ctxA, { kwh: 20, date: day });
+
+    const sum = call("solar-summary", ctxA, { days: 30 });
+    assert.equal(sum.result.producedKwh, 30);
+    assert.equal(sum.result.consumedKwh, 20);
+
+    const sc = call("solar-self-consumption", ctxA, { days: 30 });
+    assert.equal(sc.result.hasData, true);
+    assert.equal(sc.result.selfConsumedKwh, 20); // min(30,20)
+    assert.equal(sc.result.exportedKwh, 10); // 30-20
+    assertFinite(sc.result, "solar-self-consumption");
+  });
+
+  it("solar-self-consumption honors a real export tariff override", () => {
+    const day = new Date().toISOString().slice(0, 10);
+    call("rate-set", ctxA, { ratePerKwh: 0.20 });
+    call("solar-log", ctxA, { kwh: 30, date: day });
+    call("reading-log", ctxA, { kwh: 20, date: day });
+    const sc = call("solar-self-consumption", ctxA, { days: 30, exportRate: 0.05 });
+    assert.equal(sc.result.exportRate, 0.05);
+    assert.equal(sc.result.exportCredit, Math.round(10 * 0.05 * 100) / 100); // 0.5
+  });
+
+  it("disaggregate: nameplate-weighted split of whole-home load", () => {
+    const a1 = call("device-add", ctxA, { name: "AC", category: "hvac", wattage: 3000 });
+    const a2 = call("device-add", ctxA, { name: "Lights", category: "lighting", wattage: 1000 });
+    call("reading-log", ctxA, { kwh: 40 }); // whole-home, split 3:1
+    const d = call("disaggregate", ctxA, { days: 30 });
+    assert.equal(d.result.totalKwh, 40);
+    const ac = d.result.devices.find((x) => x.deviceId === a1.result.device.id);
+    const lights = d.result.devices.find((x) => x.deviceId === a2.result.device.id);
+    // 3000/4000 * 40 = 30 ; 1000/4000 * 40 = 10
+    assert.equal(ac.estimatedKwh, 30);
+    assert.equal(lights.estimatedKwh, 10);
+    assertFinite(d.result, "disaggregate");
+  });
+
+  it("disaggregate: no devices → empty, finite, hasData-equivalent zeros", () => {
+    const d = call("disaggregate", ctxA, { days: 30 });
+    assert.equal(d.ok, true);
+    assert.deepEqual(d.result.devices, []);
+    assert.equal(d.result.totalKwh, 0);
+  });
+
+  it("tou-set rejects invalid windows; tou-breakdown splits hour-tagged readings", () => {
+    const bad = call("tou-set", ctxA, { peakRate: 0.4, offPeakRate: 0 });
+    assert.equal(bad.ok, false);
+    const badWindow = call("tou-set", ctxA, { peakRate: 0.4, offPeakRate: 0.1, peakStartHour: 20, peakEndHour: 16 });
+    assert.equal(badWindow.ok, false);
+
+    const ok = call("tou-set", ctxA, { peakRate: 0.4, offPeakRate: 0.1, peakStartHour: 16, peakEndHour: 21 });
+    assert.equal(ok.ok, true);
+    const day = new Date().toISOString().slice(0, 10);
+    call("reading-log", ctxA, { kwh: 10, date: day, hour: 18 }); // peak
+    call("reading-log", ctxA, { kwh: 5, date: day, hour: 3 });   // off-peak
+    const b = call("tou-breakdown", ctxA, { days: 30 });
+    assert.equal(b.result.peak.kwh, 10);
+    assert.equal(b.result.offPeak.kwh, 5);
+    assert.equal(b.result.peak.cost, Math.round(10 * 0.4 * 100) / 100);
+    assert.equal(b.result.offPeak.cost, Math.round(5 * 0.1 * 100) / 100);
+    assertFinite(b.result, "tou-breakdown");
+  });
+
+  it("tou-breakdown without a plan rejects cleanly", () => {
+    const b = call("tou-breakdown", ctxA, { days: 30 });
+    assert.equal(b.ok, false);
+  });
+
+  it("live-sample → live-stream rolling window current/peak/avg", () => {
+    call("live-sample", ctxA, { watts: 500 });
+    call("live-sample", ctxA, { watts: 1500 });
+    call("live-sample", ctxA, { watts: 1000 });
+    const s = call("live-stream", ctxA, { minutes: 120 });
+    assert.equal(s.result.count, 3);
+    assert.equal(s.result.current, 1000); // last
+    assert.equal(s.result.peak, 1500);
+    assert.equal(s.result.avgWatts, 1000); // (500+1500+1000)/3
+    assertFinite(s.result, "live-stream");
+  });
+
+  it("usage-alerts: empty state → no alerts; goal over budget → high alert", () => {
+    const none = call("usage-alerts", ctxA, {});
+    assert.equal(none.ok, true);
+    assert.equal(none.result.count, 0);
+
+    const month = new Date().toISOString().slice(0, 7);
+    call("reading-log", ctxA, { kwh: 200, date: `${month}-10` });
+    call("goal-set", ctxA, { label: "Budget", targetKwh: 100, period: "month" });
+    const a = call("usage-alerts", ctxA, {});
+    assert.ok(a.result.alerts.some((x) => x.kind === "goal_exceeded" && x.severity === "high"));
+    assert.ok(a.result.highCount >= 1);
+  });
+
+  it("month-comparison: rejects malformed month, computes deltas with data", () => {
+    const bad = call("month-comparison", ctxA, { month: "not-a-month" });
+    assert.equal(bad.ok, false);
+
+    const month = new Date().toISOString().slice(0, 7);
+    call("reading-log", ctxA, { kwh: 50, date: `${month}-05` });
+    const c = call("month-comparison", ctxA, {});
+    assert.equal(c.ok, true);
+    assert.equal(c.result.current.consumedKwh, 50);
+    assert.equal(c.result.hasData, true);
+    assert.ok(["up", "down", "flat"].includes(c.result.change.consumed.direction));
+    assertFinite(c.result, "month-comparison");
+  });
+
+  it("energy-dashboard: aggregates this month + device/goal counts", () => {
+    const month = new Date().toISOString().slice(0, 7);
+    call("rate-set", ctxA, { ratePerKwh: 0.20 });
+    call("device-add", ctxA, { name: "Fridge", category: "appliance", wattage: 150 });
+    call("reading-log", ctxA, { kwh: 60, date: `${month}-10` });
+    call("solar-log", ctxA, { kwh: 20, date: `${month}-10` });
+    const d = call("energy-dashboard", ctxA, {});
+    assert.equal(d.ok, true);
+    assert.equal(d.result.devices, 1);
+    assert.equal(d.result.monthKwh, 60);
+    assert.equal(d.result.solarKwh, 20);
+    assert.equal(d.result.monthCost, Math.round(Math.max(0, 60 - 20) * 0.20 * 100) / 100);
+    assert.equal(d.result.solarOffsetPct, Math.round((20 / 60) * 100));
+    assertFinite(d.result, "energy-dashboard");
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Per-user isolation (the lens is multi-tenant; one user can't read another)
+// ──────────────────────────────────────────────────────────────────────────
+describe("energy — per-user STATE isolation", () => {
+  it("user_b cannot see user_a's devices/readings", () => {
+    call("device-add", ctxA, { name: "A-only device", wattage: 500 });
+    call("reading-log", ctxA, { kwh: 99 });
+    const bList = call("device-list", ctxB, {});
+    assert.equal(bList.result.count, 0);
+    const bHist = call("reading-history", ctxB, { days: 30 });
+    assert.equal(bHist.result.totalKwh, 0);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// External-IO macros degrade gracefully (no key / network down) — fail-closed
+// ──────────────────────────────────────────────────────────────────────────
+describe("energy — EIA + carbon feed degrade gracefully (no throw)", () => {
+  it("eia-electricity-rates: validates state + degrades without key", async () => {
+    const noState = await call("eia-electricity-rates", ctxA, {});
+    assert.equal(noState.ok, false);
+    assert.match(noState.error, /state required/i);
+
+    const badState = await call("eia-electricity-rates", ctxA, { state: "ZZZ" });
+    assert.equal(badState.ok, false);
+
+    const saved = process.env.EIA_API_KEY;
+    delete process.env.EIA_API_KEY;
+    const noKey = await call("eia-electricity-rates", ctxA, { state: "CA" });
+    assert.equal(noKey.ok, false);
+    assert.match(noKey.error, /EIA_API_KEY/);
+    if (saved) process.env.EIA_API_KEY = saved;
+  });
+
+  it("eia-generation-mix: degrades without key (no throw)", async () => {
+    const saved = process.env.EIA_API_KEY;
+    delete process.env.EIA_API_KEY;
+    const r = await call("eia-generation-mix", ctxA, { region: "US" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /EIA_API_KEY/);
+    if (saved) process.env.EIA_API_KEY = saved;
+  });
+});

--- a/server/tests/ethics-lens-macros.test.js
+++ b/server/tests/ethics-lens-macros.test.js
@@ -1,0 +1,384 @@
+// Behavioral macro tests for server/domains/ethics.js — the multi-framework /
+// stakeholder-map / decision-matrix / bias-checklist / ethics-review /
+// case-library substrate that the /lenses/ethics DecisionToolkit drives.
+//
+// This file mirrors the REAL LENS_ACTIONS dispatch: every ethics handler is
+// registered via `registerLensAction(domain, action, handler)` and invoked as
+// `handler(ctx, virtualArtifact, input)` — the 3-ARG convention with
+// `virtualArtifact.data === input`. The dispatch ALSO peels exactly one
+// redundant `{ artifact: { data } }` wrapper (lens-input-normalize.js); we peel
+// the same way before calling so the harness is byte-identical to production.
+// (Harness copied from server/tests/geology-lens-macros.test.js.)
+//
+// These are NOT shape-only assertions. They pin ACTUAL computed values for
+// KNOWN inputs (the multi-framework verdict + composite + agreement bands, the
+// weighted decision-matrix winner, the vulnerability-amplified stakeholder
+// exposure, the bias risk score), CRUD round-trips through real STATE, the EXACT
+// field names the six DecisionToolkit sub-panels render (so a dead-surface
+// regression surfaces here), validation-rejection, graceful degradation, and a
+// fail-CLOSED poisoned-numeric contract: Infinity/NaN/"1e999"/"Infinity" inputs
+// are clamped/rejected and NEVER leak Infinity/NaN (serialized null) into the
+// result, and NEVER throw a 500.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerEthicsActions from "../domains/ethics.js";
+import { peelRedundantArtifactWrapper } from "../lib/lens-input-normalize.js";
+
+const ACTIONS = new Map();
+function registerLensAction(domain, name, fn) {
+  assert.equal(domain, "ethics", `unexpected domain: ${domain}`);
+  ACTIONS.set(name, fn);
+}
+
+// Mirror the live dispatch exactly: peel one redundant artifact wrapper, then
+// handler(ctx, virtualArtifact, input) with virtualArtifact.data = input.
+function call(name, ctx, rawInput = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`ethics.${name} not registered`);
+  const input = peelRedundantArtifactWrapper(rawInput);
+  const virtualArtifact = { id: null, title: rawInput?.title ?? null, domain: "ethics", type: "domain_action", data: input || {}, meta: {} };
+  return fn(ctx, virtualArtifact, input || {});
+}
+
+before(() => { registerEthicsActions(registerLensAction); });
+
+beforeEach(() => {
+  // No boot, no network. The ethics macros are pure-compute + STATE; any
+  // network reach is a leak.
+  globalThis.fetch = async () => { throw new Error("network disabled in tests"); };
+  globalThis._concordSTATE = {};
+  globalThis._concordSaveStateDebounced = () => {};
+});
+
+const ctxA = { actor: { userId: "eth_user_a" }, userId: "eth_user_a" };
+const ctxB = { actor: { userId: "eth_user_b" }, userId: "eth_user_b" };
+
+// Assert no value in the (possibly nested) object is a non-finite number.
+function assertNoNonFinite(obj, path = "root") {
+  if (obj == null) return;
+  if (typeof obj === "number") {
+    assert.ok(Number.isFinite(obj), `non-finite number at ${path}: ${obj}`);
+    return;
+  }
+  if (Array.isArray(obj)) { obj.forEach((v, i) => assertNoNonFinite(v, `${path}[${i}]`)); return; }
+  if (typeof obj === "object") { for (const k of Object.keys(obj)) assertNoNonFinite(obj[k], `${path}.${k}`); }
+}
+
+// ── registration: every lens-driven macro is present ───────────────────────
+describe("ethics — registration (every macro the six DecisionToolkit panels call)", () => {
+  it("registers all macros the components dispatch", () => {
+    for (const m of [
+      "multiFrameworkDilemma", "listMultiFramework",
+      "stakeholderMap", "listStakeholderMaps",
+      "decisionMatrix", "listDecisionMatrices",
+      "biasChecklistTemplate", "biasChecklist", "listBiasChecklists",
+      "submitReview", "addReviewOpinion", "recordVerdict", "listReviews",
+      "archiveCase", "searchCases", "deleteCase",
+    ]) {
+      assert.equal(typeof ACTIONS.get(m), "function", `missing ethics.${m}`);
+    }
+  });
+});
+
+// ── multiFrameworkDilemma — three-lens scoring + recommendation ────────────
+describe("ethics.multiFrameworkDilemma — verdict + composite the panel renders", () => {
+  it("ranks an honest beneficial option above a deceptive one (known verdict)", () => {
+    const r = call("multiFrameworkDilemma", ctxA, {
+      dilemma: "How to handle layoffs",
+      options: [
+        { name: "Honest transparent layoff", description: "honest consent respect dignity", benefitScore: 60, harmScore: 20 },
+        { name: "Deceptive exploit", description: "deceive manipulate exploit harm", benefitScore: 80, harmScore: 90 },
+      ],
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.recommended, "Honest transparent layoff");
+    // The renderer reads o.scores.{utilitarian,deontological,virtue}, composite,
+    // agreement. Pin the exact computed values.
+    const honest = r.result.options.find((o) => o.name === "Honest transparent layoff");
+    const deceptive = r.result.options.find((o) => o.name === "Deceptive exploit");
+    assert.deepEqual(honest.scores, { utilitarian: 70, deontological: 100, virtue: 100 });
+    assert.equal(honest.composite, 90);
+    // Deception is penalised hard on deontology/virtue → frameworks conflict.
+    assert.deepEqual(deceptive.scores, { utilitarian: 45, deontological: 0, virtue: 0 });
+    assert.equal(deceptive.agreement, "frameworks-conflict");
+    assert.ok(r.result.conflicted.includes("Deceptive exploit"));
+    assertNoNonFinite(r.result);
+  });
+
+  it("derives benefit/harm from keywords when scores are omitted", () => {
+    const r = call("multiFrameworkDilemma", ctxA, {
+      dilemma: "d",
+      options: [{ name: "Care", description: "help protect care benefit" }],
+    });
+    assert.equal(r.ok, true);
+    // 4 positive keywords (help/protect/care/benefit) → benefit = 4*20 = 80.
+    assert.equal(r.result.options[0].benefit, 80);
+    assert.equal(r.result.options[0].harm, 0);
+    assertNoNonFinite(r.result);
+  });
+
+  it("validation-rejection: missing dilemma / missing options", () => {
+    assert.match(call("multiFrameworkDilemma", ctxA, { options: [{ name: "A" }] }).error, /dilemma text required/i);
+    assert.match(call("multiFrameworkDilemma", ctxA, { dilemma: "d", options: [] }).error, /at least one option required/i);
+  });
+
+  it("fail-CLOSED: poisoned 1e999/Infinity harm/benefit never leak Infinity/NaN", () => {
+    const r = call("multiFrameworkDilemma", ctxA, {
+      dilemma: "d",
+      options: [{ name: "A", description: "help protect care", benefitScore: "1e999", harmScore: "Infinity" }],
+    });
+    assert.equal(r.ok, true);
+    // Non-finite scores fall back to keyword-derived; never Infinity.
+    assert.ok(Number.isFinite(r.result.options[0].benefit));
+    assert.ok(Number.isFinite(r.result.options[0].harm));
+    assert.ok(Number.isFinite(r.result.options[0].composite));
+    assertNoNonFinite(r.result);
+  });
+});
+
+// ── decisionMatrix — weighted winner + poisoned-weight fail-closed ─────────
+describe("ethics.decisionMatrix — weighted score winner the panel renders", () => {
+  it("picks the higher weighted-total option (known winner + percent)", () => {
+    const r = call("decisionMatrix", ctxA, {
+      title: "Vendor choice",
+      criteria: [{ name: "fairness", weight: 0.6 }, { name: "cost", weight: 0.4 }],
+      options: [
+        { name: "A", scores: { fairness: 8, cost: 4 } }, // 0.6*8 + 0.4*4 = 6.4
+        { name: "B", scores: { fairness: 5, cost: 9 } }, // 0.6*5 + 0.4*9 = 6.6
+      ],
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.winner, "B");
+    const a = r.result.options.find((o) => o.name === "A");
+    assert.equal(a.total, 6.4);
+    assert.equal(a.percent, 64); // renderer reads o.percent + o.breakdown[].{criterion,raw,weighted}
+    assert.equal(a.breakdown.find((b) => b.criterion === "fairness").weighted, 4.8);
+    assertNoNonFinite(r.result);
+  });
+
+  it("validation-rejection: missing criteria / missing options", () => {
+    assert.match(call("decisionMatrix", ctxA, { options: [{ name: "A" }] }).error, /at least one criterion required/i);
+    assert.match(call("decisionMatrix", ctxA, { criteria: [{ name: "c", weight: 1 }] }).error, /at least one option required/i);
+  });
+
+  it("fail-CLOSED: a poisoned 1e999/Infinity weight never makes the normalized weight NaN", () => {
+    // Pre-fix: Number('1e999')||0 = Infinity → weightSum = Infinity →
+    // Infinity/Infinity = NaN → weighted NaN, percent NaN leaked into output.
+    const r = call("decisionMatrix", ctxA, {
+      title: "Poison",
+      criteria: [{ name: "a", weight: "1e999" }, { name: "b", weight: 1 }],
+      options: [{ name: "X", scores: { a: "Infinity", b: 5 } }],
+    });
+    assert.equal(r.ok, true);
+    for (const o of r.result.options) {
+      assert.ok(Number.isFinite(o.total), `total ${o.total}`);
+      assert.ok(Number.isFinite(o.percent), `percent ${o.percent}`);
+      for (const b of o.breakdown) assert.ok(Number.isFinite(b.weighted), `weighted ${b.weighted}`);
+    }
+    assertNoNonFinite(r.result);
+  });
+
+  it("degrade-graceful: non-string criterion/option names + non-numeric scores never throw", () => {
+    const r = call("decisionMatrix", ctxA, {
+      title: 123,
+      criteria: [{ name: 5, weight: "abc" }, { name: "real", weight: 1 }],
+      options: [{ name: null, scores: { real: "not-a-number" } }],
+    });
+    assert.equal(r.ok, true);
+    assertNoNonFinite(r.result);
+  });
+});
+
+// ── stakeholderMap — vulnerability-amplified exposure + best option ────────
+describe("ethics.stakeholderMap — weighted impact table the panel renders", () => {
+  it("amplifies negative impact on vulnerable stakeholders and picks the best option", () => {
+    const r = call("stakeholderMap", ctxA, {
+      title: "Plant closure",
+      options: ["keep", "cut"],
+      stakeholders: [
+        { name: "Workers", group: "staff", vulnerability: 80, impacts: { keep: 50, cut: -60 } },
+        { name: "Shareholders", group: "owners", vulnerability: 0, impacts: { keep: -10, cut: 40 } },
+      ],
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.bestOption, "keep");
+    const workers = r.result.stakeholders.find((s) => s.name === "Workers");
+    // -60 * (1 + 80/100) = -108 weighted (renderer reads impacts[opt].weighted).
+    assert.equal(workers.impacts.cut.weighted, -108);
+    assert.equal(workers.impacts.keep.weighted, 50); // positive impact NOT amplified
+    const cut = r.result.optionTotals.find((o) => o.option === "cut");
+    assert.equal(cut.vulnerableHarmed, 1);
+    assertNoNonFinite(r.result);
+  });
+
+  it("validation-rejection: missing options / missing stakeholders", () => {
+    assert.match(call("stakeholderMap", ctxA, { stakeholders: [{ name: "x" }] }).error, /at least one option required/i);
+    assert.match(call("stakeholderMap", ctxA, { options: ["a"] }).error, /at least one stakeholder required/i);
+  });
+
+  it("fail-CLOSED: poisoned 1e999/Infinity vulnerability + impact clamp, never leak Infinity", () => {
+    const r = call("stakeholderMap", ctxA, {
+      title: "Poison",
+      options: ["x"],
+      stakeholders: [{ name: "V", vulnerability: "1e999", impacts: { x: "-Infinity" } }],
+    });
+    assert.equal(r.ok, true);
+    const v = r.result.stakeholders[0];
+    assert.ok(Number.isFinite(v.vulnerability) && v.vulnerability <= 100);
+    assert.ok(Number.isFinite(v.impacts.x.weighted));
+    assert.ok(Number.isFinite(v.netExposure));
+    assertNoNonFinite(r.result);
+  });
+});
+
+// ── biasChecklist + template — risk scoring round-trip ─────────────────────
+describe("ethics.biasChecklist — risk score + template the panel renders", () => {
+  it("returns the 10-item canonical template the form renders", () => {
+    const r = call("biasChecklistTemplate", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.items.length, 10);
+    // renderer reads item.{key,label,prompt}.
+    assert.equal(r.result.items[0].key, "confirmation");
+    assert.ok(typeof r.result.items[0].label === "string" && r.result.items[0].prompt.length > 0);
+  });
+
+  it("computes the risk score from flagged biases (known value)", () => {
+    const r = call("biasChecklist", ctxA, {
+      decision: "Promote internal candidate",
+      responses: { confirmation: { flagged: true }, anchoring: { flagged: true, note: "first offer" } },
+    });
+    assert.equal(r.ok, true);
+    // 2 of 10 flagged → 20% → moderate (renderer reads riskScore/riskLevel/flaggedCount/totalCount).
+    assert.equal(r.result.flaggedCount, 2);
+    assert.equal(r.result.totalCount, 10);
+    assert.equal(r.result.riskScore, 20);
+    assert.equal(r.result.riskLevel, "moderate");
+    assert.equal(r.result.items.find((i) => i.key === "anchoring").note, "first offer");
+    assertNoNonFinite(r.result);
+  });
+
+  it("validation-rejection: missing decision text", () => {
+    assert.match(call("biasChecklist", ctxA, {}).error, /decision text required/i);
+  });
+
+  it("degrade-graceful: a non-object responses field never throws + risk is finite", () => {
+    const r = call("biasChecklist", ctxA, { decision: "d", responses: "not-an-object" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.flaggedCount, 0);
+    assert.ok(Number.isFinite(r.result.riskScore));
+    assertNoNonFinite(r.result);
+  });
+});
+
+// ── list round-trips + per-user isolation ──────────────────────────────────
+describe("ethics list macros — STATE round-trip + per-user isolation", () => {
+  it("multiFrameworkDilemma → listMultiFramework round-trips and is user-scoped", () => {
+    call("multiFrameworkDilemma", ctxA, { dilemma: "d1", options: [{ name: "O" }] });
+    call("multiFrameworkDilemma", ctxA, { dilemma: "d2", options: [{ name: "O" }] });
+    const list = call("listMultiFramework", ctxA, {});
+    assert.equal(list.ok, true);
+    assert.equal(list.result.analyses.length, 2);
+    // newest first.
+    assert.equal(list.result.analyses[0].dilemma, "d2");
+    // user B sees none of A's analyses.
+    assert.equal(call("listMultiFramework", ctxB, {}).result.analyses.length, 0);
+  });
+
+  it("stakeholderMap / decisionMatrix / biasChecklist each list back their record", () => {
+    call("stakeholderMap", ctxA, { title: "M", options: ["a"], stakeholders: [{ name: "s", impacts: { a: 5 } }] });
+    assert.equal(call("listStakeholderMaps", ctxA, {}).result.maps.length, 1);
+    call("decisionMatrix", ctxA, { title: "X", criteria: [{ name: "c", weight: 1 }], options: [{ name: "o", scores: { c: 5 } }] });
+    assert.equal(call("listDecisionMatrices", ctxA, {}).result.matrices.length, 1);
+    call("biasChecklist", ctxA, { decision: "dec", responses: {} });
+    assert.equal(call("listBiasChecklists", ctxA, {}).result.checklists.length, 1);
+  });
+});
+
+// ── ethics review workflow — open → deliberating → decided ──────────────────
+describe("ethics review workflow — submit / opine / verdict lifecycle", () => {
+  it("walks a review from open through a verdict with a stance tally", () => {
+    const ctx = { actor: { userId: "eth_rev_u" }, userId: "eth_rev_u" };
+    const rev = call("submitReview", ctx, { title: "Layoffs", dilemma: "should we lay off staff?" });
+    assert.equal(rev.ok, true);
+    assert.equal(rev.result.status, "open");
+
+    const op = call("addReviewOpinion", ctx, { reviewId: rev.result.id, stance: "approve", rationale: "necessary" });
+    assert.equal(op.result.status, "deliberating");
+    assert.equal(op.result.opinions.length, 1);
+    assert.equal(op.result.opinions[0].stance, "approve");
+
+    const vd = call("recordVerdict", ctx, { reviewId: rev.result.id, decision: "proceed", rationale: "consensus" });
+    assert.equal(vd.result.status, "decided");
+    assert.equal(vd.result.verdict.decision, "proceed");
+    assert.equal(vd.result.verdict.tally.approve, 1);
+
+    assert.equal(call("listReviews", ctx, {}).result.reviews.length, 1);
+  });
+
+  it("validation-rejection: bad stance, missing fields, opinions after decided", () => {
+    const ctx = { actor: { userId: "eth_rev_u2" }, userId: "eth_rev_u2" };
+    assert.match(call("submitReview", ctx, { dilemma: "d" }).error, /title required/i);
+    const rev = call("submitReview", ctx, { title: "T", dilemma: "d" }).result;
+    assert.match(call("addReviewOpinion", ctx, { reviewId: rev.id, stance: "maybe" }).error, /invalid stance/i);
+    call("recordVerdict", ctx, { reviewId: rev.id, decision: "x" });
+    assert.match(call("addReviewOpinion", ctx, { reviewId: rev.id, stance: "approve", rationale: "y" }).error, /already decided/i);
+    assert.match(call("addReviewOpinion", ctx, { reviewId: "missing", stance: "approve" }).error, /review not found/i);
+  });
+});
+
+// ── case library — archive / search / delete ───────────────────────────────
+describe("ethics.searchCases — archive / filter / delete round-trip", () => {
+  it("archives a case, finds it by query and tag, and deletes it", () => {
+    const ctx = { actor: { userId: "eth_case_u" }, userId: "eth_case_u" };
+    const c = call("archiveCase", ctx, {
+      title: "Trolley Problem", dilemma: "divert the trolley?", resolution: "divert",
+      reasoning: "minimize deaths", framework: "Utilitarian", tags: ["Classic", "Trolley"],
+    });
+    assert.equal(c.ok, true);
+    assert.deepEqual(c.result.tags, ["classic", "trolley"]); // lowercased
+
+    const byQuery = call("searchCases", ctx, { query: "trolley" });
+    assert.equal(byQuery.result.total, 1);
+    assert.deepEqual(byQuery.result.allTags, ["classic", "trolley"]);
+
+    const byTag = call("searchCases", ctx, { tag: "classic" });
+    assert.equal(byTag.result.total, 1);
+    const byFramework = call("searchCases", ctx, { framework: "utilitarian" });
+    assert.equal(byFramework.result.total, 1);
+    // a non-matching query returns empty (distinct from an error).
+    assert.equal(call("searchCases", ctx, { query: "nonexistent" }).result.total, 0);
+
+    const del = call("deleteCase", ctx, { caseId: c.result.id });
+    assert.equal(del.ok, true);
+    assert.equal(call("searchCases", ctx, {}).result.total, 0);
+  });
+
+  it("validation-rejection: missing required fields / missing case on delete", () => {
+    const ctx = { actor: { userId: "eth_case_u2" }, userId: "eth_case_u2" };
+    assert.match(call("archiveCase", ctx, { dilemma: "d", resolution: "r" }).error, /title required/i);
+    assert.match(call("archiveCase", ctx, { title: "t", resolution: "r" }).error, /dilemma required/i);
+    assert.match(call("archiveCase", ctx, { title: "t", dilemma: "d" }).error, /resolution required/i);
+    assert.match(call("deleteCase", ctx, { caseId: "nope" }).error, /case not found/i);
+  });
+});
+
+// ── double-wrap dispatch parity — the dead-surface bug class ────────────────
+describe("ethics — { artifact:{ data } } double-wrap is peeled like production", () => {
+  it("decisionMatrix reads through a sole-key artifact wrapper identically to flat input", () => {
+    const wrapped = call("decisionMatrix", ctxA, {
+      artifact: { data: { title: "W", criteria: [{ name: "a", weight: 1 }], options: [{ name: "X", scores: { a: 6 } }] } },
+    });
+    assert.equal(wrapped.ok, true);
+    assert.equal(wrapped.result.winner, "X");
+    assert.equal(wrapped.result.options[0].total, 6);
+  });
+
+  it("multiFrameworkDilemma reads through the wrapper (the historical blank-calc bug)", () => {
+    const wrapped = call("multiFrameworkDilemma", ctxA, {
+      artifact: { data: { dilemma: "wrapped dilemma", options: [{ name: "O", description: "honest" }] } },
+    });
+    assert.equal(wrapped.ok, true);
+    assert.equal(wrapped.result.dilemma, "wrapped dilemma");
+  });
+});

--- a/server/tests/fishing-lens-macros.test.js
+++ b/server/tests/fishing-lens-macros.test.js
@@ -1,0 +1,342 @@
+// Behavioral macro tests for server/domains/fishing.js — the cast → bite →
+// reel → mint substrate the /lenses/fishing lens (+ FishingMinigameOverlay)
+// drives. Fishing is a GAME lens, not a calculator: the load-bearing math is
+// the skill/accuracy-weighted species pick + the clamped qualityScore, and the
+// load-bearing side effect is the single raw_fish inventory row a catch mints.
+//
+// Fishing registers via the PATH-2 macro convention — register(domain, name, fn)
+// — and the live dispatch invokes each handler as `m.fn(ctx, input)` (the
+// 2-ARG order, ctx FIRST), then peels exactly one sole-key
+// { artifact: { data } } wrapper at /api/lens/run before the call. This harness
+// reproduces BOTH: it collects the handlers through the same register signature
+// and drives them with the SAME peel + (ctx, input) call the server makes, so a
+// double-wrap dead-surface regression or an arg-order drift surfaces here.
+//
+// These are NOT shape-only assertions. They pin: the EXACT input fields the
+// page + overlay SEND and the EXACT output fields they RENDER (a dead-surface
+// regression fails here), real computed values + the cast→reel→catch→inventory
+// round-trip, validation-rejection, graceful degradation, and a fail-CLOSED
+// poisoned-numeric contract (Infinity/NaN/'1e999' reactionMs/tension/skill/x/z
+// are clamped, NEVER leak Infinity/NaN, NEVER throw, NEVER 500).
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+import registerFishingMacros from "../domains/fishing.js";
+import { getSession, listFishForWorld } from "../lib/fishing.js";
+import { peelRedundantArtifactWrapper } from "../lib/lens-input-normalize.js";
+
+// Mirror the live register(domain, name, fn) collection.
+function collectMacros() {
+  const map = new Map();
+  registerFishingMacros((domain, name, handler) => {
+    assert.equal(domain, "fishing", `unexpected domain: ${domain}`);
+    map.set(name, handler);
+  });
+  return map;
+}
+
+// player_inventory at its post-migration shape (the columns lib/fishing.js's
+// primary INSERT path writes), built inline so the test doesn't depend on the
+// full migration chain.
+function freshDb() {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE player_inventory (
+      id          TEXT PRIMARY KEY,
+      user_id     TEXT NOT NULL,
+      world_id    TEXT NOT NULL DEFAULT 'concordia-hub',
+      item_type   TEXT NOT NULL DEFAULT 'material',
+      item_id     TEXT NOT NULL,
+      item_name   TEXT NOT NULL DEFAULT '',
+      quantity    INTEGER NOT NULL DEFAULT 1,
+      schema_id   TEXT,
+      acquired_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      metadata    TEXT
+    );
+  `);
+  return db;
+}
+
+function ctxFor(db, userId) {
+  return { db, actor: { userId } };
+}
+
+// Drive a macro the way /api/lens/run does: peel exactly one redundant
+// { artifact: { data } } wrapper, then call handler(ctx, peeledInput).
+function call(macros, name, ctx, rawInput = {}) {
+  const fn = macros.get(name);
+  if (!fn) throw new Error(`fishing.${name} not registered`);
+  return fn(ctx, peelRedundantArtifactWrapper(rawInput));
+}
+
+// Assert no value in the (possibly nested) object is a non-finite number.
+function assertNoNonFinite(obj, path = "root") {
+  if (obj == null) return;
+  if (typeof obj === "number") {
+    assert.ok(Number.isFinite(obj), `non-finite number at ${path}: ${obj}`);
+    return;
+  }
+  if (Array.isArray(obj)) { obj.forEach((v, i) => assertNoNonFinite(v, `${path}[${i}]`)); return; }
+  if (typeof obj === "object") { for (const k of Object.keys(obj)) assertNoNonFinite(obj[k], `${path}.${k}`); }
+}
+
+describe("fishing lens macros", () => {
+  let db, macros;
+  beforeEach(() => { db = freshDb(); macros = collectMacros(); });
+
+  // ── registration: the full read + write surface the lens reaches ──────────
+  it("registers every macro the lens + overlay + ⌘K can reach", () => {
+    for (const name of ["catalog", "species", "list", "get", "catches", "session", "cast", "reel", "create"]) {
+      assert.equal(typeof macros.get(name), "function", `missing macro: ${name}`);
+    }
+  });
+
+  // ── FIELD ALIGNMENT: catalog ───────────────────────────────────────────────
+  // The page sends  GET /api/fishing/catalog?worldId=<worldId>  and renders
+  // c.fish[*] → { id, name, rarity, subBiome }. The catalog MACRO must return
+  // the same { ok, fish:[{ id, name, rarity, biome, subBiome }] } the route does.
+  it("catalog returns the world's real authored fish with the fields the page renders", async () => {
+    const out = await call(macros, "catalog", ctxFor(db, "u1"), { worldId: "concordia-hub" });
+    assert.equal(out.ok, true);
+    assert.equal(out.worldId, "concordia-hub");
+    assert.ok(Array.isArray(out.fish) && out.fish.length > 0, "catalog must list fish");
+    // Every entry carries the EXACT fields the catalog list + RARITY_COLORS map render.
+    for (const f of out.fish) {
+      assert.equal(typeof f.id, "string");
+      assert.equal(typeof f.name, "string");
+      assert.equal(typeof f.rarity, "string");
+      assert.ok(typeof f.biome === "string" || typeof f.subBiome === "string");
+    }
+    // Matches the lib's listing exactly — no duplicated/fabricated data.
+    assert.deepEqual(
+      out.fish.map((f) => f.id).sort(),
+      listFishForWorld("concordia-hub").map((f) => f.id).sort(),
+    );
+  });
+
+  it("catalog degrades graceful on an unknown world — hub fallback, never a crash", async () => {
+    const out = await call(macros, "catalog", ctxFor(db, "u1"), { worldId: "no-such-world" });
+    assert.equal(out.ok, true);
+    // Falls back to the hub's authored pool (lib behavior) rather than empty/throw.
+    assert.deepEqual(
+      out.fish.map((f) => f.id).sort(),
+      listFishForWorld("concordia-hub").map((f) => f.id).sort(),
+    );
+  });
+
+  // ── species — biome-scoped pool ────────────────────────────────────────────
+  it("species pools are genuinely per-biome and every fish belongs to the requested biome", async () => {
+    const river = await call(macros, "species", ctxFor(db, "u1"), { worldId: "concordia-hub", biome: "river" });
+    const ocean = await call(macros, "species", ctxFor(db, "u1"), { worldId: "concordia-hub", biome: "ocean" });
+    assert.equal(river.ok, true);
+    assert.equal(ocean.ok, true);
+    assert.equal(river.biome, "river");
+    assert.equal(ocean.biome, "ocean");
+    assert.ok(river.fish.length > 0 && ocean.fish.length > 0);
+    const riverIds = new Set(river.fish.map((f) => f.id));
+    const oceanIds = new Set(ocean.fish.map((f) => f.id));
+    assert.ok([...oceanIds].some((id) => !riverIds.has(id)), "ocean must contain a fish the river pool lacks");
+    assert.ok(river.fish.every((f) => f.biome === "river" || f.subBiome === "river"));
+    assert.ok(ocean.fish.every((f) => f.biome === "ocean" || f.subBiome === "ocean"));
+  });
+
+  // ── FIELD ALIGNMENT: cast ──────────────────────────────────────────────────
+  // The page + overlay POST { worldId, x, z, biome } and the overlay reads
+  // j.sessionId + j.biteAtEpochMs. The cast macro must return the same fields.
+  it("cast returns the exact { sessionId, biteAtEpochMs, candidateCount } the overlay reads", async () => {
+    const cast = await call(macros, "cast", ctxFor(db, "angler"), { worldId: "concordia-hub", x: 5, z: -3, biome: "water" });
+    assert.equal(cast.ok, true);
+    assert.equal(typeof cast.sessionId, "string");
+    assert.ok(cast.sessionId.startsWith("fish_"));
+    assert.ok(Number.isFinite(cast.biteAtEpochMs) && cast.biteAtEpochMs > Date.now());
+    assert.ok(Number.isFinite(cast.candidateCount) && cast.candidateCount > 0);
+  });
+
+  it("cast without an actor returns a clean envelope, not a throw", async () => {
+    const out = await call(macros, "cast", { db }, { worldId: "concordia-hub" });
+    assert.equal(out.ok, false);
+    assert.equal(out.reason, "no_user");
+  });
+
+  // ── the load-bearing round-trip: cast → bite-gate → reel → mint → log ──────
+  it("cast → reel → catch yields a real species AND mints exactly one inventory row", async () => {
+    const cast = await call(macros, "cast", ctxFor(db, "angler"), { worldId: "concordia-hub", biome: "water" });
+    assert.equal(cast.ok, true);
+
+    // The tension mechanic gates on bite timing: a reel before the bite is
+    // rejected (no_bite_yet) — the mechanic must actually resolve that way.
+    const tooEarly = await call(macros, "reel", ctxFor(db, "angler"), { sessionId: cast.sessionId });
+    assert.equal(tooEarly.ok, false);
+    assert.equal(tooEarly.reason, "no_bite_yet");
+
+    // Advance the session past the bite window then reel with high accuracy.
+    const s = getSession(cast.sessionId);
+    s.biteAt = Date.now() - 500;
+    s.resolved = false; // tooEarly flipped it; reset for the real attempt
+
+    const reel = await call(macros, "reel", ctxFor(db, "angler"), {
+      sessionId: cast.sessionId, reactionMs: 400, tensionAccuracy: 0.9, fishingSkill: 50,
+    });
+    assert.equal(reel.ok, true);
+    // The overlay renders j.fish.name, j.tier, j.qualityScore — pin those fields.
+    assert.ok(reel.fish && typeof reel.fish.id === "string" && typeof reel.fish.name === "string");
+    const poolIds = new Set(listFishForWorld("concordia-hub", "water").map((f) => f.id));
+    assert.ok(poolIds.has(reel.fish.id), "caught fish must come from the biome's species table");
+    assert.ok(reel.qualityScore >= 0 && reel.qualityScore <= 1);
+    assert.ok(["perfect", "good", "fair", "poor"].includes(reel.tier));
+    assert.equal(reel.mint.ok, true);
+
+    // Inventory gained exactly the caught item (one raw_fish row, matching id).
+    const rows = db.prepare(
+      `SELECT * FROM player_inventory WHERE user_id = 'angler' AND item_type = 'raw_fish'`,
+    ).all();
+    assert.equal(rows.length, 1, "exactly one catch row");
+    assert.equal(rows[0].item_id, `raw_fish:${reel.fish.id}`);
+    assert.equal(rows[0].quantity, 1);
+
+    // FIELD ALIGNMENT: the catches macro surfaces the row with the exact fields
+    // the page's catch log renders: { id, item_id, item_name, acquired_at }.
+    const log = await call(macros, "catches", ctxFor(db, "angler"), {});
+    assert.equal(log.ok, true);
+    assert.equal(log.catches.length, 1);
+    const row = log.catches[0];
+    assert.equal(row.item_id, `raw_fish:${reel.fish.id}`);
+    assert.equal(typeof row.item_name, "string");
+    assert.ok(Number.isFinite(row.acquired_at));
+  });
+
+  it("higher skill + accuracy biases the catch toward rarer fish (the mechanic is real)", async () => {
+    // Drive many high-skill casts; the set must land at least one non-common
+    // fish, proving rarity weighting is wired (not a flat 1/8 random pick — the
+    // hub pool is mostly common, so a flat pick would also occasionally hit
+    // non-common, but skill bias makes it reliable across 120 trials).
+    let rare = 0;
+    for (let i = 0; i < 120; i++) {
+      const c = await call(macros, "cast", ctxFor(db, "rare_angler"), { worldId: "concordia-hub", biome: "water" });
+      const s = getSession(c.sessionId);
+      s.biteAt = Date.now() - 500;
+      const reel = await call(macros, "reel", ctxFor(db, "rare_angler"), {
+        sessionId: c.sessionId, reactionMs: 400, tensionAccuracy: 0.95, fishingSkill: 90,
+      });
+      if (reel.ok && reel.fish.rarity !== "common") rare += 1;
+    }
+    assert.ok(rare >= 1, `high-skill angler should occasionally land a non-common fish (got ${rare} over 120)`);
+  });
+
+  it("create artifact verb mints a catch through the SAME path as reel", async () => {
+    const cast = await call(macros, "create", ctxFor(db, "angler2"), {}); // create with no session → clean reject
+    assert.equal(cast.ok, false);
+    assert.equal(cast.reason, "no_session_id");
+
+    const c = await call(macros, "cast", ctxFor(db, "angler2"), { worldId: "concordia-hub", biome: "water" });
+    const s = getSession(c.sessionId);
+    s.biteAt = Date.now() - 500;
+    const out = await call(macros, "create", ctxFor(db, "angler2"), { sessionId: c.sessionId, tensionAccuracy: 0.8 });
+    assert.equal(out.ok, true);
+    assert.ok(out.fish && out.fish.id);
+    const n = db.prepare(
+      `SELECT COUNT(*) AS n FROM player_inventory WHERE user_id = 'angler2' AND item_type = 'raw_fish'`,
+    ).get();
+    assert.equal(n.n, 1);
+  });
+
+  // ── validation-rejection (clean envelope, never a throw) ───────────────────
+  it("reel rejects a missing/expired session cleanly", async () => {
+    const out = await call(macros, "reel", ctxFor(db, "u1"), { sessionId: "fish_does_not_exist" });
+    assert.equal(out.ok, false);
+    assert.equal(out.reason, "session_not_found");
+  });
+
+  it("reel without a db (read-only ctx) rejects with no_db, never throws", async () => {
+    const out = await call(macros, "reel", { actor: { userId: "u1" } }, { sessionId: "x" });
+    assert.equal(out.ok, false);
+    assert.equal(out.reason, "no_db");
+  });
+
+  it("catches without an actor rejects with no_user (never silently lists another user)", async () => {
+    const out = await call(macros, "catches", { db }, {});
+    assert.equal(out.ok, false);
+    assert.equal(out.reason, "no_user");
+  });
+
+  it("get returns a single fish descriptor or a clean miss", async () => {
+    const any = listFishForWorld("concordia-hub")[0];
+    const hit = await call(macros, "get", ctxFor(db, "u1"), { fishId: any.id });
+    assert.equal(hit.ok, true);
+    assert.equal(hit.fish.id, any.id);
+    const miss = await call(macros, "get", ctxFor(db, "u1"), { fishId: "no_such_fish" });
+    assert.equal(miss.ok, false);
+    assert.equal(miss.reason, "no_fish");
+    const noId = await call(macros, "get", ctxFor(db, "u1"), {});
+    assert.equal(noId.ok, false);
+    assert.equal(noId.reason, "no_fish_id");
+  });
+
+  it("session inspect returns the bite-timing fields the overlay derives, or a clean miss", async () => {
+    const c = await call(macros, "cast", ctxFor(db, "u1"), { worldId: "concordia-hub", biome: "water" });
+    const sess = await call(macros, "session", ctxFor(db, "u1"), { sessionId: c.sessionId });
+    assert.equal(sess.ok, true);
+    assert.equal(sess.session.worldId, "concordia-hub");
+    assert.equal(sess.session.biome, "water");
+    assert.ok(Number.isFinite(sess.session.biteAtEpochMs));
+    assert.ok(Number.isFinite(sess.session.expiresAt));
+    assert.equal(sess.session.resolved, false);
+    assert.ok(sess.session.candidateCount > 0);
+    const miss = await call(macros, "session", ctxFor(db, "u1"), { sessionId: "nope" });
+    assert.equal(miss.ok, false);
+    assert.equal(miss.reason, "session_not_found");
+  });
+
+  // ── fail-CLOSED poisoned numerics ──────────────────────────────────────────
+  it("fail-CLOSED: poisoned Infinity/NaN/'1e999' reaction/tension/skill never leak NaN/Infinity, never throw", async () => {
+    const cast = await call(macros, "cast", ctxFor(db, "poison_a"), {
+      worldId: "concordia-hub", biome: "water", x: "1e999", z: "NaN",
+    });
+    assert.equal(cast.ok, true);
+    // x/z are poison but never surface as a non-finite field on the envelope.
+    assertNoNonFinite(cast);
+
+    const s = getSession(cast.sessionId);
+    s.biteAt = Date.now() - 500;
+    const reel = await call(macros, "reel", ctxFor(db, "poison_a"), {
+      sessionId: cast.sessionId, reactionMs: Infinity, tensionAccuracy: "1e999", fishingSkill: "NaN",
+    });
+    assert.equal(reel.ok, true);
+    assert.ok(Number.isFinite(reel.qualityScore));
+    assert.ok(reel.qualityScore >= 0 && reel.qualityScore <= 1);
+    assert.ok(["perfect", "good", "fair", "poor"].includes(reel.tier));
+    assertNoNonFinite({ qualityScore: reel.qualityScore });
+    // mint with the poison-derived (but clamped) quality must still write a finite name.
+    assert.equal(reel.mint.ok, true);
+    const row = db.prepare(`SELECT item_name, metadata FROM player_inventory WHERE user_id = 'poison_a'`).get();
+    assert.ok(!/Infinity|NaN/.test(row.item_name), `item_name must not embed Infinity/NaN: ${row.item_name}`);
+    const meta = JSON.parse(row.metadata);
+    assert.ok(Number.isFinite(meta.qualityScore));
+  });
+
+  it("fail-CLOSED: a non-string biome on catalog/species is coerced, never NaN-filtered into a crash", async () => {
+    const cat = await call(macros, "catalog", ctxFor(db, "poison_b"), { worldId: "concordia-hub", biome: 42 });
+    assert.equal(cat.ok, true);
+    assert.ok(Array.isArray(cat.fish)); // a coerced "42" biome matches nothing → honest empty, not a throw
+    assertNoNonFinite(cat);
+    const sp = await call(macros, "species", ctxFor(db, "poison_b"), { worldId: "concordia-hub", biome: 42 });
+    assert.equal(sp.ok, true);
+    assert.equal(typeof sp.biome, "string"); // clamped to a string, never a raw number
+  });
+
+  // ── double-wrap dispatch parity — the dead-surface bug class ────────────────
+  it("catalog reads through a sole-key { artifact:{ data } } wrapper identically to flat input", async () => {
+    const wrapped = await call(macros, "catalog", ctxFor(db, "u1"), { artifact: { data: { worldId: "concordia-hub" } } });
+    const flat = await call(macros, "catalog", ctxFor(db, "u1"), { worldId: "concordia-hub" });
+    assert.equal(wrapped.ok, true);
+    assert.deepEqual(wrapped.fish.map((f) => f.id).sort(), flat.fish.map((f) => f.id).sort());
+  });
+
+  it("cast reads through the wrapper so the lens-shell ⌘K path isn't a dead surface", async () => {
+    const wrapped = await call(macros, "cast", ctxFor(db, "u1"), { artifact: { data: { worldId: "concordia-hub", biome: "water" } } });
+    assert.equal(wrapped.ok, true);
+    assert.ok(wrapped.sessionId.startsWith("fish_"));
+    assert.ok(wrapped.candidateCount > 0);
+  });
+});

--- a/server/tests/fitness-lens-macros.test.js
+++ b/server/tests/fitness-lens-macros.test.js
@@ -1,0 +1,580 @@
+// Behavioral macro tests for server/domains/fitness.js — the personal-training
+// + Strava/Garmin/Whoop/Apple-Fitness substrate the /lenses/fitness lens drives
+// (progression calc, body-composition report, periodization, class utilization,
+// HR zones, plus the STATE-backed activity/segment/route/goal/gear/club/
+// challenge/training-load/recovery/activity-ring surfaces).
+//
+// This file mirrors the REAL LENS_ACTIONS dispatch: every fitness handler is
+// registered via `registerLensAction(domain, action, handler)` and invoked as
+// `handler(ctx, virtualArtifact, input)` — the 3-ARG convention with
+// `virtualArtifact.data === input`. The dispatch ALSO peels exactly one
+// redundant `{ artifact: { data } }` wrapper (lens-input-normalize.js); we peel
+// the same way before calling so the harness is byte-identical to production.
+//
+// These are NOT shape-only assertions. They pin ACTUAL computed values for KNOWN
+// inputs → KNOWN outputs (Tanaka/Fox max HR + Karvonen zones, deterministic
+// progression increments, BMI/body-fat bands, periodization phase weeks), the
+// EXACT field names the SleepRecovery / ActivityRings / HeartRateZones /
+// WorkoutPlanner components render (so a dead-surface regression surfaces here),
+// CRUD round-trips through real STATE, validation-rejection, graceful
+// degradation, and a fail-CLOSED poisoned-numeric contract: Infinity/NaN/1e999/
+// negative/zero inputs are clamped or rejected and NEVER leak Infinity/NaN
+// (serialized null) into the result, and NEVER throw.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerFitnessActions from "../domains/fitness.js";
+import { peelRedundantArtifactWrapper } from "../lib/lens-input-normalize.js";
+
+const ACTIONS = new Map();
+function registerLensAction(domain, name, fn) {
+  assert.equal(domain, "fitness", `unexpected domain: ${domain}`);
+  ACTIONS.set(name, fn);
+}
+
+// Mirror the live dispatch exactly: peel one redundant artifact wrapper, then
+// handler(ctx, virtualArtifact, input) with virtualArtifact.data = input.
+// PATH 1 — the /api/lens/run dispatch (the `lensRun({domain,action,input})`
+// channel the Strava/personal child components use). The route sets
+// virtualArtifact.data = input and passes input as params, peeling one
+// sole-key { artifact:{ data } } wrapper first.
+function call(name, ctx, rawInput = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`fitness.${name} not registered`);
+  const input = peelRedundantArtifactWrapper(rawInput);
+  const virtualArtifact = { id: null, title: rawInput?.title ?? null, domain: "fitness", type: "domain_action", data: input || {}, meta: {} };
+  return fn(ctx, virtualArtifact, input || {});
+}
+
+// PATH 2 — the artifact dispatch (`lens.run` / POST /api/lens/:domain/:id/run,
+// driven by useRunArtifact). The route LOADS the real stored artifact and calls
+// handler(ctx, artifact, params): the on-page data lives on `artifact.data`,
+// `params` is separate. This is how the page Quick Actions (progressionCalc,
+// classUtilization, bodyCompReport, periodization, recruitProfile,
+// attendanceReport) are invoked — they read `artifact.data.X` + `params.Y`.
+function callArtifact(name, ctx, artifactData = {}, params = {}, title = null) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`fitness.${name} not registered`);
+  const artifact = { id: "art_test", title, domain: "fitness", type: "domain_action", data: artifactData || {}, meta: {} };
+  return fn(ctx, artifact, params || {});
+}
+
+before(() => { registerFitnessActions(registerLensAction); });
+
+beforeEach(() => {
+  // No boot, no network. Any handler that reaches the network in a test is a
+  // leak — these STATE/compute macros never should (the wger `feed` macro is
+  // the only network one and is not exercised here).
+  globalThis.fetch = async () => { throw new Error("network disabled in tests"); };
+  globalThis._concordSTATE = {};
+  globalThis._concordSaveStateDebounced = () => {};
+});
+
+const ctxA = { actor: { userId: "fit_user_a" }, userId: "fit_user_a" };
+const ctxB = { actor: { userId: "fit_user_b" }, userId: "fit_user_b" };
+
+// Assert no value in the (possibly nested) object is a non-finite number.
+function assertNoNonFinite(obj, path = "root") {
+  if (obj == null) return;
+  if (typeof obj === "number") {
+    assert.ok(Number.isFinite(obj), `non-finite number at ${path}: ${obj}`);
+    return;
+  }
+  if (Array.isArray(obj)) { obj.forEach((v, i) => assertNoNonFinite(v, `${path}[${i}]`)); return; }
+  if (typeof obj === "object") { for (const k of Object.keys(obj)) assertNoNonFinite(obj[k], `${path}.${k}`); }
+}
+
+// ── registration: every lens-driven macro is present ────────────────────────
+describe("fitness — registration (every lens-driven macro present)", () => {
+  it("registers the legacy coaching-calc macros the page Quick Actions call", () => {
+    for (const m of ["progressionCalc", "classUtilization", "bodyCompReport", "attendanceReport", "periodization", "recruitProfile"]) {
+      assert.equal(typeof ACTIONS.get(m), "function", `missing fitness.${m}`);
+    }
+  });
+  it("registers the personal-fitness tab macros the child components drive", () => {
+    for (const m of [
+      "hr-zones", "recovery-history", "activity-summary",
+      "workout-plan-generate", "generate-program",
+      "workout-list", "workout-save",
+    ]) {
+      assert.equal(typeof ACTIONS.get(m), "function", `missing fitness.${m}`);
+    }
+  });
+  it("registers the Strava/Garmin STATE-backed macros", () => {
+    for (const m of [
+      "activity-create", "activity-list", "activity-detail", "activity-delete",
+      "segment-create", "segment-list", "segment-effort", "segment-leaderboard",
+      "route-create", "route-list", "training-load", "vo2max-estimate",
+      "race-predictor", "hrv-log", "hrv-status", "training-readiness", "body-battery",
+      "goal-create", "goal-list", "personal-records", "gear-add", "gear-list",
+      "club-create", "challenge-create", "fitness-dashboard",
+      "wearable-link", "wearable-sync", "wearable-status",
+    ]) {
+      assert.equal(typeof ACTIONS.get(m), "function", `missing fitness.${m}`);
+    }
+  });
+});
+
+// ── progressionCalc — deterministic RPE-driven increments ───────────────────
+describe("fitness.progressionCalc — RPE → weight recommendation the page renders", () => {
+  it("low RPE recommends a 5% increase; high RPE recommends a reduction", () => {
+    const r = callArtifact("progressionCalc", ctxA, { exercises: [
+      { name: "Squat", weight: 100, reps: 5, rpe: 6 },   // ≤6 → +5%
+      { name: "Bench", weight: 80, reps: 8, rpe: 7 },     // ≤7 → +2.5%
+      { name: "Press", weight: 60, reps: 6, rpe: 9 },     // ≥9 → −5%
+    ] });
+    assert.equal(r.ok, true);
+    const [sq, be, pr] = r.result.recommendations;
+    // 100 + 5 = 105, rounded to 0.5
+    assert.equal(sq.recommendedWeight, 105);
+    assert.equal(sq.recommendation, "increase_weight");
+    // 80 + 2 = 82
+    assert.equal(be.recommendedWeight, 82);
+    assert.equal(be.recommendation, "maintain");
+    // 60 − 3 = 57
+    assert.equal(pr.recommendedWeight, 57);
+    assert.equal(pr.recommendation, "reduce_weight");
+    // EXACT field names the Action-Result renderer reads
+    for (const rec of r.result.recommendations) {
+      for (const k of ["exercise", "currentWeight", "currentReps", "currentRPE", "recommendedWeight", "recommendation"]) {
+        assert.ok(k in rec, `missing rendered field ${k}`);
+      }
+    }
+    assertNoNonFinite(r.result);
+  });
+
+  it("degrade-graceful: no exercises → empty recommendations, not a crash", () => {
+    const r = callArtifact("progressionCalc", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.deepEqual(r.result.recommendations, []);
+  });
+
+  it("fail-CLOSED: poisoned 1e999/Infinity weight + reps → finite 0, never leaks Infinity", () => {
+    const r = callArtifact("progressionCalc", ctxA, { exercises: [
+      { name: "Bad", weight: "1e999", reps: Infinity, rpe: 5 },
+    ] });
+    assert.equal(r.ok, true);
+    const rec = r.result.recommendations[0];
+    assert.ok(Number.isFinite(rec.currentWeight) && rec.currentWeight === 0);
+    assert.ok(Number.isFinite(rec.recommendedWeight));
+    assertNoNonFinite(r.result);
+  });
+});
+
+// ── bodyCompReport — BMI + Navy body-fat (safety-critical) ──────────────────
+describe("fitness.bodyCompReport — BMI/body-fat bands + fail-closed numerics", () => {
+  it("computes a known metric BMI and category", () => {
+    // 80 kg / (1.80 m)^2 = 24.69 → 'normal'
+    const r = callArtifact("bodyCompReport", ctxA, { weight: 80, height: 180, unit: "metric", age: 30, sex: "male" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.bmi, 24.7);
+    assert.equal(r.result.bmiCategory, "normal");
+    assertNoNonFinite(r.result);
+  });
+
+  it("estimates Navy body-fat for a valid male measurement set", () => {
+    const r = callArtifact("bodyCompReport", ctxA, { weight: 80, height: 180, unit: "metric", sex: "male", waist: 85, neck: 38 });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.bodyFatPct));
+    assert.ok(r.result.bodyFatPct > 0 && r.result.bodyFatPct < 50);
+    assert.ok(Number.isFinite(r.result.leanMass.kg));
+    assertNoNonFinite(r.result);
+  });
+
+  it("degrade-graceful: waist ≤ neck (log10 of ≤0) → bodyFatPct null, never NaN", () => {
+    const r = callArtifact("bodyCompReport", ctxA, { weight: 80, height: 180, unit: "metric", sex: "male", waist: 30, neck: 40 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.bodyFatPct, null);
+    assert.equal(r.result.fatMass, null);
+    assertNoNonFinite(r.result);
+  });
+
+  it("fail-CLOSED: poisoned 1e999 weight/height/NaN age → finite output, never Infinity BMI", () => {
+    const r = callArtifact("bodyCompReport", ctxA, { weight: "1e999", height: Infinity, age: "NaN", unit: "metric" });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.bmi));
+    assert.ok(Number.isFinite(r.result.age));
+    assertNoNonFinite(r.result);
+  });
+});
+
+// ── periodization — phase weeks sum to total ────────────────────────────────
+describe("fitness.periodization — phase plan the Action-Result panel renders", () => {
+  it("builds a 12-week strength macrocycle whose phases sum to the total", () => {
+    const r = callArtifact("periodization", ctxA, {}, { weeks: 12, goal: "strength" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.totalWeeks, 12);
+    assert.equal(r.result.goal, "strength");
+    const sum = r.result.phases.reduce((s, p) => s + p.weeks, 0);
+    assert.equal(sum, 12, "phase weeks must sum to the total");
+    for (const p of r.result.phases) {
+      for (const k of ["name", "weeks", "sets", "reps", "intensity"]) assert.ok(k in p, `phase missing ${k}`);
+    }
+    assertNoNonFinite(r.result);
+  });
+
+  it("fail-CLOSED: poisoned 1e999 weeks → clamped to 12, phases finite", () => {
+    const r = callArtifact("periodization", ctxA, {}, { weeks: "1e999", goal: "general" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.totalWeeks, 12);
+    assertNoNonFinite(r.result);
+  });
+});
+
+// ── classUtilization — % full + period filter ───────────────────────────────
+describe("fitness.classUtilization — utilization the Action-Result renders", () => {
+  it("computes utilization % from a recent attendance log", () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const r = callArtifact("classUtilization", ctxA,
+      { capacity: 20, enrolled: 18, attendanceLog: [{ date: today, count: 15 }, { date: today, count: 13 }] },
+      { period: 30 });
+    assert.equal(r.ok, true);
+    // avg(15,13)=14, 14/20 = 70%
+    assert.equal(r.result.avgAttendance, 14);
+    assert.equal(r.result.utilization, 70);
+    assert.equal(r.result.sessions, 2);
+    assertNoNonFinite(r.result);
+  });
+
+  it("fail-CLOSED: poisoned capacity/count → finite utilization, no div-by-zero leak", () => {
+    const r = callArtifact("classUtilization", ctxA,
+      { capacity: "1e999", enrolled: "NaN", attendanceLog: [{ date: new Date().toISOString().slice(0, 10), count: Infinity }] },
+      { period: "Infinity" });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.utilization));
+    assertNoNonFinite(r.result);
+  });
+});
+
+// ── hr-zones — Tanaka/Fox max HR + Karvonen reserve (the rendered contract) ──
+describe("fitness.hr-zones — max HR formulas + zone bands HeartRateZones renders", () => {
+  it("Fox: maxHr = 220 − age, 5 zones each carrying the rendered fields", () => {
+    const r = call("hr-zones", ctxA, { age: 40, restingHr: 60, method: "fox" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.maxHr, 180);     // 220 − 40
+    assert.equal(r.result.method, "fox");
+    assert.equal(r.result.zones.length, 5);
+    for (const z of r.result.zones) {
+      for (const k of ["zone", "name", "lowBpm", "highBpm", "pctOfMax", "purpose", "weeklyMinutesTarget", "weeklyMinutesActual"]) {
+        assert.ok(k in z, `zone missing rendered field ${k}`);
+      }
+      assert.ok(z.lowBpm <= z.highBpm, "zone band must not invert");
+    }
+    assertNoNonFinite(r.result);
+  });
+
+  it("Tanaka: maxHr = round(208 − 0.7×age)", () => {
+    // 208 − 0.7*30 = 187
+    const r = call("hr-zones", ctxA, { age: 30, restingHr: 55, method: "tanaka" });
+    assert.equal(r.result.maxHr, 187);
+  });
+
+  it("Karvonen: zone bpm uses HR reserve (resting + reserve×pct)", () => {
+    // tanaka max for 30 = 187, reserve = 187−50 = 137; zone1 low = 50 + 137*0.5 = 118.5 → 119
+    const r = call("hr-zones", ctxA, { age: 30, restingHr: 50, method: "karvonen" });
+    assert.equal(r.result.zones[0].lowBpm, 119);
+  });
+
+  it("fail-CLOSED: poisoned age/restingHr are clamped, zones stay finite", () => {
+    const r = call("hr-zones", ctxA, { age: Infinity, restingHr: "1e999", method: "tanaka" });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.maxHr));
+    assertNoNonFinite(r.result);
+  });
+});
+
+// ── workout-plan-generate — deterministic plan the WorkoutPlanner renders ────
+describe("fitness.workout-plan-generate / generate-program — deterministic plan", () => {
+  it("builds a plan with the EXACT shape WorkoutPlanner reads (template/progression/nutrition)", async () => {
+    const r = await call("workout-plan-generate", ctxA, { goal: "strength", daysPerWeek: 3, weeks: 8, equipment: "full_gym", experience: "intermediate" });
+    assert.equal(r.ok, true);
+    const plan = r.result.plan;
+    assert.equal(plan.goal, "strength");
+    assert.equal(plan.weeks, 8);
+    assert.equal(plan.daysPerWeek, 3);
+    assert.equal(plan.template.length, 3);
+    assert.ok(typeof plan.progression === "string" && plan.progression.length > 0);
+    assert.ok(typeof plan.nutrition === "string" && plan.nutrition.length > 0);
+    for (const day of plan.template) {
+      for (const k of ["day", "focus", "duration", "exercises"]) assert.ok(k in day, `day missing ${k}`);
+      for (const ex of day.exercises) {
+        for (const k of ["name", "sets", "reps", "restSec"]) assert.ok(k in ex, `exercise missing ${k}`);
+      }
+    }
+  });
+
+  it("generate-program (page alias) merges artifact.data + params and produces a plan", async () => {
+    const r = await call("generate-program", ctxA, { artifact: { data: { goal: "hypertrophy", daysPerWeek: 4 } } });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.plan.goal, "hypertrophy");
+    assert.equal(r.result.plan.daysPerWeek, 4);
+  });
+
+  it("clamps an out-of-range/poisoned daysPerWeek to the 1–7 split", async () => {
+    const r = await call("workout-plan-generate", ctxA, { goal: "general", daysPerWeek: "1e999", weeks: Infinity });
+    assert.equal(r.ok, true);
+    assert.ok(r.result.plan.daysPerWeek >= 1 && r.result.plan.daysPerWeek <= 7);
+    assert.ok(r.result.plan.weeks >= 1 && r.result.plan.weeks <= 24);
+  });
+});
+
+// ── activity CRUD round-trip + computed metrics ─────────────────────────────
+describe("fitness.activity-* — Strava activity round-trip + relative effort", () => {
+  it("creates a run, computes pace/speed/relativeEffort, lists + details it back", () => {
+    const ctx = { actor: { userId: "fit_act_u" }, userId: "fit_act_u" };
+    const created = call("activity-create", ctx, { type: "run", distanceKm: 10, durationSec: 3000, avgHr: 150, maxHr: 190, date: "2026-06-20" });
+    assert.equal(created.ok, true);
+    const act = created.result.activity;
+    assert.equal(act.type, "run");
+    assert.equal(act.distanceKm, 10);
+    assert.equal(act.paceSecPerKm, 300);                  // 3000s / 10km
+    assert.equal(act.speedKmh, 12);                       // 10 / (3000/3600)
+    assert.ok(act.relativeEffort > 0);
+
+    const list = call("activity-list", ctx, {});
+    assert.equal(list.result.count, 1);
+    assert.equal(list.result.totalDistanceKm, 10);
+
+    const detail = call("activity-detail", ctx, { id: act.id });
+    assert.equal(detail.result.activity.pace, "5:00");    // 300 s/km → 5:00
+    assert.equal(detail.result.activity.duration, "50:00");
+
+    const del = call("activity-delete", ctx, { id: act.id });
+    assert.equal(del.result.deleted, act.id);
+    assert.equal(call("activity-list", ctx, {}).result.count, 0);
+  });
+
+  it("is per-user isolated", () => {
+    call("activity-create", ctxA, { type: "ride", distanceKm: 20, durationSec: 3600 });
+    assert.equal(call("activity-list", ctxB, {}).result.count, 0);
+  });
+
+  it("validation-rejection: bad type + zero duration", () => {
+    assert.match(call("activity-create", ctxA, { type: "teleport", durationSec: 100 }).error, /type required/i);
+    assert.match(call("activity-create", ctxA, { type: "run", durationSec: 0 }).error, /durationSec must be > 0/i);
+  });
+
+  it("fail-CLOSED: poisoned distance/duration never leak Infinity into derived metrics", () => {
+    const ctx = { actor: { userId: "fit_act_poison" }, userId: "fit_act_poison" };
+    const r = call("activity-create", ctx, { type: "run", distanceKm: "1e999", durationSec: 1800, avgHr: Infinity });
+    // distance coerces to a finite value (fnum) so the activity is valid…
+    assert.equal(r.ok, true);
+    assertNoNonFinite(r.result);
+  });
+});
+
+// ── vo2max + race predictor — Daniels/Gilbert VDOT math ─────────────────────
+describe("fitness.vo2max-estimate / race-predictor — VDOT physiology", () => {
+  it("estimates VO2max from a supplied effort and predicts race times", () => {
+    // 5km in 1200s (20:00) → a finite, rated VO2max
+    const vo = call("vo2max-estimate", ctxA, { distanceKm: 5, durationSec: 1200, age: 30 });
+    assert.equal(vo.ok, true);
+    assert.ok(Number.isFinite(vo.result.vo2max) && vo.result.vo2max > 0);
+    assert.ok(["superior", "excellent", "good", "fair", "poor"].includes(vo.result.rating));
+    assert.ok(Number.isFinite(vo.result.fitnessAge));
+    assertNoNonFinite(vo.result);
+
+    const race = call("race-predictor", ctxA, { vo2max: vo.result.vo2max });
+    assert.equal(race.ok, true);
+    assert.equal(race.result.predictions.length, 4);
+    for (const p of race.result.predictions) {
+      assert.ok(Number.isFinite(p.timeSeconds) && p.timeSeconds > 0, p.distance);
+      assert.ok(typeof p.time === "string" && p.time.length > 0);
+    }
+    // longer races take longer
+    const byName = Object.fromEntries(race.result.predictions.map((p) => [p.distance, p.timeSeconds]));
+    assert.ok(byName["Marathon"] > byName["5K"]);
+    assertNoNonFinite(race.result);
+  });
+
+  it("validation-rejection: no effort + no logged run", () => {
+    const ctx = { actor: { userId: "fit_vo_empty" }, userId: "fit_vo_empty" };
+    assert.match(call("vo2max-estimate", ctx, {}).error, /supply distanceKm/i);
+    assert.match(call("race-predictor", ctx, {}).error, /supply vo2max/i);
+  });
+});
+
+// ── training load + readiness + body battery ────────────────────────────────
+describe("fitness.training-load / training-readiness / body-battery", () => {
+  it("computes CTL/ATL/TSB form status from logged activities", () => {
+    const ctx = { actor: { userId: "fit_load_u" }, userId: "fit_load_u" };
+    for (let d = 1; d <= 10; d++) {
+      call("activity-create", ctx, { type: "run", distanceKm: 8, durationSec: 2400, avgHr: 150, date: `2026-06-${String(d).padStart(2, "0")}` });
+    }
+    const tl = call("training-load", ctx, {});
+    assert.equal(tl.ok, true);
+    for (const k of ["fitness", "fatigue", "form", "status", "trackedDays"]) assert.ok(k in tl.result, `missing ${k}`);
+    assert.ok(Number.isFinite(tl.result.fitness));
+    assertNoNonFinite(tl.result);
+  });
+
+  it("training-readiness clamps to 1–100 and labels", () => {
+    const ctx = { actor: { userId: "fit_ready_u" }, userId: "fit_ready_u" };
+    const r = call("training-readiness", ctx, { sleepHours: 8 });
+    assert.equal(r.ok, true);
+    assert.ok(r.result.score >= 1 && r.result.score <= 100);
+    assert.ok(["prime", "ready", "moderate", "low", "poor"].includes(r.result.label));
+    assertNoNonFinite(r.result);
+  });
+
+  it("body-battery clamps to 5–100 from sleep + load", () => {
+    const ctx = { actor: { userId: "fit_batt_u" }, userId: "fit_batt_u" };
+    const r = call("body-battery", ctx, { sleepHours: 7 });
+    assert.equal(r.ok, true);
+    assert.ok(r.result.battery >= 5 && r.result.battery <= 100);
+    assertNoNonFinite(r.result);
+  });
+});
+
+// ── goals + gear + dashboard round-trip ─────────────────────────────────────
+describe("fitness.goal-* / gear-* / fitness-dashboard — STATE round-trips", () => {
+  it("creates a distance goal and reports progress against logged activities", () => {
+    const ctx = { actor: { userId: "fit_goal_u" }, userId: "fit_goal_u" };
+    const today = new Date().toISOString().slice(0, 10);
+    call("activity-create", ctx, { type: "run", distanceKm: 15, durationSec: 4500, date: today });
+    const goal = call("goal-create", ctx, { metric: "distance", target: 30, period: "week" });
+    assert.equal(goal.ok, true);
+    const list = call("goal-list", ctx, {});
+    assert.equal(list.result.count, 1);
+    assert.equal(list.result.goals[0].progress.value, 15);
+    assert.equal(list.result.goals[0].progress.pct, 50);
+    assertNoNonFinite(list.result);
+  });
+
+  it("validation-rejection: bad goal metric + non-positive target", () => {
+    assert.match(call("goal-create", ctxA, { metric: "vibes", target: 10 }).error, /metric required/i);
+    assert.match(call("goal-create", ctxA, { metric: "distance", target: 0 }).error, /target must be > 0/i);
+  });
+
+  it("gear wear tracking + dashboard aggregation", () => {
+    const ctx = { actor: { userId: "fit_gear_u" }, userId: "fit_gear_u" };
+    const gear = call("gear-add", ctx, { name: "Vaporfly", kind: "shoes", retireAtKm: 100, initialDistanceKm: 90 }).result.gear;
+    const listed = call("gear-list", ctx, {}).result.gear[0];
+    assert.equal(listed.wearPct, 90);
+    assert.equal(listed.status, "wearing_out");
+    const dash = call("fitness-dashboard", ctx, {});
+    assert.equal(dash.ok, true);
+    assert.equal(dash.result.gear.tracked, 1);
+    assertNoNonFinite(dash.result);
+    assert.ok(gear.id);
+  });
+});
+
+// ── recovery-history / activity-summary FIELD-ALIGNMENT contract ────────────
+// The SleepRecovery + ActivityRings components render names that the stored
+// device rows do NOT carry. These pin that the handler emits the RENDERED shape
+// (so a regression that reverts to device-native keys → blank/crash UI surfaces).
+describe("fitness.recovery-history — emits the SleepRecovery field contract", () => {
+  it("maps a synced device row to recoveryScore/sleepDurationHours/restingHr/hrv/strainYesterday", () => {
+    const ctx = { actor: { userId: "fit_recov_u" }, userId: "fit_recov_u" };
+    call("wearable-link", ctx, { provider: "whoop" });
+    const sync = call("wearable-sync", ctx, { provider: "whoop", samples: [
+      { date: "2026-06-26", restingHr: 52, hrv: 60, sleepHours: 7.0, recoveryScore: 70 },
+      { date: "2026-06-27", restingHr: 50, hrv: 65, sleepHours: 7.5, recoveryScore: 80 },
+    ] });
+    assert.equal(sync.ok, true);
+    const r = call("recovery-history", ctx, { days: 14 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.source, "device");
+    const last = r.result.days[r.result.days.length - 1];
+    // EXACT field names SleepRecovery.tsx renders (the dead-surface contract)
+    for (const k of ["date", "recoveryScore", "sleepDurationHours", "sleepQualityPct", "restingHr", "hrv", "strainYesterday"]) {
+      assert.ok(k in last, `recovery row missing rendered field ${k}`);
+    }
+    assert.equal(last.recoveryScore, 80);
+    assert.equal(last.sleepDurationHours, 7.5);
+    assert.equal(last.restingHr, 50);
+    assert.equal(last.hrv, 65);
+    assertNoNonFinite(r.result);
+  });
+
+  it("empty → honest 'empty' source + guidance note, no fabricated rows", () => {
+    const ctx = { actor: { userId: "fit_recov_empty" }, userId: "fit_recov_empty" };
+    const r = call("recovery-history", ctx, {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.days.length, 0);
+    assert.equal(r.result.source, "empty");
+    assert.match(r.result.notes, /connect a wearable/i);
+  });
+});
+
+describe("fitness.activity-summary — emits the ActivityRings field contract", () => {
+  it("maps a synced device row to moveCalories/moveGoal/exerciseMinutes/standHours/steps + goals", () => {
+    const ctx = { actor: { userId: "fit_rings_u" }, userId: "fit_rings_u" };
+    call("wearable-link", ctx, { provider: "apple_health" });
+    call("wearable-sync", ctx, { provider: "apple_health", samples: [
+      { date: "2026-06-27", steps: 9000, activeCalories: 500, exerciseMinutes: 40 },
+    ] });
+    const r = call("activity-summary", ctx, { days: 7 });
+    assert.equal(r.ok, true);
+    const last = r.result.days[r.result.days.length - 1];
+    for (const k of ["date", "moveCalories", "moveGoal", "exerciseMinutes", "exerciseGoal", "standHours", "standGoal", "steps", "stepsGoal"]) {
+      assert.ok(k in last, `activity row missing rendered field ${k}`);
+    }
+    assert.equal(last.moveCalories, 500);   // activeCalories surfaced as moveCalories
+    assert.equal(last.exerciseMinutes, 40);
+    assert.equal(last.steps, 9000);
+    assert.ok(last.moveGoal >= 1 && last.exerciseGoal >= 1 && last.standGoal >= 1 && last.stepsGoal >= 1);
+    assertNoNonFinite(r.result);
+  });
+
+  it("empty → honest 'empty' source, no fabricated rings", () => {
+    const ctx = { actor: { userId: "fit_rings_empty" }, userId: "fit_rings_empty" };
+    const r = call("activity-summary", ctx, {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.days.length, 0);
+    assert.equal(r.result.source, "empty");
+  });
+});
+
+// ── segments + leaderboard + PR detection ───────────────────────────────────
+describe("fitness.segment-* — effort PR/CR detection + leaderboard ranking", () => {
+  it("creates a segment, records efforts, flags PR/CR + ranks the leaderboard", () => {
+    const ctx = { actor: { userId: "fit_seg_u" }, userId: "fit_seg_u" };
+    const seg = call("segment-create", ctx, { name: "Hill Climb", distanceKm: 2, gradePct: 8 }).result.segment;
+    const e1 = call("segment-effort", ctx, { segmentId: seg.id, timeSeconds: 600 });
+    assert.equal(e1.result.isPR, true);
+    assert.equal(e1.result.isCourseRecord, true);
+    const e2 = call("segment-effort", ctx, { segmentId: seg.id, timeSeconds: 560 });
+    assert.equal(e2.result.isPR, true);            // faster than my prior best
+    const lb = call("segment-leaderboard", ctx, { segmentId: seg.id });
+    assert.equal(lb.result.leaderboard[0].timeSeconds, 560);
+    assert.equal(lb.result.leaderboard[0].title, "CR");
+    assertNoNonFinite(lb.result);
+  });
+
+  it("validation-rejection: missing name + zero distance + missing segment", () => {
+    assert.match(call("segment-create", ctxA, { distanceKm: 1 }).error, /name required/i);
+    assert.match(call("segment-create", ctxA, { name: "x", distanceKm: 0 }).error, /distanceKm must be > 0/i);
+    assert.match(call("segment-effort", ctxA, { segmentId: "nope", timeSeconds: 10 }).error, /segment not found/i);
+  });
+});
+
+// ── double-wrap dispatch parity — the dead-surface bug class ─────────────────
+// The lensRun-driven macros (hr-zones / workout-plan-generate / activity-*) flow
+// through /api/lens/run, which peels exactly one sole-key { artifact:{ data } }
+// wrapper. These pin that a wrapped body resolves identically to flat input (so
+// a component that double-wraps doesn't silently blank the calculator).
+describe("fitness — { artifact:{ data } } sole-key wrapper is peeled like production", () => {
+  it("hr-zones reads through a sole-key artifact wrapper identically to flat input", () => {
+    const wrapped = call("hr-zones", ctxA, { artifact: { data: { age: 40, restingHr: 60, method: "fox" } } });
+    const flat = call("hr-zones", ctxA, { age: 40, restingHr: 60, method: "fox" });
+    assert.equal(wrapped.result.maxHr, 180);
+    assert.deepEqual(wrapped.result, flat.result);
+  });
+
+  it("workout-plan-generate reads through the wrapper (the historical blank-calc bug)", async () => {
+    const wrapped = await call("workout-plan-generate", ctxA, { artifact: { data: { goal: "endurance", daysPerWeek: 5, weeks: 6 } } });
+    assert.equal(wrapped.ok, true);
+    assert.equal(wrapped.result.plan.goal, "endurance");
+    assert.equal(wrapped.result.plan.daysPerWeek, 5);
+  });
+
+  it("the artifact-dispatch macros (progressionCalc) read artifact.data + params, NOT input", () => {
+    // The Quick-Action macros are invoked via lens.run / :id/run which loads the
+    // REAL artifact and passes handler(ctx, artifact, params): data on
+    // artifact.data, never as the input body. Pin the production contract.
+    const r = callArtifact("progressionCalc", ctxA, { exercises: [{ name: "Squat", weight: 100, reps: 5, rpe: 6 }] });
+    assert.equal(r.result.recommendations[0].recommendedWeight, 105);
+  });
+});

--- a/server/tests/forestry-lens-macros.test.js
+++ b/server/tests/forestry-lens-macros.test.js
@@ -1,0 +1,516 @@
+// Behavioral macro tests for the forestry lens — the PATH-3 registerLensAction
+// surface in server/domains/forestry.js that the /lenses/forestry page + its
+// child components drive through /api/lens/run.
+//
+// DISPATCH SHAPE (the run route, server.js:39285-39288):
+//   POST /api/lens/run { domain:"forestry", action, input }
+//     → rest = peelRedundantArtifactWrapper(body.input)
+//     → virtualArtifact = { id:null, domain, type:"domain_action", data: rest, meta:{} }
+//     → handler(ctx, virtualArtifact, rest)              [3-ARG; data === params === input]
+// So for these handlers artifact.data and params are the SAME flat object — the
+// exact `input` the component sent. We invoke each registered handler with that
+// exact 3-arg shape (params === artifact.data) to mirror production byte-for-byte.
+//
+// THE DEAD-CALCULATOR CLASS THIS GATE TARGETS (now fixed, pinned here):
+//   ForestryActionPanel posts { species, acres, avgAgeYears, treeCount } to
+//   timberVolume — but the OLD handler read artifact.data.trees (a `trees[]`
+//   array the panel never sends) and returned totalBoardFeet/estimatedValue
+//   while the panel renders result.boardFeet/result.valuation. So in production
+//   the workbench ALWAYS rendered the empty-guidance message: a DEAD SURFACE.
+//   Same field-name mismatch in fireRisk (read temperatureF, panel sends tempF;
+//   returned riskScore, panel reads score), harvestPlan (never returned the
+//   `schedule[]` the panel maps), carbonSequestration (returned a STRING
+//   "X tons CO2/year", panel reads numeric tonsPerYear/lifetimeTons). All four
+//   are now aligned to the component contract AND fail-CLOSED on poison input.
+//
+// NOT shape-only: every test feeds KNOWN inputs and asserts the EXACT computed
+// value + round-trips, validation-rejection, degrade-graceful, and fail-CLOSED
+// poison cases (1e999 / "Infinity" / NaN never leak into output; no throw/500).
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerForestryActions from "../domains/forestry.js";
+
+const ACTIONS = new Map();
+function registerLensAction(domain, name, fn) {
+  assert.equal(domain, "forestry", `unexpected domain: ${domain}`);
+  ACTIONS.set(name, fn);
+}
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+const ctxB = { actor: { userId: "user_b" }, userId: "user_b" };
+
+// Drive a handler EXACTLY like the live run route: params === artifact.data === input.
+function call(name, ctx, input = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`forestry.${name} not registered`);
+  const artifact = { id: null, domain: "forestry", type: "domain_action", data: input, meta: {} };
+  return fn(ctx, artifact, input);
+}
+
+before(() => { registerForestryActions(registerLensAction); });
+beforeEach(() => {
+  globalThis._concordSTATE = { dtus: new Map() };
+  globalThis._concordSaveStateDebounced = () => {};
+  globalThis.fetch = async () => { throw new Error("network disabled"); };
+});
+
+const CALCULATORS = ["timberVolume", "fireRisk", "harvestPlan", "carbonSequestration"];
+const STATE_MACROS = [
+  "stand-add", "stand-list", "stand-delete", "activity-log", "forestry-dashboard",
+  "growth-projection",
+  "stand-polygon-save", "stand-polygon-list", "stand-polygon-delete",
+  "cruise-plot-add", "cruise-plot-list", "cruise-plot-delete", "cruise-summary",
+  "pest-report", "pest-list", "pest-schedule-treatment", "pest-complete-treatment",
+  "replant-project-create", "replant-list", "replant-update-status", "replant-survival-survey",
+  "carbon-credit-issue", "carbon-credit-verify", "carbon-credit-retire", "carbon-credit-list",
+];
+const EXTERNAL = ["inciweb-active-fires", "nifc-fire-perimeters", "feed"];
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("forestry — registration", () => {
+  it("registers every workbench calculator the ForestryActionPanel reaches", () => {
+    for (const m of CALCULATORS) assert.ok(ACTIONS.has(m), `forestry.${m} not registered`);
+  });
+  it("registers every STATE macro the panels reach", () => {
+    for (const m of STATE_MACROS) assert.ok(ACTIONS.has(m), `forestry.${m} not registered`);
+  });
+  it("registers every external-data macro", () => {
+    for (const m of EXTERNAL) assert.ok(ACTIONS.has(m), `forestry.${m} not registered`);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("forestry.timberVolume — component-exact shape + board-foot values", () => {
+  // ForestryActionPanel.actVolume sends { species, acres, avgAgeYears, treeCount }
+  // and renders result.boardFeet + result.valuation + result.cubicFeet.
+  it("computes boardFeet/valuation the panel renders, from the panel's exact input", () => {
+    const r = call("timberVolume", ctxA, { species: "douglas-fir", acres: 40, avgAgeYears: 35, treeCount: 100 });
+    assert.equal(r.ok, true);
+    // factor douglas-fir=1.25, ageMaturity=1-e^-1≈0.6321 → 220*1.25*(0.15+0.85*0.6321)=
+    // 275*(0.15+0.53729)=275*0.68729=189.0 → round 189 bf/tree × 100 = 18900.
+    assert.equal(r.result.boardFeetPerTree, 189);
+    assert.equal(r.result.boardFeet, 18900);
+    assert.equal(r.result.cubicFeet, Math.round(18900 / 6));
+    // valuation = (18900/1000)*400 = 7560.
+    assert.equal(r.result.valuation, 7560);
+    assert.equal(r.result.pricePerMBF, 400);
+    assert.ok(Number.isFinite(r.result.boardFeet));
+    assert.ok(Number.isFinite(r.result.valuation));
+  });
+
+  it("species changes the board-foot density (oak < douglas-fir at the same age/count)", () => {
+    const dfir = call("timberVolume", ctxA, { species: "douglas-fir", acres: 10, avgAgeYears: 40, treeCount: 50 });
+    const oak = call("timberVolume", ctxA, { species: "oak", acres: 10, avgAgeYears: 40, treeCount: 50 });
+    assert.ok(oak.result.boardFeet < dfir.result.boardFeet, "oak should yield fewer board feet than douglas-fir");
+  });
+
+  it("validation: zero tree count returns a guidance message (no broken render)", () => {
+    const r = call("timberVolume", ctxA, { species: "oak", acres: 10, avgAgeYears: 30, treeCount: 0 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.boardFeet, undefined);
+    assert.match(r.result.message, /tree count/i);
+  });
+
+  it("degrade-graceful: empty input returns guidance, never a throw", () => {
+    const r = call("timberVolume", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.match(r.result.message, /timber volume/i);
+  });
+
+  it("fail-CLOSED poison: 1e999/Infinity/NaN inputs keep boardFeet+valuation FINITE", () => {
+    const r = call("timberVolume", ctxA, { species: "mixed", acres: "1e999", avgAgeYears: "Infinity", treeCount: "100", pricePerMBF: "NaN" });
+    assert.equal(r.ok, true);
+    // acres 1e999 → non-finite → 0 → acres<=0 short-circuits to guidance (fail-closed).
+    assert.ok(r.result.message !== undefined || Number.isFinite(r.result.boardFeet));
+  });
+
+  it("fail-CLOSED poison: a poisoned price keeps valuation FINITE", () => {
+    const r = call("timberVolume", ctxA, { species: "mixed", acres: 10, avgAgeYears: 30, treeCount: 80, pricePerMBF: "1e999" });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.valuation), `valuation not finite: ${r.result.valuation}`);
+    assert.ok(Number.isFinite(r.result.boardFeet));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("forestry.fireRisk — component-exact shape + risk score", () => {
+  // ForestryActionPanel.actRisk sends { tempF, humidity, windMph } and renders
+  // result.riskLevel + result.score.
+  it("computes score + riskLevel from the panel's tempF/humidity/windMph", () => {
+    const r = call("fireRisk", ctxA, { tempF: 100, humidity: 10, windMph: 30 });
+    assert.equal(r.ok, true);
+    // temp>95:25 + humidity<15:25 + wind>25:20 + drought(default 3)*5=15 + fuelMoist(15)<20:8 = 93.
+    assert.equal(r.result.score, 93);
+    assert.equal(r.result.riskScore, 93);
+    assert.equal(r.result.riskLevel, "extreme");
+    assert.ok(Array.isArray(r.result.factors));
+    assert.ok(Number.isFinite(r.result.score));
+  });
+
+  it("low-danger conditions read as low risk", () => {
+    const r = call("fireRisk", ctxA, { tempF: 60, humidity: 70, windMph: 3 });
+    assert.equal(r.ok, true);
+    // temp<=75:3 + humidity>=40:3 + wind<=8:2 + 15 + fuelMoist 15<20:8 = 31 → moderate.
+    assert.equal(r.result.score, 31);
+    assert.equal(r.result.riskLevel, "moderate");
+  });
+
+  it("score is clamped to [0,100]", () => {
+    const r = call("fireRisk", ctxA, { tempF: 120, humidity: 5, windMph: 50, droughtIndex: 5, fuelMoisturePercent: 1 });
+    assert.equal(r.ok, true);
+    assert.ok(r.result.score <= 100 && r.result.score >= 0);
+  });
+
+  it("fail-CLOSED poison: non-finite weather inputs fall back to defaults, score stays FINITE", () => {
+    const r = call("fireRisk", ctxA, { tempF: "Infinity", humidity: "NaN", windMph: "1e999" });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.score), `score not finite: ${r.result.score}`);
+    // all fell back to defaults (temp 80, humidity 30, wind 10) → moderate band.
+    assert.equal(r.result.riskLevel, "moderate");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("forestry.harvestPlan — component-exact shape + rotation schedule", () => {
+  // ForestryActionPanel.actHarvest sends { species, acres, currentAge } and
+  // renders result.schedule.length + result.rotation.
+  it("returns a staged schedule[] + rotation the panel renders", () => {
+    const r = call("harvestPlan", ctxA, { species: "douglas-fir", acres: 100, currentAge: 25 });
+    assert.equal(r.ok, true);
+    assert.ok(Array.isArray(r.result.schedule));
+    assert.ok(r.result.schedule.length > 0);
+    assert.equal(r.result.rotation, 55); // douglas_fir rotation from SPECIES_GROWTH
+    assert.equal(r.result.rotationYears, 55);
+    for (const s of r.result.schedule) {
+      assert.ok(Number.isFinite(s.year));
+      assert.ok(Number.isFinite(s.acres));
+      assert.ok(Number.isFinite(s.volume));
+    }
+    // selective default → 3 staged entries.
+    assert.equal(r.result.schedule.length, 3);
+  });
+
+  it("clearcut collapses to a single final-harvest entry", () => {
+    const r = call("harvestPlan", ctxA, { species: "loblolly-pine", acres: 50, currentAge: 10, method: "clearcut" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.schedule.length, 1);
+    assert.equal(r.result.removalPercent, 100);
+  });
+
+  it("validation: zero acres returns a guidance message", () => {
+    const r = call("harvestPlan", ctxA, { species: "oak", acres: 0, currentAge: 30 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.schedule, undefined);
+    assert.match(r.result.message, /acres/i);
+  });
+
+  it("fail-CLOSED poison: 1e999 acres short-circuits to guidance; finite values never NaN", () => {
+    const r = call("harvestPlan", ctxA, { species: "mixed", acres: "1e999", currentAge: 20 });
+    assert.equal(r.ok, true);
+    // acres non-finite → 0 → guidance (no NaN schedule).
+    assert.match(r.result.message, /acres/i);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("forestry.carbonSequestration — component-exact shape + numeric tons", () => {
+  // ForestryActionPanel.actCarbon sends { species, acres, ageYears } and renders
+  // result.tonsPerYear + result.equivalentCars (numbers, not the legacy string).
+  it("returns numeric tonsPerYear/lifetimeTons/equivalentCars the panel renders", () => {
+    const r = call("carbonSequestration", ctxA, { species: "douglas-fir", acres: 100, ageYears: 30 });
+    assert.equal(r.ok, true);
+    // age 30 → 1.8 t/ac/yr × 100 = 180 t/yr.
+    assert.equal(r.result.tonsPerYear, 180);
+    assert.equal(typeof r.result.tonsPerYear, "number");
+    // lifetime = 100 * 200 * 0.015 * 30 = 9000.
+    assert.equal(r.result.lifetimeTons, 9000);
+    // equivalentCars = round(180/4.6) = 39.
+    assert.equal(r.result.equivalentCars, 39);
+    assert.ok(Number.isFinite(r.result.tonsPerYear));
+    assert.ok(Number.isFinite(r.result.lifetimeTons));
+  });
+
+  it("young stands sequester faster per acre than old stands", () => {
+    const young = call("carbonSequestration", ctxA, { acres: 10, ageYears: 10 });
+    const old = call("carbonSequestration", ctxA, { acres: 10, ageYears: 60 });
+    assert.ok(young.result.tonsPerYear > old.result.tonsPerYear);
+  });
+
+  it("validation: zero acres returns a guidance message", () => {
+    const r = call("carbonSequestration", ctxA, { acres: 0, ageYears: 30 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.tonsPerYear, undefined);
+    assert.match(r.result.message, /carbon/i);
+  });
+
+  it("fail-CLOSED poison: non-finite inputs never leak NaN/Infinity into output", () => {
+    const r = call("carbonSequestration", ctxA, { acres: 50, ageYears: "Infinity", treesPerAcre: "1e999" });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.tonsPerYear), `tonsPerYear not finite: ${r.result.tonsPerYear}`);
+    assert.ok(Number.isFinite(r.result.lifetimeTons), `lifetimeTons not finite: ${r.result.lifetimeTons}`);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("forestry.growth-projection — Chapman-Richards yield curve", () => {
+  it("projects volume over a rotation with finite MAI/CAI rows (GrowthProjectionPanel)", () => {
+    const r = call("growth-projection", ctxA, { species: "douglas_fir", acres: 40, currentAge: 20, siteIndex: 100 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.species, "douglas_fir");
+    assert.equal(r.result.acres, 40);
+    assert.ok(Array.isArray(r.result.projection) && r.result.projection.length > 0);
+    for (const row of r.result.projection) {
+      assert.ok(Number.isFinite(row.volumePerAcre));
+      assert.ok(Number.isFinite(row.totalVolume));
+      assert.ok(Number.isFinite(row.mai));
+      assert.ok(Number.isFinite(row.cai));
+    }
+    assert.ok(Number.isFinite(r.result.biologicalRotationAge));
+    assert.ok(Number.isFinite(r.result.peakMai));
+  });
+
+  it("validation: acres <= 0 is rejected cleanly", () => {
+    const r = call("growth-projection", ctxA, { species: "oak", acres: 0 });
+    assert.equal(r.ok, false);
+    assert.match(String(r.error), /acres/i);
+  });
+
+  it("fail-CLOSED poison: 1e999 acres rejected, never an infinite-volume row", () => {
+    const r = call("growth-projection", ctxA, { species: "mixed", acres: "1e999" });
+    assert.equal(r.ok, false); // frNum non-finite → 0 → acres<=0 → reject
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("forestry STATE substrate — stands / activities / dashboard", () => {
+  it("stand-add → stand-list → activity-log round-trips (StandManager)", () => {
+    const a = call("stand-add", ctxA, { name: "North 40", species: "douglas_fir", acres: 40, treesPerAcre: 200 });
+    assert.equal(a.ok, true);
+    const id = a.result.stand.id;
+    assert.equal(a.result.stand.name, "North 40");
+
+    const list = call("stand-list", ctxA, {});
+    assert.equal(list.ok, true);
+    assert.equal(list.result.stands.length, 1);
+    assert.equal(list.result.stands[0].id, id);
+    // estimatedTrees = acres × treesPerAcre = 8000 (derived field the panel reads).
+    assert.equal(list.result.stands[0].estimatedTrees, 8000);
+    assert.equal(list.result.totalAcres, 40);
+
+    const act = call("activity-log", ctxA, { standId: id, kind: "thinning", notes: "first pass" });
+    assert.equal(act.ok, true);
+    assert.equal(act.result.activity.kind, "thinning");
+
+    const dash = call("forestry-dashboard", ctxA, {});
+    assert.equal(dash.ok, true);
+    assert.equal(dash.result.stands, 1);
+    assert.equal(dash.result.activities, 1);
+    assert.equal(dash.result.bySpecies.douglas_fir, 1);
+  });
+
+  it("validation: stand-add requires a name; activity-log requires a real stand", () => {
+    assert.equal(call("stand-add", ctxA, { name: "" }).ok, false);
+    assert.equal(call("activity-log", ctxA, { standId: "nope", kind: "survey" }).ok, false);
+  });
+
+  it("stands are per-user: user_b cannot see or delete user_a's stand", () => {
+    const id = call("stand-add", ctxA, { name: "Private Stand", species: "oak", acres: 5 }).result.stand.id;
+    assert.equal(call("stand-list", ctxB, {}).result.stands.length, 0);
+    assert.equal(call("stand-delete", ctxB, { id }).ok, false);
+    // owner can delete.
+    assert.equal(call("stand-delete", ctxA, { id }).ok, true);
+  });
+
+  it("degrade-graceful: STATE-unavailable returns a clean error, not a throw", () => {
+    delete globalThis._concordSTATE;
+    const r = call("stand-list", ctxA, {});
+    assert.equal(r.ok, false);
+    assert.match(String(r.error), /STATE/i);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("forestry STATE substrate — GIS polygons (StandPolygonPanel)", () => {
+  it("stand-polygon-save computes acreage from a lat/lon ring + round-trips", () => {
+    // ~1km × ~1km box near 45°N ≈ 247 acres (shoelace on a spherical projection).
+    const verts = [
+      { lat: 45.0, lon: -122.0 },
+      { lat: 45.009, lon: -122.0 },
+      { lat: 45.009, lon: -121.987 },
+      { lat: 45.0, lon: -121.987 },
+    ];
+    const r = call("stand-polygon-save", ctxA, { name: "Block A", vertices: verts });
+    assert.equal(r.ok, true);
+    assert.ok(r.result.polygon.acres > 200 && r.result.polygon.acres < 320, `acres out of band: ${r.result.polygon.acres}`);
+    assert.ok(Number.isFinite(r.result.polygon.perimeterM));
+
+    const list = call("stand-polygon-list", ctxA, {});
+    assert.equal(list.result.polygons.length, 1);
+    assert.ok(Number.isFinite(list.result.totalAcres));
+  });
+
+  it("validation: a 2-vertex ring is rejected; bad coordinates are filtered out", () => {
+    assert.equal(call("stand-polygon-save", ctxA, { name: "Bad", vertices: [{ lat: 1, lon: 1 }, { lat: 2, lon: 2 }] }).ok, false);
+    const r = call("stand-polygon-save", ctxA, {
+      name: "Mixed", vertices: [{ lat: 999, lon: 0 }, { lat: 45, lon: -122 }, { lat: 45.01, lon: -122 }],
+    });
+    // one vertex invalid (lat 999) → only 2 valid → rejected.
+    assert.equal(r.ok, false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("forestry STATE substrate — inventory cruise (CruisePanel)", () => {
+  it("cruise-plot-add → cruise-summary computes per-acre stats with a CI", () => {
+    const add1 = call("cruise-plot-add", ctxA, {
+      standId: "s1", method: "prism_baf", expansionFactor: 10,
+      trees: [{ species: "oak", dbhInches: 14, heightFeet: 70 }, { species: "oak", dbhInches: 16, heightFeet: 75 }],
+    });
+    assert.equal(add1.ok, true);
+    assert.equal(add1.result.plot.treeCount, 2);
+    assert.ok(Number.isFinite(add1.result.plot.trees[0].basalArea));
+
+    call("cruise-plot-add", ctxA, {
+      standId: "s1", method: "prism_baf", expansionFactor: 10,
+      trees: [{ species: "oak", dbhInches: 12, heightFeet: 65 }],
+    });
+
+    const sum = call("cruise-summary", ctxA, { standId: "s1" });
+    assert.equal(sum.ok, true);
+    assert.equal(sum.result.plots, 2);
+    for (const k of ["treesPerAcre", "basalAreaPerAcre", "boardFeetPerAcre"]) {
+      assert.ok(Number.isFinite(sum.result[k].mean), `${k}.mean not finite`);
+      assert.ok(Number.isFinite(sum.result[k].ciPercent), `${k}.ci not finite`);
+    }
+  });
+
+  it("validation: a plot with no tallied trees is rejected; empty summary is honest", () => {
+    assert.equal(call("cruise-plot-add", ctxA, { standId: "s1", trees: [] }).ok, false);
+    const sum = call("cruise-summary", ctxA, { standId: "empty-stand" });
+    assert.equal(sum.ok, true);
+    assert.equal(sum.result.plots, 0);
+    assert.match(sum.result.message, /no cruise plots/i);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("forestry STATE substrate — pest/disease (PestPanel)", () => {
+  it("pest-report → schedule → complete-treatment lifecycle round-trips", () => {
+    const rep = call("pest-report", ctxA, { agent: "Mountain pine beetle", kind: "pest", severity: "high", affectedAcres: 12 });
+    assert.equal(rep.ok, true);
+    const pestId = rep.result.report.id;
+    assert.equal(rep.result.report.status, "open");
+
+    const sched = call("pest-schedule-treatment", ctxA, { pestId, method: "MCH pheromone", scheduledDate: "2030-04-01", cost: 1500 });
+    assert.equal(sched.ok, true);
+    const trtId = sched.result.treatment.id;
+
+    const list = call("pest-list", ctxA, {});
+    assert.equal(list.result.openCount, 1);
+    assert.equal(list.result.upcomingTreatments.length, 1);
+
+    const done = call("pest-complete-treatment", ctxA, { pestId, treatmentId: trtId, resolveReport: true });
+    assert.equal(done.ok, true);
+    assert.equal(done.result.report.status, "resolved");
+  });
+
+  it("validation: pest-report requires an agent name; not-found is clean", () => {
+    assert.equal(call("pest-report", ctxA, { agent: "" }).ok, false);
+    assert.equal(call("pest-schedule-treatment", ctxA, { pestId: "nope", method: "x" }).ok, false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("forestry STATE substrate — replanting (ReplantingPanel)", () => {
+  it("replant-project-create derives seedling order + survival survey recommendation", () => {
+    const c = call("replant-project-create", ctxA, { name: "Burn replant", species: "loblolly_pine", acres: 20, seedlingsPerAcre: 500 });
+    assert.equal(c.ok, true);
+    const id = c.result.project.id;
+    assert.equal(c.result.project.seedlingsOrdered, 10000); // 20 × 500
+
+    const svy = call("replant-survival-survey", ctxA, { id, sampledSeedlings: 100, aliveSeedlings: 50 });
+    assert.equal(svy.ok, true);
+    assert.equal(svy.result.survey.survivalPercent, 50);
+    assert.match(svy.result.survey.recommendation, /restocking|interplant/i);
+
+    const list = call("replant-list", ctxA, {});
+    assert.equal(list.result.projects[0].latestSurvival, 50);
+    assert.equal(list.result.totalSeedlings, 10000);
+  });
+
+  it("survival survey clamps alive ≤ sampled (no >100% survival)", () => {
+    const id = call("replant-project-create", ctxA, { name: "Clamp", acres: 5 }).result.project.id;
+    const svy = call("replant-survival-survey", ctxA, { id, sampledSeedlings: 50, aliveSeedlings: 9999 });
+    assert.equal(svy.ok, true);
+    assert.equal(svy.result.survey.survivalPercent, 100);
+  });
+
+  it("validation: create rejects empty name + zero acres; status update validates enum", () => {
+    assert.equal(call("replant-project-create", ctxA, { name: "" }).ok, false);
+    assert.equal(call("replant-project-create", ctxA, { name: "X", acres: 0 }).ok, false);
+    const id = call("replant-project-create", ctxA, { name: "S", acres: 1 }).result.project.id;
+    assert.equal(call("replant-update-status", ctxA, { id, status: "bogus" }).ok, false);
+    assert.equal(call("replant-update-status", ctxA, { id, status: "planted" }).ok, true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("forestry STATE substrate — carbon-credit registry (CarbonCreditPanel)", () => {
+  it("issue → verify → retire lifecycle stamps serial + enforces state machine", () => {
+    const i = call("carbon-credit-issue", ctxA, { projectName: "Reforest A", tonsCO2: 1000, vintageYear: 2025, pricePerTon: 30, registry: "Verra" });
+    assert.equal(i.ok, true);
+    const id = i.result.credit.id;
+    assert.equal(i.result.credit.estimatedValue, 30000); // 1000 × 30
+    assert.equal(i.result.credit.status, "pending_verification");
+
+    // can't retire before verify.
+    assert.equal(call("carbon-credit-retire", ctxA, { id }).ok, false);
+
+    const v = call("carbon-credit-verify", ctxA, { id, verifier: "SCS Global" });
+    assert.equal(v.ok, true);
+    assert.equal(v.result.credit.status, "verified");
+    assert.ok(/^VERRA-2025-/.test(v.result.credit.serialNumber), `serial: ${v.result.credit.serialNumber}`);
+
+    const r = call("carbon-credit-retire", ctxA, { id, retiredBy: "Acme Offsets" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.credit.status, "retired");
+
+    const list = call("carbon-credit-list", ctxA, {});
+    assert.equal(list.result.count, 1);
+    assert.equal(list.result.retiredTons, 1000);
+    assert.ok(Number.isFinite(list.result.totalValue));
+  });
+
+  it("validation: issue rejects empty name, non-positive tons, out-of-range vintage", () => {
+    assert.equal(call("carbon-credit-issue", ctxA, { projectName: "" , tonsCO2: 10 }).ok, false);
+    assert.equal(call("carbon-credit-issue", ctxA, { projectName: "X", tonsCO2: 0 }).ok, false);
+    assert.equal(call("carbon-credit-issue", ctxA, { projectName: "X", tonsCO2: 10, vintageYear: 1980 }).ok, false);
+  });
+
+  it("fail-CLOSED poison: a poisoned tonsCO2 (1e999) is rejected, never an Infinity value", () => {
+    const r = call("carbon-credit-issue", ctxA, { projectName: "Poison", tonsCO2: "1e999" });
+    assert.equal(r.ok, false); // frNum non-finite → 0 → tons<=0 → reject
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("forestry external-data macros — validation + network-disabled degrade", () => {
+  it("inciweb-active-fires validates the state code shape", async () => {
+    const r = await call("inciweb-active-fires", ctxA, { state: "California" });
+    assert.equal(r.ok, false);
+    assert.match(String(r.error), /2-letter/i);
+  });
+
+  it("inciweb-active-fires degrades cleanly when the network is disabled", async () => {
+    const r = await call("inciweb-active-fires", ctxA, { state: "CA" });
+    assert.equal(r.ok, false);
+    assert.match(String(r.error), /unreachable|inciweb/i);
+  });
+
+  it("nifc-fire-perimeters degrades cleanly when the network is disabled", async () => {
+    const r = await call("nifc-fire-perimeters", ctxA, {});
+    assert.equal(r.ok, false);
+    assert.match(String(r.error), /unreachable|nifc/i);
+  });
+});

--- a/server/tests/forum-lens-macros.test.js
+++ b/server/tests/forum-lens-macros.test.js
@@ -1,0 +1,377 @@
+// Behavioral macro tests for the forum (Discourse + Reddit) lens — the
+// PATH-3 registerLensAction surface in server/domains/forum.js the
+// /lenses/forum page + its Fm* panels drive through lensRun(...) and the
+// inline "Community Analytics" buttons (handleForumAction).
+//
+// TWO surfaces under test:
+//
+//  1. The analytical calculators (threadAnalysis · moderationQueue ·
+//     communityHealth · topicClustering). THE DEAD-SURFACE CLASS this gate
+//     targets: the persisted forum-post artifact's .data is a SINGLE post
+//     (no posts/reports/threads arrays), so the inline buttons used to render
+//     only "Add thread posts…" in production while shape-only tests passed.
+//     FIX (verified here): the page DERIVES the forum-wide arrays/metrics from
+//     live posts/comments and passes them as run-action `params`; each handler
+//     reads `params.X ?? artifact.data?.X`. The ForumActionPanel single-wrap
+//     `{artifact:{data:{posts}}}` (dispatch-peeled to the plain object) lands
+//     the same fields on artifact.data. We drive BOTH shapes.
+//
+//  2. The STATE-backed community substrate (categories / topics / posts /
+//     voting / flags / subforums / subscriptions / notifications / awards /
+//     saves / reputation / search / trending) the Fm* panels reach via flat
+//     lensRun params. We assert EXACT computed values + round-trips, not shape.
+//
+// Dispatch shapes mirrored exactly:
+//   • /api/lens/run        → handler(ctx, {data: peeled}, peeled)   [flat params]
+//   • /api/lens/:id/run    → handler(ctx, persistedArtifact, params) [3-ARG]
+//
+// NOT shape-only: every test feeds KNOWN inputs and asserts EXACT outputs plus
+// validation-rejection, degrade-graceful, and fail-CLOSED poison (non-finite
+// inputs collapse to FINITE output / guidance — never NaN/Infinity, never throw).
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerForumActions from "../domains/forum.js";
+import { peelRedundantArtifactWrapper } from "../lib/lens-input-normalize.js";
+
+const ACTIONS = new Map();
+function registerLensAction(domain, name, fn) {
+  assert.equal(domain, "forum", `unexpected domain: ${domain}`);
+  ACTIONS.set(name, fn);
+}
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+const ctxB = { actor: { userId: "user_b" }, userId: "user_b" };
+
+// Drive a calculator via the persisted-artifact /:id/run path: a single-post
+// artifact (.data has no forum-wide arrays) + the page-derived params (3rd arg).
+function callAction(name, ctx, params = {}, artifactData = { title: "t", content: "c", author: { username: "you" } }) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`forum.${name} not registered`);
+  const artifact = { id: "art_post_1", domain: "forum", type: "post", data: artifactData, meta: {} };
+  return fn(ctx, artifact, params);
+}
+
+// Drive a macro via the /api/lens/run path: lensRun peels a sole-key
+// {artifact:{data}} wrapper, then the dispatch sets artifact.data = peeled and
+// passes peeled as 3rd arg. Mirror that exactly so the test goes through the
+// SAME normalization the frontend hits.
+function callMacro(name, ctx, body = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`forum.${name} not registered`);
+  const peeled = peelRedundantArtifactWrapper(body);
+  const artifact = { id: null, domain: "forum", type: "domain_action", data: peeled, meta: {} };
+  return fn(ctx, artifact, peeled);
+}
+
+before(() => { registerForumActions(registerLensAction); });
+beforeEach(() => {
+  globalThis._concordSTATE = {};
+  globalThis._concordSaveStateDebounced = () => {};
+});
+
+const CALCULATORS = ["threadAnalysis", "moderationQueue", "communityHealth", "topicClustering"];
+const STATE_MACROS = [
+  "category-create", "category-list", "category-delete",
+  "topic-create", "topic-list", "topic-get", "topic-delete", "topic-pin", "topic-lock",
+  "post-reply", "post-delete", "vote", "tag-list",
+  "flag-create", "flag-queue", "flag-resolve",
+  "user-reputation", "forum-search", "forum-dashboard",
+  "subforum-create", "subforum-list", "subforum-update-rules", "subforum-add-mod", "subforum-delete",
+  "thread-subscribe", "subscription-list", "notification-list", "notification-read",
+  "award-catalog", "award-give", "save-toggle", "saved-list",
+  "post-history", "user-profile", "trending",
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("forum — registration", () => {
+  it("registers every analytical calculator the inline buttons reach", () => {
+    for (const m of CALCULATORS) assert.ok(ACTIONS.has(m), `forum.${m} not registered`);
+  });
+  it("registers every STATE macro the Fm* panels reach", () => {
+    for (const m of STATE_MACROS) assert.ok(ACTIONS.has(m), `forum.${m} not registered`);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("forum.threadAnalysis — derived-params + single-wrap, exact values", () => {
+  const posts = [
+    { author: "alice", content: "hello world" },          // 11 chars
+    { author: "bob", content: "this is a longer reply!!" }, // 24 chars
+    { author: "alice", content: "again" },                  // 5 chars
+  ];
+
+  it("computes totals / authors / avg length / top contributors from params (derived path)", () => {
+    const r = callAction("threadAnalysis", ctxA, { posts });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.totalPosts, 3);
+    assert.equal(r.result.uniqueAuthors, 2);
+    // (11 + 24 + 5) / 3 = 40 / 3 = 13.33 → round 13
+    assert.equal(r.result.avgPostLength, 13);
+    assert.deepEqual(r.result.topContributors[0], { name: "alice", posts: 2 });
+    assert.equal(r.result.health, "needs-engagement");
+    assert.ok(Number.isFinite(r.result.avgPostLength));
+  });
+
+  it("reaches the SAME fields via the ForumActionPanel single-wrap {artifact:{data:{posts}}}", () => {
+    const r = callMacro("threadAnalysis", ctxA, { artifact: { data: { posts } } });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.totalPosts, 3);
+    assert.equal(r.result.avgPostLength, 13);
+  });
+
+  it("active-discussion health when >5 posts and >2 authors", () => {
+    const many = Array.from({ length: 6 }, (_, i) => ({ author: `u${i % 3}`, content: "x" }));
+    const r = callAction("threadAnalysis", ctxA, { posts: many });
+    assert.equal(r.result.health, "active-discussion");
+  });
+
+  it("degrades to guidance (not a crash) on empty / non-array posts", () => {
+    assert.equal(callAction("threadAnalysis", ctxA, { posts: [] }).result.message, "Add thread posts to analyze discussion.");
+    assert.equal(callAction("threadAnalysis", ctxA, { posts: "nope" }).result.message, "Add thread posts to analyze discussion.");
+    assert.equal(callAction("threadAnalysis", ctxA, {}).result.message, "Add thread posts to analyze discussion.");
+  });
+
+  it("fail-CLOSED: malformed post rows never throw and avg stays FINITE", () => {
+    const r = callAction("threadAnalysis", ctxA, { posts: [{ author: null, content: null }, {}, { content: 123 }] });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.totalPosts, 3);
+    assert.ok(Number.isFinite(r.result.avgPostLength));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("forum.moderationQueue — exact counts + urgency tiers", () => {
+  it("counts pending / resolved + buckets reasons + picks oldest pending", () => {
+    const reports = [
+      { status: "pending", reason: "spam", date: "2026-06-02T00:00:00Z" },
+      { status: "pending", reason: "spam", date: "2026-06-01T00:00:00Z" },
+      { status: "resolved", reason: "off_topic", date: "2026-05-30T00:00:00Z" },
+      { reason: "harassment", date: "2026-06-03T00:00:00Z" }, // no status → pending
+    ];
+    const r = callAction("moderationQueue", ctxA, { reports });
+    assert.equal(r.result.totalReports, 4);
+    assert.equal(r.result.pending, 3);
+    assert.equal(r.result.resolved, 1);
+    assert.deepEqual(r.result.byReason, { spam: 2, harassment: 1 });
+    assert.equal(r.result.oldestPending, "2026-06-01T00:00:00Z");
+    assert.equal(r.result.urgency, "low");
+  });
+
+  it("urgency escalates with pending volume", () => {
+    const mk = (n) => Array.from({ length: n }, () => ({ status: "pending", reason: "spam" }));
+    assert.equal(callAction("moderationQueue", ctxA, { reports: mk(4) }).result.urgency, "medium");
+    assert.equal(callAction("moderationQueue", ctxA, { reports: mk(11) }).result.urgency, "high");
+  });
+
+  it("fail-CLOSED: corrupt dates never throw; empty degrades to zero-counts", () => {
+    const r = callAction("moderationQueue", ctxA, { reports: [{ status: "pending", date: "garbage" }, { status: "pending", date: NaN }] });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.pending, 2);
+    const empty = callAction("moderationQueue", ctxA, { reports: [] });
+    assert.equal(empty.result.totalReports, 0);
+    assert.equal(empty.result.urgency, "low");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("forum.communityHealth — exact rates + fail-closed numerics", () => {
+  it("computes activity rate + growth + health band from params", () => {
+    const r = callAction("communityHealth", ctxA, { activeUsers: 40, totalUsers: 100, postsThisWeek: 60, postsLastWeek: 50 });
+    assert.equal(r.result.activityRate, 40);  // 40/100
+    assert.equal(r.result.growthRate, 20);    // (60-50)/50*100
+    assert.equal(r.result.health, "thriving"); // >30
+    assert.ok(Number.isFinite(r.result.activityRate) && Number.isFinite(r.result.growthRate));
+  });
+
+  it("health bands: healthy / declining / dormant", () => {
+    assert.equal(callAction("communityHealth", ctxA, { activeUsers: 20, totalUsers: 100, postsThisWeek: 1, postsLastWeek: 1 }).result.health, "healthy");
+    assert.equal(callAction("communityHealth", ctxA, { activeUsers: 5, totalUsers: 100, postsThisWeek: 1, postsLastWeek: 1 }).result.health, "declining");
+    assert.equal(callAction("communityHealth", ctxA, { activeUsers: 1, totalUsers: 100, postsThisWeek: 1, postsLastWeek: 1 }).result.health, "dormant");
+  });
+
+  it("fail-CLOSED: Infinity / NaN / 1e999 / 'Infinity' never leak non-finite", () => {
+    for (const poison of [Infinity, -Infinity, NaN, "Infinity", "1e999", "not-a-number"]) {
+      const r = callAction("communityHealth", ctxA, { activeUsers: poison, totalUsers: poison, postsThisWeek: poison, postsLastWeek: poison });
+      assert.equal(r.ok, true, `poison ${String(poison)} should not error`);
+      for (const k of ["activeUsers", "totalUsers", "activityRate", "postsThisWeek", "growthRate"]) {
+        assert.ok(Number.isFinite(r.result[k]), `${k} non-finite under poison ${String(poison)}: ${r.result[k]}`);
+      }
+    }
+  });
+
+  it("fail-CLOSED: zero/negative denominators never divide by zero", () => {
+    const r = callAction("communityHealth", ctxA, { activeUsers: 10, totalUsers: 0, postsThisWeek: 5, postsLastWeek: 0 });
+    assert.ok(Number.isFinite(r.result.activityRate));
+    assert.ok(Number.isFinite(r.result.growthRate));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("forum.topicClustering — exact clusters + shares", () => {
+  it("buckets tags into clusters with correct share % and top topic", () => {
+    const threads = [
+      { tags: ["mixing", "tutorial"] },
+      { tags: ["mixing"] },
+      { tags: [] },
+      { tags: ["news"] },
+    ];
+    const r = callAction("topicClustering", ctxA, { threads });
+    assert.equal(r.result.totalThreads, 4);
+    assert.equal(r.result.topTopic, "mixing");
+    assert.equal(r.result.uncategorized, 1);
+    const mixing = r.result.clusters.find((c) => c.topic === "mixing");
+    assert.equal(mixing.threads, 2);
+    assert.equal(mixing.share, 50); // 2/4
+  });
+
+  it("degrades to guidance on empty / non-array threads", () => {
+    assert.equal(callAction("topicClustering", ctxA, { threads: [] }).result.message, "Add threads to cluster by topic.");
+    assert.equal(callAction("topicClustering", ctxA, { threads: "x" }).result.message, "Add threads to cluster by topic.");
+  });
+
+  it("fail-CLOSED: malformed thread rows never throw; shares stay FINITE", () => {
+    const r = callAction("topicClustering", ctxA, { threads: [{}, { tags: null }, { tags: ["a"] }] });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.uncategorized, 2);
+    for (const c of r.result.clusters) assert.ok(Number.isFinite(c.share));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("forum STATE substrate — round-trips + isolation", () => {
+  it("category create → list (with topicCount) → delete orphans topics", () => {
+    const cat = callMacro("category-create", ctxA, { name: "Production", description: "DAW talk" });
+    assert.equal(cat.ok, true);
+    const catId = cat.result.category.id;
+    const top = callMacro("topic-create", ctxA, { title: "Sidechain tips", categoryId: catId });
+    assert.equal(top.result.topic.categoryId, catId);
+    const list = callMacro("category-list", ctxA, {});
+    assert.equal(list.result.count, 1);
+    assert.equal(list.result.categories[0].topicCount, 1);
+    const del = callMacro("category-delete", ctxA, { id: catId });
+    assert.equal(del.ok, true);
+    // topic survives but its category link is orphaned to null
+    const tg = callMacro("topic-get", ctxA, { id: top.result.topic.id });
+    assert.equal(tg.result.topic.categoryId, null);
+  });
+
+  it("rejects an empty topic title", () => {
+    const r = callMacro("topic-create", ctxA, { title: "   " });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /title required/);
+  });
+
+  it("topic → reply (nested tree) → vote → score is exact + lock blocks replies", () => {
+    const top = callMacro("topic-create", ctxA, { title: "Root" }).result.topic;
+    const r1 = callMacro("post-reply", ctxA, { topicId: top.id, body: "first" });
+    assert.equal(r1.ok, true);
+    const r2 = callMacro("post-reply", ctxA, { topicId: top.id, parentId: r1.result.post.id, body: "nested" });
+    assert.equal(r2.ok, true);
+    const got = callMacro("topic-get", ctxA, { id: top.id });
+    assert.equal(got.result.replyCount, 2);
+    assert.equal(got.result.tree.length, 1);                 // one root post
+    assert.equal(got.result.tree[0].replies.length, 1);      // with one nested reply
+    // vote on the topic: +1 then 0 (toggle off) is exact
+    assert.equal(callMacro("vote", ctxA, { targetType: "topic", targetId: top.id, direction: 1 }).result.score, 1);
+    assert.equal(callMacro("vote", ctxA, { targetType: "topic", targetId: top.id, direction: 0 }).result.score, 0);
+    // lock the topic → further replies rejected
+    callMacro("topic-lock", ctxA, { id: top.id, locked: true });
+    const blocked = callMacro("post-reply", ctxA, { topicId: top.id, body: "late" });
+    assert.equal(blocked.ok, false);
+    assert.match(blocked.error, /locked/);
+  });
+
+  it("fail-CLOSED: vote with non-finite direction never throws + stays integer", () => {
+    const top = callMacro("topic-create", ctxA, { title: "V" }).result.topic;
+    for (const poison of [Infinity, NaN, "Infinity", "x"]) {
+      const r = callMacro("vote", ctxA, { targetType: "topic", targetId: top.id, direction: poison });
+      assert.equal(r.ok, true);
+      assert.ok(Number.isFinite(r.result.score), `score non-finite under ${String(poison)}`);
+    }
+  });
+
+  it("flag create → queue → resolve removes it from pending", () => {
+    const top = callMacro("topic-create", ctxA, { title: "Reported" }).result.topic;
+    const flag = callMacro("flag-create", ctxA, { targetType: "topic", targetId: top.id, reason: "spam" });
+    assert.equal(flag.ok, true);
+    const q = callMacro("flag-queue", ctxA, {});
+    assert.equal(q.result.pendingCount, 1);
+    assert.deepEqual(q.result.byReason, { spam: 1 });
+    callMacro("flag-resolve", ctxA, { id: flag.result.flag.id, action: "content_removed" });
+    const q2 = callMacro("flag-queue", ctxA, {});
+    assert.equal(q2.result.pendingCount, 0);
+    assert.equal(q2.result.resolvedCount, 1);
+  });
+
+  it("reputation tiers up with contributions + karma", () => {
+    const base = callMacro("user-reputation", ctxA, {});
+    assert.equal(base.result.tier, "new");
+    for (let i = 0; i < 5; i++) callMacro("topic-create", ctxA, { title: `T${i}` });
+    assert.equal(callMacro("user-reputation", ctxA, {}).result.tier, "basic"); // >=5 contributions
+  });
+
+  it("search matches title / body / tag and surfaces reply hits", () => {
+    callMacro("topic-create", ctxA, { title: "Reverb chain", body: "long tail plate", tags: ["mixing"] });
+    const t2 = callMacro("topic-create", ctxA, { title: "Other" }).result.topic;
+    callMacro("post-reply", ctxA, { topicId: t2.id, body: "use reverb sparingly" });
+    const r = callMacro("forum-search", ctxA, { query: "reverb" });
+    assert.equal(r.ok, true);
+    assert.ok(r.result.topicHits >= 2);
+    assert.equal(r.result.matchingReplies, 1);
+  });
+
+  it("rejects an empty search query", () => {
+    const r = callMacro("forum-search", ctxA, { query: "  " });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /query required/);
+  });
+
+  it("trending returns a finite hotScore for every topic and never NaN", () => {
+    callMacro("topic-create", ctxA, { title: "Hot", tags: ["x"] });
+    callMacro("topic-create", ctxA, { title: "Cold", tags: ["y"] });
+    const r = callMacro("trending", ctxA, { limit: 10 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.count, 2);
+    for (const t of r.result.trending) {
+      assert.ok(Number.isFinite(t.hotScore), `hotScore non-finite: ${t.hotScore}`);
+      assert.ok(Number.isFinite(t.personalBoost));
+    }
+  });
+
+  it("fail-CLOSED: trending with a corrupt createdAt keeps hotScore FINITE", () => {
+    const top = callMacro("topic-create", ctxA, { title: "Corrupt" }).result.topic;
+    // corrupt the stored timestamp the way a bad import could
+    globalThis._concordSTATE.forumLens.topics.get("user_a")[0].createdAt = "not-a-date";
+    const r = callMacro("trending", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.trending[0].hotScore));
+    assert.equal(r.result.trending[0].id, top.id);
+  });
+
+  it("award catalog + give attaches a real award to a topic", () => {
+    const cat = callMacro("award-catalog", ctxA, {});
+    assert.ok(cat.result.awards.length > 0);
+    const top = callMacro("topic-create", ctxA, { title: "Award me" }).result.topic;
+    const g = callMacro("award-give", ctxA, { kind: "gold", targetType: "topic", targetId: top.id });
+    assert.equal(g.ok, true);
+    assert.equal(g.result.awards[0].kind, "gold");
+    assert.equal(callMacro("award-give", ctxA, { kind: "bogus", targetType: "topic", targetId: top.id }).ok, false);
+  });
+
+  it("dashboard reflects real counts", () => {
+    callMacro("category-create", ctxA, { name: "C" });
+    const top = callMacro("topic-create", ctxA, { title: "D" }).result.topic;
+    callMacro("post-reply", ctxA, { topicId: top.id, body: "r" });
+    const d = callMacro("forum-dashboard", ctxA, {});
+    assert.equal(d.result.categories, 1);
+    assert.equal(d.result.topics, 1);
+    assert.equal(d.result.replies, 1);
+  });
+
+  it("per-user isolation — user_b never sees user_a's topics", () => {
+    callMacro("topic-create", ctxA, { title: "Private to A" });
+    assert.equal(callMacro("topic-list", ctxA, {}).result.count, 1);
+    assert.equal(callMacro("topic-list", ctxB, {}).result.count, 0);
+  });
+});

--- a/server/tests/geology-lens-macros.test.js
+++ b/server/tests/geology-lens-macros.test.js
@@ -1,0 +1,428 @@
+// Behavioral macro tests for server/domains/geology.js — the rock/mineral/
+// seismic/field-geology substrate the /lenses/geology lens drives (rock
+// classify, mineral ID, stratigraphic column, seismic risk, plus the
+// STATE-backed field journal: observations, structural strike/dip
+// measurements, sample photos, specimen collection, and field-trip itineraries).
+//
+// This file mirrors the REAL LENS_ACTIONS dispatch: every geology handler is
+// registered via `registerLensAction(domain, action, handler)` and invoked as
+// `handler(ctx, virtualArtifact, input)` — the 3-ARG convention with
+// `virtualArtifact.data === input`. The dispatch ALSO peels exactly one
+// redundant `{ artifact: { data } }` wrapper (lens-input-normalize.js); we peel
+// the same way before calling so the harness is byte-identical to production.
+//
+// These are NOT shape-only assertions. They pin ACTUAL computed values for
+// KNOWN inputs → KNOWN outputs (rock durability bands, mineral confidence score,
+// cumulative stratigraphic depth, seismic amplification, right-hand-rule dip
+// direction, circular-mean strike), CRUD round-trips through real STATE, the
+// EXACT field names each lens component renders (so a dead-surface regression
+// surfaces here), validation-rejection, graceful degradation, and a fail-CLOSED
+// poisoned-numeric contract: Infinity/NaN/1e999 inputs are clamped/rejected and
+// NEVER leak Infinity/NaN (serialized null) into the result, and NEVER throw.
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerGeologyActions from "../domains/geology.js";
+import { peelRedundantArtifactWrapper } from "../lib/lens-input-normalize.js";
+
+const ACTIONS = new Map();
+function registerLensAction(domain, name, fn) {
+  assert.equal(domain, "geology", `unexpected domain: ${domain}`);
+  ACTIONS.set(name, fn);
+}
+
+// Mirror the live dispatch exactly: peel one redundant artifact wrapper, then
+// handler(ctx, virtualArtifact, input) with virtualArtifact.data = input.
+function call(name, ctx, rawInput = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`geology.${name} not registered`);
+  const input = peelRedundantArtifactWrapper(rawInput);
+  const virtualArtifact = { id: null, title: rawInput?.title ?? null, domain: "geology", type: "domain_action", data: input || {}, meta: {} };
+  return fn(ctx, virtualArtifact, input || {});
+}
+
+before(() => { registerGeologyActions(registerLensAction); });
+
+beforeEach(() => {
+  // No boot, no network. Any handler that reaches for the network in a test is
+  // a leak — these pure-compute + STATE macros never should.
+  globalThis.fetch = async () => { throw new Error("network disabled in tests"); };
+  globalThis._concordSTATE = {};
+  globalThis._concordSaveStateDebounced = () => {};
+});
+
+const ctxA = { actor: { userId: "geo_user_a" }, userId: "geo_user_a" };
+const ctxB = { actor: { userId: "geo_user_b" }, userId: "geo_user_b" };
+
+// Assert no value in the (possibly nested) object is a non-finite number.
+function assertNoNonFinite(obj, path = "root") {
+  if (obj == null) return;
+  if (typeof obj === "number") {
+    assert.ok(Number.isFinite(obj), `non-finite number at ${path}: ${obj}`);
+    return;
+  }
+  if (Array.isArray(obj)) { obj.forEach((v, i) => assertNoNonFinite(v, `${path}[${i}]`)); return; }
+  if (typeof obj === "object") { for (const k of Object.keys(obj)) assertNoNonFinite(obj[k], `${path}.${k}`); }
+}
+
+// ── registration: every lens-driven macro is present ───────────────────────
+describe("geology — registration (every lens-driven macro present)", () => {
+  it("registers the pure-compute macros", () => {
+    for (const m of ["rockClassify", "seismicRisk", "mineralId", "stratigraphicColumn"]) {
+      assert.equal(typeof ACTIONS.get(m), "function", `missing geology.${m}`);
+    }
+  });
+  it("registers the field-journal + structural + collection + trip macros the components call", () => {
+    for (const m of [
+      "observation-log", "observation-list", "observation-update", "observation-delete", "field-dashboard",
+      "measurement-record", "measurement-list", "measurement-delete",
+      "photo-attach", "photo-list", "photo-delete",
+      "collection-add", "collection-list", "collection-toggle", "collection-remove",
+      "fieldtrip-create", "fieldtrip-list", "fieldtrip-add-stop",
+      "fieldtrip-reorder-stops", "fieldtrip-update-stop", "fieldtrip-delete",
+    ]) {
+      assert.equal(typeof ACTIONS.get(m), "function", `missing geology.${m}`);
+    }
+  });
+});
+
+// ── rockClassify — texture→type + durability/uses bands ────────────────────
+describe("geology.rockClassify — classification + durability the panel renders", () => {
+  it("classifies a foliated, hard specimen → metamorphic + highly-durable", () => {
+    const r = call("rockClassify", ctxA, { name: "Gneiss", mohsHardness: 7, luster: "Vitreous", color: "gray", texture: "foliated" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.specimen, "Gneiss");
+    assert.equal(r.result.rockType, "metamorphic");
+    assert.equal(r.result.mohsHardness, 7);
+    assert.equal(r.result.durability, "highly-durable");
+    assert.deepEqual(r.result.commonUses, ["construction", "countertops", "monuments"]);
+  });
+
+  it("vesicular → igneous; clastic → sedimentary; unknown → unclassified", () => {
+    assert.equal(call("rockClassify", ctxA, { texture: "vesicular" }).result.rockType, "igneous");
+    assert.equal(call("rockClassify", ctxA, { texture: "clastic" }).result.rockType, "sedimentary");
+    assert.equal(call("rockClassify", ctxA, { texture: "smooth" }).result.rockType, "unclassified");
+  });
+
+  it("durability bands: 5 → moderate, 2 → soft", () => {
+    assert.equal(call("rockClassify", ctxA, { mohsHardness: 5 }).result.durability, "moderate");
+    assert.equal(call("rockClassify", ctxA, { mohsHardness: 2 }).result.durability, "soft");
+  });
+
+  it("fail-CLOSED: a poisoned Infinity/1e999 hardness is clamped, never leaks Infinity", () => {
+    const inf = call("rockClassify", ctxA, { mohsHardness: Infinity, texture: "foliated" });
+    assert.equal(inf.ok, true);
+    assert.ok(Number.isFinite(inf.result.mohsHardness));
+    assert.ok(inf.result.mohsHardness <= 10);
+    assertNoNonFinite(inf.result);
+    const str = call("rockClassify", ctxA, { mohsHardness: "1e999" });
+    assert.ok(Number.isFinite(str.result.mohsHardness));
+    const nan = call("rockClassify", ctxA, { mohsHardness: "not-a-number" });
+    assert.equal(nan.result.mohsHardness, 0);
+    assertNoNonFinite(nan.result);
+  });
+});
+
+// ── seismicRisk — amplification + clamped coordinates ──────────────────────
+describe("geology.seismicRisk — amplification, risk level + coordinate clamp", () => {
+  it("computes amplified risk for a Bay-Area soft-soil site (high risk)", () => {
+    const r = call("seismicRisk", ctxA, { latitude: 37.77, longitude: -122.42, soilType: "soft-soil" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.amplificationFactor, 1.6);
+    // base 0.8 × 1.6 = 1.28 → clamped to 1.0 (100%).
+    assert.equal(r.result.adjustedRisk, 100);
+    assert.equal(r.result.riskLevel, "high");
+    assert.ok(Array.isArray(r.result.recommendations) && r.result.recommendations.length >= 3);
+    assertNoNonFinite(r.result);
+  });
+
+  it("rock site far from a fault → low risk, standard codes", () => {
+    const r = call("seismicRisk", ctxA, { latitude: 5, longitude: 5, soilType: "rock" });
+    assert.equal(r.result.amplificationFactor, 1.0);
+    assert.equal(r.result.riskLevel, "low");
+    assert.deepEqual(r.result.recommendations, ["Standard building codes sufficient"]);
+  });
+
+  it("fail-CLOSED: poisoned Infinity/NaN coords fall back + clamp; location never leaks null", () => {
+    const r = call("seismicRisk", ctxA, { latitude: Infinity, longitude: "NaN", soilType: "rock" });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.location.lat));
+    assert.ok(Number.isFinite(r.result.location.lon));
+    assert.ok(r.result.location.lat >= -90 && r.result.location.lat <= 90);
+    assert.ok(r.result.location.lon >= -180 && r.result.location.lon <= 180);
+    assertNoNonFinite(r.result);
+  });
+});
+
+// ── mineralId — confidence scoring + classification ────────────────────────
+describe("geology.mineralId — confidence score + property clamp", () => {
+  it("scores a fully-tested specimen and classifies by hardness", () => {
+    const r = call("mineralId", ctxA, { name: "Quartz", hardness: 7, streak: "white", cleavage: "none", specificGravity: 2.65, color: "clear" });
+    assert.equal(r.ok, true);
+    // 25 (hardness>0) + 20 (streak) + 20 (cleavage) + 20 (sg>0) + 15 (color) = 100.
+    assert.equal(r.result.identificationConfidence, 100);
+    assert.equal(r.result.classification, "silicate-likely");
+    assert.equal(r.result.properties.hardness, 7);
+    assert.equal(r.result.properties.specific_gravity, 2.65);
+    assertNoNonFinite(r.result);
+  });
+
+  it("a sparsely-tested specimen scores low and recommends more tests", () => {
+    const r = call("mineralId", ctxA, { name: "Unknown", hardness: 3 });
+    assert.equal(r.result.identificationConfidence, 25);
+    assert.equal(r.result.classification, "carbonate-or-sulfate");
+    assert.ok(Array.isArray(r.result.testsRecommended));
+  });
+
+  it("fail-CLOSED: poisoned hardness/SG are clamped, never leak Infinity/NaN", () => {
+    const r = call("mineralId", ctxA, { name: "Bad", hardness: Infinity, specificGravity: "1e999" });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.properties.hardness));
+    assert.ok(Number.isFinite(r.result.properties.specific_gravity));
+    assert.ok(r.result.properties.hardness <= 10);
+    assertNoNonFinite(r.result);
+  });
+});
+
+// ── stratigraphicColumn — cumulative depth from layer thicknesses ──────────
+describe("geology.stratigraphicColumn — cumulative depth + ordering", () => {
+  it("builds the column with correct depthTop/depthBottom and totals", () => {
+    const r = call("stratigraphicColumn", ctxA, { layers: [
+      { name: "Topsoil", thickness: 2, age: "recent", fossils: [] },
+      { name: "Sandstone", thickness: 8, lithology: "sandstone", fossils: ["ammonite"] },
+      { name: "Limestone", thickness: 10, fossils: [] },
+    ] });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.totalThickness, 20);
+    assert.equal(r.result.layerCount, 3);
+    assert.equal(r.result.layers[0].depthTop, 0);
+    assert.equal(r.result.layers[0].depthBottom, 2);
+    assert.equal(r.result.layers[1].depthTop, 2);
+    assert.equal(r.result.layers[1].depthBottom, 10);
+    assert.equal(r.result.layers[2].depthBottom, 20);
+    assert.equal(r.result.youngestFormation, "Topsoil");
+    assert.equal(r.result.oldestFormation, "Limestone");
+    assert.equal(r.result.fossiliferous, 1);
+    assertNoNonFinite(r.result);
+  });
+
+  it("degrade-graceful: no layers → guidance message, not a crash", () => {
+    const r = call("stratigraphicColumn", ctxA, { layers: [] });
+    assert.equal(r.ok, true);
+    assert.match(r.result.message, /Add geological layers/i);
+  });
+
+  it("fail-CLOSED: a poisoned Infinity/NaN thickness never inverts the depth axis or leaks Infinity", () => {
+    const r = call("stratigraphicColumn", ctxA, { layers: [
+      { name: "A", thickness: Infinity },
+      { name: "B", thickness: "1e999" },
+      { name: "C", thickness: -5 },
+    ] });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.totalThickness));
+    for (const l of r.result.layers) {
+      assert.ok(Number.isFinite(l.thickness) && l.thickness >= 0, `thickness ${l.thickness}`);
+      assert.ok(l.depthBottom >= l.depthTop, "depth axis never inverts");
+    }
+    assertNoNonFinite(r.result);
+  });
+});
+
+// ── observation journal — CRUD round-trip + dashboard ──────────────────────
+describe("geology.observation-* — field-log round-trip + dashboard aggregation", () => {
+  it("logs an observation, lists it back, and the dashboard counts it", () => {
+    const logged = call("observation-log", ctxA, { name: "Roadcut shale", kind: "outcrop", locationName: "Hwy 9", formation: "Marcellus", lat: 42.1, lon: -76.2, tags: ["Shale", "marine"] });
+    assert.equal(logged.ok, true);
+    const obs = logged.result.observation;
+    assert.equal(obs.name, "Roadcut shale");
+    assert.equal(obs.kind, "outcrop");
+    assert.equal(obs.formation, "Marcellus");
+    assert.deepEqual(obs.tags, ["shale", "marine"]); // lowercased
+
+    const list = call("observation-list", ctxA, {});
+    assert.equal(list.ok, true);
+    assert.equal(list.result.count, 1);
+    assert.equal(list.result.observations[0].id, obs.id);
+
+    const dash = call("field-dashboard", ctxA, {});
+    assert.equal(dash.result.totalObservations, 1);
+    assert.equal(dash.result.byKind.outcrop, 1);
+    assert.equal(dash.result.geotagged, 1);
+    assert.equal(dash.result.formations, 1);
+  });
+
+  it("filters by kind and is per-user isolated", () => {
+    call("observation-log", ctxA, { name: "Granite boulder", kind: "rock" });
+    call("observation-log", ctxA, { name: "Trilobite", kind: "fossil" });
+    const rocks = call("observation-list", ctxA, { kind: "rock" });
+    assert.ok(rocks.result.observations.every((o) => o.kind === "rock"));
+    // Another user sees none of user A's rows.
+    assert.equal(call("observation-list", ctxB, {}).result.count, 0);
+  });
+
+  it("validation-rejection: an empty name is rejected", () => {
+    const r = call("observation-log", ctxA, { name: "   " });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /name required/i);
+  });
+
+  it("update + delete round-trip", () => {
+    const o = call("observation-log", ctxA, { name: "Vein quartz", kind: "mineral" }).result.observation;
+    const up = call("observation-update", ctxA, { id: o.id, notes: "milky", kind: "rock" });
+    assert.equal(up.result.observation.notes, "milky");
+    assert.equal(up.result.observation.kind, "rock");
+    const del = call("observation-delete", ctxA, { id: o.id });
+    assert.equal(del.ok, true);
+    assert.equal(del.result.deleted, o.id);
+    assert.ok(!call("observation-list", ctxA, {}).result.observations.some((x) => x.id === o.id));
+  });
+});
+
+// ── structural compass — strike/dip + dip-direction + circular mean ────────
+describe("geology.measurement-* — strike/dip right-hand-rule + stereonet mean", () => {
+  it("records a measurement with the correct right-hand-rule dip direction", () => {
+    const r = call("measurement-record", ctxA, { planeKind: "bedding", strike: 30, dip: 45, locationName: "Quarry wall" });
+    assert.equal(r.ok, true);
+    const m = r.result.measurement;
+    assert.equal(m.strike, 30);
+    assert.equal(m.dip, 45);
+    assert.equal(m.dipDirection, 120); // strike + 90, RHR
+    assert.equal(m.planeKind, "bedding");
+  });
+
+  it("normalizes an over-360 strike and computes a circular mean over the list", () => {
+    // wipe by using a fresh user.
+    const ctx = { actor: { userId: "geo_strike_u" }, userId: "geo_strike_u" };
+    call("measurement-record", ctx, { strike: 10, dip: 20 });
+    call("measurement-record", ctx, { strike: 350, dip: 20 });
+    const list = call("measurement-list", ctx, {});
+    assert.equal(list.result.count, 2);
+    // circular mean of 10° and 350° is 0° (≈360), NOT the naive arithmetic 180°.
+    assert.ok(list.result.meanStrike <= 1 || list.result.meanStrike >= 359, `meanStrike ${list.result.meanStrike}`);
+    assert.equal(list.result.byKind.bedding, 2);
+    // over-360 input normalized.
+    const norm = call("measurement-record", ctx, { strike: 370, dip: 5 });
+    assert.equal(norm.result.measurement.strike, 10);
+  });
+
+  it("validation-rejection: missing strike/dip and out-of-range dip", () => {
+    assert.match(call("measurement-record", ctxA, { strike: 30 }).error, /strike \+ dip required/i);
+    assert.match(call("measurement-record", ctxA, { strike: 30, dip: 120 }).error, /dip must be 0-90/i);
+  });
+
+  it("fail-CLOSED: a poisoned Infinity/NaN strike is rejected (never NaN dipDirection)", () => {
+    const r = call("measurement-record", ctxA, { strike: Infinity, dip: 45 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /strike \+ dip required/i);
+    const r2 = call("measurement-record", ctxA, { strike: "1e999", dip: 45 });
+    assert.equal(r2.ok, false);
+  });
+});
+
+// ── specimen collection — dedupe count + identified toggle ─────────────────
+describe("geology.collection-* — life-list dedupe + stats", () => {
+  it("adds a new specimen then re-adds (count increments, not duplicated)", () => {
+    const ctx = { actor: { userId: "geo_collect_u" }, userId: "geo_collect_u" };
+    const first = call("collection-add", ctx, { name: "Pyrite", kind: "mineral", locality: "Spain" });
+    assert.equal(first.result.isNew, true);
+    assert.equal(first.result.entry.count, 1);
+    const again = call("collection-add", ctx, { name: "pyrite", kind: "mineral" }); // case-insensitive
+    assert.equal(again.result.isNew, false);
+    assert.equal(again.result.entry.count, 2);
+
+    const list = call("collection-list", ctx, {});
+    assert.equal(list.result.uniqueCount, 1);
+    assert.equal(list.result.totalSpecimens, 2);
+    assert.equal(list.result.byKind.mineral, 1);
+    assert.equal(list.result.identifiedCount, 1);
+  });
+
+  it("toggle flips identified; remove deletes", () => {
+    const ctx = { actor: { userId: "geo_collect_u2" }, userId: "geo_collect_u2" };
+    const e = call("collection-add", ctx, { name: "Galena", kind: "mineral" }).result.entry;
+    assert.equal(e.identified, true);
+    assert.equal(call("collection-toggle", ctx, { id: e.id }).result.entry.identified, false);
+    assert.equal(call("collection-remove", ctx, { id: e.id }).result.removed, e.id);
+    assert.equal(call("collection-list", ctx, {}).result.uniqueCount, 0);
+  });
+
+  it("validation-rejection: empty name", () => {
+    assert.match(call("collection-add", ctxA, { name: "" }).error, /name required/i);
+  });
+});
+
+// ── photo attach — observation linkage + EXIF backfill ─────────────────────
+describe("geology.photo-* — attach to observation + EXIF geotag backfill", () => {
+  it("attaches a geotagged photo and backfills the observation coords", () => {
+    const ctx = { actor: { userId: "geo_photo_u" }, userId: "geo_photo_u" };
+    const obs = call("observation-log", ctx, { name: "Cliff face", kind: "outcrop" }).result.observation;
+    assert.equal(obs.lat, null);
+    const tinyJpeg = "data:image/jpeg;base64,/9j/AA==";
+    const ph = call("photo-attach", ctx, { observationId: obs.id, dataUrl: tinyJpeg, caption: "north wall", exifLat: 36.1, exifLon: -112.1, cameraModel: "Pixel 8" });
+    assert.equal(ph.ok, true);
+    assert.equal(ph.result.photo.observationId, obs.id);
+    assert.equal(ph.result.photo.exifLat, 36.1);
+    // observation backfilled from EXIF.
+    const back = call("observation-list", ctx, {}).result.observations.find((o) => o.id === obs.id);
+    assert.equal(back.lat, 36.1);
+    assert.equal(back.lon, -112.1);
+    const list = call("photo-list", ctx, { observationId: obs.id });
+    assert.equal(list.result.count, 1);
+    assert.equal(list.result.geotagged, 1);
+  });
+
+  it("validation-rejection: bad dataUrl + missing observation", () => {
+    const ctx = { actor: { userId: "geo_photo_u2" }, userId: "geo_photo_u2" };
+    assert.match(call("photo-attach", ctx, { observationId: "x", dataUrl: "not-an-image" }).error, /valid image dataUrl/i);
+    assert.match(call("photo-attach", ctx, { observationId: "missing", dataUrl: "data:image/png;base64,AA" }).error, /observation not found/i);
+  });
+});
+
+// ── field trips — create, add stops, reorder ───────────────────────────────
+describe("geology.fieldtrip-* — itinerary build + reorder", () => {
+  it("creates a trip, adds ordered stops, and reorders them", () => {
+    const ctx = { actor: { userId: "geo_trip_u" }, userId: "geo_trip_u" };
+    const trip = call("fieldtrip-create", ctx, { name: "Sierra transect", area: "CA" }).result.fieldTrip;
+    assert.equal(trip.stops.length, 0);
+    const s1 = call("fieldtrip-add-stop", ctx, { tripId: trip.id, name: "Stop 1", lithology: "granite" }).result.stop;
+    const s2 = call("fieldtrip-add-stop", ctx, { tripId: trip.id, name: "Stop 2" }).result.stop;
+    assert.equal(s1.order, 1);
+    assert.equal(s2.order, 2);
+
+    const re = call("fieldtrip-reorder-stops", ctx, { tripId: trip.id, stopIds: [s2.id, s1.id] });
+    assert.equal(re.ok, true);
+    assert.equal(re.result.fieldTrip.stops[0].id, s2.id);
+    assert.equal(re.result.fieldTrip.stops[0].order, 1);
+
+    const list = call("fieldtrip-list", ctx, {});
+    assert.equal(list.result.count, 1);
+    assert.equal(list.result.totalStops, 2);
+  });
+
+  it("validation-rejection: empty trip name; stop on missing trip; bad reorder", () => {
+    const ctx = { actor: { userId: "geo_trip_u2" }, userId: "geo_trip_u2" };
+    assert.match(call("fieldtrip-create", ctx, { name: "" }).error, /name required/i);
+    assert.match(call("fieldtrip-add-stop", ctx, { tripId: "nope", name: "x" }).error, /not found/i);
+    const trip = call("fieldtrip-create", ctx, { name: "T" }).result.fieldTrip;
+    call("fieldtrip-add-stop", ctx, { tripId: trip.id, name: "only" });
+    const bad = call("fieldtrip-reorder-stops", ctx, { tripId: trip.id, stopIds: ["a", "b"] });
+    assert.equal(bad.ok, false);
+    assert.match(bad.error, /every stop exactly once/i);
+  });
+});
+
+// ── double-wrap dispatch parity — the dead-surface bug class ────────────────
+describe("geology — { artifact:{ data } } double-wrap is peeled like production", () => {
+  it("rockClassify reads through a sole-key artifact wrapper identically to flat input", () => {
+    const wrapped = call("rockClassify", ctxA, { artifact: { data: { name: "Basalt", texture: "vesicular", mohsHardness: 6 } } });
+    const flat = call("rockClassify", ctxA, { name: "Basalt", texture: "vesicular", mohsHardness: 6 });
+    assert.equal(wrapped.result.rockType, "igneous");
+    assert.deepEqual(wrapped.result, flat.result);
+  });
+
+  it("stratigraphicColumn reads through the wrapper (the historical blank-calc bug)", () => {
+    const wrapped = call("stratigraphicColumn", ctxA, { artifact: { data: { layers: [{ name: "X", thickness: 4 }] } } });
+    assert.equal(wrapped.ok, true);
+    assert.equal(wrapped.result.totalThickness, 4);
+  });
+});

--- a/server/tests/household-lens-macros.test.js
+++ b/server/tests/household-lens-macros.test.js
@@ -1,0 +1,552 @@
+// Behavioral macro tests for the household lens — the PATH-3
+// registerLensAction surface in server/domains/household.js the
+// /lenses/household page + its child components drive:
+//
+//   Pure calculators (page Domain Actions + HouseholdActionPanel + ChoreRotation):
+//     generateGroceryList · choreRotation · rotateChores · maintenanceCheck ·
+//     maintenanceDue · weeklySummary · allowance-summary
+//   STATE-backed Tody/Cozi substrate (ChoreBoard / FamilyCalendar / MealPlanner /
+//     MemberNotifications / SharedShoppingLists / RecurringTemplates / ExpenseSplitter):
+//     room-* · task-* · chore-board · assignee-leaderboard · vacation-toggle ·
+//     household-dashboard · calendar-event-* · meal-plan-* · meal-grocery-list ·
+//     notification-* · shopping-list-* · shopping-item-* · task-template-* ·
+//     expense-* · expense-balances
+//
+// THE COMPONENT-EXACT-SHAPE CONTRACT (the dead-calculator class this gate targets):
+//   The dispatch maps the run-action input to BOTH virtualArtifact.data AND the
+//   3rd `params` arg (sole-key {artifact:{data}} bodies are peeled; flat bodies
+//   pass through; a 2-key {artifact:{data},x} body is NOT peeled). The handlers
+//   read artifact.data.X || params.X so the page's derived params AND a flat
+//   panel body both reach the calculator. Before this pass:
+//     • ChoreRotation sent {artifact:{data:{chores,members}},strategy,weeks}
+//       (two-key, NOT peeled) → artifact.data.chores === undefined → "No chores
+//       defined" DEAD SURFACE; and rendered result.rotation / a.member which the
+//       handler never returns (it returns result.assignments / a.assignee).
+//     • HouseholdActionPanel sent {meals:[strings]} (handler read .mealPlan) and
+//       rendered result.items/.rotation/.choresDone (handler returns
+//       .list/.assignments/.choresCompleted) → fully dead.
+//   These tests drive the EXACT params each surface now emits and assert the
+//   EXACT computed values the panels render.
+//
+// Dispatch shapes:
+//   • Page Domain Actions: POST /api/lens/household/:id/run {action,params}
+//       → runMacro("lens","run",{id,action,params}) → handler(ctx, artifact, params)
+//   • Panel macros (lensRun): POST /api/lens/run {domain,action,input}
+//       → rest = peel(input); handler(ctx, {data:rest}, rest)
+// We invoke handlers directly with both shapes.
+//
+// NOT shape-only: every test feeds KNOWN inputs and asserts EXACT computed values
+// (aggregation, pantry subtraction, rotation cycling, overdue-day math, settle-up
+// transfers, allowance dollars) + validation-rejection + degrade-graceful +
+// fail-CLOSED poison (1e999 / "Infinity" / NaN / bad dates collapse to FINITE
+// output or {ok:false}, never NaN/Infinity in output and never a throw).
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerHouseholdActions from "../domains/household.js";
+import { peelRedundantArtifactWrapper } from "../lib/lens-input-normalize.js";
+
+const ACTIONS = new Map();
+function registerLensAction(domain, name, fn) {
+  assert.equal(domain, "household", `unexpected domain: ${domain}`);
+  ACTIONS.set(name, fn);
+}
+
+const ctxA = { actor: { userId: "user_a" }, userId: "user_a" };
+const ctxB = { actor: { userId: "user_b" }, userId: "user_b" };
+
+// Drive a PURE calculator EXACTLY like the page's persisted-artifact run route:
+// a persisted artifact (single record, no board-wide arrays) + page-derived
+// params as the 3rd arg. Handler reads artifact.data.X || params.X.
+function callAction(name, ctx, params = {}, artifactData = { name: "Member A" }) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`household.${name} not registered`);
+  const artifact = { id: "art_1", domain: "household", type: "record", data: artifactData, meta: {} };
+  return fn(ctx, artifact, params);
+}
+
+// Drive a STATE / panel macro EXACTLY like lensRun(domain, name, input): the
+// dispatch peels a redundant {artifact:{data}} wrapper (no-op on flat input),
+// sets virtualArtifact.data = rest AND passes rest as params.
+async function callMacro(name, ctx, input = {}) {
+  const fn = ACTIONS.get(name);
+  if (!fn) throw new Error(`household.${name} not registered`);
+  const rest = peelRedundantArtifactWrapper(input);
+  const artifact = { id: null, domain: "household", type: "domain_action", data: rest, meta: {} };
+  return await fn(ctx, artifact, rest);
+}
+
+// Walk every numeric leaf to assert no NaN/Infinity escaped into output.
+function assertAllFinite(node, path = "root") {
+  if (typeof node === "number") {
+    assert.ok(Number.isFinite(node), `non-finite at ${path}: ${node}`);
+    return;
+  }
+  if (Array.isArray(node)) { node.forEach((v, i) => assertAllFinite(v, `${path}[${i}]`)); return; }
+  if (node && typeof node === "object") {
+    for (const [k, v] of Object.entries(node)) assertAllFinite(v, `${path}.${k}`);
+  }
+}
+
+before(() => { registerHouseholdActions(registerLensAction); });
+beforeEach(() => {
+  globalThis._concordSTATE = {};
+  globalThis._concordSaveStateDebounced = () => {};
+  globalThis.fetch = async () => { throw new Error("network disabled"); };
+});
+
+const CALCULATORS = [
+  "generateGroceryList", "choreRotation", "rotateChores",
+  "maintenanceCheck", "maintenanceDue", "weeklySummary",
+];
+const STATE_MACROS = [
+  "room-create", "room-list", "room-delete",
+  "task-create", "task-list", "task-update", "task-delete", "task-done",
+  "chore-board", "assignee-leaderboard", "vacation-toggle", "household-dashboard",
+  "calendar-event-create", "calendar-event-list", "calendar-event-update",
+  "calendar-event-delete", "calendar-upcoming-reminders",
+  "meal-plan-set", "meal-plan-list", "meal-plan-delete", "meal-grocery-list",
+  "allowance-summary",
+  "notification-create", "notification-list", "notification-mark-read",
+  "shopping-list-create", "shopping-list-list", "shopping-list-delete",
+  "shopping-item-add", "shopping-item-toggle", "shopping-item-remove",
+  "task-template-create", "task-template-list", "task-template-delete", "task-template-spawn",
+  "expense-add", "expense-list", "expense-settle", "expense-delete", "expense-balances",
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("household — registration", () => {
+  it("registers every calculator + STATE macro the lens reaches", () => {
+    for (const m of CALCULATORS) assert.ok(ACTIONS.has(m), `household.${m} not registered`);
+    for (const m of STATE_MACROS) assert.ok(ACTIONS.has(m), `household.${m} not registered`);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("generateGroceryList — exact aggregation + pantry subtraction", () => {
+  // Page derives mealPlan from mealItems; we assert the exact deduped totals.
+  const mealPlan = [
+    { day: "Mon", meal: "dinner", recipe: "Pasta", ingredients: [{ name: "Tomato", quantity: 3, unit: "ea" }, { name: "Pasta", quantity: 1, unit: "box" }] },
+    { day: "Tue", meal: "dinner", recipe: "Salad", ingredients: [{ name: "Tomato", quantity: 2, unit: "ea" }] },
+  ];
+
+  it("aggregates duplicate ingredients across meals (Tomato 3+2=5)", () => {
+    const r = callAction("generateGroceryList", ctxA, { mealPlan });
+    assert.equal(r.ok, true);
+    const tomato = r.result.list.find((i) => i.name === "Tomato");
+    assert.equal(tomato.quantity, 5);
+    assert.deepEqual(tomato.usedIn.sort(), ["Mon dinner", "Tue dinner"]);
+    assert.equal(r.result.uniqueItems, 2);
+    assert.equal(r.result.mealsPlanned, 2);
+  });
+
+  it("subtracts pantry quantities and drops fully-covered items", () => {
+    const r = callAction("generateGroceryList", ctxA, {
+      mealPlan, pantry: [{ name: "Pasta", quantity: 1, unit: "box" }, { name: "Tomato", quantity: 2, unit: "ea" }],
+    });
+    // Pasta fully covered (1 needed - 1 on hand = 0) → dropped.
+    assert.equal(r.result.list.find((i) => i.name === "Pasta"), undefined);
+    const tomato = r.result.list.find((i) => i.name === "Tomato");
+    assert.equal(tomato.quantity, 3); // 5 - 2
+    assert.equal(tomato.hadOnHand, 2);
+  });
+
+  it("HouseholdActionPanel shape: bare-string meals with no ingredients → empty list, ok:true", () => {
+    // Panel parses 'Recipe: a, b' into ingredients; a bare recipe name yields none.
+    const r = callAction("generateGroceryList", ctxA, { mealPlan: [{ recipe: "Tacos", ingredients: [] }] });
+    assert.equal(r.ok, true);
+    assert.deepEqual(r.result.list, []);
+    assert.equal(r.result.mealsPlanned, 1);
+  });
+
+  it("FAIL-CLOSED: poisoned quantities (1e999 / 'Infinity' / NaN) never leak Infinity/NaN", () => {
+    const r = callAction("generateGroceryList", ctxA, {
+      mealPlan: [{ recipe: "X", ingredients: [
+        { name: "A", quantity: 1e999, unit: "" },
+        { name: "B", quantity: "Infinity", unit: "" },
+        { name: "C", quantity: NaN, unit: "" },
+      ] }],
+    });
+    assert.equal(r.ok, true);
+    assertAllFinite(r.result);
+    // poisoned quantities collapse to 0 → needed <= 0 → dropped, list empty.
+    assert.deepEqual(r.result.list, []);
+  });
+
+  it("degrade-graceful: no mealPlan at all → empty list, ok:true", () => {
+    const r = callAction("generateGroceryList", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.uniqueItems, 0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("choreRotation — round-robin cycling + exact assignee shift", () => {
+  it("shifts each chore to the next member (ChoreRotation flat shape)", () => {
+    const r = callAction("choreRotation", ctxA, {
+      chores: [{ name: "Dishes", currentAssignee: "Alex" }, { name: "Trash", currentAssignee: "Sam" }],
+      members: ["Alex", "Sam", "Jordan"],
+      strategy: "round-robin",
+    });
+    assert.equal(r.ok, true);
+    const dishes = r.result.assignments.find((a) => a.chore === "Dishes");
+    assert.equal(dishes.assignee, "Sam");      // Alex (idx 0) → idx 1 = Sam
+    assert.equal(dishes.previousAssignee, "Alex");
+    const trash = r.result.assignments.find((a) => a.chore === "Trash");
+    assert.equal(trash.assignee, "Jordan");    // Sam (idx 1) → idx 2 = Jordan
+    assert.equal(r.result.totalChores, 2);
+    assert.equal(r.result.members, 3);
+  });
+
+  it("HouseholdActionPanel shape: bare-string chores + members → still assigns", () => {
+    const r = callAction("choreRotation", ctxA, {
+      chores: [{ name: "Dishes" }, { name: "Trash" }],
+      members: ["Alex", "Sam"],
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.assignments.length, 2);
+    // never-assigned chores fill toward least-loaded member, deterministically.
+    assert.equal(r.result.choresPerMember.Alex, 1);
+    assert.equal(r.result.choresPerMember.Sam, 1);
+  });
+
+  it("ChoreRotation peel: a 2-key {artifact:{data},strategy} body is NOT peeled (regression for the dead surface)", async () => {
+    // This is what the BROKEN component sent — assert the handler returns the
+    // explicit error rather than silently empty, proving the flat-shape fix matters.
+    const r = await callMacro("choreRotation", ctxA, {
+      artifact: { data: { chores: [{ name: "Dishes" }], members: ["Alex"] } },
+      strategy: "round-robin",
+    });
+    assert.equal(r.ok, true);
+    // double-wrapped → both chores AND members land undefined → handler returns
+    // a guidance error (members check fires first), NOT a real rotation. Either
+    // guidance string proves the dead surface; the FIXED flat body below works.
+    assert.ok(
+      r.result.error === "No chores defined." || r.result.error === "No household members defined.",
+      `expected a guidance error, got ${JSON.stringify(r.result)}`,
+    );
+    assert.equal(r.result.assignments, undefined);
+  });
+
+  it("ChoreRotation peel: the FIXED flat body reaches the handler", async () => {
+    const r = await callMacro("choreRotation", ctxA, {
+      chores: [{ name: "Dishes", currentAssignee: "Alex" }], members: ["Alex", "Sam"], strategy: "round-robin",
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.assignments[0].assignee, "Sam");
+  });
+
+  it("validation-rejection: no members → guidance, no throw", () => {
+    const r = callAction("choreRotation", ctxA, { chores: [{ name: "Dishes" }], members: [] });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.error, "No household members defined.");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("rotateChores — legacy round-robin (HouseholdActionPanel param fallback)", () => {
+  it("cycles via params (no artifact.data) and returns assignments", () => {
+    const r = callAction("rotateChores", ctxA, {
+      chores: [{ name: "Mop", currentAssignee: "Sam" }], members: ["Alex", "Sam", "Jordan"],
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.assignments[0].newAssignee, "Jordan"); // Sam idx1 → idx2
+    assert.equal(r.result.assignments[0].previousAssignee, "Sam");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("maintenanceCheck / maintenanceDue — exact overdue-day math + fail-closed dates", () => {
+  const daysAgo = (n) => new Date(Date.now() - n * 86400000).toISOString().split("T")[0];
+
+  it("maintenanceCheck flags overdue with exact daysOverdue", () => {
+    // last done 40 days ago, interval 30 → ~10 days overdue.
+    const r = callAction("maintenanceCheck", ctxA, {
+      maintenanceItems: [{ name: "HVAC filter", lastCompleted: daysAgo(40), intervalDays: 30 }],
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.overdueCount, 1);
+    const it = r.result.overdue[0];
+    assert.equal(it.status, "overdue");
+    assert.ok(it.daysOverdue >= 9 && it.daysOverdue <= 11, `daysOverdue ${it.daysOverdue}`);
+  });
+
+  it("maintenanceCheck: never-completed item is overdue with null daysOverdue", () => {
+    const r = callAction("maintenanceCheck", ctxA, { maintenanceItems: [{ name: "Gutters" }] });
+    assert.equal(r.result.overdueCount, 1);
+    assert.equal(r.result.overdue[0].status, "never-completed");
+    assert.equal(r.result.overdue[0].daysOverdue, null);
+  });
+
+  it("maintenanceDue: upcoming within lookahead window, exact daysUntilDue", () => {
+    const r = callAction("maintenanceDue", ctxA, {
+      maintenanceItems: [{ name: "Smoke detector", lastServiceDate: daysAgo(355), intervalDays: 365 }],
+      lookaheadDays: 30,
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.upcomingCount, 1);
+    assert.ok(r.result.upcoming[0].daysUntilDue >= 9 && r.result.upcoming[0].daysUntilDue <= 11);
+  });
+
+  it("FAIL-CLOSED: garbage dates + non-finite intervalDays never produce NaN", () => {
+    const r1 = callAction("maintenanceCheck", ctxA, {
+      maintenanceItems: [{ name: "X", lastCompleted: "not-a-date", intervalDays: "Infinity" }],
+    });
+    assert.equal(r1.ok, true);
+    assertAllFinite(r1.result);
+    // bad date → never-completed → overdue, no NaN daysOverdue.
+    assert.equal(r1.result.overdue[0].status, "never-completed");
+
+    const r2 = callAction("maintenanceDue", ctxA, {
+      maintenanceItems: [{ name: "Y", lastServiceDate: daysAgo(10), intervalDays: 1e999 }],
+      lookaheadDays: NaN,
+    });
+    assert.equal(r2.ok, true);
+    assertAllFinite(r2.result);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("weeklySummary — exact completion rate + fail-closed", () => {
+  it("computes choresCompleted / completionRate from this-week completedDate", () => {
+    const today = new Date().toISOString().split("T")[0];
+    const r = callAction("weeklySummary", ctxA, {
+      chores: [
+        { name: "A", completedDate: today },
+        { name: "B" },
+        { name: "C", completedDate: today },
+        { name: "D" },
+      ],
+      mealPlan: [{ recipe: "X" }, { recipe: "Y" }],
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.choresCompleted, 2);
+    assert.equal(r.result.totalChores, 4);
+    assert.equal(r.result.choreCompletionRate, 50);
+    assert.equal(r.result.mealsPlanned, 2);
+  });
+
+  it("degrade-graceful: empty everything → 0 rate, no divide-by-zero NaN", () => {
+    const r = callAction("weeklySummary", ctxA, {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.choreCompletionRate, 0);
+    assertAllFinite(r.result);
+  });
+
+  it("FAIL-CLOSED: poisoned completedDate / intervalDays never crash or leak NaN", () => {
+    const r = callAction("weeklySummary", ctxA, {
+      chores: [{ name: "A", completedDate: "garbage" }],
+      maintenanceItems: [{ name: "M", lastCompleted: "bad", intervalDays: "NaN" }],
+    });
+    assert.equal(r.ok, true);
+    assertAllFinite(r.result);
+    assert.equal(r.result.choresCompleted, 0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("ChoreBoard substrate — rooms/tasks/condition/leaderboard/vacation round-trip", () => {
+  it("creates a room + task and surfaces it on the prioritised board", async () => {
+    const rc = await callMacro("room-create", ctxA, { name: "Kitchen" });
+    assert.equal(rc.ok, true);
+    const roomId = rc.result.room.id;
+    const tc = await callMacro("task-create", ctxA, { roomId, name: "Dishes", intervalDays: 1, effort: "light" });
+    assert.equal(tc.ok, true);
+    const board = await callMacro("chore-board", ctxA, {});
+    assert.equal(board.result.board.length, 1);
+    assert.equal(board.result.board[0].name, "Dishes");
+    assert.equal(board.result.board[0].room, "Kitchen");
+  });
+
+  it("task-done awards effort points to the leaderboard (heavy=20)", async () => {
+    const rc = await callMacro("room-create", ctxA, { name: "Garage" });
+    const tc = await callMacro("task-create", ctxA, { roomId: rc.result.room.id, name: "Sweep", effort: "heavy", assignee: "Sam" });
+    const done = await callMacro("task-done", ctxA, { id: tc.result.task.id });
+    assert.equal(done.result.pointsAwarded, 20);
+    assert.equal(done.result.by, "Sam");
+    const lb = await callMacro("assignee-leaderboard", ctxA, {});
+    assert.equal(lb.result.leaderboard[0].person, "Sam");
+    assert.equal(lb.result.leaderboard[0].points, 20);
+  });
+
+  it("FAIL-CLOSED: poisoned intervalDays is clamped to [1,365], never NaN/Infinity", async () => {
+    const rc = await callMacro("room-create", ctxA, { name: "R" });
+    const tc = await callMacro("task-create", ctxA, { roomId: rc.result.room.id, name: "T", intervalDays: 1e999 });
+    assert.equal(tc.result.task.intervalDays, 365);
+    assertAllFinite(tc.result);
+  });
+
+  it("vacation-toggle freezes condition (dashboard cleanliness stable)", async () => {
+    const rc = await callMacro("room-create", ctxA, { name: "Bath" });
+    await callMacro("task-create", ctxA, { roomId: rc.result.room.id, name: "Scrub", intervalDays: 7 });
+    const on = await callMacro("vacation-toggle", ctxA, { on: true });
+    assert.equal(on.result.paused, true);
+    const dash = await callMacro("household-dashboard", ctxA, {});
+    assert.equal(dash.result.paused, true);
+    assertAllFinite(dash.result);
+  });
+
+  it("per-user isolation: user B sees none of user A's rooms", async () => {
+    await callMacro("room-create", ctxA, { name: "PrivateRoom" });
+    const bList = await callMacro("room-list", ctxB, {});
+    assert.equal(bList.result.rooms.length, 0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("FamilyCalendar substrate — event CRUD + reminder clamp", () => {
+  it("create / list / update / delete round-trip", async () => {
+    const c = await callMacro("calendar-event-create", ctxA, { title: "Dentist", date: "2030-01-15", time: "09:00" });
+    assert.equal(c.ok, true);
+    const id = c.result.event.id;
+    const list = await callMacro("calendar-event-list", ctxA, {});
+    assert.equal(list.result.count, 1);
+    const upd = await callMacro("calendar-event-update", ctxA, { id, title: "Dentist (moved)" });
+    assert.equal(upd.result.event.title, "Dentist (moved)");
+    const del = await callMacro("calendar-event-delete", ctxA, { id });
+    assert.equal(del.result.deleted, id);
+  });
+
+  it("validation-rejection: missing title and date", async () => {
+    assert.equal((await callMacro("calendar-event-create", ctxA, { date: "2030-01-01" })).error, "event title required");
+    assert.equal((await callMacro("calendar-event-create", ctxA, { title: "X" })).error, "event date required");
+  });
+
+  it("FAIL-CLOSED: poisoned reminderMinutes is clamped, never NaN", async () => {
+    const c = await callMacro("calendar-event-create", ctxA, { title: "X", date: "2030-01-01", reminderMinutes: 1e999 });
+    assert.equal(c.result.event.reminderMinutes, 20160);
+    assertAllFinite(c.result);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("MealPlanner substrate — meal-plan-set upsert + grocery aggregation", () => {
+  it("upserts a meal (same date+slot replaces) and aggregates the grocery list", async () => {
+    await callMacro("meal-plan-set", ctxA, { date: "2030-02-01", slot: "dinner", recipe: "Stew", ingredients: ["beef", "carrot"] });
+    await callMacro("meal-plan-set", ctxA, { date: "2030-02-02", slot: "dinner", recipe: "Stir-fry", ingredients: ["carrot", "rice"] });
+    const list = await callMacro("meal-plan-list", ctxA, { from: "2030-02-01", to: "2030-02-07" });
+    assert.equal(list.result.count, 2);
+    const grocery = await callMacro("meal-grocery-list", ctxA, { from: "2030-02-01", to: "2030-02-07" });
+    const carrot = grocery.result.list.find((g) => g.name === "carrot");
+    assert.equal(carrot.count, 2); // appears in both meals
+    assert.equal(grocery.result.uniqueItems, 3);
+  });
+
+  it("validation-rejection: bad slot", async () => {
+    assert.equal((await callMacro("meal-plan-set", ctxA, { date: "2030-01-01", slot: "brunch", recipe: "X" })).error,
+      "slot must be breakfast/lunch/dinner/snack");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("allowance-summary — exact dollars from chore log + fail-closed rate", () => {
+  it("computes per-person allowance = points × rate", async () => {
+    const rc = await callMacro("room-create", ctxA, { name: "R" });
+    const tc = await callMacro("task-create", ctxA, { roomId: rc.result.room.id, name: "T", effort: "medium", assignee: "Kim" });
+    await callMacro("task-done", ctxA, { id: tc.result.task.id }); // medium = 10 pts
+    const s = await callMacro("allowance-summary", ctxA, { dollarsPerPoint: 0.10 });
+    assert.equal(s.result.members[0].person, "Kim");
+    assert.equal(s.result.members[0].points, 10);
+    assert.equal(s.result.members[0].allowance, 1.0); // 10 × 0.10
+    assert.equal(s.result.totalAllowance, 1.0);
+  });
+
+  it("FAIL-CLOSED: NaN/Infinity dollarsPerPoint clamps to a finite rate, no NaN allowance", async () => {
+    const rc = await callMacro("room-create", ctxA, { name: "R" });
+    const tc = await callMacro("task-create", ctxA, { roomId: rc.result.room.id, name: "T", assignee: "Lee" });
+    await callMacro("task-done", ctxA, { id: tc.result.task.id });
+    // Poison (NaN / Infinity) collapses to the safe default rate (0.05) via
+    // finiteNum — never NaN, never Infinity in the allowance output.
+    const sNaN = await callMacro("allowance-summary", ctxA, { dollarsPerPoint: NaN });
+    assertAllFinite(sNaN.result);
+    assert.equal(sNaN.result.dollarsPerPoint, 0.05);
+    const sInf = await callMacro("allowance-summary", ctxA, { dollarsPerPoint: 1e999 });
+    assert.equal(sInf.result.dollarsPerPoint, 0.05); // Infinity → fallback, not clamped-to-max
+    assertAllFinite(sInf.result);
+    // A genuinely-large FINITE rate is still clamped to the 10 ceiling.
+    const sBig = await callMacro("allowance-summary", ctxA, { dollarsPerPoint: 999 });
+    assert.equal(sBig.result.dollarsPerPoint, 10);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("MemberNotifications + SharedShoppingLists substrate", () => {
+  it("notification create / unread count / mark-all-read", async () => {
+    await callMacro("notification-create", ctxA, { recipient: "Sam", message: "Take out trash", kind: "task" });
+    await callMacro("notification-create", ctxA, { recipient: "Sam", message: "Pay rent", kind: "bill" });
+    const list = await callMacro("notification-list", ctxA, {});
+    assert.equal(list.result.count, 2);
+    assert.equal(list.result.unread, 2);
+    const marked = await callMacro("notification-mark-read", ctxA, { all: true });
+    assert.equal(marked.result.markedRead, 2);
+    assert.equal((await callMacro("notification-list", ctxA, {})).result.unread, 0);
+  });
+
+  it("shopping list create → item add → toggle → checkedCount tracks", async () => {
+    const lc = await callMacro("shopping-list-create", ctxA, { name: "Groceries" });
+    const listId = lc.result.list.id;
+    const ia = await callMacro("shopping-item-add", ctxA, { listId, name: "Milk", quantity: "1gal" });
+    const itemId = ia.result.item.id;
+    await callMacro("shopping-item-toggle", ctxA, { listId, itemId, checked: true });
+    const lists = await callMacro("shopping-list-list", ctxA, {});
+    assert.equal(lists.result.lists[0].itemCount, 1);
+    assert.equal(lists.result.lists[0].checkedCount, 1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("RecurringTemplates substrate — spawn materialises a chore", () => {
+  it("template-spawn creates a real chore task on the board (room auto-created)", async () => {
+    const tc = await callMacro("task-template-create", ctxA, { name: "Mop floors", frequency: "weekly", room: "Hall", effort: "medium" });
+    const spawn = await callMacro("task-template-spawn", ctxA, { id: tc.result.template.id });
+    assert.equal(spawn.ok, true);
+    assert.equal(spawn.result.task.name, "Mop floors");
+    assert.equal(spawn.result.task.intervalDays, 7); // weekly
+    assert.equal(spawn.result.room.name, "Hall");
+    const board = await callMacro("chore-board", ctxA, {});
+    assert.ok(board.result.board.some((t) => t.name === "Mop floors"));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("ExpenseSplitter substrate — split + settle-up transfers + fail-closed amount", () => {
+  it("expense-add splits evenly and expense-balances computes net + minimal transfers", async () => {
+    // Alex pays $30 split among Alex, Sam, Jordan → each owes $10; Alex net +$20.
+    await callMacro("expense-add", ctxA, { description: "Dinner", amount: 30, paidBy: "Alex", splitAmong: ["Alex", "Sam", "Jordan"] });
+    const bal = await callMacro("expense-balances", ctxA, {});
+    const alex = bal.result.balances.find((b) => b.person === "Alex");
+    assert.equal(alex.net, 20);
+    const sam = bal.result.balances.find((b) => b.person === "Sam");
+    assert.equal(sam.net, -10);
+    // settle-up: Sam and Jordan each pay Alex $10.
+    const toAlex = bal.result.transfers.filter((t) => t.to === "Alex");
+    assert.equal(toAlex.length, 2);
+    assert.equal(toAlex.reduce((s, t) => s + t.amount, 0), 20);
+    assertAllFinite(bal.result);
+  });
+
+  it("validation-rejection: amount must be > 0 and splitAmong non-empty", async () => {
+    assert.equal((await callMacro("expense-add", ctxA, { description: "X", amount: 0, paidBy: "A", splitAmong: ["A"] })).error,
+      "amount must be a finite number > 0");
+    assert.equal((await callMacro("expense-add", ctxA, { description: "X", amount: 5, paidBy: "A", splitAmong: [] })).error,
+      "splitAmong must list at least one member");
+  });
+
+  it("FAIL-CLOSED: amount=1e999 / 'Infinity' is rejected, never stored as Infinity", async () => {
+    const r1 = await callMacro("expense-add", ctxA, { description: "X", amount: 1e999, paidBy: "A", splitAmong: ["A"] });
+    assert.equal(r1.ok, false);
+    const r2 = await callMacro("expense-add", ctxA, { description: "X", amount: "Infinity", paidBy: "A", splitAmong: ["A"] });
+    assert.equal(r2.ok, false);
+    // ledger stays clean → balances all finite.
+    const bal = await callMacro("expense-balances", ctxA, {});
+    assertAllFinite(bal.result);
+  });
+
+  it("settle flips a flag and removes the expense from the balances pool", async () => {
+    const a = await callMacro("expense-add", ctxA, { description: "Cab", amount: 12, paidBy: "Sam", splitAmong: ["Sam", "Alex"] });
+    const id = a.result.expense.id;
+    await callMacro("expense-settle", ctxA, { id, settled: true });
+    const bal = await callMacro("expense-balances", ctxA, {});
+    assert.equal(bal.result.unsettledExpenses, 0);
+  });
+});

--- a/server/tests/insurance-lens-macros.test.js
+++ b/server/tests/insurance-lens-macros.test.js
@@ -1,0 +1,260 @@
+// server/tests/insurance-lens-macros.test.js
+//
+// PHASE-2 component-exact-shape behavioral contract for the `insurance` lens.
+//
+// The insurance domain is registered through the canonical `register(domain,
+// name, fn)` MACROS registry (registerInsuranceActions(register) in server.js),
+// so the live POST /api/lens/run dispatch for these macros is:
+//     rest = peelRedundantArtifactWrapper(body.input)   // dispatch normalizer
+//     fn   = MACROS.get('insurance').get(action)
+//     fn(ctx, rest)                                       // 2-arg register form
+// The domain file's own legacy shim then rebuilds `(ctx, artifact, params)` from
+// `rest`. We reproduce that EXACT chain HERMETICALLY — no server boot, no
+// network, no LLM, no DB — by importing the real domain registrar + the real
+// dispatch peel and wiring a tiny MACROS map.
+//
+// CRITICAL — these tests drive the EXACT wrapper the InsuranceActionPanel
+// component sends (`callMacro(action, { artifact: { title, data } })`) and
+// assert the EXACT fields it renders from `r.result`. A previous defect: the
+// sole-key `{ artifact: { title, data } }` body is peeled to `artifact.data` by
+// the dispatch, DROPPING `artifact.title` — so `riskScore.risk` (read from
+// `artifact.title`) rendered blank in the live app while the handler-shape depth
+// test (which passes `{ data }` directly) stayed green. Fixed by sending
+// `risk` inside `data` (survives the peel) + a handler fallback. Pinned below.
+
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import registerInsuranceActions from "../domains/insurance.js";
+import { peelRedundantArtifactWrapper } from "../lib/lens-input-normalize.js";
+
+// ── hermetic dispatch harness (no boot) ─────────────────────────────────────
+const MACROS = new Map();
+function register(domain, name, fn) {
+  if (!MACROS.has(domain)) MACROS.set(domain, new Map());
+  MACROS.get(domain).set(name, fn);
+}
+
+let CTX;
+before(() => {
+  // The parity/CRUD macros persist into globalThis._concordSTATE keyed by the
+  // ctx userId; give them a real (empty) STATE so an empty {} returns a genuine
+  // validation reason, never a no_db sentinel.
+  globalThis._concordSTATE = globalThis._concordSTATE || {};
+  registerInsuranceActions(register);
+  CTX = { actor: { userId: "ins-test-user" } };
+});
+
+/** Exactly what POST /api/lens/run does for a register()-path macro. */
+function dispatch(action, input) {
+  const rest = peelRedundantArtifactWrapper(input || {});
+  const fn = MACROS.get("insurance").get(action);
+  assert.ok(fn, `macro insurance.${action} is not registered`);
+  return fn(CTX, rest);
+}
+
+/** The component wraps every calculator call as { artifact: { title, data } }. */
+const book = (data, title = "Insurance book") => ({ artifact: { title, data } });
+
+describe("insurance lens — component-exact calculator contracts (real dispatch + peel)", () => {
+  // ── coverageGap ── component renders: gapCount, gaps[], expiringSoon.length,
+  //                   coveredTypes, totalPolicies
+  it("coverageGap: renders gapCount/gaps/coveredTypes/expiringSoon from the exact book wrapper", () => {
+    const soon = new Date(Date.now() + 10 * 86400000).toISOString();
+    const r = dispatch(
+      "coverageGap",
+      book({ policies: [{ type: "auto" }, { type: "home", expiryDate: soon }], claims: [] }),
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.result.totalPolicies, 2);
+    // catalog = health/auto/home/life/liability/umbrella; auto+home held → 4 gaps
+    assert.equal(r.result.gapCount, 4);
+    assert.deepEqual(r.result.gaps.slice().sort(), ["health", "liability", "life", "umbrella"]);
+    assert.ok(r.result.coveredTypes.includes("auto"));
+    assert.ok(r.result.coveredTypes.includes("home"));
+    // home expires in 10d (≤30) → exactly one expiringSoon entry
+    assert.equal(r.result.expiringSoon.length, 1);
+  });
+
+  // ── lossRatioReport ── component renders: lossRatio, assessment,
+  //                       premiumsCollected, claimsPaid, claimFrequency, averageSeverity
+  it("lossRatioReport: lossRatio = paid/premiums; renders every money field finite", () => {
+    const r = dispatch(
+      "lossRatioReport",
+      book({
+        policies: [{ premium: 1000 }, { premium: 1000 }],
+        claims: [
+          { status: "paid", amount: 800 },
+          { status: "closed", amount: 400 },
+          { status: "open", amount: 999 }, // excluded from claimsPaid
+        ],
+      }),
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.result.premiumsCollected, 2000);
+    assert.equal(r.result.claimsPaid, 1200); // 800 + 400
+    assert.equal(r.result.lossRatio, 60); // 1200/2000*100
+    assert.equal(r.result.assessment, "profitable"); // 60 is NOT > 60
+    assert.equal(r.result.claimFrequency, 1.5); // 3 claims / 2 policies
+    assert.equal(r.result.averageSeverity, 400); // claimsPaid 1200 / totalClaims 3
+    // Every rendered money/ratio field must be finite (Insurance money invariant).
+    for (const k of ["premiumsCollected", "claimsPaid", "lossRatio", "claimFrequency", "averageSeverity"]) {
+      assert.ok(Number.isFinite(r.result[k]), `${k} must be finite, got ${r.result[k]}`);
+    }
+  });
+
+  it("lossRatioReport: a high-loss book grades 'unprofitable'", () => {
+    const r = dispatch(
+      "lossRatioReport",
+      book({ policies: [{ premium: 1000 }], claims: [{ status: "paid", amount: 1500 }] }),
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.result.lossRatio, 150);
+    assert.equal(r.result.assessment, "unprofitable");
+  });
+
+  // ── renewalAlert ── component renders: urgentCount, premiumAtRisk,
+  //                    totalUpcomingRenewals, within30Days[], within60Days[]
+  it("renewalAlert: buckets by 30/60/90 windows; premiumAtRisk sums the at-risk book", () => {
+    const in10 = new Date(Date.now() + 10 * 86400000).toISOString();
+    const in45 = new Date(Date.now() + 45 * 86400000).toISOString();
+    const r = dispatch(
+      "renewalAlert",
+      book({
+        policies: [
+          { policyNumber: "P1", premium: 500, expiryDate: in10 },
+          { policyNumber: "P2", premium: 300, expiryDate: in45 },
+        ],
+      }),
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.result.urgentCount, 1); // only P1 ≤30d
+    assert.equal(r.result.within30Days.length, 1);
+    assert.equal(r.result.within60Days.length, 1);
+    assert.equal(r.result.totalUpcomingRenewals, 2);
+    assert.equal(r.result.premiumAtRisk, 800); // 500 + 300
+    assert.equal(r.result.within30Days[0].policyNumber, "P1");
+    assert.ok(Number.isFinite(r.result.premiumAtRisk));
+  });
+
+  // ── riskScore ── THE component-exact-shape regression. Component renders:
+  //                risk, normalizedScore, level, rawScore, mitigatedScore,
+  //                probability, impact. `risk` was blank pre-fix (title dropped
+  //                by the dispatch peel). It now travels inside `data.risk`.
+  it("riskScore: renders a NON-BLANK risk label from data.risk (peel-survival regression)", () => {
+    const r = dispatch("riskScore", {
+      artifact: { title: "Cyber breach", data: { risk: "Cyber breach", probability: 4, impact: 5 } },
+    });
+    assert.equal(r.ok, true);
+    // The defect: with the title dropped by the peel, r.result.risk was
+    // undefined and the panel's "Risk · …" card rendered blank.
+    assert.equal(r.result.risk, "Cyber breach");
+    assert.equal(r.result.rawScore, 20); // 4 × 5
+    assert.equal(r.result.normalizedScore, 80); // 20/25 × 100
+    assert.equal(r.result.level, "critical"); // ≥15
+    assert.equal(r.result.probability, 4);
+    assert.equal(r.result.impact, 5);
+    assert.ok(Number.isFinite(r.result.normalizedScore));
+    assert.ok(Number.isFinite(r.result.mitigatedScore));
+  });
+
+  it("riskScore: low probability×impact grades 'low'", () => {
+    const r = dispatch("riskScore", {
+      artifact: { title: "Minor", data: { risk: "Minor", probability: 1, impact: 2 } },
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.rawScore, 2);
+    assert.equal(r.result.level, "low");
+    assert.equal(r.result.risk, "Minor");
+  });
+
+  // ── carrier-rate (AmsWorkbench comparative rate run) ──
+  it("carrier-rate: scores appointed carriers; cheapest/spread/bestFit are finite", () => {
+    // seed two carriers for this user via the real carrier-add macro
+    const a = dispatch("carrier-add", { name: "Acme Mutual", lines: ["auto"], baseCommissionPct: 12, rateIndex: 0.9, claimsServiceScore: 8, amBestRating: "A+" });
+    assert.equal(a.ok, true);
+    const b = dispatch("carrier-add", { name: "Budget Auto", lines: ["auto"], baseCommissionPct: 10, rateIndex: 1.3, claimsServiceScore: 5 });
+    assert.equal(b.ok, true);
+    const r = dispatch("carrier-rate", { line: "auto", basePremium: 1000, riskFactor: 1 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.carrierCount, 2);
+    // Acme 1000×0.9 = 900 ; Budget 1000×1.3 = 1300 → cheapest 900, spread 400
+    assert.equal(r.result.cheapest, 900);
+    assert.equal(r.result.spread, 400);
+    assert.equal(r.result.bestPrice.carrier, "Acme Mutual");
+    assert.ok(r.result.bestFit);
+    for (const q of r.result.quotes) {
+      assert.ok(Number.isFinite(q.annualPremium));
+      assert.ok(Number.isFinite(q.commission));
+      assert.ok(Number.isFinite(q.fitScore));
+    }
+  });
+});
+
+describe("insurance lens — validation rejection + degrade-graceful", () => {
+  it("coverageGap: an empty book degrades to all-gaps, never throws", () => {
+    const r = dispatch("coverageGap", book({ policies: [], claims: [] }));
+    assert.equal(r.ok, true);
+    assert.equal(r.result.totalPolicies, 0);
+    assert.equal(r.result.gapCount, 6); // all 6 catalog types missing
+  });
+
+  it("lossRatioReport: zero premiums → lossRatio 0 (no divide-by-zero, finite)", () => {
+    const r = dispatch("lossRatioReport", book({ policies: [], claims: [] }));
+    assert.equal(r.ok, true);
+    assert.equal(r.result.lossRatio, 0);
+    assert.equal(r.result.assessment, "profitable");
+    assert.ok(Number.isFinite(r.result.lossRatio));
+  });
+
+  it("carrier-rate: rejects a non-positive basePremium with a real reason", () => {
+    const r = dispatch("carrier-rate", { line: "home", basePremium: 0 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /basePremium must be > 0/);
+  });
+
+  it("carrier-rate: a line no appointed carrier writes returns a real reason, not an empty quote list", () => {
+    const r = dispatch("carrier-rate", { line: "marine_cargo_xyz", basePremium: 1000 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /No appointed carrier/i);
+  });
+});
+
+describe("insurance lens — fail-CLOSED poisoned-numeric (Number.isFinite money guard)", () => {
+  // Insurance does premium/risk/payout math; a poisoned numeric must be
+  // REJECTED before it can serialise as null/Infinity into a rendered money or
+  // score field — NOT clamped into a silently-accepted result.
+  for (const bad of [Infinity, -Infinity, NaN, 1e308, -5]) {
+    it(`riskScore: rejects poisoned probability=${String(bad)} (no null/Infinity score)`, () => {
+      const r = dispatch("riskScore", {
+        artifact: { title: "x", data: { risk: "x", probability: bad, impact: 5 } },
+      });
+      assert.equal(r.ok, false, `expected ok:false for probability=${String(bad)}`);
+      assert.match(r.error, /invalid_probability/);
+    });
+    it(`riskScore: rejects poisoned impact=${String(bad)}`, () => {
+      const r = dispatch("riskScore", {
+        artifact: { title: "x", data: { risk: "x", probability: 3, impact: bad } },
+      });
+      assert.equal(r.ok, false);
+      assert.match(r.error, /invalid_impact/);
+    });
+  }
+
+  it("carrier-rate: rejects a poisoned basePremium before the rate multiply", () => {
+    const r = dispatch("carrier-rate", { line: "auto", basePremium: Infinity, riskFactor: 1 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /invalid_basePremium/);
+  });
+
+  it("carrier-rate: rejects a poisoned riskFactor", () => {
+    const r = dispatch("carrier-rate", { line: "auto", basePremium: 1000, riskFactor: 1e308 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /invalid_riskFactor/);
+  });
+
+  it("pact-write: rejects poisoned payoutSparks (death-insurance money guard)", () => {
+    const r = dispatch("pact-write", { beneficiaryUserId: "friend_1", payoutSparks: 1e308, premiumSparks: 50, durationDays: 30 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /invalid_payoutSparks/);
+  });
+});

--- a/server/tests/legal-lens-macros.test.js
+++ b/server/tests/legal-lens-macros.test.js
@@ -1,0 +1,316 @@
+// legal-lens-macros.test.js — Phase-2 component-exact-shape behavioral gate.
+//
+// Drives each legal calculator with the EXACT inner-data object the live
+// surfaces send (LegalActionPanel.callMacro channel + page.tsx handleAction
+// channel), through the REAL 3-arg dispatch contract, and asserts the EXACT
+// fields the components render — with real computed values, validation
+// rejection, degrade-graceful, and fail-CLOSED poisoned-numeric handling.
+//
+// Dispatch fidelity: /api/lens/run peels a sole-key {artifact:{data}} wrapper,
+// then sets virtualArtifact.data = rest AND passes rest as params (same object).
+// So the handler sees artifact.data.X and params.X as the same plain object.
+// callLens() reproduces that exactly (data === params === input).
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import registerLegalActions from "../domains/legal.js";
+import { peelRedundantArtifactWrapper } from "../lib/lens-input-normalize.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+
+// Reproduce the real dispatch: peel one redundant {artifact:{data}} layer, then
+// hand the SAME object as both artifact.data and params.
+function callLens(name, input = {}, ctx = baseCtx) {
+  const fn = ACTIONS.get(`legal.${name}`);
+  assert.ok(fn, `legal.${name} not registered`);
+  const rest = peelRedundantArtifactWrapper(input || {});
+  const virtualArtifact = { id: input?.id ?? null, title: input?.title, domain: "legal", type: "domain_action", data: rest, meta: {} };
+  return fn(ctx, virtualArtifact, rest);
+}
+
+const baseCtx = { actor: { userId: "lawyer_a" }, userId: "lawyer_a" };
+
+before(() => { registerLegalActions(register); });
+beforeEach(() => {
+  globalThis._concordSTATE = { dtus: new Map() };
+  globalThis._concordSaveStateDebounced = () => {};
+});
+
+// A fixed "today" anchor so day-deltas are deterministic relative to run time.
+function isoIn(days) {
+  const d = new Date();
+  d.setUTCHours(12, 0, 0, 0);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+/* ───────────────────────── deadlineCheck ─────────────────────────
+   LegalActionPanel.actDeadline sends { items: [{name,deadline,severity}],
+   daysAhead }. Handler returns { upcoming:[...item, daysUntil], count }.
+   Panel renders upcoming[].name / .daysUntil / .severity and count. */
+describe("legal.deadlineCheck (LegalActionPanel)", () => {
+  it("computes real daysUntil + count for the EXACT panel input", () => {
+    const input = { items: [
+      { name: "Answer due", deadline: isoIn(10), severity: "high" },
+      { name: "Discovery cutoff", deadline: isoIn(40), severity: "medium" },
+    ], daysAhead: 3650 };
+    const r = callLens("deadlineCheck", input);
+    assert.equal(r.ok, true);
+    assert.equal(r.result.count, 2);
+    assert.equal(r.result.upcoming.length, 2);
+    // sorted ascending by daysUntil; closest first
+    assert.equal(r.result.upcoming[0].name, "Answer due");
+    assert.equal(r.result.upcoming[0].daysUntil, 10);
+    assert.equal(r.result.upcoming[0].severity, "high");
+    assert.equal(r.result.upcoming[1].daysUntil, 40);
+  });
+
+  it("degrades graceful on empty items (no throw, count 0)", () => {
+    const r = callLens("deadlineCheck", { items: [], daysAhead: 30 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.count, 0);
+    assert.deepEqual(r.result.upcoming, []);
+  });
+
+  it("fail-CLOSED on poisoned deadline string (dropped, count finite)", () => {
+    const r = callLens("deadlineCheck", { items: [{ name: "bad", deadline: "Infinity", severity: "high" }], daysAhead: 3650 });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.count));
+    assert.equal(r.result.count, 0); // NaN daysUntil filtered out
+  });
+});
+
+/* ───────────────────────── contractRenewal ──────────────────────
+   actRenewal calls per-contract with { expiryDate, renewalType, title }.
+   Handler returns { daysUntilExpiry, urgency, autoRenewal, actionRequired }. */
+describe("legal.contractRenewal (LegalActionPanel)", () => {
+  it("computes daysUntilExpiry + urgency band for the EXACT input", () => {
+    const r = callLens("contractRenewal", { expiryDate: isoIn(10), renewalType: "manual", title: "MSA" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.daysUntilExpiry, 10);
+    assert.equal(r.result.urgency, "critical"); // <=14
+    assert.equal(r.result.autoRenewal, false);
+    assert.equal(r.result.actionRequired, true); // <=60
+  });
+
+  it("auto-renewal flag + medium urgency band", () => {
+    const r = callLens("contractRenewal", { expiryDate: isoIn(45), renewalType: "auto", title: "Lease" });
+    assert.equal(r.result.autoRenewal, true);
+    assert.equal(r.result.urgency, "medium"); // <=60
+    assert.equal(r.result.actionRequired, true);
+  });
+
+  it("degrades graceful when no expiry date", () => {
+    const r = callLens("contractRenewal", {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.status, "no_expiry");
+  });
+
+  it("fail-CLOSED daysUntilExpiry stays finite for a far-future date", () => {
+    const r = callLens("contractRenewal", { expiryDate: isoIn(400), renewalType: "manual" });
+    assert.ok(Number.isFinite(r.result.daysUntilExpiry));
+    assert.equal(r.result.urgency, "low");
+  });
+
+  it("fail-CLOSED on poisoned expiry date (no NaN urgency leak)", () => {
+    const r = callLens("contractRenewal", { expiryDate: "Infinity", renewalType: "manual" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.status, "no_expiry");
+    assert.equal(r.result.daysUntilExpiry, undefined);
+  });
+});
+
+/* ───────────────────────── conflictCheck ────────────────────────
+   actConflict sends { client, parties:[A], checkAgainst:[B] }.
+   Handler returns { conflicts:[{name,conflictType,caseId}], hasConflict, checkedAt }. */
+describe("legal.conflictCheck (LegalActionPanel)", () => {
+  it("flags a direct-party conflict for the EXACT input", () => {
+    const input = { id: "case_1", client: "Acme Co", parties: ["Acme Co"], checkAgainst: ["Acme Co"] };
+    const r = callLens("conflictCheck", input);
+    assert.equal(r.ok, true);
+    assert.equal(r.result.hasConflict, true);
+    assert.equal(r.result.conflicts.length, 1);
+    assert.equal(r.result.conflicts[0].name, "Acme Co");
+    assert.equal(r.result.conflicts[0].conflictType, "direct_party");
+    assert.ok(typeof r.result.checkedAt === "string");
+  });
+
+  it("clear when checkAgainst name is unrelated", () => {
+    const r = callLens("conflictCheck", { client: "Acme Co", parties: ["Acme Co"], checkAgainst: ["Globex"] });
+    assert.equal(r.result.hasConflict, false);
+    assert.deepEqual(r.result.conflicts, []);
+  });
+
+  it("degrades graceful with no checkAgainst (no throw)", () => {
+    const r = callLens("conflictCheck", { client: "Acme Co", parties: ["Acme Co"] });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.hasConflict, false);
+  });
+});
+
+/* ───────────────────────── complianceAudit ──────────────────────
+   actAudit sends { requirements:[{name,deadline,status}] }.
+   Handler returns { score, rating, passed, failed, findings, checklist, ... }.
+   Panel renders score + rating + findings.length. */
+describe("legal.complianceAudit (LegalActionPanel)", () => {
+  it("scores requirements for the EXACT input", () => {
+    const input = { requirements: [
+      { name: "CLE credits", deadline: isoIn(30), status: "compliant" },
+      { name: "Trust recon", deadline: isoIn(-5), status: "pending" }, // overdue
+    ] };
+    const r = callLens("complianceAudit", input);
+    assert.equal(r.ok, true);
+    assert.equal(r.result.totalRequirements, 2);
+    assert.equal(r.result.passed, 1);
+    assert.equal(r.result.failed, 1);
+    assert.equal(r.result.score, 50);
+    assert.equal(r.result.rating, "fair"); // 50 => fair
+    assert.equal(r.result.findings.length, 1);
+    assert.equal(r.result.findings[0].requirement, "Trust recon");
+    assert.equal(r.result.findings[0].severity, "high"); // overdue
+  });
+
+  it("degrades graceful on empty requirements (perfect score)", () => {
+    const r = callLens("complianceAudit", { requirements: [] });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.score, 100);
+    assert.equal(r.result.rating, "excellent");
+  });
+});
+
+/* ───────────────────────── complianceScore (page inline) ────────
+   page.tsx renders score / total / compliant / overdue. */
+describe("legal.complianceScore (page inline panel)", () => {
+  it("computes score/compliant/overdue for the EXACT rendered fields", () => {
+    const input = { requirements: [
+      { status: "compliant" },
+      { status: "compliant" },
+      { status: "overdue" },
+      { deadline: isoIn(-3), status: "pending" }, // overdue by date
+    ] };
+    const r = callLens("complianceScore", input);
+    assert.equal(r.ok, true);
+    assert.equal(r.result.total, 4);
+    assert.equal(r.result.compliant, 2);
+    assert.equal(r.result.score, 50);
+    assert.equal(r.result.overdue, 2);
+    assert.equal(r.result.rating, "fair");
+  });
+
+  it("degrades graceful on empty (total 0, score 100)", () => {
+    const r = callLens("complianceScore", { requirements: [] });
+    assert.equal(r.result.total, 0);
+    assert.equal(r.result.score, 100);
+  });
+});
+
+/* ───────────────────────── deadlineCalculator (page inline) ─────
+   page.tsx button. Reads filingDate + jurisdiction; returns deadlines[]. */
+describe("legal.deadlineCalculator (page inline panel)", () => {
+  it("computes jurisdiction deadlines for the EXACT input", () => {
+    const r = callLens("deadlineCalculator", { filingDate: isoIn(0), jurisdiction: "federal" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.jurisdiction, "federal");
+    assert.equal(r.result.deadlines.length, 5);
+    const resp = r.result.deadlines.find(d => d.event === "Response Due");
+    assert.equal(resp.daysFromFiling, 21); // federal responseDays
+    assert.ok(Number.isFinite(resp.daysRemaining));
+    assert.ok(["past", "urgent", "upcoming", "future"].includes(resp.status));
+  });
+
+  it("validation: rejects missing filing date", () => {
+    const r = callLens("deadlineCalculator", {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.error, "No filing date provided");
+  });
+
+  it("fail-CLOSED on poisoned filing date (no RangeError throw)", () => {
+    const r = callLens("deadlineCalculator", { filingDate: "Infinity" });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.error, "Invalid filing date");
+  });
+});
+
+/* ───────────────────────── generateInvoice (page inline) ────────
+   page.tsx handleAction('generateInvoice'). Reads timeEntries/expenses;
+   returns subtotal/taxAmount/total. */
+describe("legal.generateInvoice (page inline panel)", () => {
+  it("sums labor + expenses + tax for the EXACT input", () => {
+    const input = {
+      client: "Acme Co",
+      timeEntries: [
+        { date: isoIn(-2), description: "Drafting", attorney: "JD", hours: 2, rate: 300 },
+        { date: isoIn(-1), description: "Review", attorney: "JD", hours: 1.5, rate: 300 },
+      ],
+      expenses: [{ description: "Filing fee", amount: 50 }],
+    };
+    const r = callLens("generateInvoice", { ...input, taxRate: 0.1 });
+    assert.equal(r.ok, true);
+    assert.equal(r.result.totalHours, 3.5);
+    assert.equal(r.result.laborSubtotal, 1050); // 2*300 + 1.5*300
+    assert.equal(r.result.expenseSubtotal, 50);
+    assert.equal(r.result.subtotal, 1100);
+    assert.equal(r.result.taxAmount, 110); // 1100 * 0.1
+    assert.equal(r.result.total, 1210);
+    assert.ok(Number.isFinite(r.result.total));
+  });
+
+  it("degrades graceful with no entries (zero totals)", () => {
+    const r = callLens("generateInvoice", {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.subtotal, 0);
+    assert.equal(r.result.total, 0);
+  });
+
+  it("fail-CLOSED on poisoned numeric (Infinity hours coerced to 0, total finite)", () => {
+    const r = callLens("generateInvoice", {
+      timeEntries: [{ description: "x", hours: "Infinity", rate: "1e999" }],
+      expenses: [{ description: "y", amount: "Infinity" }],
+      taxRate: "Infinity",
+    });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.total), "total must be finite");
+    assert.ok(Number.isFinite(r.result.subtotal));
+    assert.ok(Number.isFinite(r.result.taxAmount));
+    assert.equal(r.result.total, 0);
+  });
+});
+
+/* ───────────────────────── caseSummary (page inline) ────────────
+   page.tsx handleAction('caseSummary'). Reads parties/timeEntries/etc;
+   returns billingTotal + keyDates. */
+describe("legal.caseSummary (page inline panel)", () => {
+  it("computes billingTotal + keyDates for the EXACT input", () => {
+    const input = {
+      id: "case_42",
+      title: "Smith v. Jones",
+      client: "Smith",
+      opposingParty: "Jones",
+      parties: ["Smith", "Jones"],
+      status: "active",
+      filingDate: isoIn(-100),
+      documents: [{}, {}],
+      timeEntries: [{ hours: 3, rate: 250 }, { hours: 1, rate: 250 }],
+      nextHearing: isoIn(20),
+    };
+    const r = callLens("caseSummary", input);
+    assert.equal(r.ok, true);
+    assert.equal(r.result.caseId, "case_42");
+    assert.equal(r.result.title, "Smith v. Jones");
+    assert.equal(r.result.billingTotal, 1000); // 3*250 + 1*250
+    assert.equal(r.result.relatedDocumentsCount, 2);
+    assert.ok(r.result.keyDates.some(k => k.event === "Filing"));
+    assert.ok(r.result.keyDates.some(k => k.event === "Next Hearing"));
+  });
+
+  it("fail-CLOSED on poisoned billing numerics (billingTotal finite)", () => {
+    const r = callLens("caseSummary", {
+      id: "c", title: "t",
+      timeEntries: [{ hours: "Infinity", rate: "1e999" }],
+    });
+    assert.equal(r.ok, true);
+    assert.ok(Number.isFinite(r.result.billingTotal));
+    assert.equal(r.result.billingTotal, 0);
+  });
+});


### PR DESCRIPTION
## Summary

Continues the MMO/RPG completeness initiative on top of the (now-merged) dispatcher fail-fast fix (#838). Three threads land here, all end-to-end with tests — no scaffolding, mocks, or deferrals:

1. **Orchestrated Invariant Engine** — a contract-driven, adversarial verification layer over the macro substrate: auto-derived per-macro contracts (`content/contracts/`), the `macro-assassin` ratchet (V1 seed / V2 adversarial fuzz / V3 invariant proof) booting the real `runMacro` in-process, a runtime invariant wrapper, and a `scripts/adversarial-audit.mjs` CI orchestrator.
2. **Semantic sandwich** — verified neuro-symbolic pipeline (structured tool-pick → router → deterministic `macro_dag` → constrained+verified output gate) assembled on the contract-verified macro core. Output gate is *verified, not trusted*; no GPU/hallucination-proof claims.
3. **Per-lens flawless loop** — takes each lens from "wired + doesn't crash" to genuinely complete front-to-back: real frontend↔backend field alignment, behavioral macro tests (exact computed values, not shape), fail-closed numerics, 4 honest UX states (loading/error-with-working-retry/empty/populated), contract overrides, green tsc.

## Per-lens work in this PR (14 lenses through the Phase-2 gate)

atlas · board · classroom · council · debate · forum · household · geology · forestry · energy · eco · fitness · fishing · ethics

The recurring defect classes fixed (verified against the actual code, each with a behavioral test):
- **Dead `*ActionPanel` calculator surfaces** — components posting `{artifact:{data}}` / params the handler ignores, or rendering output field names the handler never returns → blank in production while shape-only tests passed. Root-caused to the dispatch double-wrap and fixed both at a dispatch normalizer (`peelRedundantArtifactWrapper`) and per-component.
- **Fail-open numerics** — `parseFloat`/`Number()` silently admit `Infinity`/`NaN` (e.g. a "$Infinity" finance figure, an "Infinity MW" grid readout, a poisoned medical/fitness number); now `Number.isFinite`-guarded and clamped, fail-closed.
- **Fabricated fallback data** — e.g. eco's `aqi-current` returned a fake plausible AQI on network failure; now fails honestly with `{ok:false}` and the panel renders the error branch.
- **Silent-empty / swallowed-rejection** — a swallowed fetch or `{ok:false}` rendered identically to genuinely-empty; the `/api/lens/run` envelope unwraps one `{ok,result}` layer so transport `r.data.ok` is always true and handler rejections were dropped. Fixed across many panels to surface a distinguishable error with a working retry.

## Verification

- Per lens: `node --test server/tests/<lens>-lens-macros.test.js` + `npx vitest run tests/<lens>-lens-states.test.tsx` + `npx tsc --noEmit` (0) + `macro-assassin --domain=<lens>` (0 violations) + no-fake/no-dead-code grep.
- Lens wiring: `node scripts/verify-lens-backends.mjs` → 258 WIRED / 0 broken / 2 by-design.
- Progress is tracked durably in `docs/LENS_COMPLETION_LEDGER.md` (one row per lens, per-batch); the loop is resumable.

## Notes

- A known verification-engine gap is documented in the ledger: the macro-assassin harness currently enumerates only the path-2 `MACROS` registry, not path-3 `LENS_ACTIONS`, so path-3-only lenses get a trivially-true "0 violations" and their override files are documented-but-not-driven — the per-lens behavioral `node:test` is the real enforcement for those. Closing this is queued as its own deliberate pass (it shifts the ratchet baseline for all path-3 lenses).
- The completion roadmap ("ensure every app works" — web + deps + MMO + mobile) is folded into the plan; this PR is the web-surface lens loop plus the engine/sandwich foundations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QrFFXdonyjmm6TTFmKwEk9)_