### PR TITLE
Browser-Ready Campaign follow-on: 2 real post-merge CI gaps + world-lens panel declutter

### DIFF
--- a/concord-frontend/app/lenses/world/page.tsx
+++ b/concord-frontend/app/lenses/world/page.tsx
@@ -1864,6 +1864,16 @@ export default function WorldLensPage() {
         category: 'view',
         action: togglePointerLock,
       },
+      {
+        id: 'toggle-hud',
+        keys: 'h',
+        description: 'Hide/show HUD panels (clear the view for movement/screenshots)',
+        category: 'view',
+        action: () =>
+          window.dispatchEvent(
+            new CustomEvent('concordia:hide-hud', { detail: { hide: !hudHidden } })
+          ),
+      },
     ],
     { lensId: 'world' }
   );
@@ -1933,6 +1943,22 @@ export default function WorldLensPage() {
   // only when WebGL is unavailable (see webglAvailable + the effect below).
   const [viewMode, setViewMode] = useState<ViewMode>('explore');
   const [activeDistrict, setActiveDistrict] = useState<District>(DEMO_DISTRICT);
+
+  // Global HUD visibility — the ~15 permanent 2D panels floating over the
+  // 3D canvas (feeds, trackers, toolbar, resource bars) obstruct movement
+  // and the view. One toggle clears all of them at once. Also the real
+  // wiring for PhotoMode's hide-HUD dispatch, which previously had no
+  // listener on this page (PhotoMode fired 'concordia:hide-hud' into the
+  // void — see lib/event-router.ts, which only ever showed a toast).
+  const [hudHidden, setHudHidden] = useState(false);
+  useEffect(() => {
+    const onHideHud = (e: Event) => {
+      const hide = (e as CustomEvent<{ hide?: boolean }>).detail?.hide;
+      if (typeof hide === 'boolean') setHudHidden(hide);
+    };
+    window.addEventListener('concordia:hide-hud', onHideHud);
+    return () => window.removeEventListener('concordia:hide-hud', onHideHud);
+  }, []);
 
   // ── World-data honesty (W4) ────────────────────────────────────────────────
   // The scene boots on DEMO_DISTRICT seed geometry; the player must never
@@ -4426,7 +4452,7 @@ export default function WorldLensPage() {
               floats above the canvas in either windowed or fullscreen
               mode. Skyrim-shape immersion: F to toggle full, P to
               capture mouse for FPS-style aim. */}
-          <div className="absolute top-4 left-4 z-30 flex items-center gap-1.5 bg-black/60 border border-white/10 rounded-xl px-2 py-1.5 pointer-events-auto">
+          <div className={`absolute top-4 left-4 z-30 flex items-center gap-1.5 bg-black/60 border border-white/10 rounded-xl px-2 py-1.5 pointer-events-auto ${hudHidden ? 'hidden' : ''}`}>
             <button
               onClick={isFullscreen ? exitFullscreen : enterFullscreen}
               title={isFullscreen ? 'Exit fullscreen (Esc)' : 'Enter fullscreen (F)'}
@@ -4511,7 +4537,7 @@ export default function WorldLensPage() {
           />
           </ErrorBoundary>
           {/* Theme picker — 3 swatches + PBR/Toon toggle top-right */}
-          <div className="absolute top-4 right-4 z-20 flex items-center gap-1.5 bg-black/50 border border-white/10 rounded-xl px-2 py-1.5 pointer-events-auto">
+          <div className={`absolute top-4 right-4 z-20 flex items-center gap-1.5 bg-black/50 border border-white/10 rounded-xl px-2 py-1.5 pointer-events-auto ${hudHidden ? 'hidden' : ''}`}>
             {[
               { id: 'neon-punk' as const, swatch: '#6366f1', label: 'Neon Punk' },
               { id: 'classic' as const, swatch: '#e8c97a', label: 'Classic' },
@@ -4720,7 +4746,7 @@ export default function WorldLensPage() {
             worldId={activeDistrict.id}
             playerPosition={{ x: playerAvatar.position.x, y: 0, z: playerAvatar.position.z }}
           />
-          <CurrencyHUD onClick={() => setShowPanel('profile')} />
+          {!hudHidden && <CurrencyHUD onClick={() => setShowPanel('profile')} />}
           <DiegeticSurfaces
             playerPosition={playerAvatar.position}
             onOpenMap={() => setShowPanel('map')}
@@ -4924,7 +4950,7 @@ export default function WorldLensPage() {
           })}
 
           {/* Camera mode controls */}
-          <div className="absolute top-4 right-4 z-20">
+          <div className={`absolute top-4 right-4 z-20 ${hudHidden ? 'hidden' : ''}`}>
             <CameraControls
               cameraState={{
                 mode: cameraMode,
@@ -4943,21 +4969,23 @@ export default function WorldLensPage() {
             />
           </div>
           {/* HUD overlay — mode drives the top-bar label */}
-          <HUDOverlay
-            mode={(MODE_TO_HUD[inputMode] ?? 'explore') as HUDMode}
-            district={activeDistrict.name}
-            timeOfDay="day"
-            weather="clear"
-            playerCount={1}
-            currency={{ concordCoin: 0, pendingRoyalties: 0 }}
-            professionBadge=""
-            reputationLevel={1}
-            notifications={[]}
-            unreadCount={0}
-            tools={[]}
-            onToolSelect={() => {}}
-            onMenuOpen={() => setA11yMenuOpen(true)}
-          />
+          {!hudHidden && (
+            <HUDOverlay
+              mode={(MODE_TO_HUD[inputMode] ?? 'explore') as HUDMode}
+              district={activeDistrict.name}
+              timeOfDay="day"
+              weather="clear"
+              playerCount={1}
+              currency={{ concordCoin: 0, pendingRoyalties: 0 }}
+              professionBadge=""
+              reputationLevel={1}
+              notifications={[]}
+              unreadCount={0}
+              tools={[]}
+              onToolSelect={() => {}}
+              onMenuOpen={() => setA11yMenuOpen(true)}
+            />
+          )}
 
           {/* F1/F3/F4 — accessibility surfaces (subtitles, SR announcer, settings menu) */}
           <SubtitleDisplay />
@@ -5115,12 +5143,12 @@ export default function WorldLensPage() {
             onHotbar={combatCtx.activateSkill}
           />
           {/* Tutorial overlay — always present, shows ? button */}
-          <TutorialOverlay />
+          {!hudHidden && <TutorialOverlay />}
 
           {/* Emergent simulation feed — surfaces world-tick activity that
               previously fired silently (NPC death, evo-promotion, refusal
               fields, weather rolls, agent insights, etc.) */}
-          <EmergentEventFeed />
+          {!hudHidden && <EmergentEventFeed />}
           <DangerBandHUD />
           <AwakeningToast />
           <SystemFeed />
@@ -5324,7 +5352,7 @@ export default function WorldLensPage() {
 
           {/* Companion roster — pet HUD (Phase A). Mounted bottom-right;
               opens on click. Lists owned creatures, deploy/dismiss/rename. */}
-          <CompanionRosterPanel worldId={activeDistrict?.id || 'concordia-hub'} />
+          {!hudHidden && <CompanionRosterPanel worldId={activeDistrict?.id || 'concordia-hub'} />}
 
           {/* Tame attempt overlay — opens on KeyJ press near a creature.
               Shows current bond progress vs threshold + lure selector. */}
@@ -5387,14 +5415,16 @@ export default function WorldLensPage() {
           />
 
           {/* Phase AB — village gossip (NPC↔NPC graph escalations) */}
-          <VillageGossipFeed worldId={activeDistrict.id} />
+          {!hudHidden && <VillageGossipFeed worldId={activeDistrict.id} />}
 
           {/* Phase AG — district ambient chat (co-presence) */}
-          <AmbientChatPanel
-            worldId={activeDistrict.id}
-            districtId={activeDistrict.id}
-            currentUserId={playerAvatar.id}
-          />
+          {!hudHidden && (
+            <AmbientChatPanel
+              worldId={activeDistrict.id}
+              districtId={activeDistrict.id}
+              currentUserId={playerAvatar.id}
+            />
+          )}
 
           {/* Phase BB1 — active festival banner */}
           <FestivalBanner worldId={activeDistrict.id} />
@@ -5427,7 +5457,7 @@ export default function WorldLensPage() {
           <CommandPalette />
 
           {/* Phase DA4 — Run-mode hotbar group (top-right floating cluster) */}
-          <div className="pointer-events-auto fixed right-4 top-32 z-20">
+          <div className={`pointer-events-auto fixed right-4 top-32 z-20 ${hudHidden ? 'hidden' : ''}`}>
             <GameModesHotbarGroup worldId={activeDistrict.id} />
           </div>
 
@@ -5520,7 +5550,7 @@ export default function WorldLensPage() {
           )}
 
           {/* Gameplay toolbar */}
-          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-20 flex items-center gap-1 bg-black/70 border border-white/10 rounded-xl px-2 py-1.5 pointer-events-auto">
+          <div className={`absolute bottom-4 left-1/2 -translate-x-1/2 z-20 flex items-center gap-1 bg-black/70 border border-white/10 rounded-xl px-2 py-1.5 pointer-events-auto ${hudHidden ? 'hidden' : ''}`}>
             {(
               [
                 { key: 'inventory', label: 'Inventory', icon: Layers },
@@ -5942,7 +5972,7 @@ export default function WorldLensPage() {
           )}
 
           {/* Resource Bars HUD (top-left, below minimap) */}
-          <div className="absolute top-4 left-4 z-20 pointer-events-none flex flex-col gap-1 min-w-[160px]">
+          <div className={`absolute top-4 left-4 z-20 pointer-events-none flex flex-col gap-1 min-w-[160px] ${hudHidden ? 'hidden' : ''}`}>
             {(
               [
                 { key: 'hp', label: 'HP', color: '#ef4444', icon: '❤' },
@@ -6061,7 +6091,7 @@ export default function WorldLensPage() {
           )}
 
           {/* Quest tracker HUD — bottom right, above HUD bar */}
-          <div className="absolute bottom-24 right-4 z-25 flex flex-col gap-2 pointer-events-auto">
+          <div className={`absolute bottom-24 right-4 z-25 flex flex-col gap-2 pointer-events-auto ${hudHidden ? 'hidden' : ''}`}>
             <QuestTracker
               worldId={activeDistrict.id}
               onClaimReward={(_questId, _rewards) => {
@@ -6246,7 +6276,7 @@ export default function WorldLensPage() {
           )}
 
           <CrisisBanner />
-          <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20 pointer-events-auto">
+          <div className={`absolute top-2 left-1/2 -translate-x-1/2 z-20 pointer-events-auto ${hudHidden ? 'hidden' : ''}`}>
             <SeasonBanner onOpenPassPanel={() => setShowPanel('season')} />
           </div>
           <GameModeHUD />

--- a/concord-frontend/lib/event-router.ts
+++ b/concord-frontend/lib/event-router.ts
@@ -167,7 +167,7 @@ function buildHandlers(opts: {
     },
     'concordia:fps-overlay': (e) => addToast({ type: 'info', message: `FPS overlay ${e.detail?.enabled ? 'on' : 'off'}`, duration: 1500 }),
     'concordia:hint-level': (e) => addToast({ type: 'info', message: `Hint level → ${e.detail?.level ?? 'updated'}`, duration: 1500 }),
-    'concordia:hide-hud': (e) => addToast({ type: 'info', message: e.detail?.hidden ? 'HUD hidden' : 'HUD visible', duration: 1500 }),
+    'concordia:hide-hud': (e) => addToast({ type: 'info', message: e.detail?.hide ? 'HUD hidden' : 'HUD visible', duration: 1500 }),
     'concordia:building-collapse': () => addToast({ type: 'warning', message: 'A building has collapsed!', duration: 3000 }),
     'concordia:perf-alert': (e) => addToast({ type: 'warning', message: `Performance alert: ${e.detail?.reason ?? 'check overlay'}`, duration: 4000 }),
     'concordia:capture-saved': (e) => addToast({ type: 'success', message: `Capture saved${e.detail?.filename ? `: ${e.detail.filename}` : ''}`, duration: 3000 }),

--- a/concord-frontend/playwright.config.ts
+++ b/concord-frontend/playwright.config.ts
@@ -102,6 +102,16 @@ export default defineConfig({
         // michelkraemer.com enable-gpu-headless. Swap to --use-gl=angle/egl +
         // xvfb on a GPU runner for hardware accel.
         launchOptions: {
+          // Opt-in escape hatch for sandboxes with a pre-baked browser whose
+          // revision doesn't match this repo's pinned @playwright/test (e.g.
+          // a container image built before a dependency bump, where running
+          // `playwright install` to fetch the new revision isn't an option).
+          // Unset by default — every real environment (local dev via
+          // `playwright install`, CI via `npx playwright install --with-deps
+          // chromium` in ci.yml) resolves its own matching browser and never
+          // sets this, so `executablePath` stays `undefined` and Playwright's
+          // normal resolution applies untouched.
+          executablePath: process.env.PLAYWRIGHT_LOCAL_CHROMIUM_PATH || undefined,
           args: [
             '--use-angle=swiftshader',
             '--use-gl=angle',

--- a/concord-frontend/tests/components/AppShell.test.tsx
+++ b/concord-frontend/tests/components/AppShell.test.tsx
@@ -197,11 +197,18 @@ describe('AppShell', () => {
     expect(queryByTestId('legal-footer')).toBeNull();
   });
 
-  it('toggles the command palette on Cmd/Ctrl+K', async () => {
+  it('does not handle Cmd/Ctrl+K itself (CommandPalette owns that binding)', async () => {
+    // Regression pin for the double-mount race fixed in eecb0bec: AppShell
+    // used to duplicate CommandPalette's own Mod+K toggle, and the two
+    // handlers raced on the shared UI store (each reading a stale
+    // pre-render snapshot while useSyncExternalStore forced a synchronous
+    // re-render between them), which could net-cancel the open. AppShell
+    // must stay silent on this key combo — CommandPalette's own listener
+    // is the single source of truth.
     const { getByTestId } = render(<AppShell><div>Body</div></AppShell>);
     await waitFor(() => expect(getByTestId('sidebar')).toBeInTheDocument());
     fireEvent.keyDown(window, { key: 'k', ctrlKey: true });
-    expect(setCommandPaletteOpen).toHaveBeenCalledWith(true);
+    expect(setCommandPaletteOpen).not.toHaveBeenCalled();
   });
 
   it('closes the command palette on Escape when open', async () => {

--- a/concord-frontend/tests/e2e/perf.spec.ts
+++ b/concord-frontend/tests/e2e/perf.spec.ts
@@ -1,42 +1,128 @@
 /**
  * Phase AA — perf budget harness.
  *
- * Boots /lenses/world?perf=1 + asserts both tiers' budgets via
- * window.__CONCORD_PERF__.sample() + checkBudget().
+ * Boots /lenses/world?perf=1 + asserts the low-tier budget via
+ * window.__CONCORD_PERF__.sample() (mounted by ConcordiaScene's renderer
+ * init — lib/world-lens/perf-monitor.ts).
  *
- * In CI we can't actually drive the GPU at Blackwell-class fidelity
- * — the headless chromium runs on whatever the runner ships. The
- * test instead verifies:
- *   1. perf-monitor mounts when ?perf=1 is set (Stats.js DOM appears).
- *   2. window.__CONCORD_PERF__ exposes a sample getter.
- *   3. checkBudget('low') passes — i.e. the headless runner clears
- *      the integrated-GPU budget. This catches regressions that
- *      blow draw-call count past 200 even on a low-end profile.
+ * Prerequisites this spec has to arrange itself (root cause of the old
+ * deterministic failures — the spec asserted on a global that could never
+ * exist on the page it actually landed on):
+ *   1. AUTH: /lenses/world is middleware-gated (middleware.ts) — without the
+ *      concord_refresh cookie the goto 307s to /login and the global is read
+ *      off the login page. mockAuthSuccess() sets the cookie + kills the
+ *      onboarding/consent overlay stack, same as every other passing spec.
+ *   2. THE 3D BRANCH: the perf monitor mounts ONLY inside ConcordiaScene
+ *      (explore mode). The lens can default to (or fall back to) the 2D hub;
+ *      mirror playthrough.spec.ts and click the "Explore 3D" tab if present,
+ *      then wait for the canvas.
+ *   3. REAL GL: headless CI runs SwiftShader (playwright.config.ts chromium
+ *      launch args). If GL is genuinely unavailable or dies (the page's
+ *      webglcontextlost → 2D-hub fallback), there is NO real 3D render to
+ *      sample — the honest outcome is test.skip(), never a fabricated
+ *      sample (mountPerfMonitor must stay 3D-only). The low quality preset
+ *      is forced via localStorage (concord-quality-preset — the real knob
+ *      ConcordiaScene reads; there is no ?quality= query param) to give
+ *      software GL the best chance of surviving to a real sample.
  *
- * The Blackwell-tier check is best-run locally on the documented
- * hardware; CI surfaces it as a `test.fixme` placeholder for now
- * with a comment explaining why.
+ * The Blackwell-tier check is best-run locally on the documented hardware;
+ * CI surfaces it as a `test.fixme` placeholder with a comment explaining why.
  */
 
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
+import { mockAuthSuccess } from './_helpers';
 
 test.use({ browserName: 'chromium' });
 
+/**
+ * Auth + navigate + drive the explore (3D) branch.
+ * Returns true when the 3D canvas is attached; false means the lens is in
+ * the 2D fallback (no GL) and there is nothing real to sample.
+ */
+async function gotoWorldPerf(page: Page): Promise<boolean> {
+  await mockAuthSuccess(page);
+  // Force the lowest quality preset (the knob ConcordiaScene actually
+  // reads — getStoredQualityPreset()) so SwiftShader has the least shader
+  // load and the best chance of producing a real low-tier sample.
+  await page.addInitScript(() => {
+    try { localStorage.setItem('concord-quality-preset', 'low'); } catch { /* private mode */ }
+  });
+  await page.goto('/lenses/world?perf=1', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await page.waitForTimeout(2_500);
+
+  // The lens may sit on the 2D overview; the canvas only mounts in explore
+  // mode (same dance as playthrough.spec.ts).
+  const explore = page
+    .locator('button:has-text("Explore 3D"), [role="tab"]:has-text("Explore 3D")')
+    .first();
+  if (await explore.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await explore.click();
+  }
+
+  const canvas = page.locator('canvas').first();
+  return canvas
+    .waitFor({ state: 'attached', timeout: 15_000 })
+    .then(() => true)
+    .catch(() => false);
+}
+
+/**
+ * The perf global appears late in ConcordiaScene's async init (after
+ * terrain/buildings/avatars, right after WebGLRenderer construction), so
+ * poll rather than one fixed sleep. Returns true when it appeared.
+ */
+async function perfGlobalAppeared(page: Page, timeoutMs: number): Promise<boolean> {
+  return page
+    .waitForFunction(
+      () => {
+        type W = { __CONCORD_PERF__?: { sample: () => unknown } };
+        return typeof (window as W).__CONCORD_PERF__?.sample === 'function';
+      },
+      undefined,
+      { timeout: timeoutMs },
+    )
+    .then(() => true)
+    .catch(() => false);
+}
+
+/**
+ * Distinguish "GL died → 2D fallback took over" (honest skip) from "3D scene
+ * is up but the perf monitor is broken" (real failure). After the fallback,
+ * ConcordiaScene unmounts and its canvas leaves the DOM.
+ */
+async function canvasStillMounted(page: Page): Promise<boolean> {
+  return page
+    .locator('canvas')
+    .first()
+    .isVisible({ timeout: 1_000 })
+    .catch(() => false);
+}
+
 test.describe('Phase AA — perf budget', () => {
   test('perf-monitor mounts when ?perf=1', async ({ page }) => {
-    await page.goto('/lenses/world?perf=1', { waitUntil: 'domcontentloaded', timeout: 30_000 });
-    await page.waitForTimeout(2_500);
-    // The Stats.js DOM widget is positioned fixed top-left.
-    const handle = await page.evaluate(() => {
-      type W = { __CONCORD_PERF__?: { sample: () => unknown } };
-      return typeof (window as W).__CONCORD_PERF__?.sample === 'function';
-    });
-    expect(handle).toBe(true);
+    const canvasUp = await gotoWorldPerf(page);
+    test.skip(!canvasUp, 'No WebGL on this runner — lens fell back to the 2D hub; no real 3D render to sample.');
+
+    const mounted = await perfGlobalAppeared(page, 30_000);
+    if (!mounted && !(await canvasStillMounted(page))) {
+      test.skip(true, 'GL context lost mid-init (webglcontextlost → 2D fallback) — no real 3D render to sample.');
+    }
+    // Canvas is alive but the global never appeared → the perf monitor is
+    // genuinely broken. Hard failure.
+    expect(mounted).toBe(true);
   });
 
   test('low-tier budget passes on headless chromium', async ({ page }) => {
-    await page.goto('/lenses/world?perf=1', { waitUntil: 'domcontentloaded', timeout: 30_000 });
-    // Warm up — let the world settle for 8s before sampling.
+    const canvasUp = await gotoWorldPerf(page);
+    test.skip(!canvasUp, 'No WebGL on this runner — lens fell back to the 2D hub; no real 3D render to sample.');
+
+    const mounted = await perfGlobalAppeared(page, 30_000);
+    if (!mounted && !(await canvasStillMounted(page))) {
+      test.skip(true, 'GL context lost mid-init (webglcontextlost → 2D fallback) — no real 3D render to sample.');
+    }
+    expect(mounted).toBe(true);
+
+    // Warm up — let the world settle before sampling.
     await page.waitForTimeout(8_000);
     const sample = await page.evaluate(() => {
       type W = { __CONCORD_PERF__?: { sample: () => { fps: number; frameMs: number; drawCalls: number; triangles: number } } };
@@ -53,8 +139,14 @@ test.describe('Phase AA — perf budget', () => {
   // Blackwell-tier (60fps + 500 draws + 2M tri at full quality + 200 NPCs +
   // storm weather) only meaningfully runs on the documented hardware.
   // CI marks it fixme to keep the test enumerated; local runs un-fix it.
+  // NOTE: quality is a localStorage preset (concord-quality-preset), not a
+  // query param — set it to 'ultra' via addInitScript when un-fixing.
   test.fixme('high-tier budget passes on Blackwell', async ({ page }) => {
-    await page.goto('/lenses/world?perf=1&quality=ultra', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+    await mockAuthSuccess(page);
+    await page.addInitScript(() => {
+      try { localStorage.setItem('concord-quality-preset', 'ultra'); } catch { /* private mode */ }
+    });
+    await page.goto('/lenses/world?perf=1', { waitUntil: 'domcontentloaded', timeout: 30_000 });
     await page.waitForTimeout(8_000);
     const sample = await page.evaluate(() => {
       type W = { __CONCORD_PERF__?: { sample: () => { fps: number; frameMs: number; drawCalls: number; triangles: number } } };

--- a/docs/BROWSER_READY_CAMPAIGN.md
+++ b/docs/BROWSER_READY_CAMPAIGN.md
@@ -1,0 +1,282 @@
+# Browser-Ready Campaign — CI-red fixes, debt-to-zero, go-live hardening
+
+## 🟢 HANDOFF — start here
+
+**Status update (2026-07-05): the campaign is SHIPPED.** PR #845 (Waves A/B/C)
+merged to `main` at `514fe8a5` on 2026-07-05 07:45 UTC. The merge's own
+post-merge CI surfaced two real, previously-invisible failures (Deploy's depth
+gate, CI's Lint & Test job); both are root-caused, fixed, and verified below
+on branch `claude/wave-abc-ci-fixes-debt-434jn3`. If you're picking this up
+next: check `git log origin/main..HEAD` on that branch for anything not yet
+merged, otherwise there is no open work — the arc is closed.
+
+- **What this campaign was:** a full code-first audit → research → fix pass to
+  make `main` deployable to browser users. Three waves: **A** (P0 — fix the
+  gates that were red), **B** (debt-to-zero — close tolerated defects, ratchet
+  baselines down instead of just living with them), **C** (ops/UX — go-live
+  checklist, doc-drift, fabrication hunt). A fourth, unplanned round (this
+  doc's own session) found and fixed two real gaps the merge itself exposed,
+  plus a user-reported UX defect (2D panel clutter blocking 3D movement).
+- **How this was worked:** the method in CLAUDE.md's "How we work here" —
+  honest-by-construction (no fabricated data, ever), compute-don't-guess
+  (verify via the engine, not memory), runtime-truth over source-guessing,
+  and the anti-cheat discipline (`guard.mjs` PROTECTs graders/baselines;
+  ratchets only move down via an orchestrator-authored, evidenced commit).
+  Delegation for this campaign followed CLAUDE.md §6: disjoint-file units to
+  parallel subagents, each carrying the honesty rules explicitly; PROTECTED
+  files (detector/invariant-engine baselines) edited directly, never
+  delegated.
+- **Ground rules that bound every unit:** develop on the designated branch
+  only; no fabricated data anywhere (a skip with a documented reason beats a
+  fake success); stage only named files, never `-A`; one heavy Node process
+  at a time (`next build` and `node --test` never run concurrently); every
+  unit verified against a live run, not just a typecheck; transient
+  regenerated artifacts (`audit/invariant-engine/violations.json`,
+  `docs/smoke-screenshots/*`) reverted after a suite run, never committed.
+
+---
+
+## A. Wave A — P0 CI-red fixes (PR #845, merged)
+
+Fixed the gates that were red on `main` before this campaign: Deploy gate's
+depth-test failures, E2E Core's failures (auth register missing
+`dateOfBirth`, Service-Worker mock leaks, Playwright strict-mode selector
+collisions, admin-gate 403 mocks), Playthrough's login-401, autoloop.yml's
+broken branch ref, a real sort-tiebreak bug in `research.js`, and two real
+production crash bugs (`BrainMonitor.tsx`, 30 unsafe optional-chain sites in
+`admin/page.tsx`). Commits `991ee97e` … `838146bd` (see `git log
+518ad60b..e5d25308` for the full 12-commit list).
+
+## B. Wave B — debt-to-zero (PR #845, merged)
+
+Removed 2 fabricated-data surfaces (a fake telemetry route, a client-side
+random "power score"), wired `voice.tts` to honor per-request voice, wired
+ReplayForensics' dead Trace button to the real royalty-cascade endpoint,
+fixed a stale-code-detector false positive (flagged for owner sign-off per
+policy — `dde70f7f`), bounded 6 unbounded module-level caches, fixed 2
+`SELECT *` queries, and ratcheted both PROTECTED baselines down (detector
+218→68 fingerprints / 27→1 medium; invariant-engine 12→1) — both edits made
+by the orchestrator directly, never delegated, per the anti-cheat rule.
+Commits `20eb3cfc` … `593a547d`.
+
+## C. Wave C — ops/docs (PR #845, merged)
+
+Doc-drift fixes, `next.config` `remotePatterns` migration, Sentry silenced
+when DSN unset, a real `scripts/verify-prod-env.mjs` + go-live checklist, and
+`docs/PR_TRIAGE.md` (triage recommendations for the 18 pre-existing open
+PRs — see that doc; its own "#845 pending" row is now stale, see §F).
+Commits `3ad83be1` … `20ea5290`.
+
+## D. Closing round — deploy-gate reliability + the final CommandPalette fix
+
+`ci-test-tolerant.mjs` extended with `--depth-only` so the depth suite gets
+the same isolate-and-retry tolerance as the main suite (`142fd633`) —
+verified 5653/5653 clean at merge time. Final fix before merge: a real
+production bug where `CommandPalette` was mounted twice per lens page
+(globally in `AppShell` + again in `app/lenses/layout.tsx`), and `AppShell`
+also duplicated `CommandPalette`'s own Ctrl+K handler — the two raced on the
+shared UI store and could net-cancel the palette open. Fixed both, verified
+44/44 on `navigation.spec.ts` + 15/15 repeats (`eecb0bec`). Merged as
+PR #845 at `514fe8a5`.
+
+## E. Post-merge round (this doc's session) — 2 real CI gaps + 1 UX fix
+
+Main's own post-merge CI run surfaced two failures the campaign's local
+verification hadn't caught, plus a live UX complaint. All three are
+root-caused, fixed, and verified below (branch
+`claude/wave-abc-ci-fixes-debt-434jn3`, based fresh off `main` per the
+merged-PR restart policy):
+
+### E1 — Deploy gate: `NODE_ENV=test` missing on the depth-test invocation
+
+**Symptom:** Deploy's "Depth behavioral tests" step failed 13/5900+ (all
+external-API graceful-refusal tests — Jamendo, Audius, iTunes, World Bank,
+ESPN, TheSportsDB, Launch Library).
+
+**Root cause:** `server/package.json`'s `test:depth:raw` set `DB_PATH` but
+never `NODE_ENV=test`. `tests/preload/no-egress.mjs`'s fetch-blocking guard
+(which makes external fetches fail instantly so these tests exercise their
+documented offline-refusal branch) is itself gated on `NODE_ENV=test`. On an
+internet-connected GitHub runner, the external fetches escaped the guard and
+either succeeded or hung against real endpoints instead of hitting the
+offline branch the tests assert on. Every local pre-merge verification of
+this campaign ran inside a sandbox that blocks egress at the network layer,
+which masked the gap — the tests "passed" locally for the wrong reason.
+
+**Fix:** `9c6a0bb2` — add `NODE_ENV=test` to `test:depth:raw`.
+
+**Verification:** direct probe proved the guard rejects an external fetch
+instantly with `NODE_ENV=test` set and escapes to the real network without
+it; all 10 CI-failing depth files re-run clean at 272/272; full depth suite
+via `npm run test:depth:ci` (the actual gate invocation): **5619/5619
+pass, 0 fail**.
+
+### E2 — `perf.spec.ts`: never authenticated, asserted on a global that only exists in the 3D branch
+
+**Symptom:** both `perf.spec.ts` tests failed deterministically in CI.
+
+**Root cause (two-stacked):** (1) the spec never called `mockAuthSuccess()`
+unlike every other E2E spec — `middleware.ts` gates `/lenses/world` on the
+`concord_refresh` cookie, so the `goto` 307-redirected to `/login` and
+`window.__CONCORD_PERF__` was read off the login page. (2) Even once
+authenticated, `mountPerfMonitor()` (`lib/world-lens/perf-monitor.ts`) is
+called only from `ConcordiaScene.tsx`, which renders only in the world
+lens's 3D `explore` branch — a branch the page can fall back away from (no
+WebGL, or a `webglcontextlost` mid-init) to a 2D hub with no perf monitor at
+all.
+
+**Fix:** `ee0f147d` — authenticate via `mockAuthSuccess`, drive explore mode
+the same way `playthrough.spec.ts` does, force the `low` quality preset
+(discovered the real knob is `concord-quality-preset` in `localStorage`, not
+a `?quality=` query param as the prior comment claimed), and — honoring the
+project's honest-by-construction rule — `test.skip()` with an explicit
+reason when the 3D branch genuinely never comes up, rather than asserting
+on a sample that isn't real.
+
+**Verification:** live E2E run — both tests skip cleanly with the exact
+coded reason (`"No WebGL on this runner — lens fell back to the 2D hub; no
+real 3D render to sample."`), confirmed via the JSON reporter's skip
+annotations. Full E2E core suite (both frontend and the live backend
+running, matching CI's exact recipe): **0 failed, 187 passed, 8 skipped**
+(perf.spec's 2 honest skips + the always-`fixme` Blackwell tier + 5 more).
+`playthrough.spec.ts` passed all 6 canon worlds (one flaked once on
+documented SwiftShader instability and passed on retry — pre-existing,
+not a regression).
+
+### E3 — Stale unit test pinning behavior the campaign itself had removed
+
+**Symptom:** main's "CI" workflow (separate from "Deploy") failed at
+`tests/components/AppShell.test.tsx` › "toggles the command palette on
+Cmd/Ctrl+K" — cascading to skip E2E Core/Infra/Integration/Smoke downstream
+in that workflow.
+
+**Root cause:** NOT a regression from this session — `eecb0bec` (§D, already
+on `main`) correctly *removed* `AppShell`'s duplicate Ctrl+K handler as the
+fix for the double-mount race, but never updated this pre-existing unit
+test, which still asserted the old, now-intentionally-removed behavior
+(`setCommandPaletteOpen` called directly from `AppShell`).
+
+**Fix:** `73de530a` — rewrote the test to assert the corrected contract:
+`AppShell` must stay silent on Ctrl+K (`CommandPalette`'s own listener is
+the sole handler). This is now a regression pin against the double-mount
+bug recurring, not just a fixed assertion.
+
+**Verification:** 12/12 in the file; full frontend unit suite matching
+CI's exact invocation (`npm run test:coverage`, same `--max-old-space-size`)
+**489/489 test files, 4454/4454 tests pass**.
+
+### E4 — 2D panel clutter blocking 3D movement (user-reported)
+
+**Symptom:** "how's anyone gonna move in the 3d world with a million 2d
+panels in the way" — the world lens's explore mode stacks ~15 permanent 2D
+panels (resource bars, currency HUD, theme picker, camera controls, a
+30-button gameplay toolbar, quest tracker, companion roster, village gossip,
+ambient chat, emergent event feed, run-mode hotbar, season banner, tutorial
+button, top HUD bar) across every screen edge — several literally
+overlapping (theme picker/camera controls share `top-4 right-4`; quest
+tracker/companion roster share `bottom-24 right-4`) — and each carries
+`pointer-events-auto`, intercepting clicks meant for the canvas
+raycaster/pointer-lock.
+
+**Root cause of no existing fix:** `PhotoMode.tsx` already dispatches
+`concordia:hide-hud` on open/close, but nothing on the world-lens page ever
+listened for it. `lib/event-router.ts` only showed a toast for the event —
+and read the wrong field (`e.detail?.hidden` when `PhotoMode` actually sends
+`{ hide: boolean }`), so even the toast was silently wrong. (`PhotoMode`
+itself remains separately dead-wired — hardcoded `open={false}` at its
+mount site — left as a residual, see §G.)
+
+**Fix:** `d1796f07` — a real `hudHidden` state + listener on the exact event
+`PhotoMode` already fires, a new `H` hotkey via the existing
+`useLensCommand` registration (which already excludes text-input focus), and
+a hidden-class/conditional-render guard on all ~15 permanent panel mount
+sites. Event-driven overlays (toasts, combat HUD, boss bars, dialogue) are
+untouched — only the always-on chrome hides. Also fixed the
+`detail.hidden`/`detail.hide` field-name bug in `event-router.ts`.
+
+**Verification:** `tsc --noEmit` clean; live E2E core suite 0 failed / 187
+passed (no regression from touching 15 mount sites in a 6,300-line file).
+
+### D2 — Local-sandbox Playwright browser-revision mismatch (opt-in fix, not a repo bug)
+
+Not a code defect: this session's fresh `npm ci` resolved `@playwright/test`
+1.58.1, which expects browser revision r1208, while the container's
+pre-baked browser is r1194 and `playwright install` isn't available in this
+sandbox. `41867615` adds an **opt-in, unset-by-default**
+`PLAYWRIGHT_LOCAL_CHROMIUM_PATH` env var to `playwright.config.ts` —real CI
+(`npx playwright install --with-deps chromium` in `ci.yml`) and normal local
+dev never set it, so `executablePath` stays `undefined` and Playwright's own
+resolution is unaffected. Documented here because it's a legitimate,
+permanent addition (not a revert-before-commit hack) that future sessions in
+similarly-pinned sandboxes can reuse.
+
+### D3 — `docs/WIRING.md` regeneration
+
+Caught stale by `generate-wiring-doc.mjs --check` (last generated at
+`fe3517a4`, before this branch's commits). Regenerated (`d52ce003`) —
+route-prefix count and invariant-link count both shifted.
+
+---
+
+## F. Verification ladder (full commands, all green on this branch)
+
+Deploy-gate replication (`.github/workflows/deploy.yml`, in order):
+```bash
+(cd server && npm run lint:ci)                                        # ✓ 0 warnings
+(cd concord-frontend && npm run type-check)                           # ✓ clean
+(cd concord-frontend && node ../server/scripts/prophet-check.js)      # ✓ 0 warnings
+node scripts/check-depth-tests.mjs --ci                                # ✓ 6042 behavioral tests, 198 domains
+(cd server && npm run test:depth:ci)                                   # ✓ 5619/5619
+(cd server && node scripts/run-detectors.js --consumer security --diff --ci)  # ✓ 0 new high/critical
+```
+
+Detector + adversarial + doc gates (other blocking workflows):
+```bash
+(cd server && node scripts/run-detectors.js --diff --ci)              # ✓ 0 new high/critical (2 new info)
+node scripts/adversarial-audit.mjs                                     # ✓ all 4 gates PASS
+node scripts/check-doc-claims-all.mjs --ci                             # ✓ 88/88 files clean
+node scripts/verify-invariant-test-links.mjs --ci                      # ✓ 99/99 resolve
+node scripts/generate-wiring-doc.mjs --check                           # ✓ matches (after D3 regen)
+```
+
+E2E + unit suites:
+```bash
+cd concord-frontend && CI=true npm run test:e2e:core -- --project=chromium   # ✓ 0 failed, 187 passed, 8 skipped
+NODE_OPTIONS=--max-old-space-size=6144 npm run test:coverage                  # ✓ 489/489 files, 4454/4454 tests
+```
+
+(E2E core requires both the frontend prod build/server AND the live backend
+— `node server.js` with `NODE_ENV=ci PORT=5050 CONCORD_DISABLE_BRAINS=true
+CONCORD_DISABLE_HEARTBEAT=true JWT_SECRET=test-secret-for-ci-only-do-not-use-in-production` — running; the earlier local run without the backend
+mis-attributed 2 real backend-dependent `playthrough.spec.ts` failures to a
+code bug before this was caught.)
+
+## G. Honest residuals (not fixed in this campaign, flagged for the next one)
+
+- **`PhotoMode` itself is still dead-wired** — hardcoded `open={false}` at
+  its mount site in `app/lenses/world/page.tsx`, so the real photo-mode UI
+  (camera-only capture, freecam) is unreachable even though its hide-HUD
+  event now works when fired. A future unit: give it a real open trigger.
+- **`perf.spec.ts`'s Blackwell-tier test stays `test.fixme`** by design —
+  meaningfully only runs on the documented RTX PRO 4500 hardware; CI/sandbox
+  SwiftShader can't validate 60fps/2M-triangle budgets.
+- **Headless SwiftShader WebGL is inherently flaky in this class of
+  sandbox** — observed in this session (one `playthrough.spec.ts` world
+  flaked once on GL context loss, passed on retry) and already documented
+  elsewhere in the codebase (`playthrough.spec.ts`'s own header comment).
+  Not a regression; a known environmental characteristic.
+- **CodeQL Security Analysis was still `in_progress`** at last check
+  (~1.6h into main's post-merge run) — normal for a 2M+ LOC codebase, not
+  actionable; if it eventually reports a finding, triage separately.
+- **`docs/PR_TRIAGE.md`'s "#845 — Ready for review… see
+  `docs/BROWSER_READY_CAMPAIGN.md`" row is now stale** (#845 is merged, not
+  pending) — update in the same PR that ships this doc.
+
+## H. Related docs
+
+- `docs/WALKTHROUGH_TRIAGE.md` — the 19-surface browser walk triage.
+- `docs/PR_TRIAGE.md` — the 18-pre-existing-open-PR audit (§G notes its
+  stale row).
+- `docs/smoke-screenshots/` — Phase Z world-load screenshots (regenerated
+  by `playthrough.spec.ts`; transient, not committed per-run — see the
+  ground rules above).

--- a/docs/PR_TRIAGE.md
+++ b/docs/PR_TRIAGE.md
@@ -43,7 +43,7 @@ These predate this campaign and targeted CI/lint/test issues that this campaign'
 
 | PR | Status |
 |---|---|
-| #845 | Draft — the browser-ready campaign itself. Ready for review once Phase 4-6 final verification completes (see `docs/BROWSER_READY_CAMPAIGN.md`). |
+| #845 | **Merged** 2026-07-05 07:45 UTC (`514fe8a5`). Follow-on fixes for 2 real gaps the merge's own post-merge CI surfaced (deploy-gate `NODE_ENV`, a stale unit test) plus a user-reported UX fix landed on `claude/wave-abc-ci-fixes-debt-434jn3` — see `docs/BROWSER_READY_CAMPAIGN.md` for the full closeout. |
 
 ## Summary recommendation
 

--- a/docs/WIRING.md
+++ b/docs/WIRING.md
@@ -1,6 +1,6 @@
 # Concord — Wiring Status (GENERATED — do not hand-edit)
 
-> Generated from commit `fe3517a4` by `scripts/generate-wiring-doc.mjs`.
+> Generated from commit `41867615` by `scripts/generate-wiring-doc.mjs`.
 > Every number below is COMPUTED by the named verifier at generation time.
 > Regenerate: `node scripts/generate-wiring-doc.mjs` · Drift gate: `--check` in CI.
 
@@ -12,11 +12,11 @@
 | Lenses NO-BACKEND-CALL | 2 |
 | Total lenses | 260 |
 | Macro domains | 531 |
-| Route prefixes | 2976 |
+| Route prefixes | 2965 |
 
 ## Invariant → test-link integrity — `scripts/verify-invariant-test-links.mjs` (live run)
 
-- 96/96 `pinned by tests/…` claims resolve to real files on disk.
+- 99/99 `pinned by tests/…` claims resolve to real files on disk.
 - All invariant proofs exist. A missing one fails CI (detectors-cartography workflow).
 
 ## Lens UX polish — `scripts/grade-ux-polish.mjs` (committed artifact `audit/ux-polish.json`)

--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,7 @@
     "test:clean-exit": "node --test --import=./tests/preload/no-egress.mjs --test-timeout=300000 'tests/**/*.test.js' 'tests/**/*-tests.js'",
     "test:ci": "node scripts/ci-test-tolerant.mjs",
     "test:depth:ci": "node scripts/ci-test-tolerant.mjs --depth-only",
-    "test:depth:raw": "DB_PATH=/tmp/deploy-gate-depth.db node --test --import=./tests/preload/no-egress.mjs --test-concurrency=2 --test-force-exit --test-timeout=60000 'tests/depth/*.test.js'",
+    "test:depth:raw": "NODE_ENV=test DB_PATH=/tmp/deploy-gate-depth.db node --test --import=./tests/preload/no-egress.mjs --test-concurrency=2 --test-force-exit --test-timeout=60000 'tests/depth/*.test.js'",
     "test:watch": "node --test --watch --test-timeout=60000 'tests/**/*.test.js' 'tests/**/*-tests.js'",
     "test:coverage": "node --test --import=./tests/preload/no-egress.mjs --test-force-exit --test-timeout=60000 --experimental-test-coverage 'tests/**/*.test.js' 'tests/**/*-tests.js'",
     "test:e2e": "node --test --test-force-exit --test-timeout=60000 'tests/e2e/**/*.test.js'",


### PR DESCRIPTION
## Summary

PR #845 (the Browser-Ready Campaign) merged to `main` and its own first post-merge CI run surfaced two real, previously-invisible gaps, plus a user-reported UX issue came in during verification. All three are root-caused, fixed, and verified end-to-end here. Full write-up: `docs/BROWSER_READY_CAMPAIGN.md`.

- **Deploy gate — depth tests failing on real CI.** `test:depth:raw` set `DB_PATH` but never `NODE_ENV=test`, so `tests/preload/no-egress.mjs`'s fetch-blocking guard never installed. On an internet-connected runner, 13 external-API graceful-refusal tests (Jamendo/Audius/iTunes/World Bank/ESPN/TheSportsDB/Launch Library) hit the real network instead of exercising their offline-refusal branch. Every local pre-merge check ran in a sandbox that blocks egress at the network layer, which masked the gap. Fix: add `NODE_ENV=test`.
- **CI's "Lint & Test" job — a stale unit test.** `eecb0bec` (already on `main`, part of the merged campaign) correctly removed `AppShell`'s duplicate Ctrl+K handler to fix a real double-mount race with `CommandPalette`, but never updated the unit test that pinned the old, now-removed behavior. Rewrote the test to assert the corrected contract (`AppShell` stays silent on Ctrl+K) — now a regression pin against the bug recurring instead of a stale assertion.
- **World-lens 2D panel clutter (user-reported).** Explore mode stacks ~15 permanent panels across every screen edge, several literally overlapping, all intercepting clicks meant for the 3D canvas. Wired a real hide-HUD toggle (`H` key) onto the event `PhotoMode` already fires but nothing listened for — also fixed a field-name bug (`detail.hidden` vs the actual `detail.hide`) in the toast handler that read it.
- Plus: an opt-in `PLAYWRIGHT_LOCAL_CHROMIUM_PATH` env var (unset by default, real CI/local dev unaffected) for sandboxes with a pre-baked browser revision mismatch, and a `docs/WIRING.md` regen caught stale by its own drift gate.

## Test plan

- [x] Deploy-gate depth suite: `npm run test:depth:ci` — **5619/5619 pass**
- [x] Depth-honesty gate: `node scripts/check-depth-tests.mjs --ci` — pass (6042 behavioral tests, 198 domains)
- [x] Server lint / frontend type-check / prophet-check — all clean
- [x] Security + full detector ratchet — 0 new high/critical
- [x] Adversarial composite gate (`node scripts/adversarial-audit.mjs`) — all 4 gates pass
- [x] Doc-claims / invariant-link / wiring-doc gates — all pass (88/88, 99/99, matches)
- [x] E2E core suite (frontend + live backend, matching CI's exact recipe) — **0 failed, 187 passed, 8 skipped** (perf.spec's 2 honest WebGL-unavailable skips are by design, not failures)
- [x] `playthrough.spec.ts` — all 6 canon worlds pass (one flaked once on documented SwiftShader instability, passed on retry)
- [x] Full frontend unit suite w/ coverage (`npm run test:coverage`, matching CI's heap size) — **489/489 files, 4454/4454 tests**

Full command list and honest residuals in `docs/BROWSER_READY_CAMPAIGN.md`.

https://claude.ai/code/session_01QaktqjwpkTWUM1XXD4LMhJ


---
_Generated by [Claude Code](https://claude.ai/code/session_01QaktqjwpkTWUM1XXD4LMhJ)_