### PR TITLE
Real assets everywhere: armor, avatar quality floor, gathering tools + resource nodes

### DIFF
--- a/concord-frontend/app/lenses/world/page.tsx
+++ b/concord-frontend/app/lenses/world/page.tsx
@@ -3858,6 +3858,25 @@ export default function WorldLensPage() {
       if (sign) window.dispatchEvent(new CustomEvent('concordia:sign-placed', { detail: sign }));
     };
     worldSocket.on('world:sign-placed', handleSignPlaced);
+    // NPC resource gathering (server/lib/npc-simulator.js's _emitGather) —
+    // previously a completely silent DB write with no world-lens signal at
+    // all. Same combat-anim + dust-particle bridge the player's own click-
+    // to-gather (concordia:node-click handler, above) already fires, just
+    // targeted at the NPC's entityId and the real node's position instead
+    // of the player's.
+    const handleNpcGather = (...args: unknown[]) => {
+      const data = args[0] as { npcId?: string; x?: number; y?: number; z?: number } | undefined;
+      if (!data?.npcId) return;
+      window.dispatchEvent(new CustomEvent('concordia:combat-anim', {
+        detail: { entityId: data.npcId, animation: 'attack-light' },
+      }));
+      if (typeof data.x === 'number' && typeof data.z === 'number') {
+        window.dispatchEvent(new CustomEvent('concordia:particle-effect', {
+          detail: { type: 'dust', position: { x: data.x, y: data.y ?? 0, z: data.z }, count: 16 },
+        }));
+      }
+    };
+    worldSocket.on('world:npc-gather', handleNpcGather);
     // E2 — horror tension → window event for SoundscapeEngine's dissonant stem
     // + spatial ghost footstep. Server emits per-investigator from the
     // horror-dread-cycle heartbeat.
@@ -3915,6 +3934,7 @@ export default function WorldLensPage() {
       worldSocket.off('concordia:terrain-deformed', handleWorldDeformation);
       worldSocket.off('world:sonic-pulse', handleSonicPulse);
       worldSocket.off('world:sign-placed', handleSignPlaced);
+      worldSocket.off('world:npc-gather', handleNpcGather);
       worldSocket.off('horror:tension', handleHorrorTension);
       for (const [kind, h] of srBridges) worldSocket.off(kind, h);
     };

--- a/concord-frontend/app/lenses/world/page.tsx
+++ b/concord-frontend/app/lenses/world/page.tsx
@@ -2812,7 +2812,7 @@ export default function WorldLensPage() {
     return () => clearInterval(interval);
   }, [currentWorldId]);
 
-  const gatherFromNode = async (nodeId: string) => {
+  const gatherFromNode = useCallback(async (nodeId: string) => {
     setGatheringNode(nodeId);
     try {
       const node = nearbyNodes.find((n) => n.id === nodeId);
@@ -2865,7 +2865,7 @@ export default function WorldLensPage() {
     } finally {
       setGatheringNode(null);
     }
-  };
+  }, [currentWorldId, nearbyNodes]);
 
   // Load NPCs from API and keep positions fresh every 10s
   useEffect(() => {
@@ -4132,6 +4132,35 @@ export default function WorldLensPage() {
     window.addEventListener('concordia:gather-request', handler);
     return () => window.removeEventListener('concordia:gather-request', handler);
   }, [currentWorldId, pushCombatLog, playerAvatar.id]);
+
+  // Click-to-gather: ConcordiaScene's canvas raycaster dispatches
+  // concordia:node-click when the player clicks a real resource-node mesh
+  // (tree/ore/crystal/herb/spring — resource-node-renderer.ts). Reuses the
+  // SAME tool-swing + dust-particle feedback as the freeform right-click
+  // path above, then calls the existing gatherFromNode (the same function
+  // the 2D "Nearby resources" HUD list's Gather button already used) so
+  // there's one real gather call path, not two. A depleted node (stump)
+  // skips the swing and shows an honest inline message instead of a
+  // silent no-op — the server is the source of truth either way.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { nodeId: string; nodeType: string | null; depleted: boolean; point: { x: number; y: number; z: number } } | undefined;
+      if (!detail?.nodeId) return;
+      if (detail.depleted) {
+        pushCombatLog('That resource is depleted — wait for it to respawn.', 'info');
+        return;
+      }
+      window.dispatchEvent(new CustomEvent('concordia:combat-anim', {
+        detail: { entityId: playerAvatar.id, animation: 'attack-light' },
+      }));
+      window.dispatchEvent(new CustomEvent('concordia:particle-effect', {
+        detail: { type: 'dust', position: detail.point, count: 16 },
+      }));
+      void gatherFromNode(detail.nodeId);
+    };
+    window.addEventListener('concordia:node-click', handler);
+    return () => window.removeEventListener('concordia:node-click', handler);
+  }, [gatherFromNode, pushCombatLog, playerAvatar.id]);
 
   // Phase F fix 2: ConcordiaScene's canvas raycaster dispatches
   // `concordia:open-dialogue` when the player clicks an NPC mesh. Look up

--- a/concord-frontend/components/concordia/crafting/BlueprintPanel.tsx
+++ b/concord-frontend/components/concordia/crafting/BlueprintPanel.tsx
@@ -3,6 +3,18 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { api } from '@/lib/api/client';
 import { CraftingMinigame } from './CraftingMinigame';
+import { playActionAtPlayer } from '@/lib/concordia/play-action';
+
+// dtu.type → labor verb, mirrors CraftingPanelV2's mapping (see
+// action-biomechanics.ts's ACTION_DESCRIPTORS for the per-verb sfx/vfx).
+const TYPE_TO_VERB: Record<string, string> = {
+  weapon: 'forge',
+  tool: 'forge',
+  armor: 'craft',
+  consumable: 'cook',
+  structure: 'build',
+  material: 'mill',
+};
 
 interface Material { id: string; quantity: number; }
 interface InventoryItem { item_id: string; quantity: number; }
@@ -70,6 +82,7 @@ export function BlueprintPanel({ playerId: _playerId, toolTier, skillLevel, onCl
         setResult(`✓ Crafted ${data.dtu?.name ?? selected.designTitle ?? selected.title} at ×${multiplier} quality.`);
         // Refresh inventory so the materials-checklist updates immediately
         api.get('/api/world/inventory').then((ir) => setInventory(ir.data?.items ?? [])).catch(() => {});
+        playActionAtPlayer(TYPE_TO_VERB[data.dtu?.type ?? ''] ?? 'craft');
         // Surface to the polish-pass toast + craft-ding via existing event channels
         if (typeof window !== 'undefined') {
           const ratedRarity = multiplier >= 1.4 ? 'epic'

--- a/concord-frontend/components/world-lens/AvatarSystem3D.tsx
+++ b/concord-frontend/components/world-lens/AvatarSystem3D.tsx
@@ -802,10 +802,27 @@ export default function AvatarSystem3D({
     []
   );
 
-  // Phase A1: smart wrapper — enhanced builder for local player + hero
-  // NPCs, legacy primitive path for crowd. Stores FacialController +
-  // tickEyes + dispose in sidecar refs so the per-frame loop + dispose
-  // path can find them by avatar id.
+  // Phase A1 (2026-07-21 quality-floor pass): enhanced builder (hair-
+  // cards, skin-SSS, eye-parallax, real per-character armor) for EVERY
+  // avatar that gets a mesh at all — not just hero/legend/local-player.
+  // The flat-primitive legacy path below stays wired only as the
+  // exception-safety fallback (buildEnhancedAvatar throws -> falls
+  // through to it), never the default.
+  //
+  // This is safe on the existing render budget, not a new one:
+  // MAX_FULLY_ANIMATED (50) already hard-caps how many players+NPCs get
+  // ANY full mesh built per world — everyone beyond that cap gets no
+  // mesh at all, regardless of tier (see the two `.slice(0,
+  // MAX_FULLY_ANIMATED)` call sites below). Before this change, a large
+  // fraction of that already-bounded-50 population was silently using
+  // the cheaper flat-color box/cylinder/sphere tier anyway (only NPCs
+  // whose archetype matched hero-mesh-registry's keyword list, or whose
+  // bodyArchetype was 'legend', got the real one) — the population size
+  // this decision applies to doesn't change, only the per-avatar fidelity
+  // within it. Not independently profiled against real frame-time
+  // budgets in this session — flagged honestly, not assumed free.
+  // Stores FacialController + tickEyes + dispose in sidecar refs so the
+  // per-frame loop + dispose path can find them by avatar id.
   const createAvatarMeshSmart = useCallback(
     async (
       avatarId: string,
@@ -839,8 +856,14 @@ export default function AvatarSystem3D({
         }
       }
 
-      const wantEnhanced =
-        opts.isLocalPlayer || opts.isHero || appearance.bodyType === 'legend';
+      // Always true now — see this function's own doc comment above for
+      // why (every avatar that reaches this call already passed the
+      // MAX_FULLY_ANIMATED budget gate; only which BUILDER they get was
+      // ever conditional). `opts` is no longer read here, but stays a
+      // real parameter — isHero still selects the hero-GLB attempt below,
+      // and isLocalPlayer still controls the enhanced builder's own
+      // local-player-specific behavior.
+      const wantEnhanced = true;
       if (wantEnhanced) {
         // Phase L — pull hydrated hints from the world-load cache. Read
         // once up-front (was previously read a second time, identically,

--- a/concord-frontend/components/world-lens/AvatarSystem3D.tsx
+++ b/concord-frontend/components/world-lens/AvatarSystem3D.tsx
@@ -326,6 +326,14 @@ export default function AvatarSystem3D({
   // These two are new — per-frame eye tickers and enhanced-disposers.
   const eyeTickersRef = useRef<Map<string, (dt: number) => void>>(new Map());
   const enhancedDisposeRef = useRef<Map<string, () => void>>(new Map());
+  // Set once the player's active mount spawns (see the mount-spawn block
+  // below). The movement loop's terrain-elevation clamp reads this to
+  // skip clamping Y to ground height while mounted — rider-ik's astride
+  // seat lift owns Y in that case instead. Without this gate, the two
+  // systems fight every frame (rider-ik sets the seat height, then the
+  // terrain clamp immediately stomps it back to ground level), which is
+  // exactly why the seat lift shipped default-off until this fix.
+  const isMountedRiderRef = useRef(false);
 
   // Phase AA2 — Web Worker for gait synthesis. The hook spawns one
   // worker for the lifetime of this component; per-frame requestGait
@@ -1989,11 +1997,13 @@ export default function AvatarSystem3D({
           // (not a hardcoded 'Steed'), seat-offset-aware, and FOLLOW the player
           // instead of freezing at a static +1.2m. The mount tracks the rider's
           // position + heading each frame and ticks its gait by actual speed.
-          // NOTE (chair-verified follow-on): the rider astride-seat pose —
-          // lifting the player onto the saddle via rider-ik.computeRiderIkTargets
-          // + rein-hand FABRIK — interacts with the locomotion ground-clamp and
-          // is tuned visually in the next slice; this slice makes the mount
-          // appear, correct, and attached (today it never spawned at all).
+          // The rider astride-seat pose — lifting the player onto the saddle
+          // via rider-ik.computeRiderIkTargets + rein-hand FABRIK — used to
+          // fight the locomotion ground-clamp (the movement loop's terrain
+          // elevation clamp ran after this ticker and stomped the seat Y back
+          // to ground height every frame). Now gated by isMountedRiderRef,
+          // which the movement loop's clamp skips while set, so the seat lift
+          // is the default: real astride riding, not just a following mount.
           const sp = active.species || { size_class: 'medium' as const, display_name: 'Steed' };
           const seat = active.seatOffset || { x: 0, y: 1.4, z: 0, yaw: 0 };
           const { createMountGroup } = await import('@/components/concordia/mounts/MountAvatar3D');
@@ -2001,17 +2011,15 @@ export default function AvatarSystem3D({
           m.group.position.copy(playerMesh.position);
           m.setRotation(playerMesh.rotation.y);
           avatarGroup.add(m.group);
+          isMountedRiderRef.current = true;
           // Follow the rider: seat the mount horizontally under the rider via the
           // species seat offset (inverse of computeSaddleAnchor), yaw-aligned,
           // gait ticked by movement speed. Registered in the frame-loop ticker.
-          // Wave 7a #3 — rider astride-seat via rider-ik. computeRiderIkTargets
-          // gives the pelvis target (saddle anchor + seat offset + per-gait
-          // bounce). Applying the vertical seat fights the locomotion ground-clamp,
-          // so it's behind a default-OFF flag (chair-tunable): when enabled, the
-          // rider lifts onto the saddle with gait bounce; default leaves the mount
-          // following under the rider (already a clear win over the old 1.2m offset).
-          const seatOn = typeof window !== 'undefined'
-            && (window as unknown as { __concordMountRiderSeat?: boolean }).__concordMountRiderSeat === true;
+          // Escape hatch for QA/rollback: set window.__concordMountRiderSeat =
+          // false to fall back to the old following-only behavior without a
+          // code change.
+          const seatOn = typeof window === 'undefined'
+            || (window as unknown as { __concordMountRiderSeat?: boolean }).__concordMountRiderSeat !== false;
           const prev = playerMesh.position.clone();
           let riderIk: typeof import('@/lib/concordia/mounts/rider-ik') | null = null;
           if (seatOn) { import('@/lib/concordia/mounts/rider-ik').then((mod) => { riderIk = mod; }).catch(() => {}); }
@@ -2630,7 +2638,15 @@ export default function AvatarSystem3D({
           // Terrain elevation — clamp Y to ground (only when grounded).
           if (!isAirborne && !isSwimming) {
             const elevation = elevationRef.current?.(pos.x, pos.z) ?? pos.y;
-            pos.y = elevation;
+            // While mounted, playerPositionRef stays an approximate saddle
+            // height (ground + a fixed seat offset) — good enough for
+            // network/far-field consumers of playerPositionRef (water check,
+            // onMove sync). The precise per-frame seat bounce is applied
+            // directly to playerMesh.position by the rider-ik eyeTicker
+            // (`mount:*` in eyeTickersRef, runs earlier this frame); the
+            // pm.position.set below must not overwrite that with this
+            // approximation or the two fight every frame.
+            pos.y = isMountedRiderRef.current ? elevation + 1.3 : elevation;
           }
 
           // Auto-face movement direction with smooth rotation.
@@ -2651,7 +2667,14 @@ export default function AvatarSystem3D({
 
           const pm = playerMeshRef.current as InstanceType<typeof import('three').Group>;
           if (pm) {
-            pm.position.set(pos.x, pos.y, pos.z);
+            if (isMountedRiderRef.current) {
+              // Y stays whatever the rider-ik eyeTicker set this frame —
+              // see the terrain-elevation comment above for why.
+              pm.position.x = pos.x;
+              pm.position.z = pos.z;
+            } else {
+              pm.position.set(pos.x, pos.y, pos.z);
+            }
             pm.rotation.y = playerRotationRef.current;
 
             // ── Procedural gait synthesis ──────────────────
@@ -3109,6 +3132,7 @@ export default function AvatarSystem3D({
       enhancedDisposals.clear();
       facialControllers.clear();
       eyeTickers.clear();
+      isMountedRiderRef.current = false;
 
       if (avatarGroupRef.current) {
         const group = avatarGroupRef.current as {

--- a/concord-frontend/components/world-lens/AvatarSystem3D.tsx
+++ b/concord-frontend/components/world-lens/AvatarSystem3D.tsx
@@ -842,6 +842,27 @@ export default function AvatarSystem3D({
       const wantEnhanced =
         opts.isLocalPlayer || opts.isHero || appearance.bodyType === 'legend';
       if (wantEnhanced) {
+        // Phase L — pull hydrated hints from the world-load cache. Read
+        // once up-front (was previously read a second time, identically,
+        // inside the procedural-fallback try-block below).
+        const cache = (typeof window !== 'undefined' ? (window as { __CONCORD_NPC_APPEARANCE_CACHE__?: Map<string, unknown> }).__CONCORD_NPC_APPEARANCE_CACHE__ : null);
+        const hint = cache?.get(avatarId) as {
+          factionVisual?: { primary_color?: string; secondary_color?: string; accent_color?: string };
+          appearanceText?: string;
+          heroMesh?: boolean;
+          factionId?: string;
+          archetype?: string;
+          homeWorldId?: string;
+        } | undefined;
+
+        // Everyone-unique — the rich appearance (armor included) is now
+        // computed once up front and reused by whichever path actually
+        // renders, so a hero-GLB NPC's real mesh wears the SAME
+        // deterministic armor kit a procedural-fallback build of them
+        // would have gotten, not a second independently-rolled one.
+        let rich: import('@/lib/world-lens/character-schema').RichAppearanceConfig | null = null;
+        const schemaModPromise = import('@/lib/world-lens/character-schema');
+
         // Phase S — try the baked GLB path first for hero NPCs. The
         // home-world archetype carries an NPC's visual identity
         // across cross-world travel (Phase T): a courier from
@@ -849,12 +870,24 @@ export default function AvatarSystem3D({
         // courier when visiting concordia-hub.
         if (opts.isHero && !opts.isLocalPlayer) {
           try {
-            const heroMod = await import('@/lib/concordia/hero-mesh-registry');
-            const cache = (typeof window !== 'undefined' ? (window as { __CONCORD_NPC_APPEARANCE_CACHE__?: Map<string, unknown> }).__CONCORD_NPC_APPEARANCE_CACHE__ : null);
-            const heroHint = cache?.get(avatarId) as { homeWorldId?: string; archetype?: string } | undefined;
-            const archetype = opts.archetype ?? heroHint?.archetype ?? 'warrior';
-            const homeWorld = heroHint?.homeWorldId ?? opts.worldId;
-            const loaded = await heroMod.loadHeroMesh(avatarId, archetype, homeWorld);
+            const [heroMod, schemaMod] = await Promise.all([import('@/lib/concordia/hero-mesh-registry'), schemaModPromise]);
+            const archetype = opts.archetype ?? hint?.archetype ?? 'warrior';
+            const homeWorld = hint?.homeWorldId ?? opts.worldId;
+            rich = schemaMod.generateAppearance({
+              id: avatarId,
+              worldId: opts.worldId || 'concordia-hub',
+              factionId: opts.factionId ?? hint?.factionId ?? null,
+              archetype: opts.archetype ?? hint?.archetype ?? null,
+              themeId: 'concordia-hub',
+              heroMesh: true,
+              factionVisual: hint?.factionVisual ?? null,
+              npcAppearanceText: hint?.appearanceText ?? null,
+              override: {
+                skinColor: appearance.skinColor,
+                hairColor: appearance.hairColor,
+              },
+            });
+            const loaded = await heroMod.loadHeroMesh(avatarId, archetype, homeWorld, rich.armor);
             if (loaded?.group) {
               return loaded.group as InstanceType<typeof import('three').Group>;
             }
@@ -867,18 +900,9 @@ export default function AvatarSystem3D({
         try {
           const [{ buildEnhancedAvatar }, schemaMod] = await Promise.all([
             import('@/lib/world-lens/enhanced-avatar-builder'),
-            import('@/lib/world-lens/character-schema'),
+            schemaModPromise,
           ]);
-          // Phase L — pull hydrated hints from the world-load cache.
-          const cache = (typeof window !== 'undefined' ? (window as { __CONCORD_NPC_APPEARANCE_CACHE__?: Map<string, unknown> }).__CONCORD_NPC_APPEARANCE_CACHE__ : null);
-          const hint = cache?.get(avatarId) as {
-            factionVisual?: { primary_color?: string; secondary_color?: string; accent_color?: string };
-            appearanceText?: string;
-            heroMesh?: boolean;
-            factionId?: string;
-            archetype?: string;
-          } | undefined;
-          const rich = schemaMod.generateAppearance({
+          rich ??= schemaMod.generateAppearance({
             id: avatarId,
             worldId: opts.worldId || 'concordia-hub',
             factionId: opts.factionId ?? hint?.factionId ?? null,

--- a/concord-frontend/components/world-lens/BuildingRenderer3D.tsx
+++ b/concord-frontend/components/world-lens/BuildingRenderer3D.tsx
@@ -174,6 +174,8 @@ export default function BuildingRenderer3D({
         const { silhouetteForBuildingType } = await import('@/lib/world-lens/building-silhouette');
         const sil = silhouetteForBuildingType(buildingType);
         const dtuArch: ProcArch = hasExplicit ? (explicitArch as ProcArch) : sil.archetype;
+        const feature = (dtu as { feature?: import('@/lib/world-lens/procedural-buildings').IconicFeature }).feature ?? sil.feature;
+        const factionVisual = (dtu as { faction_visual?: { primary_color?: string; secondary_color?: string; accent_color?: string } }).faction_visual;
 
         // Real-asset-first: try a real GLB keyed by archetype (CC0-sourced,
         // dropped at /public/models/building/{archetype}.glb) before falling
@@ -193,6 +195,40 @@ export default function BuildingRenderer3D({
             cloned.userData = { buildingId: dtu.id, dtuName: dtu.name, realAsset: true };
             const box = new THREE.Box3().setFromObject(cloned);
             const size = box.getSize(new THREE.Vector3());
+            // A real GLB is the SAME asset for every building of this
+            // archetype — previously the ONLY differentiation was a uniform
+            // per-axis rescale to the DTU's declared dimensions, so every
+            // player-authored tavern/archive/market looked identical
+            // regardless of the iconic feature (dome/spire/colonnade/belfry)
+            // they actually chose when publishing it. Composite the same
+            // addIconicFeature() geometry the procedural fallback already
+            // uses. addIconicFeature's own geometry (dome radius, spire
+            // height, etc.) AND its roofline position are both derived from
+            // its single `scale` param on the assumption that the base
+            // archetype is ~8 units tall at scale=1 (see BuildingRenderer3D's
+            // own procedural-path rescale a few lines down: height/8) — so
+            // passing `scale=1` here would size the feature for an 8-unit
+            // building while sitting it on this GLB's real roofline,
+            // producing a toy-sized dome on a much taller real building.
+            // Deriving scale from the GLB's own measured height keeps both
+            // proportion AND position consistent, and this all happens
+            // BEFORE the group-wide rescale below carries the feature along
+            // with the rest of the mesh — mirrors createBuilding's own
+            // build-at-base-scale-then-rescale pipeline exactly.
+            if (feature && size.y > 0) {
+              try {
+                const { addIconicFeature } = await import('@/lib/world-lens/procedural-buildings');
+                const roofMat = new THREE.MeshStandardMaterial({
+                  color: factionVisual?.secondary_color ?? '#8a7a68', roughness: 0.8,
+                });
+                const trimMat = new THREE.MeshStandardMaterial({
+                  color: factionVisual?.accent_color ?? '#5c5044', roughness: 0.7, metalness: 0.1,
+                });
+                addIconicFeature(THREE, cloned, feature, size.y / 8, roofMat, trimMat);
+              } catch (featErr) {
+                if (typeof console !== 'undefined') console.warn('[BuildingRenderer3D] iconic-feature compositing failed, real asset still renders', featErr);
+              }
+            }
             if (size.x > 0 && size.y > 0 && size.z > 0) {
               cloned.scale.set(dtu.dimensions.width / size.x, dtu.dimensions.height / size.y, dtu.dimensions.depth / size.z);
             }
@@ -201,9 +237,6 @@ export default function BuildingRenderer3D({
         } catch (err) {
           if (typeof console !== 'undefined') console.warn('[BuildingRenderer3D] real-asset lookup failed, falling back to procedural', err);
         }
-
-        const feature = (dtu as { feature?: import('@/lib/world-lens/procedural-buildings').IconicFeature }).feature ?? sil.feature;
-        const factionVisual = (dtu as { faction_visual?: { primary_color?: string; secondary_color?: string; accent_color?: string } }).faction_visual;
         const archStyleByArch: Record<ProcArch, 'fortified' | 'gracile' | 'crystalline' | 'organic' | 'industrial'> = {
           tavern: 'organic', archive: 'gracile', forge: 'fortified',
           market: 'gracile', tower: 'fortified',

--- a/concord-frontend/components/world-lens/CombatInputController.tsx
+++ b/concord-frontend/components/world-lens/CombatInputController.tsx
@@ -45,6 +45,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { createInputBuffer, cancelState } from '@/lib/concordia/combat-input-buffer';
 import { sfx } from '@/lib/concordia/juice';
+import { playActionAtPlayer } from '@/lib/concordia/play-action';
 import {
   type KeyAction,
   loadActiveProfile,
@@ -616,31 +617,46 @@ export default function CombatInputController({
   }, [inputMode]);
 
   // Ranged combat — Mouse0 fire. Only live when the resolved hand's
-  // equipped weaponClass is a firearm ('pistol'/'rifle', inferred from
-  // inventory item names by server/lib/combat/loadout.js and mirrored onto
-  // the loadout prop); otherwise a left-click does nothing here and falls
-  // through to ConcordiaScene's ordinary interact-click. The client
-  // cooldown below is soft feel-tuning only — the server's own per-class
-  // cooldown (attack-cooldown.js's 'fire' class) is the real rate gate, and
+  // equipped weaponClass is a firearm ('pistol'/'rifle') or the spell-caster
+  // class ('staff', which item names like "wand"/"rod" also infer to —
+  // inferred from inventory item names by server/lib/combat/loadout.js and
+  // mirrored onto the loadout prop); otherwise a left-click does nothing
+  // here and falls through to ConcordiaScene's ordinary interact-click. The
+  // client cooldown below is soft feel-tuning only — the server's own
+  // per-class cooldown (attack-cooldown.js, falls back to the 'attack-light'
+  // class for the 'magic' style tag since staves don't have a bespoke
+  // cooldown entry yet) is the real rate gate, and
   // combat-limits.js#clampAttackRange caps the range server-side too.
   const lastRangedFireAtRef = useRef<number>(0);
   const dispatchFire = useCallback(() => {
     const hand = resolveHand();
     const weaponClass = hand === 'left' ? loadout?.leftHand?.weaponClass : loadout?.rightHand?.weaponClass;
-    if (weaponClass !== 'pistol' && weaponClass !== 'rifle') return;
+    const isStaff = weaponClass === 'staff';
+    if (weaponClass !== 'pistol' && weaponClass !== 'rifle' && !isStaff) return;
     const now = performance.now();
     if (now - lastRangedFireAtRef.current < 220) return; // soft client floor; server is authoritative
     lastRangedFireAtRef.current = now;
 
-    // Client-predicted swing anim — the SAME event melee attacks dispatch,
-    // so the existing discharge-flash + weapon-trail + tracer wiring in
-    // AvatarSystem3D fires for free. Damage/hit stays server-authoritative.
     if (playerId && typeof window !== 'undefined') {
-      window.dispatchEvent(new CustomEvent('concordia:combat-anim', {
-        detail: { entityId: playerId, animation: 'attack-light', predicted: true },
-      }));
+      if (isStaff) {
+        // A staff/wand equip is the spell-caster class — play the real
+        // cast_channel archetype (arms sweep up/out, hold, release; own
+        // spell_cast sfx + arcane vfx via the descriptor) instead of
+        // reusing the melee attack-light swing. Previously EVERY equipped
+        // weapon (including staves) fell through to attack-light here, so
+        // casting looked identical to a normal attack.
+        playActionAtPlayer('cast');
+      } else {
+        // Client-predicted swing anim — the SAME event melee attacks
+        // dispatch, so the existing discharge-flash + weapon-trail +
+        // tracer wiring in AvatarSystem3D fires for free. Damage/hit
+        // stays server-authoritative.
+        window.dispatchEvent(new CustomEvent('concordia:combat-anim', {
+          detail: { entityId: playerId, animation: 'attack-light', predicted: true },
+        }));
+        sfx('combat-gunshot');
+      }
     }
-    sfx('combat-gunshot');
 
     if (!worldSocket?.isConnected) return;
     // aimHitEntityId is ConcordiaScene's crosshair raycast result (published
@@ -649,11 +665,11 @@ export default function CombatInputController({
     // picking nearest-in-range when neither is set.
     worldSocket.emit('combat:attack', {
       targetId: cameraLookState.aimHitEntityId ?? _lockedTargetId(),
-      baseDamage: weaponClass === 'rifle' ? 16 : 11,
+      baseDamage: weaponClass === 'rifle' ? 16 : isStaff ? 14 : 11,
       range: 45,
       armorPierce: 1,
       heavy: false,
-      style: 'fire',
+      style: isStaff ? 'magic' : 'fire',
       actionOverride: 'ranged',
       modifier: !!modifierHeld,
       hand,

--- a/concord-frontend/components/world-lens/ConcordiaScene.tsx
+++ b/concord-frontend/components/world-lens/ConcordiaScene.tsx
@@ -2168,6 +2168,39 @@ export default function ConcordiaScene({
         }
       }
 
+      // Check resource nodes (trees/ore/crystal/herbs/springs) next —
+      // resource-node-renderer.ts tags every mesh in a node's object
+      // (real GLB or procedural fallback) with userData.isResourceNode +
+      // .nodeId so a hit resolves back to the node regardless of which
+      // sub-mesh the ray actually intersects. A depleted node (stump) is
+      // still clickable — the server honestly rejects the gather with a
+      // real reason rather than the client silently blocking the click.
+      const infrastructureGroup = layersRef.current['infrastructure'] as InstanceType<
+        typeof import('three').Group
+      > | undefined;
+      if (infrastructureGroup) {
+        const hits = rc.intersectObjects(infrastructureGroup.children, true);
+        const nodeHit = hits.find((h) => (h.object.userData as { isResourceNode?: boolean })?.isResourceNode);
+        if (nodeHit) {
+          const ud = nodeHit.object.userData as { nodeId?: string; nodeType?: string; depleted?: boolean };
+          if (ud.nodeId) {
+            try {
+              window.dispatchEvent(new CustomEvent('concordia:node-click', {
+                detail: {
+                  nodeId:   ud.nodeId,
+                  nodeType: ud.nodeType ?? null,
+                  depleted: !!ud.depleted,
+                  point:    { x: nodeHit.point.x, y: nodeHit.point.y, z: nodeHit.point.z },
+                  screenX:  e.clientX,
+                  screenY:  e.clientY,
+                },
+              }));
+            } catch { /* dispatch best-effort */ }
+            return;
+          }
+        }
+      }
+
       // Check buildings layer next
       const buildingsGroup = layersRef.current['buildings'] as InstanceType<
         typeof import('three').Group

--- a/concord-frontend/components/world-lens/CraftingPanelV2.tsx
+++ b/concord-frontend/components/world-lens/CraftingPanelV2.tsx
@@ -12,6 +12,21 @@
  */
 
 import { useEffect, useState, useCallback } from 'react';
+import { playActionAtPlayer } from '@/lib/concordia/play-action';
+
+// Recipe.category → the labor verb that plays on the avatar. Chosen per
+// output type so a weapon/tool craft looks like real forge-work (hammer_tap
+// loop, sparks, forge_ring sfx) while a consumable craft looks like cooking
+// (sizzle/steam) — see action-biomechanics.ts's ACTION_DESCRIPTORS table for
+// the full per-verb sfx/vfx profile each of these resolves to.
+const CATEGORY_TO_VERB: Record<string, string> = {
+  weapon: 'forge',
+  tool: 'forge',
+  armor: 'craft',
+  consumable: 'cook',
+  structure: 'build',
+  material: 'mill',
+};
 
 interface Recipe {
   id: string;
@@ -74,6 +89,7 @@ export default function CraftingPanelV2({ worldId: _worldId, onClose }: Crafting
       if (data?.ok) {
         showToast('ok', `Crafted ${recipe.output.name}.`);
         refresh();
+        playActionAtPlayer(CATEGORY_TO_VERB[recipe.category ?? recipe.output.type ?? ''] ?? 'craft');
         try {
           window.dispatchEvent(new CustomEvent('concordia:game-juice', {
             detail: { trigger: 'craft-complete', opts: { value: recipe.output.name } },

--- a/concord-frontend/components/world/GlyphCastHUD.tsx
+++ b/concord-frontend/components/world/GlyphCastHUD.tsx
@@ -11,6 +11,7 @@
  */
 
 import { useEffect, useState } from 'react';
+import { playActionAtPlayer } from '@/lib/concordia/play-action';
 
 interface Spell {
   id: number;
@@ -126,8 +127,18 @@ export default function GlyphCastHUD({ worldId = 'concordia-hub', playerPos }: {
     }).catch(() => null);
     const raw = r ? await r.json().catch(() => null) : null;
     const data = raw?.result ?? raw;
-    if (data?.ok) setCastStatus(`Cast ${data.element || ''} (${data.feedbackApplied || 0} channels)`);
-    else setCastStatus(`Failed: ${data?.error || data?.reason || 'unknown'}`);
+    if (data?.ok) {
+      setCastStatus(`Cast ${data.element || ''} (${data.feedbackApplied || 0} channels)`);
+      // A successful glyph_spells.cast previously produced NO visual result
+      // at all — it's a real world-effect macro (embodied signal deltas at
+      // the cast cell), but nothing in the 3D scene reacted, so casting
+      // looked broken rather than environmental. Reuses the same
+      // cast_channel archetype + element-keyed VFX (skill-motion.ts) that
+      // GlyphSpellComposer's mint already uses.
+      playActionAtPlayer('cast', { element: data.element });
+    } else {
+      setCastStatus(`Failed: ${data?.error || data?.reason || 'unknown'}`);
+    }
     window.setTimeout(() => setCastStatus(null), 3000);
   };
 

--- a/concord-frontend/components/world/GlyphSpellComposer.tsx
+++ b/concord-frontend/components/world/GlyphSpellComposer.tsx
@@ -10,6 +10,7 @@ import { X, Wand2, Loader2 } from 'lucide-react';
 import { StationOverlayShell } from './_StationOverlayShell';
 import type { OverlayProps } from './StationInteractionRouter';
 import { milestoneJuice, sfx } from '@/lib/concordia/juice';
+import { playActionAtPlayer } from '@/lib/concordia/play-action';
 
 interface Component {
   id: string;
@@ -89,6 +90,10 @@ export function GlyphSpellComposer({ building, onClose, worldId }: OverlayProps)
       const j = await r.json();
       if (j?.ok) {
         milestoneJuice('ui_glyph_mint');
+        // cast_channel archetype (arms sweep up/out, hold, release) — the
+        // player visibly channels the glyph they just composed instead of
+        // the mint being a pure UI action with a static avatar.
+        playActionAtPlayer('compose_spell', { element: preview?.element });
         setMinted(j.spellId || j.dtuId || 'minted');
         setChain([]); setSpellName(''); setPreview(null);
       } else {

--- a/concord-frontend/lib/concordia/armor-system.ts
+++ b/concord-frontend/lib/concordia/armor-system.ts
@@ -11,9 +11,23 @@
  */
 
 import * as THREE from 'three';
+import { makePBR, type ProceduralKind } from '@/lib/world-lens/procedural-texture';
 
 export type ArmorSlot = 'head' | 'torso' | 'arms' | 'legs';
 export type ArmorSilhouette = 'heavy_plate' | 'robed' | 'leather' | 'exposed';
+
+/**
+ * Silhouette → the procedural material kind whose real-reference-grounded
+ * normal/roughness detail (see procedural-texture.ts + material-reference-
+ * palettes.ts) dresses that silhouette's surface. 'exposed' (light/minimal
+ * armor over bare skin — straps and wraps, not plate) reads as leather.
+ */
+const SILHOUETTE_KIND: Record<ArmorSilhouette, ProceduralKind> = {
+  heavy_plate: 'metal',
+  robed: 'cloth',
+  leather: 'leather',
+  exposed: 'leather',
+};
 
 export interface ArmorAppearance {
   silhouette:    ArmorSilhouette;
@@ -57,22 +71,46 @@ function darken(hex: string, amount: number): string {
   return '#' + [r, g, b].map(v => v.toString(16).padStart(2, '0')).join('');
 }
 
+/**
+ * Real-reference-grounded surface detail (see procedural-texture.ts +
+ * material-reference-palettes.ts) for this silhouette, keyed so every
+ * armor piece sharing a seed gets the same micro-detail rather than a
+ * fresh canvas per material slot. `normalMap`/`roughnessMap` only — never
+ * `map` (albedo) — so the real per-faction dye color (`appearance.
+ * primaryColor` etc, applied via `material.color`) stays the actual
+ * displayed color; the texture only contributes real material surface
+ * detail (brushed-metal streaks, leather crinkle, cloth weave) on top.
+ */
+function proceduralDetail(appearance: ArmorAppearance): { normalMap: THREE.Texture; roughnessMap: THREE.Texture } {
+  const kind = SILHOUETTE_KIND[appearance.silhouette];
+  const seed = hashSeed(appearance.seed ?? appearance.silhouette);
+  const set = makePBR(THREE, { kind, seed, size: 128 });
+  return { normalMap: set.normal, roughnessMap: set.roughness };
+}
+
 function buildMaterials(appearance: ArmorAppearance): { primary: THREE.MeshStandardMaterial; secondary: THREE.MeshStandardMaterial; accent: THREE.MeshStandardMaterial } {
   const wear = appearance.wear ?? 0;
   const wearAmount = wear * 0.25;
   const isMetal = appearance.silhouette === 'heavy_plate';
+  const detail = proceduralDetail(appearance);
   const primary = new THREE.MeshStandardMaterial({
     color: darken(appearance.primaryColor, wearAmount),
     roughness: isMetal ? 0.35 + wear * 0.4 : 0.85,
     metalness: isMetal ? 0.7 : 0.05,
+    normalMap: detail.normalMap,
+    roughnessMap: detail.roughnessMap,
   });
   const secondary = new THREE.MeshStandardMaterial({
     color: darken(appearance.secondaryColor, wearAmount * 0.5),
     roughness: 0.7, metalness: isMetal ? 0.4 : 0.05,
+    normalMap: detail.normalMap,
+    roughnessMap: detail.roughnessMap,
   });
   const accent = new THREE.MeshStandardMaterial({
     color: appearance.accentColor,
     roughness: 0.4, metalness: isMetal ? 0.85 : 0.2,
+    normalMap: detail.normalMap,
+    roughnessMap: detail.roughnessMap,
   });
   return { primary, secondary, accent };
 }

--- a/concord-frontend/lib/concordia/hero-mesh-registry.ts
+++ b/concord-frontend/lib/concordia/hero-mesh-registry.ts
@@ -75,7 +75,15 @@ const OCCUPATION_KEYWORDS: [RegExp, string][] = [
   [/mage|mystic|rune|hedge|heal|priest|shaman|witch/i, 'mystic'],
   [/scholar|archiv|lore|scribe|analy|lab tech|reporter|investigat/i, 'scholar'],
   [/trad|fence|fix|broker|runner|corpo|pilgrim|farm|merchant|vendor/i, 'trader'],
-  [/sword|sellsword|vigilante|getaway|forg|smith|tinker|netrunner|ripperdoc|drone-tech|informant|forger/i, 'warrior'],
+  // 'warrior' itself must be in this list: routes/worlds.js's occupation
+  // field falls back to the raw archetype column (`state.occupation ||
+  // r.archetype`) when no live routine occupation is set, so an
+  // authored NPC's archetype string ("warrior") is frequently the
+  // occupation text verbatim — every other archetype's own name already
+  // self-matched its keyword list (guard/hunt.../mystic/scholar/trad...);
+  // warrior's list was the one gap, silently stranding every
+  // warrior-archetype NPC on the procedural fallback.
+  [/warrior|sword|sellsword|vigilante|getaway|forg|smith|tinker|netrunner|ripperdoc|drone-tech|informant|forger/i, 'warrior'],
 ];
 
 /**

--- a/concord-frontend/lib/concordia/hero-mesh-registry.ts
+++ b/concord-frontend/lib/concordia/hero-mesh-registry.ts
@@ -17,6 +17,7 @@
  */
 
 import * as THREE from 'three';
+import { createArmorSet, type ArmorAppearance, type ArmorSlot } from '@/lib/concordia/armor-system';
 
 export interface HeroMeshLoadResult {
   group:         THREE.Group;
@@ -113,6 +114,7 @@ export async function loadHeroMesh(
   npcId: string,
   archetype: string,
   homeWorldId?: string,
+  armor?: ArmorAppearance,
 ): Promise<HeroMeshLoadResult | null> {
   const cacheKey = `${npcId}::${homeWorldId ?? ''}`;
   if (cache.has(cacheKey)) return cache.get(cacheKey)!;
@@ -137,6 +139,7 @@ export async function loadHeroMesh(
       const loader = await getLoader();
       const gltf = await loader.load(candidate.url);
       const boneMap = buildBoneMap(gltf.scene);
+      if (armor) attachArmorToHeroMesh(gltf.scene, boneMap, armor);
       const result: HeroMeshLoadResult = {
         group: gltf.scene,
         source: candidate.source,
@@ -151,6 +154,57 @@ export async function loadHeroMesh(
     }
   }
   return null;
+}
+
+// Slot -> which bone(s) to try, in priority order. Real skinned rigs
+// (Mixamo / 3ds Max Biped, both normalized into CANONICAL_BONES by
+// buildBoneMap) always carry Hips/Head; Spine2 is present on most but
+// not universally, hence the Spine1/Spine fallback chain for 'arms'.
+const ARMOR_SLOT_BONES: Record<ArmorSlot, readonly string[]> = {
+  head:  ['Head'],
+  torso: ['Hips'],
+  arms:  ['Spine2', 'Spine1', 'Spine'],
+  legs:  ['Hips'],
+};
+
+/**
+ * Attaches a real per-character armor set (armor-system.ts, grounded in
+ * real material reference data — see material-reference-palettes.ts) onto
+ * a loaded hero GLB's skeleton, so hero NPCs wear their armor too, not
+ * just the procedural-body population (enhanced-avatar-builder.ts).
+ *
+ * Uses `Object3D.attach()` — the standard three.js technique for parenting
+ * a freshly-built object onto a bone while landing it at the bone's
+ * current WORLD position with identity world-rotation (not the bone's own
+ * local rest-pose rotation, which for a limb bone typically points along
+ * the limb rather than world-up and would otherwise leave the armor
+ * piece sideways). `attach()` recomputes the local transform under the
+ * new parent to preserve whatever world transform the object had at
+ * attach time — the piece then moves/rotates WITH the bone as the rig
+ * animates, correct equipped-item behavior.
+ *
+ * `root.updateMatrixWorld(true)` first forces the (never-yet-rendered)
+ * skeleton's rest-pose world matrices to compute — otherwise every
+ * bone's matrixWorld is still the uninitialized identity default and
+ * every piece would land at the mesh's local origin.
+ *
+ * A slot with no matching bone on this particular skeleton is skipped,
+ * never thrown — a partial armor kit beats a crashed avatar.
+ */
+export function attachArmorToHeroMesh(root: THREE.Group, boneMap: Map<string, THREE.Bone>, armor: ArmorAppearance): void {
+  root.updateMatrixWorld(true);
+  const armorSet = createArmorSet(armor);
+  const worldPos = new THREE.Vector3();
+  for (const [slot, piece] of armorSet) {
+    const bone = ARMOR_SLOT_BONES[slot].map((n) => boneMap.get(n)).find((b): b is THREE.Bone => !!b);
+    if (!bone) continue;
+    bone.getWorldPosition(worldPos);
+    piece.position.copy(worldPos);
+    piece.quaternion.identity();
+    piece.scale.setScalar(1);
+    piece.traverse((obj) => { (obj as THREE.Mesh).castShadow = true; });
+    bone.attach(piece);
+  }
 }
 
 async function checkExists(url: string): Promise<boolean> {

--- a/concord-frontend/lib/world-lens/character-schema.ts
+++ b/concord-frontend/lib/world-lens/character-schema.ts
@@ -257,8 +257,11 @@ export interface Accessories {
   jewelry: Array<'earrings' | 'necklace' | 'arm-bands' | 'rings' | 'nose-ring' | 'lip-ring' | 'circlet'>;
   /** Tattoos / scarification / glyph markings — drives a decal pass over skin. */
   markings: Array<{ kind: 'tattoo' | 'scar-pattern' | 'paint' | 'glyph'; region: 'face' | 'arms' | 'torso' | 'back'; color: string }>;
-  /** Visible carried gear at the hip / shoulder. Drives a prop layer on the mesh. */
-  carry?: Array<'sword' | 'staff' | 'wand' | 'pistol' | 'rifle' | 'bow' | 'satchel' | 'tome' | 'tool-belt' | 'pouch'>;
+  /** Visible carried gear at the hip / shoulder. Drives a prop layer on the mesh.
+   *  axe/pickaxe/hoe/sickle (2026-07-21) are gathering tools, not weapons —
+   *  a character carrying one reads as someone who actually gathers
+   *  resources in this world, not an NPC running an invisible macro. */
+  carry?: Array<'sword' | 'staff' | 'wand' | 'pistol' | 'rifle' | 'bow' | 'satchel' | 'tome' | 'tool-belt' | 'pouch' | 'axe' | 'pickaxe' | 'hoe' | 'sickle'>;
   /** Cybernetic augments (chrome arm, eye implant) — visible chrome materials on the mesh. */
   augments?: Array<{ region: 'left-arm' | 'right-arm' | 'eye' | 'face' | 'chest'; material: 'chrome' | 'matte-black' | 'gold' }>;
 }
@@ -981,6 +984,17 @@ export function generateAppearance(opts: {
   if (archetype === 'guard'   && !carry.includes('sword')) carry.unshift('sword');
   if (archetype === 'hunter'  && !carry.includes('bow'))   carry.unshift('bow');
   if (archetype === 'scholar' && !carry.includes('tome'))  carry.unshift('tome');
+  // Civilians (no matched combat/scholar archetype) — a seeded chance to
+  // carry a real gathering tool, so "regular townsfolk" read as people who
+  // actually chop/mine/farm in this world rather than generic idle
+  // extras. Ties directly to the resource-node substrate (server/lib/
+  // world-gathering.js's tool-compatibility table: axe->tree, pickaxe->
+  // ore/stone/crystal/fuel, sickle->herb/soil, hoe reads as the farming-
+  // adjacent visual pairing for soil/herb work alongside sickle).
+  if (!archetype && _seededFloat(seed, 60) < 0.35) {
+    const tool = _seededPick(['axe', 'pickaxe', 'hoe', 'sickle'] as const, seed, 61);
+    if (!carry.includes(tool)) carry.unshift(tool);
+  }
 
   const augments: Accessories['augments'] = [];
   if (style.augmentChance > 0 && _seededFloat(seed, 40) < style.augmentChance) {

--- a/concord-frontend/lib/world-lens/character-schema.ts
+++ b/concord-frontend/lib/world-lens/character-schema.ts
@@ -55,6 +55,7 @@
 
 import type { ConcordiaThemeId } from './concordia-theme';
 import { parseAuthoredAppearance } from './appearance-parse';
+import type { ArmorAppearance, ArmorSilhouette } from '@/lib/concordia/armor-system';
 
 /* ── Body proportions ─────────────────────────────────────────────── */
 
@@ -287,6 +288,13 @@ export interface RichAppearanceConfig {
 
   /* Accessories + markings */
   accessories:     Accessories;
+
+  /* Worn armor — deterministic per-character (see generateAppearance's
+   * armor block), so every individual reads as their own person rather
+   * than a recolored clone of their archetype/faction. Rendered via
+   * armor-system.ts's createArmorSet(), grounded in real material
+   * reference data (procedural-texture.ts). */
+  armor:           ArmorAppearance;
 
   /* Provenance — which world/faction did this character get authored for? */
   worldId:         string;
@@ -798,6 +806,22 @@ function _seededFloat(seed: number, salt: number): number {
   return (((seed + salt * 2654435761) >>> 0) / 0xffffffff);
 }
 
+/* ── Armor silhouette ─────────────────────────────────────────────── */
+
+/** Archetype -> the armor-system.ts silhouette that reads as that
+ *  archetype's default kit. Matches the same 7-archetype vocabulary
+ *  hero-mesh-registry.ts's archetypeForOccupation resolves to, so a
+ *  warrior NPC's armor silhouette and their real hero-GLB pick agree. */
+const ARCHETYPE_SILHOUETTE: Record<string, ArmorSilhouette> = {
+  warrior: 'heavy_plate',
+  guard:   'heavy_plate',
+  legend:  'heavy_plate',
+  scholar: 'robed',
+  mystic:  'robed',
+  hunter:  'leather',
+  trader:  'leather',
+};
+
 /* ── Deterministic appearance generator ───────────────────────────── */
 
 /**
@@ -980,6 +1004,33 @@ export function generateAppearance(opts: {
 
   const accessories: Accessories = { jewelry, markings, carry, augments };
 
+  /* Armor — every character gets a deterministic kit so no two NPCs read
+   * as recolored clones. Archetype picks the default silhouette; civilians/
+   * unrecognized archetypes get a seeded pick between the two lighter
+   * kits (leather straps or exposed harness) instead of defaulting to
+   * nothing. Colors reuse the character's own clothing palette so armor
+   * reads as part of one coherent outfit, not a mismatched overlay.
+   * `legend` bodies always get the top tier (matches their glyph-pattern
+   * cape treatment above). The seed string is the SAME composite id this
+   * whole function hashes from, so armor uniqueness tracks character
+   * identity 1:1 with every other generated trait. */
+  // An authored override's bodyArchetype (applied via `...override` at
+  // the very end of this function) should also drive tier — otherwise a
+  // hand-authored `override: { bodyArchetype: 'legend' }` deity NPC
+  // would keep a random 1-4 armor tier because this block only ever saw
+  // the pre-override seeded local. `authored wins` is this function's
+  // existing convention (see the `authored.x ?? seeded` pattern above).
+  const effectiveBodyArchetype = override?.bodyArchetype ?? bodyArchetype;
+  const armor: ArmorAppearance = {
+    silhouette: ARCHETYPE_SILHOUETTE[archetype ?? ''] ?? _seededPick(['leather', 'exposed'] as const, seed, 50),
+    primaryColor: clothing.top.color,
+    secondaryColor: clothing.bottom.color,
+    accentColor: clothing.hat?.color ?? clothing.cape?.color ?? clothing.boots?.color ?? clothing.top.color,
+    tier: effectiveBodyArchetype === 'legend' ? 5 : _seededPick([1, 2, 3, 4, 5] as const, seed, 51),
+    wear: _seededFloat(seed, 52),
+    seed: `${worldId}::${factionId ?? '_'}::${id}`,
+  };
+
   return {
     bodyArchetype,
     totalHeight,
@@ -994,6 +1045,7 @@ export function generateAppearance(opts: {
     facial,
     clothing,
     accessories,
+    armor,
     worldId,
     factionId,
     cultureTags: [styleId, ...(factionId ? [factionId] : [])],

--- a/concord-frontend/lib/world-lens/enhanced-avatar-builder.ts
+++ b/concord-frontend/lib/world-lens/enhanced-avatar-builder.ts
@@ -346,6 +346,24 @@ export function buildEnhancedAvatar(rich: RichAppearanceConfig, opts: { isLocalP
     rifle.rotation.y = Math.PI / 2;
     group.add(rifle);
   }
+  if (rich.accessories.carry?.includes('axe')) {
+    // Gathering axe — reuses the real 'axe' weapon archetype (real GLB,
+    // see weapon-archetypes.ts/CREDITS.md) rather than a second axe
+    // asset; a lumberjack's axe and a combat axe are the same object in
+    // this world. Holstered at the hip (matching the pistol treatment)
+    // rather than held mid-air — this is carried gear, not a drawn
+    // weapon, and it's what the click-to-gather swing animation reaches
+    // for on a tree node.
+    const axe = createWeapon({
+      archetype: 'axe',
+      tier: 2,
+      accentColor: rich.clothing.top.color,
+      seed: rich.worldId + ':axe:' + (rich.factionId ?? ''),
+    });
+    axe.position.set(p.hipWidth * 0.6, p.legLength * 0.6, -p.headDepth * 0.25);
+    axe.rotation.z = Math.PI / 2.6;
+    group.add(axe);
+  }
 
   // Non-weapon carry gear — satchel/tome/tool-belt/pouch previously had no
   // branch here at all (unlike every weapon `carry` value above), despite
@@ -441,6 +459,73 @@ export function buildEnhancedAvatar(rich: RichAppearanceConfig, opts: { isLocalP
     tomeGroup.position.set(-p.hipWidth * 0.3, p.legLength + p.torsoLength * 0.25, -p.headDepth * 0.4);
     tomeGroup.rotation.y = Math.PI;
     group.add(tomeGroup);
+  }
+
+  // Gathering tools (pickaxe/hoe/sickle) — no real GLB exists for these
+  // (only 'axe' has one, handled above via weapon-archetypes.ts), so
+  // they're simple, honest procedural props: a wooden shaft + a metal
+  // head shaped for the tool, in the same style already established for
+  // tool-belt's cylinders and the tome's cover+pages. Strapped
+  // diagonally across the back, matching the rifle/bow shoulder-carry
+  // treatment, so it reads as equipped kit rather than mid-swing.
+  const toolHandleMat = new THREE.MeshStandardMaterial({
+    color: new THREE.Color('#6b4a2b'),
+    roughness: PBR_REFERENCE.wood.roughness,
+    metalness: 0,
+  });
+  const toolHeadMat = new THREE.MeshStandardMaterial({
+    color: new THREE.Color('#9a9a9a'),
+    roughness: PBR_REFERENCE.iron.roughness,
+    metalness: PBR_REFERENCE.iron.metalness,
+  });
+  if (rich.accessories.carry?.includes('pickaxe')) {
+    const toolGroup = new THREE.Group();
+    toolGroup.name = 'carry_pickaxe';
+    const shaft = new THREE.Mesh(new THREE.CylinderGeometry(0.02, 0.025, 0.7, 6), toolHandleMat);
+    toolGroup.add(shaft);
+    // Two angled head-spikes meeting at the shaft top, reading as a pick.
+    for (const sign of [-1, 1] as const) {
+      const spike = new THREE.Mesh(new THREE.ConeGeometry(0.035, 0.32, 5), toolHeadMat);
+      spike.position.set(sign * 0.15, 0.35, 0);
+      spike.rotation.z = sign * (Math.PI / 2.3);
+      toolGroup.add(spike);
+    }
+    toolGroup.position.set(-p.shoulderWidth * 0.5, p.legLength + p.torsoLength * 0.55, -p.headDepth * 0.35);
+    toolGroup.rotation.z = Math.PI / 2.4;
+    toolGroup.rotation.y = Math.PI / 2;
+    group.add(toolGroup);
+  }
+  if (rich.accessories.carry?.includes('hoe')) {
+    const toolGroup = new THREE.Group();
+    toolGroup.name = 'carry_hoe';
+    const shaft = new THREE.Mesh(new THREE.CylinderGeometry(0.02, 0.025, 0.75, 6), toolHandleMat);
+    toolGroup.add(shaft);
+    const blade = new THREE.Mesh(new THREE.BoxGeometry(0.18, 0.05, 0.02), toolHeadMat);
+    blade.position.y = 0.37;
+    blade.rotation.z = Math.PI / 2;
+    toolGroup.add(blade);
+    toolGroup.position.set(-p.shoulderWidth * 0.5, p.legLength + p.torsoLength * 0.55, -p.headDepth * 0.35);
+    toolGroup.rotation.z = Math.PI / 2.4;
+    toolGroup.rotation.y = Math.PI / 2;
+    group.add(toolGroup);
+  }
+  if (rich.accessories.carry?.includes('sickle')) {
+    const toolGroup = new THREE.Group();
+    toolGroup.name = 'carry_sickle';
+    const shaft = new THREE.Mesh(new THREE.CylinderGeometry(0.02, 0.022, 0.35, 6), toolHandleMat);
+    toolGroup.add(shaft);
+    // A curved blade — a partial torus arc reads as a sickle's hook far
+    // better than a flat box (same technique the tool-belt band above
+    // already uses for a full ring, just a shorter arc).
+    const blade = new THREE.Mesh(new THREE.TorusGeometry(0.16, 0.015, 6, 12, Math.PI * 1.1), toolHeadMat);
+    blade.position.y = 0.2;
+    blade.rotation.y = Math.PI / 2;
+    toolGroup.add(blade);
+    // Strapped lower on the back than the pick/hoe (a shorter tool),
+    // opposite the tome's placement.
+    toolGroup.position.set(p.hipWidth * 0.55, p.legLength * 0.6, -p.headDepth * 0.2);
+    toolGroup.rotation.z = Math.PI / 2.6;
+    group.add(toolGroup);
   }
 
   /* ── Augments (cyber/superhero — chrome arm, etc.) ──────────── */

--- a/concord-frontend/lib/world-lens/enhanced-avatar-builder.ts
+++ b/concord-frontend/lib/world-lens/enhanced-avatar-builder.ts
@@ -46,6 +46,19 @@ import { FacialController } from '@/lib/concordia/facial-blend-shapes';
 import type { RichAppearanceConfig, HairStyle as RichHairStyle } from '@/lib/world-lens/character-schema';
 import { PBR_REFERENCE } from '@/lib/world-lens/character-schema';
 import { createWeapon } from '@/lib/concordia/weapon-archetypes';
+import { createArmorSet } from '@/lib/concordia/armor-system';
+
+/** armor-system.ts's parametric geometry (chestplate 0.50m, leg length
+ *  0.65m, etc) is dimensioned for the 'average' body archetype's 1.75m
+ *  reference height (character-schema.ts's heightBand table). Scaling
+ *  uniformly by totalHeight/REFERENCE keeps armor proportionate on
+ *  every archetype (petite through legend) without needing armor-
+ *  system.ts itself to take per-limb proportions as an input — an
+ *  approximation (it doesn't correct for width/depth ratio differences
+ *  between archetypes), but a close one, and far simpler than threading
+ *  BodyProportions through the armor builder's own geometry.
+ */
+const ARMOR_REFERENCE_HEIGHT_M = 1.75;
 
 export interface EnhancedAvatarResult {
   group:    THREE.Group;
@@ -196,6 +209,31 @@ export function buildEnhancedAvatar(rich: RichAppearanceConfig, opts: { isLocalP
     foot.position.set(sign * (p.hipWidth / 4), p.headWidth * 0.1, p.footLength * 0.3);
     foot.castShadow = true;
     group.add(foot);
+  }
+
+  /* ── Armor (real-material-detail, deterministic per-character) ──
+   * See character-schema.ts's generateAppearance armor block — every
+   * character gets a unique (silhouette, tier, wear, dye, seed)
+   * combination, so no two NPCs read as recolored clones. Anchor
+   * points below match armor-system.ts's own internal coordinate
+   * convention for each slot (verified against buildHelm/buildTorso/
+   * buildArms/buildLegs's own internal offsets): head centers on the
+   * head mesh; torso + legs share the waist line (chest offsets up
+   * from it, robes/legs hang down from it); arms anchor the shoulder
+   * line. */
+  const armorScale = p.totalHeight / ARMOR_REFERENCE_HEIGHT_M;
+  const armorSet = createArmorSet(rich.armor);
+  const waistY = p.legLength;
+  const shoulderY = p.legLength + p.torsoLength;
+  const headY = p.legLength + p.torsoLength + p.neckLength + p.headHeight / 2;
+  const armorAnchorY: Record<'head' | 'torso' | 'arms' | 'legs', number> = {
+    head: headY, torso: waistY, arms: shoulderY, legs: waistY,
+  };
+  for (const [slot, piece] of armorSet) {
+    piece.scale.setScalar(armorScale);
+    piece.position.y = armorAnchorY[slot];
+    piece.traverse((obj) => { (obj as THREE.Mesh).castShadow = true; });
+    group.add(piece);
   }
 
   /* ── Cape (if present — secondary-physics will animate it later) ── */

--- a/concord-frontend/lib/world-lens/material-reference-palettes.ts
+++ b/concord-frontend/lib/world-lens/material-reference-palettes.ts
@@ -1,0 +1,37 @@
+/**
+ * Real-photo-adjacent color statistics for 3 material kinds (leather,
+ * metal, cloth) that procedural-texture.ts's makePBR() synthesizes but
+ * previously colored from hand-picked hex constants.
+ *
+ * Provenance note (read this before treating these the same as
+ * terrain-reference-palettes.ts): these are sampled from Roblox's own
+ * SurfaceAppearance material-reference gallery (creator-docs repo,
+ * content/en-us/assets/modeling/surface-appearance/*.png — same
+ * CC-BY-4.0 license as the terrain photos, see public/models/CREDITS.md)
+ * — rendered PBR-material preview spheres (WornLeather, WornMetals,
+ * CottonCanvasDenim), NOT flat photographed material swatches the way
+ * the terrain JPEGs are. They are real reference renders of real
+ * material presets, sampled with a center-crop (45% of the frame) to
+ * stay inside the sphere and away from the white page background, and
+ * an 8th/92nd luminance-percentile pick for dark/light (not a literal
+ * min/max) so the specular highlight and silhouette ambient-occlusion
+ * — lighting artifacts of a rendered sphere, not material color — don't
+ * skew the result the way they would for a flat-lit photograph.
+ *
+ * Unlike the terrain photos, these preview images are not shipped in
+ * the repo or displayed anywhere — only the extracted avg/dark/light
+ * statistics below are used, by the same one-time headless-Chromium
+ * canvas-sampling methodology as terrain-reference-palettes.ts.
+ */
+
+export interface MaterialReferencePalette {
+  avg: readonly [number, number, number];
+  dark: readonly [number, number, number];
+  light: readonly [number, number, number];
+}
+
+export const MATERIAL_REFERENCE_PALETTES: Record<string, MaterialReferencePalette> = {
+  leather: { avg: [116, 75, 59], dark: [95, 57, 39], light: [136, 92, 74] },
+  metal:   { avg: [123, 102, 75], dark: [58, 40, 19], light: [247, 200, 148] },
+  cloth:   { avg: [230, 209, 168], dark: [201, 181, 142], light: [251, 229, 187] },
+};

--- a/concord-frontend/lib/world-lens/procedural-texture.ts
+++ b/concord-frontend/lib/world-lens/procedural-texture.ts
@@ -15,17 +15,20 @@
  * on better-than-this; this module is the catalog floor that never has
  * to be authored.
  *
- * 2026-07-21 — 7 of the 13 kinds (dirt, brick, grass, sand, cobblestone,
- * gravel, asphalt) are grounded in real photographed color data
- * (terrain-reference-palettes.ts, sampled from the CC-BY-4.0 terrain
- * textures at public/models/terrain/*.jpg — see CREDITS.md) instead of
- * hand-picked hex constants: `paletteFor()` returns each kind's real
- * average/shadow/highlight tones, and the pattern generators below mix
- * between them per-pixel. The (kind, seed) space was already infinite;
- * this just anchors every combination's base colors to something a
- * camera actually saw, rather than an eyeballed guess. Kinds with no
- * terrain photo counterpart (stone, wood, cloth, metal, leather, thatch)
- * keep their original hardcoded palette unchanged.
+ * 2026-07-21 — 10 of the 13 kinds are grounded in real reference color
+ * data instead of hand-picked hex constants: `paletteFor()` returns each
+ * kind's real average/shadow/highlight tones, and the pattern generators
+ * below mix between them per-pixel. Two provenance tiers:
+ *   - dirt, brick, grass, sand, cobblestone, gravel, asphalt (7) —
+ *     terrain-reference-palettes.ts, sampled from the CC-BY-4.0
+ *     photographed terrain textures at public/models/terrain/*.jpg.
+ *   - cloth, metal, leather (3) — material-reference-palettes.ts,
+ *     sampled from Roblox's CC-BY-4.0 SurfaceAppearance material-preview
+ *     renders (see that file's own doc comment for why these are a
+ *     distinct provenance tier from the terrain photos).
+ * The (kind, seed) space was already infinite; this anchors every
+ * combination's base colors to something real rather than an eyeballed
+ * guess. Only stone/wood/thatch (3) keep their original hardcoded palette.
  *
  * Performance: textures are cached per (kind, seed, size); 512×512
  * default, drops to 256 on low quality.
@@ -35,6 +38,7 @@
 
 import type * as THREE_NS from 'three';
 import { TERRAIN_REFERENCE_PALETTES, type ReferencePalette } from './terrain-reference-palettes';
+import { MATERIAL_REFERENCE_PALETTES } from './material-reference-palettes';
 
 export type ProceduralKind =
   | 'stone'
@@ -51,10 +55,12 @@ export type ProceduralKind =
   | 'gravel'
   | 'asphalt';
 
-/** Real-photo palette for kinds that have one; undefined for the 6
- *  original kinds with no terrain-photo counterpart. */
+/** Real-reference palette for kinds that have one — either a photographed
+ *  terrain ground tone or a rendered-material-preview tone (see
+ *  material-reference-palettes.ts for the provenance distinction).
+ *  Undefined for the 3 original kinds with neither (stone, wood, thatch). */
 function paletteFor(kind: ProceduralKind): ReferencePalette | undefined {
-  return TERRAIN_REFERENCE_PALETTES[kind];
+  return TERRAIN_REFERENCE_PALETTES[kind] ?? MATERIAL_REFERENCE_PALETTES[kind];
 }
 
 function rgbStr([r, g, b]: readonly [number, number, number], a = 1): string {
@@ -212,10 +218,15 @@ function makeAlbedoCanvas(kind: ProceduralKind, seed: number, size: number): HTM
       break;
     }
     case 'cloth': {
-      // Linen / cotton weave
-      ctx.fillStyle = '#c9c2b3';
+      // Real-reference-grounded (Roblox SurfaceAppearance "Cotton Canvas
+      // Denim" preview — see material-reference-palettes.ts). Base fill +
+      // weave threads + fleck modulation all mix toward the real avg/dark/
+      // light tones instead of an eyeballed off-white.
+      const palC = paletteFor('cloth');
+      ctx.fillStyle = palC ? rgbStr(palC.avg) : '#c9c2b3';
       ctx.fillRect(0, 0, size, size);
-      ctx.strokeStyle = 'rgba(80, 70, 55, 0.18)';
+      const threadC = palC ? lerpTone(palC, 0.1) : [80, 70, 55];
+      ctx.strokeStyle = `rgba(${threadC[0]}, ${threadC[1]}, ${threadC[2]}, 0.18)`;
       ctx.lineWidth = 1;
       for (let i = 0; i < size; i += 4) {
         ctx.beginPath(); ctx.moveTo(0, i); ctx.lineTo(size, i); ctx.stroke();
@@ -224,16 +235,28 @@ function makeAlbedoCanvas(kind: ProceduralKind, seed: number, size: number): HTM
       // Slight colour modulation
       for (let i = 0; i < 200; i++) {
         const x = rng() * size, y = rng() * size;
-        ctx.fillStyle = `rgba(${130 + Math.floor(rng() * 30)}, ${120 + Math.floor(rng() * 30)}, ${110 + Math.floor(rng() * 25)}, 0.4)`;
+        if (palC) {
+          const c = lerpTone(palC, 0.4 + rng() * 0.5);
+          ctx.fillStyle = `rgba(${c[0]}, ${c[1]}, ${c[2]}, 0.4)`;
+        } else {
+          ctx.fillStyle = `rgba(${130 + Math.floor(rng() * 30)}, ${120 + Math.floor(rng() * 30)}, ${110 + Math.floor(rng() * 25)}, 0.4)`;
+        }
         ctx.fillRect(x, y, 2, 2);
       }
       break;
     }
     case 'metal': {
-      ctx.fillStyle = '#8b8e94';
+      // Real-reference-grounded (Roblox SurfaceAppearance "Worn Metals"
+      // preview — see material-reference-palettes.ts). Base fill uses the
+      // real average tone; brushed lines mix toward the real dark tone
+      // (the specular-highlight "light" tone is deliberately NOT used for
+      // the brushed-line darkening — that's a lighting artifact of the
+      // rendered reference sphere, not a material color).
+      const palM = paletteFor('metal');
+      ctx.fillStyle = palM ? rgbStr(palM.avg) : '#8b8e94';
       ctx.fillRect(0, 0, size, size);
-      // Brushed lines
-      ctx.strokeStyle = 'rgba(60, 65, 72, 0.25)';
+      const brushM = palM ? lerpTone(palM, 0.15) : [60, 65, 72];
+      ctx.strokeStyle = `rgba(${brushM[0]}, ${brushM[1]}, ${brushM[2]}, 0.25)`;
       ctx.lineWidth = 1;
       for (let y = 0; y < size; y += 2) {
         ctx.beginPath();
@@ -241,7 +264,7 @@ function makeAlbedoCanvas(kind: ProceduralKind, seed: number, size: number): HTM
         ctx.lineTo(size, y + (rng() - 0.5) * 4);
         ctx.stroke();
       }
-      // Speckle scratches
+      // Speckle scratches — genuinely near-white highlight glints, kept as-is
       for (let i = 0; i < 80; i++) {
         const x = rng() * size, y = rng() * size;
         const dx = (rng() - 0.5) * 20, dy = (rng() - 0.5) * 10;
@@ -251,14 +274,24 @@ function makeAlbedoCanvas(kind: ProceduralKind, seed: number, size: number): HTM
       break;
     }
     case 'leather': {
-      ctx.fillStyle = '#5a3a26';
+      // Real-reference-grounded (Roblox SurfaceAppearance "Worn Leather"
+      // preview — see material-reference-palettes.ts). Base fill + crinkle
+      // cells mix toward the real avg/dark tones instead of an eyeballed
+      // brown.
+      const palL = paletteFor('leather');
+      ctx.fillStyle = palL ? rgbStr(palL.avg) : '#5a3a26';
       ctx.fillRect(0, 0, size, size);
       // Crinkle pattern via overlapping radial cells
       for (let i = 0; i < 600; i++) {
         const x = rng() * size, y = rng() * size;
         const r = 3 + rng() * 6;
-        const dark = Math.floor(rng() * 25);
-        ctx.fillStyle = `rgba(${70 - dark}, ${50 - dark}, ${30 - dark}, 0.4)`;
+        if (palL) {
+          const c = lerpTone(palL, rng() * 0.5);
+          ctx.fillStyle = `rgba(${c[0]}, ${c[1]}, ${c[2]}, 0.4)`;
+        } else {
+          const dark = Math.floor(rng() * 25);
+          ctx.fillStyle = `rgba(${70 - dark}, ${50 - dark}, ${30 - dark}, 0.4)`;
+        }
         ctx.beginPath(); ctx.arc(x, y, r, 0, Math.PI * 2); ctx.fill();
       }
       break;

--- a/concord-frontend/lib/world-lens/resource-node-renderer.ts
+++ b/concord-frontend/lib/world-lens/resource-node-renderer.ts
@@ -25,6 +25,7 @@
  */
 import * as THREE from 'three';
 import { worldToSceneAxis, sampleGroundY } from './coord-frame';
+import { loadAsset, instanceFromCache, resolveAssetReference } from './asset-loader';
 
 // ── Wire types ──────────────────────────────────────────────────────────────
 
@@ -147,14 +148,62 @@ interface TrackedNode {
   swayPhase: number;
 }
 
-/** Build the mesh for a node given its visual descriptor. */
-function buildNodeObject(visual: NodeVisual): {
+/**
+ * Real-asset-first: try a real GLB for kinds that have one (tree, bush)
+ * before falling back to the procedural primitive shape. `realAssetUrls`
+ * is pre-warmed once at renderer creation (see `warmRealAssets` below) —
+ * this stays synchronous-shaped (returns a Promise but never blocks a
+ * caller that doesn't await it) so `reconcile`'s existing structure only
+ * needs `await` added, not a rewrite. `variantSeed` picks deterministically
+ * among multiple real variants (tree_01..04) so nodes of the same kind
+ * aren't visually identical clones.
+ */
+async function tryRealAsset(
+  urls: string[],
+  variantSeed: string,
+  targetHeight: number,
+): Promise<THREE.Object3D | null> {
+  if (urls.length === 0) return null;
+  const url = urls[Math.floor(hashU(variantSeed + ':variant') * urls.length)];
+  try {
+    const inst = await instanceFromCache(url, THREE);
+    if (!inst) return null;
+    const cloned = inst as THREE.Object3D;
+    const box = new THREE.Box3().setFromObject(cloned);
+    const size = box.getSize(new THREE.Vector3());
+    if (size.y > 0.001) cloned.scale.multiplyScalar(targetHeight / size.y);
+    cloned.rotation.y = hashU(variantSeed + ':yaw') * Math.PI * 2;
+    return cloned;
+  } catch {
+    return null; // fall through to procedural
+  }
+}
+
+/** Build the mesh for a node given its visual descriptor. Tries a real
+ *  asset first for kinds that have one (see `realAssets` param); the
+ *  procedural shape below is the honest fallback when no real asset is
+ *  available for this kind, not a placeholder that's meant to be removed. */
+async function buildNodeObject(
+  visual: NodeVisual,
+  nodeId: string,
+  realAssets: { tree: string[]; bush: string[] },
+): Promise<{
   object: THREE.Object3D;
   geometries: THREE.BufferGeometry[];
   materials: THREE.Material[];
-} {
+}> {
   const geometries: THREE.BufferGeometry[] = [];
   const materials: THREE.Material[] = [];
+
+  if (!visual.depleted) {
+    if (visual.kind === 'tree') {
+      const real = await tryRealAsset(realAssets.tree, nodeId, 3.5 + hashU(nodeId + ':height') * 2.5);
+      if (real) return { object: real, geometries, materials };
+    } else if (visual.kind === 'bush') {
+      const real = await tryRealAsset(realAssets.bush, nodeId, 0.9 + hashU(nodeId + ':height') * 0.4);
+      if (real) return { object: real, geometries, materials };
+    }
+  }
 
   if (visual.depleted) {
     // Depleted → a short stump / hollow marker so the spot reads as "spent".
@@ -310,8 +359,51 @@ export function createResourceNodeRenderer(
   let disposed = false;
   let intervalId: ReturnType<typeof setInterval> | null = null;
 
-  function reconcile(nodes: ResourceNode[]): void {
+  // Real-asset-first: pre-warm the CC0 tree/bush GLBs once at creation
+  // (mirrors TreeLayer.tsx's exact pattern) so buildNodeObject's per-node
+  // real-asset attempt is a cache hit, not a fresh network fetch, in the
+  // common case. loadAsset never throws — a missing variant just leaves
+  // that slot out of the array and the node falls back to the existing
+  // procedural cone/icosahedron shape (never a fake or blocked node).
+  const realAssets: { tree: string[]; bush: string[] } = { tree: [], bush: [] };
+  const realAssetsReady = (async () => {
+    for (const id of ['tree_01', 'tree_02', 'tree_03', 'tree_04']) {
+      try {
+        const loaded = await loadAsset({ kind: 'vegetation', id }, THREE);
+        if (loaded) {
+          const assetUrl = await resolveAssetReference({ kind: 'vegetation', id });
+          if (assetUrl) realAssets.tree.push(assetUrl);
+        }
+      } catch { /* variant unavailable — skip it */ }
+    }
+    try {
+      const loaded = await loadAsset({ kind: 'vegetation', id: 'bush_01' }, THREE);
+      if (loaded) {
+        const assetUrl = await resolveAssetReference({ kind: 'vegetation', id: 'bush_01' });
+        if (assetUrl) realAssets.bush.push(assetUrl);
+      }
+    } catch { /* unavailable — skip it */ }
+  })();
+
+  // reconcile is async (real-asset lookups await network/cache work) —
+  // unlike the old fully-synchronous version, two calls CAN now overlap
+  // (the construction-time auto-refresh racing an explicit refresh() or
+  // poll tick under slow network). Without serialization, two concurrent
+  // calls can both pass the "not yet in `tracked`" check for the same
+  // node before either writes back, each building + adding its own
+  // object — a real duplicate-mesh bug, not a hypothetical one (caught
+  // via a real headless-browser render during development: 5 nodes
+  // rendered as 10 objects). `reconcileChain` makes every call wait for
+  // the previous one to fully finish before it starts.
+  let reconcileChain: Promise<void> = Promise.resolve();
+  function reconcile(nodes: ResourceNode[]): Promise<void> {
+    reconcileChain = reconcileChain.then(() => reconcileOnce(nodes));
+    return reconcileChain;
+  }
+
+  async function reconcileOnce(nodes: ResourceNode[]): Promise<void> {
     if (disposed) return;
+    await realAssetsReady;
 
     const seen = new Set<string>();
 
@@ -339,11 +431,21 @@ export function createResourceNodeRenderer(
       }
 
       if (existing) disposeTracked(existing, parentGroup);
+      if (disposed) return; // renderer disposed while an await above was in flight
 
-      const built = buildNodeObject(visual);
+      const built = await buildNodeObject(visual, node.id, realAssets);
+      if (disposed) return;
       built.object.position.set(sx, ny, sz);
       const initialScale = existing ? existing.object.scale.x : visual.scale;
       built.object.scale.setScalar(initialScale);
+      // Tag every mesh in the (possibly multi-mesh real GLB) object with
+      // the node id + a resource-node marker so ConcordiaScene's
+      // click-to-gather raycast can resolve a hit back to this node
+      // regardless of which sub-mesh the ray actually intersects.
+      built.object.userData = { ...built.object.userData, isResourceNode: true, nodeId: node.id, nodeType: node.node_type, depleted: visual.depleted };
+      built.object.traverse((child) => {
+        child.userData = { ...child.userData, isResourceNode: true, nodeId: node.id, nodeType: node.node_type, depleted: visual.depleted };
+      });
       parentGroup.add(built.object);
 
       tracked.set(node.id, {
@@ -378,7 +480,7 @@ export function createResourceNodeRenderer(
       if (!res.ok) return; // honest: render nothing on a bad response
       const data = (await res.json()) as NodesResponse;
       if (!data || !Array.isArray(data.nodes)) return;
-      reconcile(data.nodes);
+      await reconcile(data.nodes);
     } catch {
       // Network/parse failure → render nothing new (no fake nodes).
     }
@@ -434,4 +536,15 @@ function hashPhase(id: string): number {
     h = (h * 31 + id.charCodeAt(i)) | 0;
   }
   return ((h >>> 0) % 1000) / 1000 * Math.PI * 2;
+}
+
+/** Stable [0, 1) float from a seed string — same FNV-1a technique as
+ *  TreeLayer.tsx's own `hashU`, used here to pick a real-asset variant
+ *  and jitter its height/yaw deterministically per node id. */
+function hashU(s: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h = ((h ^ s.charCodeAt(i)) * 16777619) >>> 0;
+  }
+  return h / 0xffffffff;
 }

--- a/concord-frontend/public/models/CREDITS.md
+++ b/concord-frontend/public/models/CREDITS.md
@@ -361,6 +361,33 @@ headless-Chromium render during development (5 server nodes rendered as
 10 scene objects) before being serialized with a chained-promise guard
 (`reconcileChain`) and re-verified (5 nodes → 5 objects).
 
+### Gathering tools + NPC gather visibility (2026-07-21, later same session)
+
+Two closing pieces for "AI NPCs will be cutting down trees... it's hard
+to do that with no tool":
+
+- **`axe`/`pickaxe`/`hoe`/`sickle` are now real `Accessories['carry']`
+  values.** `axe` reuses the real `axe.glb` weapon archetype directly
+  (`weapon-archetypes.ts`, `createWeapon({archetype:'axe',...})`) —
+  holstered at the hip, not drawn — since a lumberjack's axe and a combat
+  axe are the same object in this world; no second asset needed.
+  `pickaxe`/`hoe`/`sickle` have no real GLB, so they're honest procedural
+  props (wood-shaft cylinder + shaped metal head — a bent-cone pick, a
+  flat-blade hoe, a curved-torus-arc sickle) in the same style already
+  established for `tool-belt`/`tome`. `character-schema.ts`'s
+  `generateAppearance` gives civilian (unmatched-archetype) characters a
+  seeded 35% chance to carry one — "regular townsfolk" now read as
+  people who actually chop/mine/farm, not generic idle extras.
+- **NPC gathering is no longer silent.** `server/lib/npc-simulator.js`'s
+  `gather_resource` action wrote only to the DB (`activity_resources` +
+  `world_resource_nodes`) with zero broadcast. A new `_emitGather`
+  (mirroring the file's own existing `_emitBark` pattern exactly) sends
+  `world:npc-gather` with the real node's position/type/resource —
+  `world/page.tsx`'s `handleNpcGather` bridges it into the SAME
+  tool-swing + dust-particle feedback the player's own click-to-gather
+  gets, targeted at the NPC's own entity id. An NPC gathering resources
+  is now a real, watchable action.
+
 ## Known limitations (honest, not hidden)
 
 - **`forge` and `tower` building archetypes** have no real asset yet — they

--- a/concord-frontend/public/models/CREDITS.md
+++ b/concord-frontend/public/models/CREDITS.md
@@ -255,6 +255,72 @@ never `map` (albedo): the real per-faction dye color
 via `material.color`) stays the actual displayed color — the texture
 only adds surface detail, it doesn't override the color customization.
 
+### Everyone wears their own armor now (2026-07-21, later same session)
+
+`armor-system.ts`'s builder existed but nothing called it — `createArmorSet`/
+`createArmorPiece` had zero callers anywhere in the app. Wired in two places:
+
+- **`character-schema.ts`'s `generateAppearance`** now computes a real,
+  individually-seeded `ArmorAppearance` for every character (archetype
+  picks the default silhouette — warrior/guard/legend→heavy_plate,
+  scholar/mystic→robed, hunter/trader→leather; civilians get a seeded
+  pick between leather/exposed; colors reuse the character's own
+  clothing palette so armor reads as one coherent outfit). The seed
+  string is the SAME composite `worldId::factionId::id` this whole
+  function hashes everything else from, so no two characters — including
+  two NPCs of the same archetype/faction — read as recolored clones.
+- **`enhanced-avatar-builder.ts`** (the local player + every hero-flagged
+  NPC's procedural body) now builds and attaches that armor, scaled by
+  `totalHeight / 1.75` (armor-system.ts's geometry is dimensioned for the
+  'average' archetype's 1.75m reference height) and anchored at the
+  correct body landmark per slot (head centers on the head mesh; torso +
+  legs share the waist line; arms anchor the shoulder line — verified
+  against armor-system.ts's own internal per-slot offsets).
+- **`hero-mesh-registry.ts`** (`attachArmorToHeroMesh`) extends the same
+  armor onto real hero GLB meshes (Microsoft Rocketbox / Mixamo rigs) via
+  `Object3D.attach()` — the standard three.js technique for parenting a
+  freshly-built object onto a bone while landing it at the bone's current
+  world position with identity rotation (not the bone's own rest-pose
+  local rotation, which for a limb bone points along the limb rather than
+  world-up) — so armor pieces then move/rotate WITH the bone as the rig
+  animates. Torso/legs attach to `Hips`, arms to `Spine2` (falling back to
+  `Spine1`/`Spine`), head to `Head`; a skeleton missing a bone just skips
+  that slot rather than throwing. `AvatarSystem3D.tsx` now computes the
+  rich appearance (armor included) once, up front, and passes `rich.armor`
+  into `loadHeroMesh` before attempting the GLB — the procedural fallback
+  path reuses the same object instead of rolling a second one, so a hero
+  NPC wears the identical deterministic kit whichever render path it
+  actually takes.
+
+Verified with a real headless-Chromium WebGL render of the actual bundled
+`buildEnhancedAvatar` + `generateAppearance` modules (not a mock): three
+different archetypes (warrior/scholar/hunter) render as three visibly
+distinct characters — a dark-plated knight with pauldrons and a chest
+sigil, a hooded robe reaching the ankles, and a tan leather-vest hunter
+carrying a bow — proving the per-character seed genuinely drives visible
+variety, not just distinct data. The bone-attach mechanism (parent
+tracking, world-position landing, moves-with-the-bone-on-rig-animation)
+is unit-tested directly (`tests/lib/hero-mesh-armor-attach.test.ts`); it
+was not separately verified against a REAL Rocketbox rig's actual
+rest-pose bone orientations in a live render (no real hero-GLB NPC was
+available to render in this session's headless-browser harness) — flagged
+as the one honest residual on this half of the feature, not silently
+assumed correct.
+
+One known, pre-existing architectural quirk this work exposed rather than
+introduced: `generateAppearance`'s `override` parameter only overwrites
+the FINAL returned object's fields — it does not retroactively influence
+other fields computed earlier in the function from the pre-override
+local variable (e.g. `override: { bodyArchetype: 'legend' }` does not
+change `totalHeight`/`proportions`, which are derived from the seeded
+pick before override is ever applied). Armor's own tier-5-for-legend rule
+was fixed to read `override?.bodyArchetype` directly so authored deity
+NPCs get it right, but the broader quirk (also affecting
+`CharacterPreviewCanvas.tsx`'s live clothing-color selections not
+retroactively recoloring armor) is a pre-existing characteristic of this
+function's design, not something this session's scope covered fixing
+everywhere it appears.
+
 ## Known limitations (honest, not hidden)
 
 - **`forge` and `tower` building archetypes** have no real asset yet — they

--- a/concord-frontend/public/models/CREDITS.md
+++ b/concord-frontend/public/models/CREDITS.md
@@ -217,6 +217,44 @@ against `terrain-reference-palettes.ts`'s real sampled values outside any
 renderer to rule out a browser color-management artifact skewing the
 visual check.
 
+### `cloth`/`metal`/`leather` also grounded, from a different real source (2026-07-21, later same session)
+
+The remaining 3 of the 6 previously-hardcoded procedural kinds
+(`cloth`, `metal`, `leather` — `stone`/`wood`/`thatch` still have no real
+reference and are unchanged) are now grounded too, via
+`lib/world-lens/material-reference-palettes.ts`. Source: the same
+`Roblox/creator-docs` repo (CC-BY-4.0, same license as the 7 terrain
+photos), but a different asset type —
+`content/en-us/assets/modeling/surface-appearance/{013_WornLeather,
+023_WornMetals,07_CottonCanvasDenim}.png`, Roblox's own rendered
+material-preview spheres for their SurfaceAppearance material catalog
+documentation. **This is a genuinely different provenance tier from the
+terrain photos and is documented as such in
+`material-reference-palettes.ts`'s own doc comment** — these are rendered
+PBR-material preview renders (a sphere lit against a white page
+background), not flat photographed material swatches. Sampling used a
+45%-center-crop (stays inside the sphere, away from the white background)
+and an 8th/92nd luminance-percentile pick for dark/light instead of a
+literal min/max (a literal min/max would have picked up the sphere's
+specular hotspot and silhouette ambient-occlusion shadow — lighting
+artifacts of the render, not material color). Unlike the terrain photos,
+these preview images are not shipped in the repo or displayed anywhere —
+only the extracted avg/dark/light statistics are used, so there are no
+new files under `public/models/` for this entry.
+
+`lib/concordia/armor-system.ts` (the 4-slot parametric armor-piece
+builder — head/torso/arms/legs × heavy_plate/robed/leather/exposed
+silhouettes) previously built every material as a flat solid-color
+`MeshStandardMaterial` with zero texture detail. It now calls
+`makePBR()` for a `normalMap`/`roughnessMap` pair keyed off silhouette
+(heavy_plate→metal, robed→cloth, leather & exposed→leather) — real
+material surface detail (brushed-metal streaks, leather crinkle, cloth
+weave) layered on top. Deliberately `normalMap`/`roughnessMap` only,
+never `map` (albedo): the real per-faction dye color
+(`appearance.primaryColor`/`secondaryColor`/`accentColor`, still applied
+via `material.color`) stays the actual displayed color — the texture
+only adds surface detail, it doesn't override the color customization.
+
 ## Known limitations (honest, not hidden)
 
 - **`forge` and `tower` building archetypes** have no real asset yet — they

--- a/concord-frontend/public/models/CREDITS.md
+++ b/concord-frontend/public/models/CREDITS.md
@@ -43,7 +43,8 @@ it; delete a file to fall back to the existing procedural generator
 | File | Source name | Used for |
 |---|---|---|
 | `vegetation/tree_01.glb`..`tree_04.glb` | Tree_01_Art..Tree_04_Art (MomusPark) | `TreeLayer.tsx` — picked per-tree by a seeded hash for variety |
-| `vegetation/bush_01.glb`, `flower_01.glb` | Bush_01_Art, Flower_01_a (MomusPark) | sourced, not yet wired to a consumer — vegetation-kind bonus content for a future pass |
+| `vegetation/bush_01.glb` | Bush_01_Art (MomusPark) | `resource-node-renderer.ts` — real GLB for `herb` resource nodes (2026-07-21), real-asset-first ahead of the procedural icosahedron fallback |
+| `vegetation/flower_01.glb` | Flower_01_a (MomusPark) | sourced, not yet wired to a consumer — vegetation-kind bonus content for a future pass |
 | `building/tavern.glb` | Shelter_Art (MomusPark) | `BuildingRenderer3D.tsx` `tavern` archetype |
 | `building/market.glb` | Booth_Food01 (medieval-fair) | `BuildingRenderer3D.tsx` `market` archetype |
 | `building/archive.glb` | Str_Amphitheater_01_Art (MomusPark) | `BuildingRenderer3D.tsx` `archive` archetype |
@@ -320,6 +321,45 @@ NPCs get it right, but the broader quirk (also affecting
 retroactively recoloring armor) is a pre-existing characteristic of this
 function's design, not something this session's scope covered fixing
 everywhere it appears.
+
+### Resource nodes are real, real-asset-first, and clickable (2026-07-21, later same session)
+
+`lib/world-lens/resource-node-renderer.ts` (real per-node meshes polling
+`GET /api/worlds/:worldId/nodes`, already wired into `ConcordiaScene.tsx`
+via `attach-world-renderers.ts`) previously built every node kind from
+flat-color procedural primitives only — no real asset was ever attempted,
+and nothing on the mesh was clickable (the only gather UI was a
+disconnected 2D "Nearby resources" HUD list). Two fixes:
+
+- **Real GLB first for `tree`/`herb` node kinds.** Reuses the exact
+  `loadAsset`/`instanceFromCache`/`resolveAssetReference` pipeline
+  `TreeLayer.tsx` already uses (same real CC0 `tree_01-04.glb` variants),
+  plus finally wires `bush_01.glb` (previously sourced but unused — see
+  the vegetation table above) for `herb` nodes. `ore_vein`/`stone`/
+  `crystal`/`spring` node kinds have no real asset available and keep
+  their existing distinct procedural shapes (rock/crystal/water) — an
+  honest gap, not silently hidden.
+- **Click-to-gather.** Every built node object (real GLB or procedural)
+  is tagged `userData.isResourceNode` + `nodeId` (recursively, via
+  `traverse`, so a hit on any sub-mesh of a multi-mesh real GLB still
+  resolves). `ConcordiaScene.tsx`'s existing canvas-click raycaster
+  (already checks avatars → now resource nodes → buildings → terrain, in
+  that priority order) dispatches `concordia:node-click`; `world/page.tsx`
+  listens and calls the SAME `gatherFromNode()` the 2D HUD list's Gather
+  button already used — one real gather call path, not two — with the
+  same tool-swing + dust-particle feedback the freeform right-click
+  gather path already had. A depleted node (rendered as a stump) shows an
+  honest "depleted" message instead of a silent no-op.
+
+A real concurrency bug was caught and fixed during development, not
+shipped: making `reconcile()` async (real-asset lookups need to
+`await`) meant two overlapping calls — the renderer's own construction-
+time auto-refresh racing an explicit `refresh()` — could each pass the
+"not yet tracked" check for the same node before either wrote back,
+building and adding two objects for one node. Confirmed via a real
+headless-Chromium render during development (5 server nodes rendered as
+10 scene objects) before being serialized with a chained-promise guard
+(`reconcileChain`) and re-verified (5 nodes → 5 objects).
 
 ## Known limitations (honest, not hidden)
 

--- a/concord-frontend/tests/components/blueprint-panel-action-anim.test.tsx
+++ b/concord-frontend/tests/components/blueprint-panel-action-anim.test.tsx
@@ -1,0 +1,77 @@
+// Animation-coverage audit (2026-07-21) — BlueprintPanel (workbench-based
+// general crafting, POST /api/crafting/execute) had the exact same silent
+// gap as CraftingPanelV2: a successful craft dispatched item-acquired/
+// craft-success toast events but never touched the avatar. Fixed by mapping
+// the crafted dtu.type onto the same labor-verb table CraftingPanelV2 uses.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { BlueprintPanel } from '@/components/concordia/crafting/BlueprintPanel';
+
+const playActionAtPlayer = vi.fn();
+vi.mock('@/lib/concordia/play-action', () => ({
+  playActionAtPlayer: (...args: unknown[]) => playActionAtPlayer(...args),
+}));
+
+const apiGet = vi.fn();
+const apiPost = vi.fn();
+vi.mock('@/lib/api/client', () => ({
+  api: { get: (...a: unknown[]) => apiGet(...a), post: (...a: unknown[]) => apiPost(...a) },
+}));
+
+// The minigame's own resolution UI is unrelated to this fix — stub it to a
+// single button that calls onComplete with a fixed quality multiplier.
+vi.mock('@/components/concordia/crafting/CraftingMinigame', () => ({
+  CraftingMinigame: ({ onComplete }: { onComplete: (m: number) => void }) => (
+    <button onClick={() => onComplete(1.0)}>finish-minigame</button>
+  ),
+}));
+
+const BLUEPRINT = { id: 'bp1', title: 'Iron Helm', createdAt: new Date().toISOString(), requiredMaterials: [], requiredToolTier: 0 };
+
+describe('BlueprintPanel — real avatar feedback on craft (not a silent panel)', () => {
+  beforeEach(() => {
+    playActionAtPlayer.mockClear();
+    apiGet.mockImplementation((url: string) => {
+      if (url === '/api/blueprints') return Promise.resolve({ data: { blueprints: [BLUEPRINT] } });
+      if (url.startsWith('/api/blueprints/')) return Promise.resolve({ data: { blueprint: BLUEPRINT } });
+      if (url === '/api/world/inventory') return Promise.resolve({ data: { items: [] } });
+      return Promise.resolve({ data: {} });
+    });
+  });
+
+  afterEach(() => { vi.clearAllMocks(); });
+
+  it('plays the armor verb (dtu.type=armor) on a successful workbench craft', async () => {
+    apiPost.mockResolvedValue({ data: { ok: true, dtu: { name: 'Iron Helm', type: 'armor' } } });
+
+    const { getByText } = render(<BlueprintPanel playerId="u1" toolTier={0} skillLevel={1} onClose={() => {}} />);
+    await waitFor(() => { expect(getByText('Iron Helm')).toBeTruthy(); });
+
+    fireEvent.click(getByText('Iron Helm'));
+    await waitFor(() => { expect(getByText('Begin Crafting')).toBeTruthy(); });
+    fireEvent.click(getByText('Begin Crafting'));
+
+    const finishBtn = await waitFor(() => getByText('finish-minigame'));
+    fireEvent.click(finishBtn);
+
+    await waitFor(() => { expect(playActionAtPlayer).toHaveBeenCalledWith('craft'); });
+  });
+
+  it('does not play an animation when the server rejects the craft', async () => {
+    apiPost.mockResolvedValue({ data: { ok: false, error: 'Insufficient resources', missing_resources: [] } });
+
+    const { getByText } = render(<BlueprintPanel playerId="u1" toolTier={0} skillLevel={1} onClose={() => {}} />);
+    await waitFor(() => { expect(getByText('Iron Helm')).toBeTruthy(); });
+
+    fireEvent.click(getByText('Iron Helm'));
+    await waitFor(() => { expect(getByText('Begin Crafting')).toBeTruthy(); });
+    fireEvent.click(getByText('Begin Crafting'));
+
+    const finishBtn = await waitFor(() => getByText('finish-minigame'));
+    fireEvent.click(finishBtn);
+
+    await waitFor(() => { expect(getByText(/Need:/)).toBeTruthy(); });
+    expect(playActionAtPlayer).not.toHaveBeenCalled();
+  });
+});

--- a/concord-frontend/tests/components/crafting-panel-v2-action-anim.test.tsx
+++ b/concord-frontend/tests/components/crafting-panel-v2-action-anim.test.tsx
@@ -1,0 +1,79 @@
+// Animation-coverage audit (2026-07-21) — CraftingPanelV2 was the primary
+// player-facing craft loop (mounted directly on the world page, no station
+// proximity needed) and was completely silent: a successful craft dispatched
+// toast/juice/SFX events but never called playAction/playActionAtPlayer, so
+// the avatar stood idle through it. Fixed by mapping recipe.category (or
+// output.type as a fallback) onto the labor verb table already used by
+// station overlays (RestaurantDashboard/FarmTileEditor/etc via
+// lib/concordia/play-action.ts), so e.g. a weapon/tool recipe plays the real
+// forge pose (hammer_tap loop, sparks, forge_ring sfx) and a consumable
+// recipe plays the real cook pose (sizzle/steam) instead of nothing at all.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import CraftingPanelV2 from '@/components/world-lens/CraftingPanelV2';
+
+const playActionAtPlayer = vi.fn();
+vi.mock('@/lib/concordia/play-action', () => ({
+  playActionAtPlayer: (...args: unknown[]) => playActionAtPlayer(...args),
+}));
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({ ok: true, json: () => Promise.resolve(body) } as Response);
+}
+
+const RECIPE = {
+  id: 'r1',
+  category: 'weapon',
+  ingredients: [{ type: 'wood', quantity: 2, name: 'Wood' }],
+  output: { name: 'Iron Sword', type: 'weapon' },
+  craftable: true,
+};
+
+describe('CraftingPanelV2 — real avatar feedback on craft (not a silent panel)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    playActionAtPlayer.mockClear();
+    fetchMock = vi.fn((url: string) => {
+      if (url === '/api/starter/recipes') return jsonResponse({ recipes: [RECIPE] });
+      if (url === '/api/starter/inventory') return jsonResponse({ items: [] });
+      return jsonResponse({ ok: false });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('plays the forge verb (category=weapon) on a successful craft', async () => {
+    const { getByText } = render(<CraftingPanelV2 worldId="w1" />);
+    await waitFor(() => { expect(getByText('Craft')).toBeTruthy(); });
+
+    fetchMock.mockImplementation((url: string, opts?: RequestInit) => {
+      if (url === '/api/starter/craft') {
+        expect(JSON.parse(String(opts?.body)).recipeId).toBe('r1');
+        return jsonResponse({ ok: true });
+      }
+      return jsonResponse({ recipes: [RECIPE], items: [] });
+    });
+
+    fireEvent.click(getByText('Craft'));
+
+    await waitFor(() => { expect(playActionAtPlayer).toHaveBeenCalledWith('forge'); });
+  });
+
+  it('does not play an animation when the craft fails', async () => {
+    const { getByText } = render(<CraftingPanelV2 worldId="w1" />);
+    await waitFor(() => { expect(getByText('Craft')).toBeTruthy(); });
+
+    fetchMock.mockImplementation((url: string) => {
+      if (url === '/api/starter/craft') return jsonResponse({ ok: false, error: 'insufficient_resources', missing: [] });
+      return jsonResponse({ recipes: [RECIPE], items: [] });
+    });
+
+    fireEvent.click(getByText('Craft'));
+
+    await waitFor(() => { expect(getByText(/Need:/)).toBeTruthy(); });
+    expect(playActionAtPlayer).not.toHaveBeenCalled();
+  });
+});

--- a/concord-frontend/tests/components/glyph-cast-hud-real-feedback.test.tsx
+++ b/concord-frontend/tests/components/glyph-cast-hud-real-feedback.test.tsx
@@ -1,0 +1,76 @@
+// UGC-rendering-fidelity audit (2026-07-21) — GlyphCastHUD.tsx's cast()
+// is a real world-effect macro (glyph_spells.cast writes embodied signal
+// deltas at the cast cell + spell_cast_log), but a successful cast produced
+// NO visual result at all in the 3D scene — only a text status string
+// ("Cast fire (2 channels)"). Fixed by playing the same cast_channel
+// archetype + element-keyed VFX (skill-motion.ts) GlyphSpellComposer's mint
+// already uses, so casting a composed spell into the world is now a real,
+// watchable action instead of a silent macro call with a toast.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import GlyphCastHUD from '@/components/world/GlyphCastHUD';
+
+const playActionAtPlayer = vi.fn();
+vi.mock('@/lib/concordia/play-action', () => ({
+  playActionAtPlayer: (...args: unknown[]) => playActionAtPlayer(...args),
+}));
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({ ok: true, json: () => Promise.resolve(body) } as Response);
+}
+
+const SPELL = { id: 7, name: 'Ember Lance', components_json: '[{"element":"fire"}]' };
+
+describe('GlyphCastHUD — real avatar/VFX feedback on cast (was silent)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    playActionAtPlayer.mockClear();
+    fetchMock = vi.fn((url: string, opts?: RequestInit) => {
+      const body = opts?.body ? JSON.parse(String(opts.body)) : {};
+      if (url === '/api/lens/run' && body.name === 'list_for_user') {
+        return jsonResponse({ result: { ok: true, spells: [SPELL] } });
+      }
+      if (url === '/api/lens/run' && body.name === 'cast') {
+        return jsonResponse({ result: { ok: true, element: 'fire', feedbackApplied: 2 } });
+      }
+      return jsonResponse({ ok: false });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('plays a real cast animation with the spell\'s element on a successful cast', async () => {
+    const { getByText } = render(<GlyphCastHUD worldId="w1" playerPos={{ x: 10, z: 20 }} />);
+
+    await waitFor(() => { expect(getByText(/1 spell/)).toBeTruthy(); });
+    fireEvent.click(getByText(/1 spell/));
+
+    await waitFor(() => { expect(getByText('Ember Lance')).toBeTruthy(); });
+    fireEvent.click(getByText('Ember Lance'));
+
+    await waitFor(() => {
+      expect(playActionAtPlayer).toHaveBeenCalledWith('cast', { element: 'fire' });
+    });
+  });
+
+  it('does not play an animation when the cast fails (e.g. sanctuary zone refusal)', async () => {
+    const { getByText } = render(<GlyphCastHUD worldId="w1" playerPos={{ x: 10, z: 20 }} />);
+    await waitFor(() => { expect(getByText(/1 spell/)).toBeTruthy(); });
+    fireEvent.click(getByText(/1 spell/));
+    await waitFor(() => { expect(getByText('Ember Lance')).toBeTruthy(); });
+
+    fetchMock.mockImplementation((url: string, opts?: RequestInit) => {
+      const body = opts?.body ? JSON.parse(String(opts.body)) : {};
+      if (body.name === 'cast') return jsonResponse({ result: { ok: false, reason: 'zone_combat_refusal' } });
+      return jsonResponse({ result: { ok: true, spells: [SPELL] } });
+    });
+
+    fireEvent.click(getByText('Ember Lance'));
+
+    await waitFor(() => { expect(getByText(/Failed:/)).toBeTruthy(); });
+    expect(playActionAtPlayer).not.toHaveBeenCalled();
+  });
+});

--- a/concord-frontend/tests/components/glyph-spell-composer-cast-anim.test.tsx
+++ b/concord-frontend/tests/components/glyph-spell-composer-cast-anim.test.tsx
@@ -1,0 +1,66 @@
+// Animation-coverage audit (2026-07-21) — GlyphSpellComposer only ever
+// fired milestoneJuice('ui_glyph_mint') (a screen-flash, no avatar motion)
+// on a successful mint. A cast_channel archetype ('cast'/'compose_spell')
+// already existed in action-biomechanics.ts but had zero call sites — dead
+// code. Fixed by calling playActionAtPlayer('compose_spell', ...) so the
+// player visibly channels the glyph they just composed, carrying the
+// composed element (fire/ice/lightning/...) through so the cast amplitude/
+// VFX modulate per play-action.ts's `element` option.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { GlyphSpellComposer } from '@/components/world/GlyphSpellComposer';
+
+const playActionAtPlayer = vi.fn();
+vi.mock('@/lib/concordia/play-action', () => ({
+  playActionAtPlayer: (...args: unknown[]) => playActionAtPlayer(...args),
+}));
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({ ok: true, json: () => Promise.resolve(body) } as Response);
+}
+
+const COMPONENTS = [
+  { id: 'c1', glyph: '⟐', element: 'fire', name: 'Ember Seed' },
+  { id: 'c2', glyph: '⊚', element: 'fire', name: 'Ember Core' },
+];
+
+describe('GlyphSpellComposer — real avatar feedback on mint (was UI-only juice)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    playActionAtPlayer.mockClear();
+    fetchMock = vi.fn((url: string) => {
+      if (url === '/api/glyph-spells/components') return jsonResponse({ ok: true, components: COMPONENTS });
+      if (url === '/api/glyph-spells/compose') {
+        return jsonResponse({ ok: true, composed_glyph: '⟐⊚', element: 'fire', max_damage: 20, range_m: 8, costs: { mana: 5 } });
+      }
+      if (url === '/api/glyph-spells/mint') return jsonResponse({ ok: true, spellId: 'spell-1' });
+      return jsonResponse({ ok: false });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('plays compose_spell with the composed element on a successful mint', async () => {
+    const { getByTitle, getByText } = render(
+      <GlyphSpellComposer
+        building={{ id: 'b1', building_type: 'glyph_altar', x: 0, z: 0, name: 'Glyph Altar' }}
+        worldId="w1"
+        onClose={() => {}}
+      />,
+    );
+
+    await waitFor(() => { expect(getByTitle('Ember Seed')).toBeTruthy(); });
+    fireEvent.click(getByTitle('Ember Seed'));
+    fireEvent.click(getByTitle('Ember Core'));
+
+    await waitFor(() => { expect(getByText('Mint')).not.toHaveProperty('disabled', true); });
+    fireEvent.click(getByText('Mint'));
+
+    await waitFor(() => {
+      expect(playActionAtPlayer).toHaveBeenCalledWith('compose_spell', { element: 'fire' });
+    });
+  });
+});

--- a/concord-frontend/tests/concordia/resource-node-real-assets.test.ts
+++ b/concord-frontend/tests/concordia/resource-node-real-assets.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as THREE from 'three';
+
+// 2026-07-21 — resource nodes previously rendered as flat-color primitive
+// shapes with no real asset attempt and no click interaction ("no rendered
+// resource nodes or anything else" — the reported gap). Real CC0 tree/bush
+// GLBs already existed on disk (public/models/vegetation/) but were never
+// tried for tree/herb node kinds. Every built node object is also now
+// tagged with userData.isResourceNode + nodeId so ConcordiaScene's canvas
+// raycaster can resolve a click back to a specific node.
+//
+// Test-setup note: createResourceNodeRenderer fires an internal fetch as
+// soon as it's constructed (the synchronous portion of its own `void
+// refresh()` call runs before the constructor returns). global.fetch MUST
+// be stubbed BEFORE calling createResourceNodeRenderer in every test below
+// — stubbing it after construction races that internal call and produces
+// a flaky, order-dependent failure (caught once during development: the
+// depleted-node test intermittently picked up a PRIOR test's still-
+// installed fetch mock because the reassignment happened one tick too
+// late). vi.resetAllMocks() (not clearAllMocks) in beforeEach because
+// clearAllMocks does not undo a prior test's `.mockResolvedValue(...)`.
+
+vi.mock('@/lib/world-lens/asset-loader', () => ({
+  loadAsset: vi.fn(),
+  instanceFromCache: vi.fn(),
+  resolveAssetReference: vi.fn(),
+}));
+
+import { instanceFromCache } from '@/lib/world-lens/asset-loader';
+import { createResourceNodeRenderer } from '@/lib/world-lens/resource-node-renderer';
+
+function makeGlbGroup(height = 5): THREE.Group {
+  const g = new THREE.Group();
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(1, height, 1), new THREE.MeshStandardMaterial());
+  mesh.position.y = height / 2;
+  g.add(mesh);
+  return g;
+}
+
+function stubFetch(nodes: Array<Record<string, unknown>>): void {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ ok: true, nodes }),
+  }));
+}
+
+describe('resource-node-renderer — real-asset-first for tree/bush', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('tries a real tree GLB for a tree node when one is available, and tags it with nodeId', async () => {
+    const { loadAsset, resolveAssetReference } = await import('@/lib/world-lens/asset-loader');
+    (loadAsset as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    (resolveAssetReference as ReturnType<typeof vi.fn>).mockResolvedValue('/models/vegetation/tree_01.glb');
+    (instanceFromCache as ReturnType<typeof vi.fn>).mockResolvedValue(makeGlbGroup(8));
+    stubFetch([{ id: 'node-1', node_type: 'tree', x: 0, y: 0, z: 0, quantity_remaining: 100, max_quantity: 100 }]);
+
+    const parent = new THREE.Group();
+    const renderer = createResourceNodeRenderer(parent, { worldId: 'w1', pollMs: 999999 });
+    await renderer.refresh();
+
+    expect(instanceFromCache).toHaveBeenCalled();
+    const found = parent.children.find((c) => (c.userData as { nodeId?: string }).nodeId === 'node-1');
+    expect(found).toBeTruthy();
+    expect((found!.userData as { isResourceNode?: boolean }).isResourceNode).toBe(true);
+    expect((found!.userData as { nodeType?: string }).nodeType).toBe('tree');
+
+    renderer.dispose();
+  });
+
+  it('falls back to the procedural cone/cylinder tree shape when no real asset is available', async () => {
+    const { loadAsset, resolveAssetReference } = await import('@/lib/world-lens/asset-loader');
+    (loadAsset as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    (resolveAssetReference as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (instanceFromCache as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    stubFetch([{ id: 'node-2', node_type: 'tree', x: 0, y: 0, z: 0, quantity_remaining: 100, max_quantity: 100 }]);
+
+    const parent = new THREE.Group();
+    const renderer = createResourceNodeRenderer(parent, { worldId: 'w1', pollMs: 999999 });
+    await renderer.refresh();
+
+    const found = parent.children.find((c) => (c.userData as { nodeId?: string }).nodeId === 'node-2') as THREE.Group;
+    expect(found).toBeTruthy();
+    // Procedural tree is a Group with a cylinder trunk + cone canopy (2 children).
+    expect(found.children.length).toBe(2);
+
+    renderer.dispose();
+  });
+
+  it('every mesh in a multi-mesh node object is tagged (traverse, not just the root)', async () => {
+    const { loadAsset } = await import('@/lib/world-lens/asset-loader');
+    (loadAsset as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    (instanceFromCache as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    stubFetch([{ id: 'node-3', node_type: 'tree', x: 0, y: 0, z: 0, quantity_remaining: 100, max_quantity: 100 }]);
+
+    const parent = new THREE.Group();
+    const renderer = createResourceNodeRenderer(parent, { worldId: 'w1', pollMs: 999999 });
+    await renderer.refresh();
+
+    const found = parent.children.find((c) => (c.userData as { nodeId?: string }).nodeId === 'node-3')!;
+    let taggedCount = 0;
+    found.traverse((child) => {
+      if ((child.userData as { nodeId?: string }).nodeId === 'node-3') taggedCount++;
+    });
+    // root group + trunk mesh + canopy mesh = 3
+    expect(taggedCount).toBe(3);
+
+    renderer.dispose();
+  });
+
+  it('a depleted node is tagged depleted:true (stump shape, no real-asset attempt)', async () => {
+    stubFetch([{ id: 'node-4', node_type: 'tree', x: 0, y: 0, z: 0, quantity_remaining: 0, max_quantity: 100, is_depleted: 1 }]);
+
+    const parent = new THREE.Group();
+    const renderer = createResourceNodeRenderer(parent, { worldId: 'w1', pollMs: 999999 });
+    await renderer.refresh();
+
+    const found = parent.children.find((c) => (c.userData as { nodeId?: string }).nodeId === 'node-4');
+    expect(found).toBeTruthy();
+    expect((found!.userData as { depleted?: boolean }).depleted).toBe(true);
+    // instanceFromCache must not be called for a depleted stump.
+    expect(instanceFromCache).not.toHaveBeenCalled();
+
+    renderer.dispose();
+  });
+
+  it('does not throw when asset-loader rejects (network failure) — falls back honestly', async () => {
+    const { loadAsset } = await import('@/lib/world-lens/asset-loader');
+    (loadAsset as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('network down'));
+    stubFetch([{ id: 'node-5', node_type: 'herb', x: 0, y: 0, z: 0, quantity_remaining: 100, max_quantity: 100 }]);
+
+    const parent = new THREE.Group();
+    const renderer = createResourceNodeRenderer(parent, { worldId: 'w1', pollMs: 999999 });
+    await expect(renderer.refresh()).resolves.not.toThrow();
+    const found = parent.children.find((c) => (c.userData as { nodeId?: string }).nodeId === 'node-5');
+    expect(found).toBeTruthy();
+
+    renderer.dispose();
+  });
+});

--- a/concord-frontend/tests/lib/armor-system-procedural-detail.test.ts
+++ b/concord-frontend/tests/lib/armor-system-procedural-detail.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { createArmorPiece, createArmorSet, type ArmorAppearance } from '@/lib/concordia/armor-system';
+import { clearProceduralCache } from '@/lib/world-lens/procedural-texture';
+
+// 2026-07-21 — armor-system.ts previously built flat solid-color
+// MeshStandardMaterials with no texture detail at all. Wired to
+// procedural-texture.ts's makePBR() (real-reference-grounded per
+// material-reference-palettes.ts) for normalMap/roughnessMap surface
+// detail, while keeping `.color` as the real per-faction dye — so
+// customization is preserved and armor gains genuine material detail
+// (brushed-metal streaks, leather crinkle, cloth weave) grounded in the
+// same real reference data as terrain/procedural-texture.ts's other kinds.
+describe('armor-system procedural material detail', () => {
+  const base: ArmorAppearance = {
+    silhouette: 'heavy_plate',
+    primaryColor: '#3a4a5c',
+    secondaryColor: '#222833',
+    accentColor: '#c8a838',
+    tier: 3,
+    seed: 'test-seed-1',
+  };
+
+  it('every material slot carries a normalMap and roughnessMap (not flat color-only)', () => {
+    clearProceduralCache();
+    const piece = createArmorPiece('torso', base);
+    let materialCount = 0;
+    piece.traverse((obj) => {
+      const mesh = obj as THREE.Mesh;
+      if (!(mesh as THREE.Mesh).isMesh) return;
+      const mat = mesh.material as THREE.MeshStandardMaterial;
+      expect(mat.normalMap, 'material should have real-reference normal detail').toBeTruthy();
+      expect(mat.roughnessMap, 'material should have real-reference roughness detail').toBeTruthy();
+      materialCount++;
+    });
+    expect(materialCount).toBeGreaterThan(0);
+  });
+
+  it('the real per-faction dye color is preserved — .color is untouched by the texture', () => {
+    clearProceduralCache();
+    const piece = createArmorPiece('head', base);
+    const firstMesh = piece.children.find((c) => (c as THREE.Mesh).isMesh) as THREE.Mesh;
+    const mat = firstMesh.material as THREE.MeshStandardMaterial;
+    expect(mat.map, 'albedo map must NOT be set — texture is detail-only, color stays the real dye').toBeFalsy();
+    // primaryColor darkened by wear=0 should equal primaryColor exactly
+    expect(mat.color.getHexString()).toBe(new THREE.Color(base.primaryColor).getHexString());
+  });
+
+  it('heavy_plate -> metal, robed -> cloth, leather/exposed -> leather detail kind', () => {
+    clearProceduralCache();
+    const plate = createArmorPiece('torso', { ...base, silhouette: 'heavy_plate', seed: 'k1' });
+    const robed = createArmorPiece('torso', { ...base, silhouette: 'robed', seed: 'k1' });
+    const leather = createArmorPiece('torso', { ...base, silhouette: 'leather', seed: 'k1' });
+    const exposed = createArmorPiece('torso', { ...base, silhouette: 'exposed', seed: 'k1' });
+
+    const normalMapOf = (g: THREE.Group) => {
+      const m = g.children.find((c) => (c as THREE.Mesh).isMesh) as THREE.Mesh;
+      return (m.material as THREE.MeshStandardMaterial).normalMap;
+    };
+
+    // Same seed, different silhouette -> different procedural kind -> different texture
+    expect(normalMapOf(plate)).not.toBe(normalMapOf(robed));
+    expect(normalMapOf(plate)).not.toBe(normalMapOf(leather));
+    // leather and exposed share the 'leather' kind + same seed -> identical cached texture
+    expect(normalMapOf(leather)).toBe(normalMapOf(exposed));
+  });
+
+  it('all 4 slots of one armor set share the same seed -> the same cached texture (visually consistent suit)', () => {
+    clearProceduralCache();
+    const set = createArmorSet(base);
+    const normalMaps = new Set<THREE.Texture>();
+    for (const group of set.values()) {
+      group.traverse((obj) => {
+        const mesh = obj as THREE.Mesh;
+        if (!(mesh as THREE.Mesh).isMesh) return;
+        const mat = mesh.material as THREE.MeshStandardMaterial;
+        if (mat.normalMap) normalMaps.add(mat.normalMap);
+      });
+    }
+    expect(normalMaps.size).toBe(1);
+  });
+
+  it('a different seed produces a different (non-cached) texture for the same silhouette', () => {
+    clearProceduralCache();
+    const a = createArmorPiece('torso', { ...base, seed: 'seed-a' });
+    const b = createArmorPiece('torso', { ...base, seed: 'seed-b' });
+    const matA = (a.children.find((c) => (c as THREE.Mesh).isMesh) as THREE.Mesh).material as THREE.MeshStandardMaterial;
+    const matB = (b.children.find((c) => (c as THREE.Mesh).isMesh) as THREE.Mesh).material as THREE.MeshStandardMaterial;
+    expect(matA.normalMap).not.toBe(matB.normalMap);
+  });
+
+  it('never throws across every silhouette', () => {
+    clearProceduralCache();
+    const silhouettes: ArmorAppearance['silhouette'][] = ['heavy_plate', 'robed', 'leather', 'exposed'];
+    for (const silhouette of silhouettes) {
+      expect(() => createArmorSet({ ...base, silhouette })).not.toThrow();
+    }
+  });
+});

--- a/concord-frontend/tests/lib/character-schema-armor-uniqueness.test.ts
+++ b/concord-frontend/tests/lib/character-schema-armor-uniqueness.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { generateAppearance } from '@/lib/world-lens/character-schema';
+
+// 2026-07-21 — every character now gets a deterministic, individually-
+// seeded armor kit (character-schema.ts's generateAppearance armor
+// block) so no two NPCs read as recolored clones of their archetype/
+// faction — "everyone unique" per the session's own framing.
+describe('generateAppearance — per-character armor uniqueness', () => {
+  it('every character gets a real ArmorAppearance with all required fields', () => {
+    const rich = generateAppearance({ id: 'npc_a', worldId: 'concordia-hub', archetype: 'warrior', themeId: 'concordia-hub' });
+    expect(rich.armor).toBeDefined();
+    expect(rich.armor.silhouette).toBeTypeOf('string');
+    expect(rich.armor.primaryColor).toMatch(/^#[0-9a-fA-F]{6}$/);
+    expect(rich.armor.secondaryColor).toMatch(/^#[0-9a-fA-F]{6}$/);
+    expect(rich.armor.accentColor).toMatch(/^#[0-9a-fA-F]{6}$/);
+    expect(rich.armor.tier).toBeGreaterThanOrEqual(1);
+    expect(rich.armor.tier).toBeLessThanOrEqual(5);
+    expect(rich.armor.wear).toBeGreaterThanOrEqual(0);
+    expect(rich.armor.wear).toBeLessThanOrEqual(1);
+    expect(rich.armor.seed).toBeTypeOf('string');
+  });
+
+  it('is fully deterministic — same (id, worldId, factionId) always produces identical armor', () => {
+    const a = generateAppearance({ id: 'npc_aldra_sahm', worldId: 'concordia-hub', factionId: 'concordant_curators', archetype: 'scholar', themeId: 'concordia-hub' });
+    const b = generateAppearance({ id: 'npc_aldra_sahm', worldId: 'concordia-hub', factionId: 'concordant_curators', archetype: 'scholar', themeId: 'concordia-hub' });
+    expect(a.armor).toEqual(b.armor);
+  });
+
+  it('different ids produce different armor (tier and/or wear and/or seed vary across a sample)', () => {
+    const sample = Array.from({ length: 20 }, (_, i) =>
+      generateAppearance({ id: `npc_civilian_${i}`, worldId: 'concordia-hub', archetype: null, themeId: 'concordia-hub' }));
+    const tiers = new Set(sample.map((r) => r.armor.tier));
+    const wears = new Set(sample.map((r) => Math.round(r.armor.wear * 1000)));
+    const seeds = new Set(sample.map((r) => r.armor.seed));
+    // Every one of the 20 seed strings must be distinct (identity-keyed).
+    expect(seeds.size).toBe(20);
+    // Tier and wear should show real variation across 20 samples, not
+    // all collapse to one value (which would mean the RNG salt is dead).
+    expect(tiers.size).toBeGreaterThan(1);
+    expect(wears.size).toBeGreaterThan(1);
+  });
+
+  it('archetype maps to the expected default silhouette', () => {
+    const cases: Array<[string, string]> = [
+      ['warrior', 'heavy_plate'],
+      ['guard', 'heavy_plate'],
+      ['scholar', 'robed'],
+      ['mystic', 'robed'],
+      ['hunter', 'leather'],
+      ['trader', 'leather'],
+    ];
+    for (const [archetype, expected] of cases) {
+      const rich = generateAppearance({ id: `npc_${archetype}_test`, worldId: 'concordia-hub', archetype, themeId: 'concordia-hub' });
+      expect(rich.armor.silhouette, `archetype ${archetype}`).toBe(expected);
+    }
+  });
+
+  it('civilians (no recognized archetype) still get a real silhouette, never undefined', () => {
+    const sample = Array.from({ length: 10 }, (_, i) =>
+      generateAppearance({ id: `npc_civ_${i}`, worldId: 'concordia-hub', archetype: 'some-unmapped-job', themeId: 'concordia-hub' }));
+    for (const rich of sample) {
+      expect(['leather', 'exposed']).toContain(rich.armor.silhouette);
+    }
+  });
+
+  it("'legend' body archetype always gets the top armor tier (5)", () => {
+    const rich = generateAppearance({
+      id: 'goddess_test', worldId: 'concordia-hub', archetype: 'legend', themeId: 'concordia-hub',
+      override: { bodyArchetype: 'legend' },
+    });
+    expect(rich.bodyArchetype).toBe('legend');
+    expect(rich.armor.tier).toBe(5);
+  });
+
+  it('armor colors reuse the character\'s own clothing palette (coherent outfit, not a mismatched overlay)', () => {
+    const rich = generateAppearance({ id: 'npc_coherence_test', worldId: 'concordia-hub', archetype: 'guard', themeId: 'concordia-hub' });
+    expect(rich.armor.primaryColor).toBe(rich.clothing.top.color);
+    expect(rich.armor.secondaryColor).toBe(rich.clothing.bottom.color);
+  });
+
+  it("armor seed is the character's own composite identity string, matching the base appearance seed source", () => {
+    const rich = generateAppearance({ id: 'npc_seed_check', worldId: 'concordia-hub', factionId: 'crime_syndicate', archetype: 'trader', themeId: 'concordia-hub' });
+    expect(rich.armor.seed).toBe('concordia-hub::crime_syndicate::npc_seed_check');
+  });
+});

--- a/concord-frontend/tests/lib/enhanced-avatar-builder-armor.test.ts
+++ b/concord-frontend/tests/lib/enhanced-avatar-builder-armor.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { buildEnhancedAvatar } from '@/lib/world-lens/enhanced-avatar-builder';
+import { generateAppearance } from '@/lib/world-lens/character-schema';
+import { clearProceduralCache } from '@/lib/world-lens/procedural-texture';
+
+function richFor(id: string, archetype: string | null, overrides: Parameters<typeof generateAppearance>[0]['override'] = {}) {
+  return generateAppearance({ id, worldId: 'concordia-hub', archetype, themeId: 'concordia-hub', override: overrides });
+}
+
+function armorMaterials(group: THREE.Group): THREE.MeshStandardMaterial[] {
+  const out: THREE.MeshStandardMaterial[] = [];
+  group.traverse((obj) => {
+    if ((obj as THREE.Group).userData?.isArmor) {
+      obj.traverse((child) => {
+        const mesh = child as THREE.Mesh;
+        if ((mesh as THREE.Mesh).isMesh) out.push(mesh.material as THREE.MeshStandardMaterial);
+      });
+    }
+  });
+  return out;
+}
+
+// 2026-07-21 — buildEnhancedAvatar previously built the body only; armor
+// (character-schema.ts's deterministic per-character armor block) was
+// generated but never attached. Every character using this builder (the
+// local player + every hero-flagged NPC) now wears their armor kit.
+describe('buildEnhancedAvatar — armor attachment', () => {
+  it('attaches all 4 armor slots (head/torso/arms/legs) as real userData-tagged groups', () => {
+    clearProceduralCache();
+    const rich = richFor('npc_armor_attach_1', 'warrior');
+    const { group } = buildEnhancedAvatar(rich);
+    const armorGroups: THREE.Group[] = [];
+    group.traverse((obj) => {
+      if ((obj as THREE.Group).userData?.isArmor) armorGroups.push(obj as THREE.Group);
+    });
+    const slots = armorGroups.map((g) => g.userData.slot).sort();
+    expect(slots).toEqual(['arms', 'head', 'legs', 'torso']);
+  });
+
+  it('every armor material carries real-reference normalMap/roughnessMap detail', () => {
+    clearProceduralCache();
+    const rich = richFor('npc_armor_attach_2', 'guard');
+    const { group } = buildEnhancedAvatar(rich);
+    const mats = armorMaterials(group);
+    expect(mats.length).toBeGreaterThan(0);
+    for (const mat of mats) {
+      expect(mat.normalMap).toBeTruthy();
+      expect(mat.roughnessMap).toBeTruthy();
+    }
+  });
+
+  it('armor is scaled by totalHeight / 1.75 to stay proportionate on every archetype', () => {
+    clearProceduralCache();
+    const armorScaleOf = (g: THREE.Group) => {
+      let scale = 0;
+      g.traverse((obj) => { if ((obj as THREE.Group).userData?.isArmor) scale = (obj as THREE.Group).scale.x; });
+      return scale;
+    };
+    // Sample several ids so the seeded bodyArchetype pick lands on a real
+    // spread of heights (slim/average/stocky/tall/broad/petite/legend) —
+    // the scale formula must track totalHeight for whichever archetype
+    // each character's own seed actually produced.
+    for (let i = 0; i < 8; i++) {
+      const rich = richFor(`npc_scale_sample_${i}`, 'trader');
+      const scale = armorScaleOf(buildEnhancedAvatar(rich).group);
+      expect(scale).toBeCloseTo(rich.totalHeight / 1.75, 5);
+    }
+  });
+
+  it('a manually-constructed taller RichAppearanceConfig gets proportionately larger armor', () => {
+    clearProceduralCache();
+    // Bypass generateAppearance's seeded bodyArchetype pick entirely
+    // (override does not cascade into proportions — a pre-existing
+    // characteristic of that function, not something this test should
+    // fight) by constructing two full RichAppearanceConfig objects by
+    // hand with only totalHeight/proportions differing, isolating the
+    // scale formula itself.
+    const base = richFor('npc_scale_isolation_base', 'trader');
+    const tall = { ...base, totalHeight: 2.1, proportions: { ...base.proportions, totalHeight: 2.1 } };
+    const short = { ...base, totalHeight: 1.55, proportions: { ...base.proportions, totalHeight: 1.55 } };
+    const armorScaleOf = (g: THREE.Group) => {
+      let scale = 0;
+      g.traverse((obj) => { if ((obj as THREE.Group).userData?.isArmor) scale = (obj as THREE.Group).scale.x; });
+      return scale;
+    };
+    const tallScale = armorScaleOf(buildEnhancedAvatar(tall).group);
+    const shortScale = armorScaleOf(buildEnhancedAvatar(short).group);
+    expect(tallScale).toBeCloseTo(2.1 / 1.75, 5);
+    expect(shortScale).toBeCloseTo(1.55 / 1.75, 5);
+    expect(tallScale).toBeGreaterThan(shortScale);
+  });
+
+  it('armor slots anchor at the correct body landmarks (head/shoulder/waist lines)', () => {
+    clearProceduralCache();
+    const rich = richFor('npc_anchor_test', 'warrior');
+    const { group } = buildEnhancedAvatar(rich);
+    const p = rich.proportions;
+    const anchors: Record<string, number> = {};
+    group.traverse((obj) => {
+      const g = obj as THREE.Group;
+      if (g.userData?.isArmor) anchors[g.userData.slot] = g.position.y;
+    });
+    const headY = p.legLength + p.torsoLength + p.neckLength + p.headHeight / 2;
+    const shoulderY = p.legLength + p.torsoLength;
+    const waistY = p.legLength;
+    expect(anchors.head).toBeCloseTo(headY, 5);
+    expect(anchors.arms).toBeCloseTo(shoulderY, 5);
+    expect(anchors.torso).toBeCloseTo(waistY, 5);
+    expect(anchors.legs).toBeCloseTo(waistY, 5);
+  });
+
+  it('two different characters with different armor seeds get different (non-shared) armor textures', () => {
+    clearProceduralCache();
+    const a = richFor('npc_unique_a', 'warrior');
+    const b = richFor('npc_unique_b', 'warrior');
+    expect(a.armor.seed).not.toBe(b.armor.seed);
+    const matsA = armorMaterials(buildEnhancedAvatar(a).group);
+    const matsB = armorMaterials(buildEnhancedAvatar(b).group);
+    expect(matsA[0].normalMap).not.toBe(matsB[0].normalMap);
+  });
+
+  it('dispose() does not throw with armor attached', () => {
+    clearProceduralCache();
+    const rich = richFor('npc_dispose_test', 'mystic');
+    const result = buildEnhancedAvatar(rich);
+    expect(() => result.dispose()).not.toThrow();
+  });
+
+  it('never throws across every archetype (all 4 default silhouettes + civilian)', () => {
+    clearProceduralCache();
+    const archetypes = ['warrior', 'guard', 'scholar', 'mystic', 'hunter', 'trader', null];
+    for (const archetype of archetypes) {
+      const rich = richFor(`npc_arch_${archetype ?? 'civ'}`, archetype);
+      expect(() => buildEnhancedAvatar(rich)).not.toThrow();
+    }
+  });
+});

--- a/concord-frontend/tests/lib/gather-tools-carry.test.ts
+++ b/concord-frontend/tests/lib/gather-tools-carry.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { buildEnhancedAvatar } from '@/lib/world-lens/enhanced-avatar-builder';
+import { generateAppearance } from '@/lib/world-lens/character-schema';
+import { clearProceduralCache } from '@/lib/world-lens/procedural-texture';
+
+function richFor(id: string, archetype: string | null, overrides: Parameters<typeof generateAppearance>[0]['override'] = {}) {
+  return generateAppearance({ id, worldId: 'concordia-hub', archetype, themeId: 'concordia-hub', override: overrides });
+}
+
+// 2026-07-21 — "It's hard to [depict NPCs gathering resources] with no
+// tool." Accessories['carry'] previously had no axe/pickaxe/hoe/sickle
+// values at all, and enhanced-avatar-builder.ts had no branch to render
+// them even if it did. Civilian (unmatched-archetype) characters now get
+// a seeded chance to carry a real gathering tool.
+describe('gathering tools — carry-item type + rendering', () => {
+  it('generateAppearance can produce all 4 gather-tool carry values via override', () => {
+    for (const tool of ['axe', 'pickaxe', 'hoe', 'sickle'] as const) {
+      const rich = richFor(`npc_tool_${tool}`, null, { accessories: { jewelry: [], markings: [], carry: [tool], augments: [] } });
+      expect(rich.accessories.carry).toContain(tool);
+    }
+  });
+
+  it('civilians (null archetype) get a real, non-trivial chance of carrying a gather tool across a sample', () => {
+    const sample = Array.from({ length: 40 }, (_, i) =>
+      richFor(`npc_civ_gather_${i}`, null));
+    const withTool = sample.filter((r) =>
+      r.accessories.carry?.some((c) => (['axe', 'pickaxe', 'hoe', 'sickle'] as const).includes(c as 'axe' | 'pickaxe' | 'hoe' | 'sickle')));
+    expect(withTool.length).toBeGreaterThan(0);
+    expect(withTool.length).toBeLessThan(sample.length); // not everyone — it's a seeded chance, not forced
+  });
+
+  it('buildEnhancedAvatar renders a real mesh group for each gather tool, never throwing', () => {
+    clearProceduralCache();
+    for (const tool of ['axe', 'pickaxe', 'hoe', 'sickle'] as const) {
+      const rich = richFor(`npc_render_${tool}`, null, { accessories: { jewelry: [], markings: [], carry: [tool], augments: [] } });
+      const { group } = buildEnhancedAvatar(rich);
+      const found = group.children.find((c) => c.name === `carry_${tool}` || (tool === 'axe' && c.name?.startsWith('weapon_axe')));
+      expect(found, `${tool} should render a real mesh group`).toBeTruthy();
+    }
+  });
+
+  it('the axe carry item reuses the real axe weapon archetype (weapon_axe name), not a duplicate asset', () => {
+    clearProceduralCache();
+    const rich = richFor('npc_axe_reuse', null, { accessories: { jewelry: [], markings: [], carry: ['axe'], augments: [] } });
+    const { group } = buildEnhancedAvatar(rich);
+    const axe = group.children.find((c) => (c as THREE.Group).name?.startsWith('weapon_axe'));
+    expect(axe).toBeTruthy();
+  });
+
+  it('pickaxe/hoe/sickle are procedural (wood shaft + metal head), each a distinct named group', () => {
+    clearProceduralCache();
+    const rich = richFor('npc_tools_all', null, { accessories: { jewelry: [], markings: [], carry: ['pickaxe', 'hoe', 'sickle'], augments: [] } });
+    const { group } = buildEnhancedAvatar(rich);
+    const names = group.children.map((c) => c.name).filter(Boolean);
+    expect(names).toContain('carry_pickaxe');
+    expect(names).toContain('carry_hoe');
+    expect(names).toContain('carry_sickle');
+  });
+
+  it('a character with no carry array (or an empty one) renders no gather-tool meshes', () => {
+    clearProceduralCache();
+    const rich = richFor('npc_no_tools', null, { accessories: { jewelry: [], markings: [], carry: [], augments: [] } });
+    const { group } = buildEnhancedAvatar(rich);
+    const names = group.children.map((c) => c.name).filter(Boolean);
+    expect(names).not.toContain('carry_pickaxe');
+    expect(names).not.toContain('carry_hoe');
+    expect(names).not.toContain('carry_sickle');
+  });
+});

--- a/concord-frontend/tests/lib/hero-mesh-armor-attach.test.ts
+++ b/concord-frontend/tests/lib/hero-mesh-armor-attach.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { attachArmorToHeroMesh, buildBoneMap } from '@/lib/concordia/hero-mesh-registry';
+import type { ArmorAppearance } from '@/lib/concordia/armor-system';
+import { clearProceduralCache } from '@/lib/world-lens/procedural-texture';
+
+function boneTreeWithOffsets(entries: Array<[string, [number, number, number]]>): THREE.Group {
+  const root = new THREE.Group();
+  for (const [name, pos] of entries) {
+    const bone = new THREE.Bone();
+    bone.name = name;
+    bone.position.set(...pos);
+    root.add(bone);
+  }
+  return root;
+}
+
+const ARMOR: ArmorAppearance = {
+  silhouette: 'heavy_plate',
+  primaryColor: '#334455',
+  secondaryColor: '#223344',
+  accentColor: '#aa8822',
+  tier: 3,
+  wear: 0.2,
+  seed: 'test-hero-armor',
+};
+
+// 2026-07-21 — hero GLB NPCs (real Rocketbox/Mixamo meshes) previously
+// wore no armor at all — armor-system.ts's output only ever reached the
+// procedural body (enhanced-avatar-builder.ts). attachArmorToHeroMesh
+// uses the standard three.js Object3D.attach() technique to parent
+// real-material-detail armor pieces onto the loaded skeleton's bones.
+describe('attachArmorToHeroMesh', () => {
+  it('attaches all 4 slots when every required bone exists on the skeleton', () => {
+    clearProceduralCache();
+    const root = boneTreeWithOffsets([
+      ['Hips', [0, 0.9, 0]],
+      ['Spine2', [0, 1.3, 0]],
+      ['Head', [0, 1.7, 0]],
+    ]);
+    const boneMap = buildBoneMap(root);
+    attachArmorToHeroMesh(root, boneMap, ARMOR);
+
+    const armorGroups: THREE.Group[] = [];
+    root.traverse((obj) => { if ((obj as THREE.Group).userData?.isArmor) armorGroups.push(obj as THREE.Group); });
+    const slots = armorGroups.map((g) => g.userData.slot).sort();
+    expect(slots).toEqual(['arms', 'head', 'legs', 'torso']);
+  });
+
+  it('parents each slot to the correct bone (torso/legs -> Hips, arms -> Spine2, head -> Head)', () => {
+    clearProceduralCache();
+    const root = boneTreeWithOffsets([
+      ['Hips', [0, 0.9, 0]],
+      ['Spine2', [0, 1.3, 0]],
+      ['Head', [0, 1.7, 0]],
+    ]);
+    const boneMap = buildBoneMap(root);
+    attachArmorToHeroMesh(root, boneMap, ARMOR);
+
+    const bySlot = new Map<string, THREE.Object3D>();
+    root.traverse((obj) => {
+      if ((obj as THREE.Group).userData?.isArmor) bySlot.set((obj as THREE.Group).userData.slot, obj.parent!);
+    });
+    expect(bySlot.get('head')).toBe(boneMap.get('Head'));
+    expect(bySlot.get('torso')).toBe(boneMap.get('Hips'));
+    expect(bySlot.get('legs')).toBe(boneMap.get('Hips'));
+    expect(bySlot.get('arms')).toBe(boneMap.get('Spine2'));
+  });
+
+  it('positions each piece at its bone\'s real world position (not the mesh local origin)', () => {
+    clearProceduralCache();
+    const root = boneTreeWithOffsets([
+      ['Hips', [0, 0.9, 0]],
+      ['Spine2', [0, 1.3, 0]],
+      ['Head', [0.05, 1.7, 0]],
+    ]);
+    const boneMap = buildBoneMap(root);
+    attachArmorToHeroMesh(root, boneMap, ARMOR);
+
+    const headPiece = [...root.children].flatMap((c) => c.children).find((c) => (c as THREE.Group).userData?.slot === 'head')
+      ?? (boneMap.get('Head')!.children.find((c) => (c as THREE.Group).userData?.slot === 'head'));
+    expect(headPiece).toBeTruthy();
+    const worldPos = new THREE.Vector3();
+    headPiece!.getWorldPosition(worldPos);
+    expect(worldPos.x).toBeCloseTo(0.05, 5);
+    expect(worldPos.y).toBeCloseTo(1.7, 5);
+  });
+
+  it('falls back through the arms bone chain (Spine2 -> Spine1 -> Spine) when Spine2 is absent', () => {
+    clearProceduralCache();
+    const root = boneTreeWithOffsets([
+      ['Hips', [0, 0.9, 0]],
+      ['Spine1', [0, 1.2, 0]],
+      ['Head', [0, 1.7, 0]],
+    ]);
+    const boneMap = buildBoneMap(root);
+    attachArmorToHeroMesh(root, boneMap, ARMOR);
+    const armsPiece = boneMap.get('Spine1')!.children.find((c) => (c as THREE.Group).userData?.slot === 'arms');
+    expect(armsPiece).toBeTruthy();
+  });
+
+  it('skips a slot gracefully (no throw) when NO candidate bone exists for it', () => {
+    clearProceduralCache();
+    // No Hips at all — torso and legs have nowhere to attach.
+    const root = boneTreeWithOffsets([['Head', [0, 1.7, 0]]]);
+    const boneMap = buildBoneMap(root);
+    expect(() => attachArmorToHeroMesh(root, boneMap, ARMOR)).not.toThrow();
+    const armorGroups: THREE.Group[] = [];
+    root.traverse((obj) => { if ((obj as THREE.Group).userData?.isArmor) armorGroups.push(obj as THREE.Group); });
+    expect(armorGroups.map((g) => g.userData.slot).sort()).toEqual(['head']);
+  });
+
+  it('every attached material carries real-reference normalMap/roughnessMap detail', () => {
+    clearProceduralCache();
+    const root = boneTreeWithOffsets([['Hips', [0, 0.9, 0]], ['Head', [0, 1.7, 0]]]);
+    const boneMap = buildBoneMap(root);
+    attachArmorToHeroMesh(root, boneMap, ARMOR);
+    let checked = 0;
+    root.traverse((obj) => {
+      const mesh = obj as THREE.Mesh;
+      if ((mesh as THREE.Mesh).isMesh && mesh.material) {
+        const mat = mesh.material as THREE.MeshStandardMaterial;
+        if (mat.normalMap !== undefined) {
+          expect(mat.normalMap).toBeTruthy();
+          expect(mat.roughnessMap).toBeTruthy();
+          checked++;
+        }
+      }
+    });
+    expect(checked).toBeGreaterThan(0);
+  });
+
+  it('is a pure attachment call — armor pieces are real children of the bone in the object graph, so they move with the rig', () => {
+    clearProceduralCache();
+    const root = boneTreeWithOffsets([['Hips', [0, 0.9, 0]]]);
+    const boneMap = buildBoneMap(root);
+    attachArmorToHeroMesh(root, boneMap, ARMOR);
+    const hips = boneMap.get('Hips')!;
+    const torsoPiece = hips.children.find((c) => (c as THREE.Group).userData?.slot === 'torso')!;
+    // Move the bone -> the armor piece's world position must move with it.
+    const before = new THREE.Vector3();
+    torsoPiece.getWorldPosition(before);
+    hips.position.y += 0.5;
+    hips.updateMatrixWorld(true);
+    const after = new THREE.Vector3();
+    torsoPiece.getWorldPosition(after);
+    expect(after.y - before.y).toBeCloseTo(0.5, 5);
+  });
+});

--- a/concord-frontend/tests/lib/hero-mesh-registry-bone-map.test.ts
+++ b/concord-frontend/tests/lib/hero-mesh-registry-bone-map.test.ts
@@ -86,6 +86,17 @@ describe('hero-mesh-registry archetypeForOccupation', () => {
     expect(archetypeForOccupation('hunter')).toBe('hunter');
     expect(archetypeForOccupation('scholar')).toBe('scholar');
     expect(archetypeForOccupation('trader')).toBe('trader');
+    expect(archetypeForOccupation('mystic')).toBe('mystic');
+    // Regression: routes/worlds.js's live NPC `occupation` field falls back
+    // to the raw authored `archetype` DB column (`state.occupation ||
+    // r.archetype`) when no routine occupation is set — so an NPC's
+    // archetype string is frequently the occupation text verbatim. Every
+    // other archetype already self-matched its own keyword list; 'warrior'
+    // was the one gap (its regex only matched sword/sellsword/forge/smith/
+    // etc, never the literal word "warrior"), silently stranding every one
+    // of the 14 warrior-archetype authored NPCs on the procedural fallback
+    // even though a real archetype GLB exists for them.
+    expect(archetypeForOccupation('warrior')).toBe('warrior');
   });
 
   it('keyword-matches real authored occupations from content/world/*/npcs.json to an archetype', () => {

--- a/concord-frontend/tests/lib/procedural-texture.test.ts
+++ b/concord-frontend/tests/lib/procedural-texture.test.ts
@@ -125,3 +125,60 @@ describe('terrain-reference-palettes grounding', () => {
     }
   });
 });
+
+// 2026-07-21 (same session, later) — cloth/metal/leather grounded in
+// material-reference-palettes.ts (Roblox SurfaceAppearance material-
+// preview renders — a distinct provenance tier from the terrain photos,
+// see that file's own doc comment). paletteFor() now checks both maps.
+describe('material-reference-palettes grounding', () => {
+  it('MATERIAL_REFERENCE_PALETTES has all 3 material kinds, each a real (non-placeholder) RGB triple', async () => {
+    const { MATERIAL_REFERENCE_PALETTES } = await import('@/lib/world-lens/material-reference-palettes');
+    const lum = ([r, g, b]: readonly [number, number, number]) => 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    for (const kind of ['leather', 'metal', 'cloth']) {
+      const pal = MATERIAL_REFERENCE_PALETTES[kind];
+      expect(pal, `${kind} should have a palette`).toBeDefined();
+      for (const tone of ['avg', 'dark', 'light'] as const) {
+        for (const channel of pal[tone]) {
+          expect(channel).toBeGreaterThanOrEqual(0);
+          expect(channel).toBeLessThanOrEqual(255);
+        }
+      }
+      expect(lum(pal.dark)).toBeLessThan(lum(pal.light));
+    }
+  });
+
+  it('the terrain-photo kinds have no entry in MATERIAL_REFERENCE_PALETTES (distinct maps, no overlap)', async () => {
+    const { MATERIAL_REFERENCE_PALETTES } = await import('@/lib/world-lens/material-reference-palettes');
+    for (const kind of ['dirt', 'brick', 'grass', 'sand', 'cobblestone', 'gravel', 'asphalt']) {
+      expect(MATERIAL_REFERENCE_PALETTES[kind]).toBeUndefined();
+    }
+  });
+
+  it('stone/wood/thatch have no entry in either real-reference map', async () => {
+    const { TERRAIN_REFERENCE_PALETTES } = await import('@/lib/world-lens/terrain-reference-palettes');
+    const { MATERIAL_REFERENCE_PALETTES } = await import('@/lib/world-lens/material-reference-palettes');
+    for (const kind of ['stone', 'wood', 'thatch']) {
+      expect(TERRAIN_REFERENCE_PALETTES[kind]).toBeUndefined();
+      expect(MATERIAL_REFERENCE_PALETTES[kind]).toBeUndefined();
+    }
+  });
+
+  it('cloth/metal/leather each produce a distinct cache entry and never throw', () => {
+    const kinds = ['cloth', 'metal', 'leather'] as const;
+    const sets = kinds.map((k) => makePBR(THREE, { kind: k, size: 32, seed: 11 }));
+    for (let i = 0; i < sets.length; i++) {
+      expect(() => makePBR(THREE, { kind: kinds[i], size: 16, seed: 5 })).not.toThrow();
+      for (let j = i + 1; j < sets.length; j++) {
+        expect(sets[i].albedo).not.toBe(sets[j].albedo);
+      }
+    }
+  });
+
+  it('cloth/metal/leather still respect the (kind, seed, size) cache key', () => {
+    const a = makePBR(THREE, { kind: 'leather', size: 64, seed: 3 });
+    const b = makePBR(THREE, { kind: 'leather', size: 64, seed: 3 });
+    const c = makePBR(THREE, { kind: 'leather', size: 64, seed: 4 });
+    expect(a.albedo).toBe(b.albedo);
+    expect(a.albedo).not.toBe(c.albedo);
+  });
+});

--- a/concord-frontend/tests/world-lens-avatar-armor-wiring.test.ts
+++ b/concord-frontend/tests/world-lens-avatar-armor-wiring.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// AvatarSystem3D.tsx is a large Three.js/DOM-heavy component (this repo's
+// established pattern for such files is a source-pinning regression test
+// rather than a full render, see tests/world-page-*.test.ts). This pins
+// the "everyone unique" armor wiring: hero-GLB NPCs now get the SAME
+// deterministic rich.armor a procedural-fallback build of them would
+// have gotten, computed once and reused, not skipped or double-rolled.
+const src = readFileSync(join(process.cwd(), 'components/world-lens/AvatarSystem3D.tsx'), 'utf8');
+
+describe('AvatarSystem3D — hero-GLB armor wiring', () => {
+  it('computes the rich appearance before attempting the hero-GLB load, not only in the procedural fallback', () => {
+    const heroBlockIdx = src.indexOf("if (opts.isHero && !opts.isLocalPlayer)");
+    const richAssignIdx = src.indexOf('rich = schemaMod.generateAppearance(', heroBlockIdx);
+    expect(heroBlockIdx).toBeGreaterThan(-1);
+    expect(richAssignIdx).toBeGreaterThan(heroBlockIdx);
+  });
+
+  it('passes rich.armor as the 4th argument to loadHeroMesh', () => {
+    expect(src).toContain('heroMod.loadHeroMesh(avatarId, archetype, homeWorld, rich.armor)');
+  });
+
+  it('the procedural-fallback path reuses the already-computed rich via nullish-assignment, not a second generateAppearance call', () => {
+    const fallbackIdx = src.indexOf('const result = buildEnhancedAvatar(rich,');
+    const reuseIdx = src.lastIndexOf('rich ??= schemaMod.generateAppearance(', fallbackIdx);
+    expect(fallbackIdx).toBeGreaterThan(-1);
+    expect(reuseIdx).toBeGreaterThan(-1);
+    expect(reuseIdx).toBeLessThan(fallbackIdx);
+  });
+
+  it('the appearance-cache hint (including homeWorldId) is read exactly once for both paths', () => {
+    const matches = src.match(/cache\?\.get\(avatarId\)/g) ?? [];
+    expect(matches.length).toBe(1);
+    expect(src).toContain('homeWorldId?: string;');
+  });
+});

--- a/concord-frontend/tests/world-lens-avatar-armor-wiring.test.ts
+++ b/concord-frontend/tests/world-lens-avatar-armor-wiring.test.ts
@@ -36,3 +36,23 @@ describe('AvatarSystem3D — hero-GLB armor wiring', () => {
     expect(src).toContain('homeWorldId?: string;');
   });
 });
+
+// 2026-07-21 (later same session) — quality floor: every avatar that gets
+// a mesh at all (already budget-capped at MAX_FULLY_ANIMATED, unchanged)
+// now gets the enhanced builder (hair-cards, skin-SSS, real armor)
+// instead of a large fraction silently falling to the flat-color box/
+// cylinder/sphere legacy tier. Regression guard against silently
+// reverting to the old tiered gate.
+describe('AvatarSystem3D — quality floor (no more flat-primitive default)', () => {
+  it('wantEnhanced is unconditionally true, not gated on isLocalPlayer/isHero/legend', () => {
+    expect(src).toContain('const wantEnhanced = true;');
+    // The old gated expression must be gone, not just shadowed.
+    expect(src).not.toContain("opts.isLocalPlayer || opts.isHero || appearance.bodyType === 'legend';");
+  });
+
+  it('the legacy primitive builder (createAvatarMesh) is still reachable as the exception-safety fallback, not deleted out from under error handling', () => {
+    const wantEnhancedIdx = src.indexOf('const wantEnhanced = true;');
+    const fallbackCallIdx = src.indexOf('return await createAvatarMesh(appearance, THREE);', wantEnhancedIdx);
+    expect(fallbackCallIdx).toBeGreaterThan(wantEnhancedIdx);
+  });
+});

--- a/concord-frontend/tests/world-lens-building-feature-on-real-asset.test.ts
+++ b/concord-frontend/tests/world-lens-building-feature-on-real-asset.test.ts
@@ -1,0 +1,78 @@
+// UGC-rendering-fidelity audit (2026-07-21) — BuildingRenderer3D.tsx is a
+// Three.js/DOM-heavy component (its building-mesh construction runs inside
+// an async effect closure, not a standalone exported function), so this is
+// a source-pinning regression test per this repo's established pattern
+// (see tests/world-lens-ranged-combat-wiring.test.ts's own header comment).
+//
+// Finding: a player-authored building (game-design.building-publish) only
+// ever chooses an archetype (5 values) + an optional iconic `feature`
+// (dome/spire/colonnade/belfry, 4 values) + a bounding box — no material or
+// structural choice. When a real sourced GLB exists for the chosen
+// archetype (public/models/building/{tavern,archive,market}.glb), the
+// real-asset-first branch loaded it and rescaled it to the DTU's declared
+// dimensions, but NEVER read `feature` at all — every building of the same
+// archetype rendered as the exact same mesh regardless of what landmark the
+// player actually chose. The procedural fallback path already read
+// `feature` correctly via addIconicFeature(); this wires the same call into
+// the real-asset branch too, deriving its `scale` param from the GLB's own
+// measured height (size.y / 8, since addIconicFeature's geometry AND
+// roofline position both assume an ~8-unit-tall base building at scale=1 —
+// passing a fixed scale=1 would size the feature for an 8-unit building
+// while positioning it on the real GLB's own roofline, producing a
+// toy-sized dome on a much taller real building). Verified numerically
+// against the real tavern.glb (scratch script, not committed): with
+// scale=size.y/8, the feature's roofTop (8*scale) landed at Y=1.63 against
+// the GLB's own measured roofline of Y=1.55 — a ~5%-of-height gap, not a
+// floating/buried mesh.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(
+  path.resolve(__dirname, '..', 'components/world-lens/BuildingRenderer3D.tsx'),
+  'utf8',
+);
+
+describe('BuildingRenderer3D.tsx — iconic feature composited onto real-asset buildings', () => {
+  it('hoists feature + factionVisual above the real-asset branch so both branches share one computation', () => {
+    const realAssetIdx = src.indexOf('Real-asset-first: try a real GLB');
+    const featureDeclIdx = src.indexOf('const feature = ');
+    expect(featureDeclIdx).toBeGreaterThan(-1);
+    expect(realAssetIdx).toBeGreaterThan(-1);
+    expect(featureDeclIdx).toBeLessThan(realAssetIdx);
+  });
+
+  it('composites addIconicFeature onto the loaded real GLB when the DTU has a feature, after measuring its bounding box but before the group-wide rescale', () => {
+    const sizeIdx = src.indexOf('const size = box.getSize(new THREE.Vector3());');
+    expect(sizeIdx).toBeGreaterThan(-1);
+    const scaleSetIdx = src.indexOf('cloned.scale.set(dtu.dimensions.width / size.x');
+    expect(scaleSetIdx).toBeGreaterThan(sizeIdx);
+    const block = src.slice(sizeIdx, scaleSetIdx);
+    expect(block).toMatch(/if \(feature && size\.y > 0\) \{/);
+    expect(block).toMatch(/const \{ addIconicFeature \} = await import\('@\/lib\/world-lens\/procedural-buildings'\);/);
+  });
+
+  it('derives the feature scale from the real GLB\'s own measured height (size.y / 8), not a fixed scale — so the feature\'s own geometry proportions match the building instead of assuming the procedural archetypes\' fixed 8-unit base height', () => {
+    const idx = src.indexOf('addIconicFeature(THREE, cloned, feature,');
+    expect(idx).toBeGreaterThan(-1);
+    expect(src.slice(idx, idx + 80)).toMatch(/addIconicFeature\(THREE, cloned, feature, size\.y \/ 8, roofMat, trimMat\);/);
+  });
+
+  it('builds roofMat/trimMat from the same faction-visual colors the procedural path uses, falling back to a neutral stone/trim palette', () => {
+    const idx = src.indexOf('const roofMat = new THREE.MeshStandardMaterial({');
+    expect(idx).toBeGreaterThan(-1);
+    const block = src.slice(idx, idx + 400);
+    expect(block).toMatch(/factionVisual\?\.secondary_color \?\? '#8a7a68'/);
+    expect(block).toMatch(/factionVisual\?\.accent_color \?\? '#5c5044'/);
+  });
+
+  it('never lets a feature-compositing failure block the real asset from rendering — wrapped in its own try/catch, separate from the outer real-asset lookup catch', () => {
+    const idx = src.indexOf('if (feature && size.y > 0) {');
+    const block = src.slice(idx, idx + 800);
+    expect(block).toMatch(/\} catch \(featErr\) \{/);
+    expect(block).toMatch(/console\.warn\('\[BuildingRenderer3D\] iconic-feature compositing failed, real asset still renders', featErr\);/);
+  });
+});

--- a/concord-frontend/tests/world-lens-mount-rider-seat-wiring.test.ts
+++ b/concord-frontend/tests/world-lens-mount-rider-seat-wiring.test.ts
@@ -1,0 +1,71 @@
+// Mount rider-seat activation — AvatarSystem3D.tsx (Three.js/DOM-heavy,
+// source-pinned per this repo's established pattern, see
+// tests/world-lens-ranged-combat-wiring.test.ts's own header comment).
+//
+// rider-ik.ts's astride-seat lift (computeRiderIkTargets) was fully built
+// and tested (tests/components/MountAvatar3D.test.tsx) but never actually
+// activated: it read window.__concordMountRiderSeat === true, a flag
+// nothing in the codebase ever set, so the mount always rendered as
+// "following under the rider" rather than the rider genuinely sitting the
+// saddle with gait bounce. Naively flipping the flag on isn't safe by
+// itself — the movement loop's terrain-elevation clamp (which runs AFTER
+// the rider-ik eyeTicker in the same frame) unconditionally set
+// pm.position.y from a ground-height value, stomping the seat lift back
+// down every single frame while moving. This file pins both halves of the
+// real fix: the seat activates by default, and the terrain clamp / final
+// position.set no longer fight it.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(
+  path.resolve(__dirname, '..', 'components/world-lens/AvatarSystem3D.tsx'),
+  'utf8',
+);
+
+describe('AvatarSystem3D.tsx — mount rider-seat activation', () => {
+  it('declares isMountedRiderRef, defaulting to false', () => {
+    expect(src).toMatch(/const isMountedRiderRef = useRef\(false\);/);
+  });
+
+  it('sets isMountedRiderRef true when the mount actually spawns', () => {
+    const idx = src.indexOf('avatarGroup.add(m.group);');
+    expect(idx).toBeGreaterThan(-1);
+    const block = src.slice(idx, idx + 200);
+    expect(block).toMatch(/isMountedRiderRef\.current = true;/);
+  });
+
+  it('seatOn defaults to true — the seat lift is on unless a caller explicitly opts out via window.__concordMountRiderSeat = false', () => {
+    const idx = src.indexOf('const seatOn =');
+    expect(idx).toBeGreaterThan(-1);
+    const block = src.slice(idx, idx + 200);
+    expect(block).toMatch(/__concordMountRiderSeat\?: boolean \}\)\.__concordMountRiderSeat !== false;/);
+  });
+
+  it('resets isMountedRiderRef to false on unmount so a remount without a mount does not carry a stale true', () => {
+    const idx = src.indexOf('eyeTickers.clear();');
+    expect(idx).toBeGreaterThan(-1);
+    const block = src.slice(idx, idx + 100);
+    expect(block).toMatch(/isMountedRiderRef\.current = false;/);
+  });
+
+  it('the terrain-elevation clamp uses a saddle-height approximation while mounted instead of the raw ground elevation', () => {
+    const idx = src.indexOf('Terrain elevation — clamp Y to ground');
+    expect(idx).toBeGreaterThan(-1);
+    const block = src.slice(idx, idx + 1000);
+    expect(block).toMatch(/pos\.y = isMountedRiderRef\.current \? elevation \+ 1\.3 : elevation;/);
+  });
+
+  it('the final per-frame position.set skips overwriting Y while mounted, so it never stomps the rider-ik eyeTicker\'s seat-bounce write from earlier in the same frame', () => {
+    const idx = src.indexOf('const pm = playerMeshRef.current as InstanceType<typeof import(\'three\').Group>;');
+    expect(idx).toBeGreaterThan(-1);
+    const block = src.slice(idx, idx + 500);
+    expect(block).toMatch(/if \(isMountedRiderRef\.current\) \{/);
+    expect(block).toMatch(/pm\.position\.x = pos\.x;/);
+    expect(block).toMatch(/pm\.position\.z = pos\.z;/);
+    expect(block).toMatch(/\} else \{\s*pm\.position\.set\(pos\.x, pos\.y, pos\.z\);/);
+  });
+});

--- a/concord-frontend/tests/world-lens-node-click-to-gather.test.ts
+++ b/concord-frontend/tests/world-lens-node-click-to-gather.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// ConcordiaScene.tsx and app/lenses/world/page.tsx are large Three.js/DOM-
+// heavy files (this repo's established pattern for such files is a
+// source-pinning regression test, see tests/world-page-*.test.ts). This
+// pins the click-to-gather wiring added 2026-07-21: a resource-node mesh
+// (real GLB or procedural fallback) is now a real, clickable game object,
+// not just a decorative shape with a disconnected 2D HUD list.
+const sceneSrc = readFileSync(join(process.cwd(), 'components/world-lens/ConcordiaScene.tsx'), 'utf8');
+const pageSrc = readFileSync(join(process.cwd(), 'app/lenses/world/page.tsx'), 'utf8');
+
+describe('ConcordiaScene — resource-node click raycast', () => {
+  it('raycasts the infrastructure layer and filters for isResourceNode-tagged hits', () => {
+    expect(sceneSrc).toContain("layersRef.current['infrastructure']");
+    expect(sceneSrc).toContain('isResourceNode?: boolean');
+  });
+
+  it('dispatches concordia:node-click with nodeId, nodeType, depleted, and the world-space hit point', () => {
+    const idx = sceneSrc.indexOf("new CustomEvent('concordia:node-click'");
+    expect(idx).toBeGreaterThan(-1);
+    const slice = sceneSrc.slice(idx, idx + 400);
+    expect(slice).toContain('nodeId:');
+    expect(slice).toContain('nodeType:');
+    expect(slice).toContain('depleted:');
+    expect(slice).toContain('point:');
+  });
+
+  it('the resource-node check runs before the buildings/terrain checks, after the avatar check', () => {
+    const avatarIdx = sceneSrc.indexOf('concordia:npc-context-menu');
+    const nodeIdx = sceneSrc.indexOf('concordia:node-click');
+    const buildingIdx = sceneSrc.indexOf('// Check buildings layer next');
+    expect(avatarIdx).toBeGreaterThan(-1);
+    expect(nodeIdx).toBeGreaterThan(avatarIdx);
+    expect(buildingIdx).toBeGreaterThan(nodeIdx);
+  });
+});
+
+describe('world/page.tsx — click-to-gather consumer', () => {
+  it('gatherFromNode is a stable useCallback (not a fresh closure every render)', () => {
+    expect(pageSrc).toContain('const gatherFromNode = useCallback(async (nodeId: string) => {');
+  });
+
+  it('listens for concordia:node-click and calls the existing gatherFromNode (one real gather call path)', () => {
+    const idx = pageSrc.indexOf("window.addEventListener('concordia:node-click'");
+    expect(idx).toBeGreaterThan(-1);
+    const before = pageSrc.slice(Math.max(0, idx - 1500), idx);
+    expect(before).toContain('void gatherFromNode(detail.nodeId)');
+  });
+
+  it('reuses the same tool-swing + dust-particle feedback as the freeform right-click gather path', () => {
+    const idx = pageSrc.indexOf("window.addEventListener('concordia:node-click'");
+    const before = pageSrc.slice(Math.max(0, idx - 1500), idx);
+    expect(before).toContain("animation: 'attack-light'");
+    expect(before).toContain("type: 'dust'");
+  });
+
+  it('a depleted node click shows an honest message instead of silently no-op-ing', () => {
+    const idx = pageSrc.indexOf("window.addEventListener('concordia:node-click'");
+    const before = pageSrc.slice(Math.max(0, idx - 1500), idx);
+    expect(before).toContain('depleted');
+    expect(before).toMatch(/pushCombatLog\(.*depleted/i);
+  });
+});

--- a/concord-frontend/tests/world-lens-npc-gather-visibility.test.ts
+++ b/concord-frontend/tests/world-lens-npc-gather-visibility.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// world/page.tsx is a large Three.js/DOM-heavy file (this repo's
+// established pattern is a source-pinning regression test, see
+// tests/world-page-*.test.ts). Pins the world:npc-gather wiring added
+// 2026-07-21: an NPC's gather_resource action (server/lib/npc-simulator.js)
+// was previously a completely silent DB write — no signal reached the
+// world lens at all. handleNpcGather bridges the new server broadcast
+// into the SAME tool-swing + dust-particle feedback the player's own
+// click-to-gather already gets, so NPCs gathering resources is now a
+// real, watchable action instead of an invisible macro call.
+const src = readFileSync(join(process.cwd(), 'app/lenses/world/page.tsx'), 'utf8');
+
+describe('world/page.tsx — NPC gather visibility (world:npc-gather)', () => {
+  it('subscribes to world:npc-gather on the world socket, with matching cleanup', () => {
+    expect(src).toContain("worldSocket.on('world:npc-gather', handleNpcGather);");
+    expect(src).toContain("worldSocket.off('world:npc-gather', handleNpcGather);");
+  });
+
+  it('dispatches concordia:combat-anim targeted at the NPC entity (not the player)', () => {
+    const idx = src.indexOf('const handleNpcGather = ');
+    expect(idx).toBeGreaterThan(-1);
+    const body = src.slice(idx, idx + 900);
+    expect(body).toContain('entityId: data.npcId');
+    expect(body).toContain("animation: 'attack-light'");
+  });
+
+  it('dispatches a dust particle burst at the real node position (x/y/z from the emit payload)', () => {
+    const idx = src.indexOf('const handleNpcGather = ');
+    const body = src.slice(idx, idx + 900);
+    expect(body).toContain("type: 'dust'");
+    expect(body).toContain('x: data.x');
+    expect(body).toContain('z: data.z');
+  });
+
+  it('guards on a missing npcId — never dispatches for a malformed payload', () => {
+    const idx = src.indexOf('const handleNpcGather = ');
+    const body = src.slice(idx, idx + 300);
+    expect(body).toContain('if (!data?.npcId) return;');
+  });
+});

--- a/concord-frontend/tests/world-lens-ranged-combat-wiring.test.ts
+++ b/concord-frontend/tests/world-lens-ranged-combat-wiring.test.ts
@@ -106,11 +106,12 @@ describe('AvatarSystem3D.tsx — firearm discharge fires a projectile tracer', (
 });
 
 describe('CombatInputController.tsx — Mouse0 fire binding', () => {
-  it('gates fire on the resolved hand actually holding a pistol/rifle', () => {
+  it('gates fire on the resolved hand holding a pistol/rifle/staff (staff = spell-caster class, added when staff-equip casting was wired up)', () => {
     const idx = combatInput.indexOf('const dispatchFire');
     expect(idx).toBeGreaterThan(-1);
     const block = combatInput.slice(idx, idx + 1500);
-    expect(block).toMatch(/if \(weaponClass !== 'pistol' && weaponClass !== 'rifle'\) return;/);
+    expect(block).toMatch(/const isStaff = weaponClass === 'staff';/);
+    expect(block).toMatch(/if \(weaponClass !== 'pistol' && weaponClass !== 'rifle' && !isStaff\) return;/);
   });
 
   it('enforces a soft client-side cooldown floor distinct from the melee per-key cooldown map', () => {
@@ -120,17 +121,19 @@ describe('CombatInputController.tsx — Mouse0 fire binding', () => {
     expect(block).toMatch(/now - lastRangedFireAtRef\.current < 220/);
   });
 
-  it('dispatches the same predicted concordia:combat-anim event melee attacks use, so discharge-flash/trail/tracer wiring fires for free', () => {
+  it('dispatches the predicted concordia:combat-anim event for firearms (attack-light, so discharge-flash/trail/tracer wiring fires for free), but a real cast_channel playAction for a staff — casting no longer looks identical to a normal attack', () => {
     const idx = combatInput.indexOf('const dispatchFire');
-    const block = combatInput.slice(idx, idx + 1500);
+    const block = combatInput.slice(idx, idx + 1800);
+    expect(block).toMatch(/if \(isStaff\) \{/);
+    expect(block).toMatch(/playActionAtPlayer\('cast'\);/);
     expect(block).toMatch(/animation: 'attack-light', predicted: true/);
   });
 
-  it('emits combat:attack with style "fire", targeting the crosshair hit or lock-on, range-capped under the server ceiling', () => {
+  it('emits combat:attack with style "fire" for firearms / "magic" for a staff, targeting the crosshair hit or lock-on, range-capped under the server ceiling', () => {
     const idx = combatInput.indexOf('const dispatchFire');
-    const block = combatInput.slice(idx, idx + 1500);
+    const block = combatInput.slice(idx, idx + 2400);
     expect(block).toMatch(/targetId: cameraLookState\.aimHitEntityId \?\? _lockedTargetId\(\),/);
-    expect(block).toMatch(/style: 'fire',/);
+    expect(block).toMatch(/style: isStaff \? 'magic' : 'fire',/);
     expect(block).toMatch(/actionOverride: 'ranged',/);
     expect(block).toMatch(/range: 45,/);
   });

--- a/content/evo-seed/world-lens-manifest.json
+++ b/content/evo-seed/world-lens-manifest.json
@@ -1,0 +1,54 @@
+{
+  "spec": "concord-evo-seed/world-lens/v1",
+  "note": "Real, licensed 3D/texture assets sourced directly from GitHub repos this session for the World Lens (weapons, terrain photos, buildings, vegetation, creatures, hero character meshes) — see concord-frontend/public/models/CREDITS.md and concord-frontend/public/meshes/heroes/CREDITS.md for full per-file provenance/license detail. Registered at a real production-quality level (4-6, not the '1' used for the primitive placeholder seed in manifest.json) so the evo-asset engine's interaction-tracking + refinement-pass scheduler has genuine reference material to track and evolve, not just CC0 placeholder cubes.",
+  "publicDir": "concord-frontend/public",
+  "assets": [
+    { "file": "models/terrain/grass.jpg", "kind": "texture", "category": "terrain", "tags": ["terrain", "ground", "grass", "cc-by-4.0", "roblox-creator-docs"], "qualityLevel": 5 },
+    { "file": "models/terrain/dirt.jpg", "kind": "texture", "category": "terrain", "tags": ["terrain", "ground", "dirt", "cc-by-4.0", "roblox-creator-docs"], "qualityLevel": 5 },
+    { "file": "models/terrain/cobblestone.jpg", "kind": "texture", "category": "terrain", "tags": ["terrain", "ground", "cobblestone", "cc-by-4.0", "roblox-creator-docs"], "qualityLevel": 5 },
+    { "file": "models/terrain/sand.jpg", "kind": "texture", "category": "terrain", "tags": ["terrain", "ground", "sand", "cc-by-4.0", "roblox-creator-docs"], "qualityLevel": 5 },
+    { "file": "models/terrain/asphalt.jpg", "kind": "texture", "category": "terrain", "tags": ["terrain", "ground", "asphalt", "cc-by-4.0", "roblox-creator-docs"], "qualityLevel": 5 },
+    { "file": "models/terrain/brick.jpg", "kind": "texture", "category": "terrain", "tags": ["terrain", "ground", "brick", "cc-by-4.0", "roblox-creator-docs"], "qualityLevel": 5 },
+    { "file": "models/terrain/gravel.jpg", "kind": "texture", "category": "terrain", "tags": ["terrain", "ground", "gravel", "substitute-for-ground", "cc-by-4.0", "roblox-creator-docs"], "qualityLevel": 4 },
+
+    { "file": "models/weapon/mace.glb", "kind": "mesh", "category": "weapon", "tags": ["weapon", "mace", "cc0", "speed-dungeon", "opengameart-19-low-poly-fantasy-weapons"], "qualityLevel": 5 },
+    { "file": "models/weapon/club.glb", "kind": "mesh", "category": "weapon", "tags": ["weapon", "club", "cc-by-3.0", "attribution-required", "mastahcez", "speed-dungeon"], "qualityLevel": 5 },
+    { "file": "models/weapon/spear.glb", "kind": "mesh", "category": "weapon", "tags": ["weapon", "spear", "cc0", "speed-dungeon", "opengameart-19-low-poly-fantasy-weapons"], "qualityLevel": 5 },
+    { "file": "models/weapon/bow.glb", "kind": "mesh", "category": "weapon", "tags": ["weapon", "bow", "ranged", "cc0", "speed-dungeon", "opengameart-19-low-poly-fantasy-weapons"], "qualityLevel": 5 },
+    { "file": "models/weapon/firearm_pistol.glb", "kind": "mesh", "category": "weapon", "tags": ["weapon", "firearm", "pistol", "ranged", "cc0", "kenney-starter-kit-fps"], "qualityLevel": 5 },
+    { "file": "models/weapon/firearm_rifle.glb", "kind": "mesh", "category": "weapon", "tags": ["weapon", "firearm", "rifle", "ranged", "cc0", "kenney-starter-kit-fps"], "qualityLevel": 5 },
+    { "file": "models/weapon/staff.glb", "kind": "mesh", "category": "weapon", "tags": ["weapon", "staff", "cc0", "kaykit-adventurers"], "qualityLevel": 5 },
+    { "file": "models/weapon/wand.glb", "kind": "mesh", "category": "weapon", "tags": ["weapon", "wand", "cc0", "kaykit-adventurers"], "qualityLevel": 5 },
+    { "file": "models/weapon/dagger.glb", "kind": "mesh", "category": "weapon", "tags": ["weapon", "dagger", "cc0", "kaykit-adventurers"], "qualityLevel": 5 },
+    { "file": "models/weapon/shortsword.glb", "kind": "mesh", "category": "weapon", "tags": ["weapon", "shortsword", "sword", "cc0", "kaykit-adventurers"], "qualityLevel": 5 },
+    { "file": "models/weapon/longsword.glb", "kind": "mesh", "category": "weapon", "tags": ["weapon", "longsword", "sword", "cc0", "kaykit-adventurers"], "qualityLevel": 5 },
+    { "file": "models/weapon/greatsword.glb", "kind": "mesh", "category": "weapon", "tags": ["weapon", "greatsword", "sword", "two-handed", "cc0", "kaykit-adventurers"], "qualityLevel": 5 },
+    { "file": "models/weapon/axe.glb", "kind": "mesh", "category": "weapon", "tags": ["weapon", "axe", "cc0", "kaykit-adventurers"], "qualityLevel": 5 },
+    { "file": "models/weapon/halberd.glb", "kind": "mesh", "category": "weapon", "tags": ["weapon", "halberd", "polearm", "cc0", "kaykit-adventurers"], "qualityLevel": 4 },
+    { "file": "models/weapon/crossbow.glb", "kind": "mesh", "category": "weapon", "tags": ["weapon", "crossbow", "ranged", "cc0", "kaykit-adventurers"], "qualityLevel": 5 },
+
+    { "file": "models/building/tavern.glb", "kind": "mesh", "category": "building", "tags": ["building", "tavern", "cc0", "polygonal-mind", "momuspark"], "qualityLevel": 5 },
+    { "file": "models/building/market.glb", "kind": "mesh", "category": "building", "tags": ["building", "market", "cc0", "polygonal-mind", "medieval-fair"], "qualityLevel": 5 },
+    { "file": "models/building/archive.glb", "kind": "mesh", "category": "building", "tags": ["building", "archive", "cc0", "polygonal-mind", "momuspark"], "qualityLevel": 5 },
+
+    { "file": "models/vegetation/tree_01.glb", "kind": "mesh", "category": "vegetation", "tags": ["vegetation", "tree", "cc0", "polygonal-mind", "momuspark"], "qualityLevel": 5 },
+    { "file": "models/vegetation/tree_02.glb", "kind": "mesh", "category": "vegetation", "tags": ["vegetation", "tree", "cc0", "polygonal-mind", "momuspark"], "qualityLevel": 5 },
+    { "file": "models/vegetation/tree_03.glb", "kind": "mesh", "category": "vegetation", "tags": ["vegetation", "tree", "cc0", "polygonal-mind", "momuspark"], "qualityLevel": 5 },
+    { "file": "models/vegetation/tree_04.glb", "kind": "mesh", "category": "vegetation", "tags": ["vegetation", "tree", "cc0", "polygonal-mind", "momuspark"], "qualityLevel": 5 },
+    { "file": "models/vegetation/bush_01.glb", "kind": "mesh", "category": "vegetation", "tags": ["vegetation", "bush", "cc0", "polygonal-mind", "momuspark"], "qualityLevel": 5 },
+    { "file": "models/vegetation/flower_01.glb", "kind": "mesh", "category": "vegetation", "tags": ["vegetation", "flower", "cc0", "polygonal-mind", "momuspark"], "qualityLevel": 5 },
+
+    { "file": "models/creature/quadruped_01.glb", "kind": "creature", "category": "creature", "tags": ["creature", "quadruped", "cc0", "polygonal-mind", "momuspark"], "qualityLevel": 5 },
+    { "file": "models/creature/quadruped_02.glb", "kind": "creature", "category": "creature", "tags": ["creature", "quadruped", "cc0", "polygonal-mind", "momuspark"], "qualityLevel": 5 },
+    { "file": "models/creature/quadruped_03.glb", "kind": "creature", "category": "creature", "tags": ["creature", "quadruped", "cc0", "polygonal-mind", "momuspark"], "qualityLevel": 5 },
+    { "file": "models/creature/winged_biped_01.glb", "kind": "creature", "category": "creature", "tags": ["creature", "winged_biped", "owl", "cc0", "polygonal-mind", "momuspark"], "qualityLevel": 5 },
+
+    { "file": "meshes/heroes/_archetype_warrior.glb", "kind": "mesh", "category": "hero-archetype", "tags": ["character", "hero-archetype", "warrior", "mit", "microsoft-rocketbox"], "qualityLevel": 6 },
+    { "file": "meshes/heroes/_archetype_guard.glb", "kind": "mesh", "category": "hero-archetype", "tags": ["character", "hero-archetype", "guard", "mit", "microsoft-rocketbox"], "qualityLevel": 6 },
+    { "file": "meshes/heroes/_archetype_hunter.glb", "kind": "mesh", "category": "hero-archetype", "tags": ["character", "hero-archetype", "hunter", "mit", "microsoft-rocketbox"], "qualityLevel": 6 },
+    { "file": "meshes/heroes/_archetype_scholar.glb", "kind": "mesh", "category": "hero-archetype", "tags": ["character", "hero-archetype", "scholar", "mit", "microsoft-rocketbox"], "qualityLevel": 6 },
+    { "file": "meshes/heroes/_archetype_mystic.glb", "kind": "mesh", "category": "hero-archetype", "tags": ["character", "hero-archetype", "mystic", "mit", "microsoft-rocketbox"], "qualityLevel": 6 },
+    { "file": "meshes/heroes/_archetype_trader.glb", "kind": "mesh", "category": "hero-archetype", "tags": ["character", "hero-archetype", "trader", "mit", "microsoft-rocketbox"], "qualityLevel": 6 },
+    { "file": "meshes/heroes/_archetype_legend.glb", "kind": "mesh", "category": "hero-archetype", "tags": ["character", "hero-archetype", "legend", "mixamo"], "qualityLevel": 5 }
+  ]
+}

--- a/server/lib/evo-asset/scheduler.js
+++ b/server/lib/evo-asset/scheduler.js
@@ -1,7 +1,18 @@
 // server/lib/evo-asset/scheduler.js
 // Heartbeat-driven evolution scheduler.
 //
-// Every ~5 minutes (every 100th heartbeat tick) the scheduler:
+// Every 100th governorTick() call the scheduler fires. governorTick()'s own
+// interval defaults to 60s (server.js's _startGovernorHeartbeat,
+// clamp(heartbeatMs ?? 60000, 15s, 10min)), so this is ~100 minutes between
+// evolution ticks by default, not the "~5 minutes" this comment used to
+// claim — that figure assumed a faster per-entity tick loop elsewhere in
+// the codebase, not the actual governor interval this gate reads from
+// (STATE.__bgTickCounter, incremented once per governorTick() call). The
+// scheduler does run and IS live at boot (verified against
+// _startGovernorHeartbeat's setTimeout(..., 50_000) boot wiring) — the
+// interval was simply mis-documented.
+//
+// On each fire the scheduler:
 //   1. Recomputes evolution_score for the top N most-active assets
 //   2. Selects up to 3 candidates with highest score
 //   3. Picks the next refinement pass for each based on current quality_level
@@ -58,6 +69,26 @@ export async function runEvolutionTick(STATE, db, deps = {}) {
 
       const passKind = nextPassFor(asset.quality_level);
       if (!passKind) continue;
+
+      // KNOWN GAP (2026-07-21, verified by direct investigation, not fixed
+      // here): subdivision/procedural_wear/higher_lod all read local_path
+      // via fs.readFile + JSON.parse, expecting the {positions, indices}
+      // mesh-JSON format content/evo-seed/*.mesh.json seed primitives use.
+      // The real world-lens assets (bootstrapWorldLensAssets — building/
+      // tree/creature/weapon GLBs, terrain JPGs) fail JSON.parse on binary
+      // GLB data and are swallowed by each pass's own try/catch, returning
+      // null (a silent no-op, not a crash — see the `if (!result) continue`
+      // a few lines down). material_upgrade is the one pass that survives
+      // (it never reads sourcePath), but produces no file/version a
+      // consumer reads. detail_maps needs callImageGen, wired to an
+      // async()=>null stub in this build. So candidate SELECTION genuinely
+      // reaches real assets (this file, confirmed) and the frontend CAN
+      // resolve a promoted version once one exists (asset-loader.ts, fixed
+      // this pass — see bootstrapWorldLensAssets' concordia-alias rows),
+      // but no pass can currently PRODUCE one for a GLB/texture asset.
+      // Closing this needs a GLB-aware pass (or a pre-extraction step from
+      // GLB → {positions,indices}), which is new engineering, not a wiring
+      // fix — out of scope here.
 
       // Compute interaction density for the wear pass.
       const interactionDensity = (() => {

--- a/server/lib/evo-asset/source-loaders.js
+++ b/server/lib/evo-asset/source-loaders.js
@@ -305,6 +305,65 @@ export function bootstrapLocalSeed(db, dir = SEED_DIR) {
   return stats;
 }
 
+// content/evo-seed/world-lens-manifest.json — real, licensed 3D/texture
+// assets sourced directly from GitHub repos for the World Lens (weapons,
+// terrain photos, buildings, vegetation, creatures, hero character
+// meshes), distinct from manifest.json's CC0 primitive placeholder floor.
+// Override with EVO_WORLD_LENS_SEED_DIR.
+const WORLD_LENS_SEED_DIR = process.env.EVO_WORLD_LENS_SEED_DIR
+  || path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../content/evo-seed");
+
+/**
+ * Registers the real, licensed World Lens assets sourced this session
+ * (weapons/terrain/buildings/vegetation/creatures/hero archetypes — see
+ * concord-frontend/public/models/CREDITS.md +
+ * concord-frontend/public/meshes/heroes/CREDITS.md for full per-file
+ * provenance) into the evo-asset registry, so the interaction-tracking +
+ * refinement-pass scheduler (server/lib/evo-asset/scheduler.js) has real
+ * reference material to track and evolve instead of only the 3 CC0
+ * primitive placeholder meshes bootstrapLocalSeed provides.
+ *
+ * `source: 'github'` (migration 373) is the honest tag — these files did
+ * not come from Kenney/PolyHaven/ambientCG/OS3A/Sketchfab as platforms,
+ * they were downloaded directly from their origin GitHub repos.
+ * `sourceId` is `world-lens:<relative-path>` so re-runs dedupe cleanly.
+ *
+ * Deliberately registers only the 7 universal hero-archetype slots, not
+ * all ~46 per-world variant files — those are the same underlying asset
+ * reused for cross-world visual identity (see hero-mesh-registry.ts),
+ * not distinct assets worth separate evolution tracking.
+ */
+export function bootstrapWorldLensAssets(db, dir = WORLD_LENS_SEED_DIR) {
+  const stats = { found: 0, registered: 0 };
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(path.join(dir, "world-lens-manifest.json"), "utf8"));
+  } catch {
+    return stats; // no world-lens seed manifest present
+  }
+  const publicDir = path.resolve(dir, "..", "..", manifest.publicDir || "concord-frontend/public");
+  for (const entry of (manifest.assets || [])) {
+    const file = entry?.file;
+    if (!file) continue;
+    const localPath = path.join(publicDir, file);
+    if (!fs.existsSync(localPath)) continue;
+    stats.found += 1;
+    try {
+      const r = registerAsset(db, {
+        kind: entry.kind || "mesh",
+        source: "github",
+        sourceId: `world-lens:${file}`,
+        localPath,
+        category: entry.category ?? null,
+        tags: entry.tags ?? [],
+        qualityLevel: entry.qualityLevel ?? 4,
+      });
+      if (r?.created) stats.registered += 1;
+    } catch { /* registration best-effort */ }
+  }
+  return stats;
+}
+
 /**
  * Run all available bootstrappers. Caller controls ordering + limits.
  * Designed to be invoked once at server boot (best-effort, behind try/catch).
@@ -317,6 +376,7 @@ export function bootstrapLocalSeed(db, dir = SEED_DIR) {
 export async function bootstrapAllSources(db, opts = {}) {
   const out = {};
   try { out.localSeed = bootstrapLocalSeed(db, opts.seedDir ?? SEED_DIR); } catch { out.localSeed = { error: true }; }
+  try { out.worldLensAssets = bootstrapWorldLensAssets(db, opts.worldLensSeedDir ?? WORLD_LENS_SEED_DIR); } catch { out.worldLensAssets = { error: true }; }
   try { out.polyhaven = await bootstrapPolyHaven(db, opts.polyhaven ?? {}); } catch { out.polyhaven = { error: true }; }
   try { out.ambientcg = await bootstrapAmbientCG(db, opts.ambientcg ?? {}); } catch { out.ambientcg = { error: true }; }
   try { out.os3a      = await bootstrapOS3A(db, opts.os3a ?? {}); } catch { out.os3a = { error: true }; }

--- a/server/lib/evo-asset/source-loaders.js
+++ b/server/lib/evo-asset/source-loaders.js
@@ -332,6 +332,20 @@ const WORLD_LENS_SEED_DIR = process.env.EVO_WORLD_LENS_SEED_DIR
  * all ~46 per-world variant files — those are the same underlying asset
  * reused for cross-world visual identity (see hero-mesh-registry.ts),
  * not distinct assets worth separate evolution tracking.
+ *
+ * ALSO registers a second `source: 'concordia'` alias row per asset, keyed
+ * by the bare filename (no extension, e.g. `tavern` for
+ * `models/building/tavern.glb`) — the exact `(source, sourceId)` pair
+ * `concord-frontend/lib/world-lens/asset-loader.ts#resolveAssetReference`
+ * actually queries (every real call site — BuildingRenderer3D,
+ * creature-renderer, resource-node-renderer, weapon-archetypes — omits
+ * `source`, which defaults to `"concordia"`, and passes `id` as this bare
+ * filename). Without this alias, `resolveCurrentBest` never matched
+ * anything registered under the `github`/`world-lens:` key, so a promoted
+ * evo-asset refinement of a world-lens GLB could never reach the renderer
+ * — the two halves of the pipeline were keyed in different namespaces.
+ * The `github`-sourced row is left untouched (still the honest provenance
+ * record); this alias is purely a resolution-key bridge to the same file.
  */
 export function bootstrapWorldLensAssets(db, dir = WORLD_LENS_SEED_DIR) {
   const stats = { found: 0, registered: 0 };
@@ -360,6 +374,18 @@ export function bootstrapWorldLensAssets(db, dir = WORLD_LENS_SEED_DIR) {
       });
       if (r?.created) stats.registered += 1;
     } catch { /* registration best-effort */ }
+    try {
+      const bareId = path.basename(file, path.extname(file));
+      registerAsset(db, {
+        kind: entry.kind || "mesh",
+        source: "concordia",
+        sourceId: bareId,
+        localPath,
+        category: entry.category ?? null,
+        tags: entry.tags ?? [],
+        qualityLevel: entry.qualityLevel ?? 4,
+      });
+    } catch { /* alias registration best-effort — the github row above is the real record */ }
   }
   return stats;
 }

--- a/server/lib/npc-simulator.js
+++ b/server/lib/npc-simulator.js
@@ -334,6 +334,38 @@ function _emitBark(npc, worldId, rung, text, arrest = null) {
 }
 
 /**
+ * Emit world:npc-gather socket event — the World Lens's only signal that
+ * an NPC gathering was previously a silent DB write (activity_resources +
+ * world_resource_nodes updated, nothing else). Mirrors `_emitBark`'s
+ * pattern exactly. `nodeType` drives which tool-swing reads correctly
+ * (axe for tree, pickaxe for ore/stone/crystal/fuel, sickle/hoe for
+ * herb/soil — same table `world-gathering.js`'s TOOL_COMPAT already
+ * encodes for the player-facing yield-estimate path).
+ */
+function _emitGather(npc, worldId, gathered) {
+  if (!gathered) return;
+  try {
+    const io = globalThis._concordREALTIME?.io;
+    io?.to(`world:${worldId}`).emit('world:npc-gather', {
+      worldId,
+      npcId:        npc.id,
+      // Node position, NOT npc.location — the tool-swing/particle burst
+      // should land at the resource node the NPC is actually gathering
+      // from, which can be up to 30m away (getNearbyNodes' search radius),
+      // not "wherever the NPC happens to be standing" per npc.location.
+      x:            gathered.x,
+      y:            gathered.y,
+      z:            gathered.z,
+      nodeId:       gathered.nodeId,
+      nodeType:     gathered.nodeType ?? null,
+      resourceId:   gathered.resourceId,
+      resourceName: gathered.resourceName,
+      amount:       gathered.amount,
+    });
+  } catch { /* non-fatal */ }
+}
+
+/**
  * Emit world:npc-alert socket event and mark nearby NPCs as alerted.
  */
 function _callForHelp(npc, worldId, db) {
@@ -845,6 +877,11 @@ Choose one action for this NPC. Return JSON only:
           resources[resourceId] = Math.min(50, (resources[resourceId] || 0) + amount);
           this._db.prepare('UPDATE world_npcs SET activity_resources = ? WHERE id = ?')
             .run(JSON.stringify(resources), this.id);
+
+          // Only a real node hit (not the always-succeeds abstract fallback
+          // above) is worth broadcasting — the frontend swing/particle
+          // reads against a real node position.
+          if (gathered) _emitGather(this, this.worldId, gathered);
         } catch { /* non-fatal */ }
         break;
       }

--- a/server/lib/world-gathering.js
+++ b/server/lib/world-gathering.js
@@ -271,7 +271,13 @@ export function npcGatherFromNode(db, worldId, npcX, npcZ, npcLevel = 1, preferr
     WHERE id = ?
   `).run(newQty, depleted ? 1 : 0, depleted ? 1 : 0, now, `npc:${npcLevel}`, now, target.id);
 
-  return { resourceId: target.resource_id, resourceName: target.resource_name, amount, nodeId: target.id };
+  return {
+    resourceId: target.resource_id, resourceName: target.resource_name, amount, nodeId: target.id,
+    // Node kind + position so the caller (npc-simulator.js) can broadcast a
+    // real socket event for the world lens to show the NPC's tool-swing at
+    // the actual node, not just an approximate "somewhere near the NPC" spot.
+    nodeType: target.node_type, x: target.x, y: target.y, z: target.z,
+  };
 }
 
 // ── Respawn tick ─────────────────────────────────────────────────────────────

--- a/server/migrations/373_evo_assets_github_source.js
+++ b/server/migrations/373_evo_assets_github_source.js
@@ -1,0 +1,100 @@
+// server/migrations/373_evo_assets_github_source.js
+//
+// Extend the evo_assets CHECK constraint to admit 'github' as a source
+// value. This session sourced real, licensed 3D/texture assets directly
+// from GitHub repos (SnowdenWintermute/speed-dungeon for weapons,
+// Roblox/creator-docs for terrain photos, microsoft/Microsoft-Rocketbox
+// for hero character meshes, plus earlier building/tree/creature GLBs) —
+// none of the existing source values ('kenney', 'polyhaven', 'ambientcg',
+// 'os3a', 'sketchfab', 'authored', 'evolved', 'concordia') honestly
+// describes them: 'authored' would falsely claim Concord created the
+// geometry, and the platform-specific values name platforms these assets
+// did not come from. Per-file provenance + license (CC0 / MIT / CC-BY,
+// attribution where required) lives in concord-frontend/public/models/
+// CREDITS.md and public/meshes/heroes/CREDITS.md — 'github' is the
+// honest umbrella source tag; sourceId carries the exact repo path.
+//
+// Same idempotent table-rename approach as migration 202. Pre-existing
+// rows are preserved; the only change is the source enumeration accepts
+// one more value.
+
+export async function up(db) {
+  // Skip if the new source is already accepted (re-run safety)
+  try {
+    const probe = db.prepare(`
+      INSERT INTO evo_assets (id, kind, source, source_id, local_path)
+      VALUES ('__probe_github__', 'mesh', 'github', '__probe_github__', 'probe')
+    `);
+    probe.run();
+    db.prepare(`DELETE FROM evo_assets WHERE id = '__probe_github__'`).run();
+    return; // CHECK already accepts 'github'; nothing to do
+  } catch {
+    // CHECK rejected — proceed with rename
+  }
+
+  const fkBefore  = db.pragma("foreign_keys", { simple: true });
+  const altBefore = db.pragma("legacy_alter_table", { simple: true });
+  db.pragma("foreign_keys = OFF");
+  db.pragma("legacy_alter_table = ON");
+
+  try {
+    db.exec("ALTER TABLE evo_assets RENAME TO evo_assets_v3");
+
+    db.exec(`
+      CREATE TABLE evo_assets (
+        id                  TEXT PRIMARY KEY,
+        kind                TEXT NOT NULL
+                              CHECK (kind IN (
+                                'mesh', 'texture', 'material', 'hdri', 'sprite',
+                                'creature', 'item', 'skill', 'drop', 'craft', 'species',
+                                'blueprint'
+                              )),
+        source              TEXT NOT NULL
+                              CHECK (source IN (
+                                'kenney', 'polyhaven', 'ambientcg', 'os3a', 'sketchfab',
+                                'authored', 'evolved', 'concordia', 'github'
+                              )),
+        source_id           TEXT,
+        local_path          TEXT,
+        category            TEXT,
+        tags_json           TEXT NOT NULL DEFAULT '[]',
+        quality_level       INTEGER NOT NULL DEFAULT 0
+                              CHECK (quality_level BETWEEN 0 AND 10),
+        evolution_score     REAL NOT NULL DEFAULT 0,
+        interaction_points  INTEGER NOT NULL DEFAULT 0,
+        last_evolved_at     INTEGER,
+        last_interacted_at  INTEGER,
+        archived_at         INTEGER,
+        canonical_dtu_id    TEXT,
+        created_at          INTEGER NOT NULL DEFAULT (unixepoch())
+      )
+    `);
+
+    db.exec(`
+      INSERT INTO evo_assets (
+        id, kind, source, source_id, local_path, category, tags_json,
+        quality_level, evolution_score, interaction_points,
+        last_evolved_at, last_interacted_at, archived_at,
+        canonical_dtu_id, created_at
+      )
+      SELECT
+        id, kind, source, source_id, local_path, category, tags_json,
+        quality_level, evolution_score, interaction_points,
+        last_evolved_at, last_interacted_at, archived_at,
+        canonical_dtu_id, created_at
+      FROM evo_assets_v3
+    `);
+
+    db.exec("DROP TABLE evo_assets_v3");
+
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_evo_assets_quality   ON evo_assets(quality_level DESC, interaction_points DESC)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_evo_assets_kind      ON evo_assets(kind, archived_at)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_evo_assets_source    ON evo_assets(source, source_id)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_evo_assets_canonical ON evo_assets(canonical_dtu_id)`);
+  } finally {
+    db.pragma(`legacy_alter_table = ${altBefore ? "ON" : "OFF"}`);
+    db.pragma(`foreign_keys = ${fkBefore ? "ON" : "OFF"}`);
+  }
+}
+
+export const description = "Admit 'github' as an evo_assets source for real licensed assets sourced directly from GitHub repos";

--- a/server/tests/integration/evo-asset-world-lens-seed.test.js
+++ b/server/tests/integration/evo-asset-world-lens-seed.test.js
@@ -1,0 +1,98 @@
+/**
+ * bootstrapWorldLensAssets — registers the real, licensed World Lens assets
+ * sourced this session (weapons/terrain/buildings/vegetation/creatures/hero
+ * archetypes, see concord-frontend/public/models/CREDITS.md +
+ * concord-frontend/public/meshes/heroes/CREDITS.md) into the evo-asset
+ * registry, so the interaction-tracking + refinement-pass scheduler has real
+ * reference material instead of only the 3 CC0 primitive placeholder meshes.
+ *
+ * Run: node --test tests/integration/evo-asset-world-lens-seed.test.js
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+
+import { up as up073 } from "../../migrations/073_evo_assets.js";
+import { up as up084 } from "../../migrations/084_evo_asset_cdn_urls.js";
+import { up as up100 } from "../../migrations/100_evo_assets_gameplay_kinds.js";
+import { up as up202 } from "../../migrations/202_evo_assets_blueprint_kind.js";
+import { up as up373 } from "../../migrations/373_evo_assets_github_source.js";
+
+import { bootstrapWorldLensAssets, bootstrapAllSources } from "../../lib/evo-asset/source-loaders.js";
+import { selectEvolutionCandidates } from "../../lib/evo-asset/registry.js";
+
+function setupDb() {
+  const db = new Database(":memory:");
+  for (const up of [up073, up084, up100, up202, up373]) {
+    try { up(db); } catch { /* later migrations may add optional cols only */ }
+  }
+  return db;
+}
+
+describe("evo-asset world-lens seed", () => {
+  it("registers the real terrain/weapon/building/vegetation/creature/hero assets with source='github'", () => {
+    const db = setupDb();
+    const stats = bootstrapWorldLensAssets(db);
+    // 7 terrain + 15 weapons + 3 buildings + 6 vegetation + 4 creatures + 7 hero archetypes = 42
+    assert.ok(stats.found >= 40, `expected >= 40 real files found on disk, got ${stats.found}`);
+    assert.equal(stats.registered, stats.found, "every found file should register on a fresh DB");
+
+    const rows = db.prepare(`SELECT * FROM evo_assets WHERE source = 'github'`).all();
+    assert.equal(rows.length, stats.registered);
+    for (const row of rows) {
+      assert.ok(row.source_id.startsWith("world-lens:"), "sourceId should be namespaced world-lens:");
+      assert.ok(row.quality_level >= 4, "real licensed assets should register above the CC0-primitive floor (1)");
+      assert.ok(row.local_path.length > 0, "local_path must be populated");
+    }
+  });
+
+  it("is idempotent — re-seeding registers nothing new", () => {
+    const db = setupDb();
+    bootstrapWorldLensAssets(db);
+    const second = bootstrapWorldLensAssets(db);
+    assert.equal(second.registered, 0, "re-seed must not duplicate rows");
+  });
+
+  it("the club.glb CC-BY-3.0 asset carries an attribution-required tag, not silently dropped as CC0", () => {
+    const db = setupDb();
+    bootstrapWorldLensAssets(db);
+    const club = db.prepare(`SELECT * FROM evo_assets WHERE source_id = 'world-lens:models/weapon/club.glb'`).get();
+    assert.ok(club, "club.glb should be registered");
+    const tags = JSON.parse(club.tags_json);
+    assert.ok(tags.includes("cc-by-3.0"));
+    assert.ok(tags.includes("attribution-required"));
+    assert.ok(!tags.includes("cc0"), "club.glb is NOT CC0 — must not be mislabeled");
+  });
+
+  it("registers only the 7 universal hero-archetype slots, not the ~46 per-world variants", () => {
+    const db = setupDb();
+    bootstrapWorldLensAssets(db);
+    const heroRows = db.prepare(`SELECT * FROM evo_assets WHERE category = 'hero-archetype'`).all();
+    assert.equal(heroRows.length, 7, "exactly the 7 universal archetype slots");
+    for (const row of heroRows) {
+      assert.ok(!row.source_id.includes("__"), "per-world variant files (double-underscore suffix) must not be registered");
+    }
+  });
+
+  it("gracefully returns an empty result when the manifest directory doesn't exist", () => {
+    const db = setupDb();
+    const stats = bootstrapWorldLensAssets(db, "/nonexistent/path/xyz");
+    assert.deepEqual(stats, { found: 0, registered: 0 });
+  });
+
+  it("bootstrapAllSources folds world-lens assets into the total floor", async () => {
+    const db = setupDb();
+    const result = await bootstrapAllSources(db);
+    assert.ok(result.worldLensAssets, "bootstrapAllSources should report a worldLensAssets stat");
+    assert.ok(result.worldLensAssets.registered >= 40, "world-lens assets should be part of the boot-time floor");
+    assert.ok(result.total >= 40 + 3, "total should include both the primitive seed and the real world-lens assets");
+  });
+
+  it("real world-lens assets are real evolution candidates", () => {
+    const db = setupDb();
+    bootstrapWorldLensAssets(db);
+    const candidates = selectEvolutionCandidates(db, 50);
+    assert.ok(candidates.length >= 40, "the scheduler should see the real assets as candidates");
+  });
+});

--- a/server/tests/integration/evo-asset-world-lens-seed.test.js
+++ b/server/tests/integration/evo-asset-world-lens-seed.test.js
@@ -20,7 +20,7 @@ import { up as up202 } from "../../migrations/202_evo_assets_blueprint_kind.js";
 import { up as up373 } from "../../migrations/373_evo_assets_github_source.js";
 
 import { bootstrapWorldLensAssets, bootstrapAllSources } from "../../lib/evo-asset/source-loaders.js";
-import { selectEvolutionCandidates } from "../../lib/evo-asset/registry.js";
+import { selectEvolutionCandidates, resolveCurrentBest } from "../../lib/evo-asset/registry.js";
 
 function setupDb() {
   const db = new Database(":memory:");
@@ -68,7 +68,12 @@ describe("evo-asset world-lens seed", () => {
   it("registers only the 7 universal hero-archetype slots, not the ~46 per-world variants", () => {
     const db = setupDb();
     bootstrapWorldLensAssets(db);
-    const heroRows = db.prepare(`SELECT * FROM evo_assets WHERE category = 'hero-archetype'`).all();
+    // Scoped to source='github' — the primary provenance registration this
+    // test is about. The concordia-alias row (see the "resolution alias"
+    // describe block below) also carries category='hero-archetype', so an
+    // unscoped count would double to 14 and this assertion would be testing
+    // the alias mechanism by accident instead of the hero-slot dedup logic.
+    const heroRows = db.prepare(`SELECT * FROM evo_assets WHERE category = 'hero-archetype' AND source = 'github'`).all();
     assert.equal(heroRows.length, 7, "exactly the 7 universal archetype slots");
     for (const row of heroRows) {
       assert.ok(!row.source_id.includes("__"), "per-world variant files (double-underscore suffix) must not be registered");
@@ -94,5 +99,77 @@ describe("evo-asset world-lens seed", () => {
     bootstrapWorldLensAssets(db);
     const candidates = selectEvolutionCandidates(db, 50);
     assert.ok(candidates.length >= 40, "the scheduler should see the real assets as candidates");
+  });
+});
+
+describe("evo-asset world-lens seed — frontend resolution alias (source/sourceId key mismatch fix)", () => {
+  // Every real renderer call site (BuildingRenderer3D.tsx, creature-renderer.ts,
+  // resource-node-renderer.ts, weapon-archetypes.ts) calls loadAsset() without
+  // a `source` override, so concord-frontend/lib/world-lens/asset-loader.ts
+  // defaults to source='concordia' and passes the bare filename (no
+  // extension) as sourceId — e.g. {kind:'building', id:'tavern'} for
+  // models/building/tavern.glb. The registration above only ever wrote
+  // source='github', sourceId='world-lens:models/building/tavern.glb', a
+  // completely different (source, sourceId) pair. resolveCurrentBest's exact
+  // match meant a promoted evo-asset refinement of a world-lens GLB could
+  // NEVER reach the renderer — the two halves of the pipeline were keyed in
+  // different namespaces and never intersected. These tests pin the fix: a
+  // second alias row under the exact key the frontend actually queries.
+
+  it("registers a concordia-sourced alias row per asset, keyed by the bare filename (no extension)", () => {
+    const db = setupDb();
+    bootstrapWorldLensAssets(db);
+    const alias = db.prepare(`SELECT * FROM evo_assets WHERE source = 'concordia' AND source_id = 'tavern'`).get();
+    assert.ok(alias, "a concordia/tavern alias row should exist for models/building/tavern.glb");
+    assert.ok(alias.local_path.endsWith("models/building/tavern.glb"));
+    assert.equal(alias.category, "building");
+  });
+
+  it("resolveCurrentBest now finds a match using the EXACT (source, sourceId) the frontend asset-loader queries — this is the observable fix", () => {
+    const db = setupDb();
+    bootstrapWorldLensAssets(db);
+    // Mirrors asset-loader.ts#resolveAssetReference's real call:
+    // resolveAssetUrl({ source: ref.source ?? "concordia", sourceId: ref.id })
+    // with ref = { kind: 'building', id: 'tavern' } — before this fix,
+    // resolveCurrentBest(db, {source:'concordia', sourceId:'tavern'}) always
+    // returned null (not_registered), so the frontend silently fell through
+    // to the static /models/building/tavern.glb path — byte-identical output
+    // today, but with zero path for a future promoted refinement to surface.
+    const resolved = resolveCurrentBest(db, { source: "concordia", sourceId: "tavern" });
+    assert.ok(resolved, "resolveCurrentBest should find the concordia alias row");
+    assert.ok(resolved.canonicalPath.endsWith("models/building/tavern.glb"));
+    assert.ok(resolved.qualityLevel >= 4);
+  });
+
+  it("does not disturb the existing github-sourced provenance row — both rows coexist, pointing at the same file", () => {
+    const db = setupDb();
+    bootstrapWorldLensAssets(db);
+    const githubRow = db.prepare(`SELECT * FROM evo_assets WHERE source = 'github' AND source_id = 'world-lens:models/building/tavern.glb'`).get();
+    const aliasRow = db.prepare(`SELECT * FROM evo_assets WHERE source = 'concordia' AND source_id = 'tavern'`).get();
+    assert.ok(githubRow, "the original github provenance row must still exist, unchanged");
+    assert.ok(aliasRow);
+    assert.notEqual(githubRow.id, aliasRow.id, "two distinct rows, not a mutation of the same row");
+    assert.equal(githubRow.local_path, aliasRow.local_path, "both point at the same file on disk");
+  });
+
+  it("re-seeding is idempotent for the alias rows too — no duplicates on a second run", () => {
+    const db = setupDb();
+    bootstrapWorldLensAssets(db);
+    const before = db.prepare(`SELECT COUNT(*) AS n FROM evo_assets WHERE source = 'concordia'`).get().n;
+    bootstrapWorldLensAssets(db);
+    const after = db.prepare(`SELECT COUNT(*) AS n FROM evo_assets WHERE source = 'concordia'`).get().n;
+    assert.equal(before, after);
+    assert.ok(before >= 40, "one alias row per found asset");
+  });
+
+  it("aliases resolve correctly for the other asset kinds real renderers actually query (weapon, vegetation, creature)", () => {
+    const db = setupDb();
+    bootstrapWorldLensAssets(db);
+    // weapon-archetypes.ts calls loadAsset({kind:'weapon', id}) for e.g. 'mace'
+    assert.ok(resolveCurrentBest(db, { source: "concordia", sourceId: "mace" }), "weapon/mace.glb should resolve");
+    // resource-node-renderer.ts calls loadAsset({kind:'vegetation', id:'bush_01'})
+    assert.ok(resolveCurrentBest(db, { source: "concordia", sourceId: "bush_01" }), "vegetation/bush_01.glb should resolve");
+    // creature-renderer.ts calls loadAsset({kind:'creature', id})
+    assert.ok(resolveCurrentBest(db, { source: "concordia", sourceId: "quadruped_01" }), "creature/quadruped_01.glb should resolve");
   });
 });

--- a/server/tests/npc-simulator-gather-emit-wiring.test.js
+++ b/server/tests/npc-simulator-gather-emit-wiring.test.js
@@ -1,0 +1,52 @@
+// server/tests/npc-simulator-gather-emit-wiring.test.js
+//
+// npc-simulator.js has no existing test coverage for its class (verified:
+// no test file imports it, even for the sibling _emitBark/_callForHelp
+// socket-emit helpers this new _emitGather mirrors) — instantiating
+// NPCSimulator requires heavy world-state setup out of scope for this
+// specific fix. This is a source-pinning regression test (same pattern
+// this session already used for large, hard-to-render frontend files)
+// confirming the wiring: an NPC's gather_resource action previously wrote
+// only to the DB, completely silently — no socket event existed for the
+// world lens to react to. _emitGather closes that gap.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(HERE, "../lib/npc-simulator.js"), "utf8");
+
+describe("npc-simulator.js — world:npc-gather emit wiring", () => {
+  it("_emitGather follows the same globalThis._concordREALTIME?.io pattern as the existing _emitBark/_callForHelp helpers", () => {
+    const idx = src.indexOf("function _emitGather(");
+    assert.ok(idx > -1, "_emitGather should be defined");
+    const body = src.slice(idx, idx + 700);
+    assert.ok(body.includes("globalThis._concordREALTIME?.io"));
+    assert.ok(body.includes("emit('world:npc-gather'"));
+  });
+
+  it("broadcasts x/y/z/nodeType/nodeId/resourceId/amount — enough for the frontend to pick the right tool-swing and locate the node", () => {
+    const idx = src.indexOf("function _emitGather(");
+    const body = src.slice(idx, idx + 900);
+    for (const field of ["x", "y", "z", "nodeId", "nodeType", "resourceId", "resourceName", "amount"]) {
+      assert.ok(body.includes(`${field}:`), `emit payload should carry ${field}`);
+    }
+  });
+
+  it("uses the node's real position (gathered.x/y/z), not npc.location — a node can be up to 30m from the NPC", () => {
+    const idx = src.indexOf("function _emitGather(");
+    const body = src.slice(idx, idx + 900);
+    assert.ok(body.includes("gathered.x") || body.includes("x:            gathered.x"));
+    assert.ok(!body.includes("position:     npc.location"), "must not fall back to the old npc.location shape");
+  });
+
+  it("gather_resource calls _emitGather only when a real node was hit, not on the always-succeeds abstract fallback", () => {
+    const caseIdx = src.indexOf('case "gather_resource"');
+    assert.ok(caseIdx > -1);
+    const caseBody = src.slice(caseIdx, caseIdx + 1800);
+    assert.ok(caseBody.includes("if (gathered) _emitGather(this, this.worldId, gathered);"));
+  });
+});

--- a/server/tests/world-gathering-npc-node-fields.test.js
+++ b/server/tests/world-gathering-npc-node-fields.test.js
@@ -1,0 +1,77 @@
+// server/tests/world-gathering-npc-node-fields.test.js
+//
+// 2026-07-21 — npcGatherFromNode's return only ever carried
+// {resourceId, resourceName, amount, nodeId}; npc-simulator.js's
+// gather_resource action wrote this into the DB and threw the rest away —
+// no socket emit anywhere, so an NPC gathering was a completely silent
+// state change ("It's hard to [depict NPCs gathering] with no rendered
+// resource nodes or anything else"). This pins the extended return shape
+// (nodeType/x/y/z) that server/lib/npc-simulator.js's new _emitGather now
+// broadcasts as world:npc-gather.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+import { runMigrations } from "../migrate.js";
+import { npcGatherFromNode, getNearbyNodes } from "../lib/world-gathering.js";
+
+function seedNode(db, overrides = {}) {
+  const node = {
+    id: "node-test-1", world_id: "w1", node_type: "tree", resource_id: "wood",
+    resource_name: "Wood", biome: "forest", x: 100, y: 5, z: 200,
+    quantity_remaining: 100, max_quantity: 100,
+    ...overrides,
+  };
+  db.prepare(`
+    INSERT INTO world_resource_nodes (id, world_id, node_type, resource_id, resource_name, biome, x, y, z, quantity_remaining, max_quantity)
+    VALUES (@id, @world_id, @node_type, @resource_id, @resource_name, @biome, @x, @y, @z, @quantity_remaining, @max_quantity)
+  `).run(node);
+  return node;
+}
+
+describe("npcGatherFromNode — extended return shape for socket broadcast", () => {
+  let db;
+  beforeEach(async () => {
+    db = new Database(":memory:");
+    await runMigrations(db);
+  });
+  afterEach(() => { try { db.close(); } catch { /* noop */ } });
+
+  it("returns nodeType and the node's real x/y/z alongside the existing resourceId/amount/nodeId fields", () => {
+    const node = seedNode(db, { id: "node-a", x: 111, y: 7, z: 222, node_type: "tree" });
+    const result = npcGatherFromNode(db, "w1", node.x, node.z, 5, []);
+    assert.ok(result);
+    assert.equal(result.nodeId, "node-a");
+    assert.equal(result.nodeType, "tree");
+    assert.equal(result.x, 111);
+    assert.equal(result.y, 7);
+    assert.equal(result.z, 222);
+    // Pre-existing fields must still be present (additive change, not a rename).
+    assert.equal(result.resourceId, "wood");
+    assert.equal(result.resourceName, "Wood");
+    assert.ok(typeof result.amount === "number" && result.amount > 0);
+  });
+
+  it("nodeType reflects whichever node the NPC actually gathered from, not a fixed value", () => {
+    seedNode(db, { id: "node-b", x: 50, y: 0, z: 50, node_type: "ore_vein", resource_id: "iron-ore", resource_name: "Iron Ore" });
+    const result = npcGatherFromNode(db, "w1", 50, 50, 5, []);
+    assert.equal(result.nodeType, "ore_vein");
+    assert.equal(result.resourceId, "iron-ore");
+  });
+
+  it("returns null (not a broadcast-shaped object with nulls) when no node is nearby — caller correctly skips the emit", () => {
+    const result = npcGatherFromNode(db, "w1", 999, 999, 5, []);
+    assert.equal(result, null);
+  });
+
+  it("getNearbyNodes (the underlying lookup) still returns node_type/x/y/z verbatim — the source npcGatherFromNode's new fields come from", () => {
+    seedNode(db, { id: "node-c", x: 300, y: 12, z: 400, node_type: "crystal" });
+    const nearby = getNearbyNodes(db, "w1", 300, 400, 30);
+    const found = nearby.find((n) => n.id === "node-c");
+    assert.ok(found);
+    assert.equal(found.node_type, "crystal");
+    assert.equal(found.x, 300);
+    assert.equal(found.y, 12);
+    assert.equal(found.z, 400);
+  });
+});


### PR DESCRIPTION
Follow-on to #867 (merged) on the same branch. This batch is the "stop treating it as just a simulation" pass: every rendered character now gets real, per-character-unique detail, and the world has real tools/resource nodes to gather from instead of nothing to look at.

## Avatar quality + uniqueness
- Root-cause of the "toonish, low quality" look: `wantEnhanced` in `AvatarSystem3D.tsx` only granted the real procedural builder (hair-cards, skin-SSS, eye-parallax, real armor) to the local player/hero/legend-tier avatars — everyone else fell back to the flat-primitive skeleton. Made it unconditional: every avatar now gets the real builder.
- Wired `armor-system.ts` (previously built but unused) into both the procedural avatar builder and the real hero-GLB mesh registry, so every character — hero or procedural — wears armor. Armor silhouette/tier/colors are seeded per-character (`hash(worldId::factionId::id)`) so no two characters look the same, using the platform's existing deterministic-generation tech rather than randomness.
- Grounded cloth/metal/leather materials in real reference textures instead of flat colors.

## Resource nodes + gathering
- Resource nodes (trees, bushes) now render with real GLB assets (same fallback-chain pattern already proven for buildings/vegetation) and are click-to-gather via raycast, reusing the existing gather API.
- Civilians have a seeded chance of carrying a real gather tool (axe via the existing weapon-GLB pipeline; pickaxe/hoe/sickle as new procedural geometry, since no real asset exists for those yet).
- NPC gathering is now visible: previously an NPC's `gather_resource` action wrote only to the DB with zero signal reaching the world lens. Added a real socket emit (`world:npc-gather`, using the node's own position since a node can be up to 30m from the NPC) and wired it into the same tool-swing + dust-particle feedback the player's own click-to-gather already gets.

## Testing
- New test files: `character-schema-armor-uniqueness`, `enhanced-avatar-builder-armor`, `hero-mesh-armor-attach`, `world-lens-avatar-armor-wiring`, `resource-node-real-assets`, `world-lens-node-click-to-gather`, `gather-tools-carry`, `world-lens-npc-gather-visibility` (frontend) and `world-gathering-npc-node-fields`, `npc-simulator-gather-emit-wiring` (server) — all passing.
- A real concurrency bug was caught and fixed during this work: converting the resource-node renderer's `reconcile()` to async (for real-asset lookups) introduced a race between the construction-time auto-refresh and an explicit caller refresh, both passing a "not yet tracked" check before either wrote back — fixed with a chained-promise serialization guard, confirmed via headless-Chromium render (was 5 nodes → 10 duplicate objects, now 5 → 5).
- Full frontend suite: 738 files / 6317 tests passing. Full server suite: 33263 tests, 33237 passing / 17 failing / 4 cancelled — the specific files touched by this PR pass 100% in isolation (8/8 server, 10/10 frontend); the remaining failures are consistent with this repo's documented parallel-load flakiness (e.g. AllianceWorkspace timing tests) and the full-run log's failure detail wasn't retained (piped through `tail -40` from an earlier session), so they're flagged here rather than asserted clean.
- `tsc --noEmit` and `eslint` clean on all touched files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xp627drKGAWAXcXE42RtXA)_