### PR TITLE
Add 5 detectors for the "what other bugs could there even be" categories

### DIFF
--- a/server/lib/detectors/checker-self-coverage-detector.js
+++ b/server/lib/detectors/checker-self-coverage-detector.js
@@ -1,0 +1,127 @@
+// server/lib/detectors/checker-self-coverage-detector.js
+//
+// A meta-detector: it doesn't look for bugs in application code, it looks for
+// bugs in the THINGS THAT LOOK FOR BUGS. Seeded by two real, confirmed
+// instances found in one CI-debugging session (2026-07-31), neither of which
+// showed up as a "failing test" until someone tripped over their symptom:
+//   1. lib/ssrf-guard.js#fetchWithPinnedIp imported undici directly and
+//      called its fetch, bypassing globalThis.fetch entirely — silently
+//      defeating tests/preload/no-egress.mjs's test-isolation guard for
+//      every macro routed through it. No test asserted "no-egress actually
+//      blocks fetches reached via the SSRF-guarded path", so nothing caught
+//      it until ~40 unrelated tests started intermittently making real
+//      network calls.
+//   2. tests/invariants/emit-subscribe-pairing.test.js's own
+//      collectSubscribes() truncated its SocketEvent-union parse at the
+//      first semicolon — which happened to sit inside a `//` comment —
+//      silently dropping every union member declared after it and
+//      misreporting 27 real, subscribed events as dead.
+// Both are the same failure shape: a checker (a test-isolation guard, a
+// detection regex) with no test proving IT works, in either direction. This
+// detector doesn't re-derive whether any specific checker is currently
+// buggy — that's undecidable by cross-referencing test presence — it
+// verifies the CHEAPER, sufficient precondition: does a pinning test exist
+// at all. "No test imports this checker" is exactly the condition that let
+// both bugs above go unnoticed for as long as they did.
+//
+// Scope: every file in server/lib/detectors/*.js (excluding framework/
+// registry infrastructure) and every scripts/*.mjs file whose name matches
+// the audit/check/verify/grade gate-script convention already used across
+// this repo's own CI (scripts/audit-*.mjs, scripts/check-*.mjs,
+// scripts/verify-*.mjs, scripts/grade-*.mjs).
+
+import path from "node:path";
+import { readSafe, makeReport, makeError, relPath, walk } from "./_framework.js";
+
+const INFRA_DETECTOR_FILES = new Set(["_framework.js", "index.js", "baseline.js"]);
+const GATE_SCRIPT_RE = /^(audit|check|verify|grade)-.+\.mjs$/;
+
+export async function runCheckerSelfCoverageDetector({ root, opts = {} } = {}) {
+  const t0 = Date.now();
+  if (!root) return makeError("checker-self-coverage", "no_root", null, t0);
+  try {
+    // 1. Enumerate checkers.
+    const detectorDir = path.join(root, "server", "lib", "detectors");
+    const detectorFiles = (await walk(detectorDir, [".js"]))
+      .filter((f) => !INFRA_DETECTOR_FILES.has(path.basename(f)));
+
+    const scriptsDir = path.join(root, "scripts");
+    const scriptFiles = (await walk(scriptsDir, [".mjs"]))
+      .filter((f) => GATE_SCRIPT_RE.test(path.basename(f)));
+
+    // 2. Build a haystack of ALL test file contents (server/tests + repo-root
+    // tests + concord-frontend/tests, matching this repo's actual test tree
+    // shape) to substring-match checker basenames against.
+    const testDirs = [
+      path.join(root, "server", "tests"),
+      path.join(root, "tests"),
+      path.join(root, "concord-frontend", "tests"),
+    ];
+    let testBlob = "";
+    let testFileCount = 0;
+    for (const dir of testDirs) {
+      const files = await walk(dir, [".js", ".ts", ".tsx", ".mjs"]);
+      testFileCount += files.length;
+      for (const f of files) testBlob += "\n" + (await readSafe(f));
+    }
+
+    const findings = [];
+    let uncoveredDetectors = 0, uncoveredScripts = 0;
+
+    for (const f of detectorFiles) {
+      const base = path.basename(f, ".js");
+      const rel = relPath(root, f);
+      // A checker is "covered" if any test file's content references its
+      // basename (import path or the exported run-function pattern the
+      // registry uses: runXyzDetector).
+      const covered = testBlob.includes(`detectors/${base}`) || testBlob.includes(`detectors/${base}.js`);
+      if (!covered) {
+        uncoveredDetectors++;
+        findings.push({
+          id: "checker_no_pinning_test_detector",
+          severity: "medium",
+          kind: "static",
+          category: "quality",
+          subject: { kind: "file", path: rel },
+          message: `${rel} has no test anywhere in the tree importing it — a bidirectional bug in this detector (false positive OR false negative) has nothing to catch it`,
+          location: `${rel}:1`,
+          evidence: { detector: base },
+          fixHint: "add_bidirectional_pinning_test_for_detector",
+        });
+      }
+    }
+
+    for (const f of scriptFiles) {
+      const base = path.basename(f, ".mjs");
+      const rel = relPath(root, f);
+      const covered = testBlob.includes(base);
+      if (!covered) {
+        uncoveredScripts++;
+        findings.push({
+          id: "checker_no_pinning_test_script",
+          severity: "medium",
+          kind: "static",
+          category: "quality",
+          subject: { kind: "file", path: rel },
+          message: `${rel} (a gate/audit script) has no test anywhere in the tree referencing it — its own correctness is unverified`,
+          location: `${rel}:1`,
+          evidence: { script: base },
+          fixHint: "add_pinning_test_invoking_this_gate_script",
+        });
+      }
+    }
+
+    findings.unshift({
+      id: "checker_self_coverage_summary",
+      severity: "info",
+      kind: "static",
+      category: "quality",
+      message: `${detectorFiles.length} detector(s) + ${scriptFiles.length} gate script(s) checked against ${testFileCount} test file(s): ${uncoveredDetectors} detector(s) and ${uncoveredScripts} script(s) have no referencing test`,
+      evidence: { detectorFiles: detectorFiles.length, scriptFiles: scriptFiles.length, testFileCount, uncoveredDetectors, uncoveredScripts },
+    });
+
+    return makeReport("checker-self-coverage", findings, t0);
+  } catch (err) {
+    return makeError("checker-self-coverage", "exception", err, t0);
+  }
+}

--- a/server/lib/detectors/doc-claim-resolution-detector.js
+++ b/server/lib/detectors/doc-claim-resolution-detector.js
@@ -54,23 +54,52 @@ const PLACEHOLDER_RE = /path\/to\/|yourname|\.\.\.\//;
 // githubusercontent.com alone (no trailing path) is already a strong enough
 // external-source signal on its own; github.com specifically still requires
 // a path so a bare mention of "github.com" in passing doesn't over-trigger.
-// Host-anchored (CodeQL flagged the prior version — "may match anywhere,
-// arbitrary hosts may come before or after it"): a negative lookbehind for
-// `[\w-]` (NOT `.`) immediately before "github" stops a substring match
-// inside a LOOKALIKE host label like "notgithub.com/x" or
-// "evilgithubusercontent.com" (glued directly onto the real label, no
-// separator) from being read as the real github.com/githubusercontent.com
-// host, while still allowing a genuine dot-separated subdomain like
-// "raw.githubusercontent.com" (real GitHub CDN host, and a fixture this
-// detector must keep recognizing — see the doc-claim-resolution test).
-// This scanner never makes a network request or an authz decision off this
-// regex (it only classifies doc prose), but the anchor is the correct fix
-// regardless of blast radius.
-const EXTERNAL_GITHUB_URL_RE = /(?<![\w-])githubusercontent\.com\b|(?<![\w-])github\.com\/(?!concorddev\/)[\w-]+(?:\/[\w.-]+)?/i;
+// CodeQL kept flagging every lookbehind-tuned version of a regex that
+// substring-matches "github.com"/"githubusercontent.com" inside arbitrary
+// text (js/incomplete-url-substring-sanitization-family rule — "may match
+// anywhere, arbitrary hosts may come before or after it"), because no
+// amount of negative-lookbehind tuning changes the SHAPE the checker
+// pattern-matches on: a host name matched as a substring of an unbounded
+// string, with no `^`/`$` anchor at all. The actual, durable fix isn't a
+// smarter regex — it's not using a substring-scanning host regex in the
+// first place. This tokenizes the line into url/word-like chunks first,
+// then does an EXACT string comparison (`===`/`endsWith`) against the
+// isolated token's host portion. Exact comparison can't be spoofed by a
+// lookalike host no matter how it's glued together, and there is no
+// unanchored regex left for CodeQL's rule to match against.
+const TOKEN_RE = /[^\s`()<>[\]"']+/g;
 const EXTERNAL_OWNER_REPO_NEAR_GITHUB_RE = /\bGitHub\b[\s\S]{0,80}?\b(?!concorddev\/)([\w-]+)\/([\w.-]+)\b|\b([\w-]+)\/([\w.-]+)\b[\s\S]{0,80}?\bGitHub\b/i;
 
+/**
+ * True if `tok` is a github.com/githubusercontent.com reference to a
+ * DIFFERENT project than this repo's own org (ConcordDev). Splits the
+ * token into host + path manually and compares the host EXACTLY (`===` or
+ * `.endsWith(".host")` for a real subdomain) — never a regex match against
+ * the raw token. githubusercontent.com alone (no path) is already a strong
+ * enough external-source signal on its own; github.com specifically still
+ * requires a path so a bare mention of "github.com" in passing doesn't
+ * over-trigger.
+ */
+function isExternalGithubToken(tok) {
+  const rest = tok.replace(/^https?:\/\//i, "");
+  const slashIdx = rest.search(/[/?#]/);
+  const host = (slashIdx === -1 ? rest : rest.slice(0, slashIdx)).toLowerCase();
+  const pathPart = slashIdx === -1 ? "" : rest.slice(slashIdx + 1);
+  if (host === "githubusercontent.com" || host.endsWith(".githubusercontent.com")) return true;
+  if (host === "github.com" || host.endsWith(".github.com")) {
+    if (!pathPart) return false; // bare host mention, no path — not a strong signal
+    const owner = pathPart.split("/")[0].toLowerCase();
+    return owner !== "concorddev" && owner !== "";
+  }
+  return false;
+}
+
 function citesExternalRepo(line) {
-  if (EXTERNAL_GITHUB_URL_RE.test(line)) return true;
+  TOKEN_RE.lastIndex = 0;
+  let tm;
+  while ((tm = TOKEN_RE.exec(line)) != null) {
+    if (isExternalGithubToken(tm[0])) return true;
+  }
   const m = EXTERNAL_OWNER_REPO_NEAR_GITHUB_RE.exec(line);
   if (!m) return false;
   const owner = (m[1] || m[3] || "").toLowerCase();

--- a/server/lib/detectors/doc-claim-resolution-detector.js
+++ b/server/lib/detectors/doc-claim-resolution-detector.js
@@ -54,7 +54,19 @@ const PLACEHOLDER_RE = /path\/to\/|yourname|\.\.\.\//;
 // githubusercontent.com alone (no trailing path) is already a strong enough
 // external-source signal on its own; github.com specifically still requires
 // a path so a bare mention of "github.com" in passing doesn't over-trigger.
-const EXTERNAL_GITHUB_URL_RE = /githubusercontent\.com\b|github\.com\/(?!concorddev\/)[\w-]+(?:\/[\w.-]+)?/i;
+// Host-anchored (CodeQL flagged the prior version — "may match anywhere,
+// arbitrary hosts may come before or after it"): a negative lookbehind for
+// `[\w-]` (NOT `.`) immediately before "github" stops a substring match
+// inside a LOOKALIKE host label like "notgithub.com/x" or
+// "evilgithubusercontent.com" (glued directly onto the real label, no
+// separator) from being read as the real github.com/githubusercontent.com
+// host, while still allowing a genuine dot-separated subdomain like
+// "raw.githubusercontent.com" (real GitHub CDN host, and a fixture this
+// detector must keep recognizing — see the doc-claim-resolution test).
+// This scanner never makes a network request or an authz decision off this
+// regex (it only classifies doc prose), but the anchor is the correct fix
+// regardless of blast radius.
+const EXTERNAL_GITHUB_URL_RE = /(?<![\w-])githubusercontent\.com\b|(?<![\w-])github\.com\/(?!concorddev\/)[\w-]+(?:\/[\w.-]+)?/i;
 const EXTERNAL_OWNER_REPO_NEAR_GITHUB_RE = /\bGitHub\b[\s\S]{0,80}?\b(?!concorddev\/)([\w-]+)\/([\w.-]+)\b|\b([\w-]+)\/([\w.-]+)\b[\s\S]{0,80}?\bGitHub\b/i;
 
 function citesExternalRepo(line) {

--- a/server/lib/detectors/doc-claim-resolution-detector.js
+++ b/server/lib/detectors/doc-claim-resolution-detector.js
@@ -1,0 +1,160 @@
+// server/lib/detectors/doc-claim-resolution-detector.js
+//
+// Seeded by a real instance found this session: a plan doc described
+// "server/lib/external-fetch.js has NO SSRF guard" as the largest remaining
+// security item — and the file had, in fact, already been fixed (guarded via
+// fetchPublicUrl, dated 2026-07-27), which only came to light by directly
+// reading the source instead of trusting the doc. CLAUDE.md's own "Docs are a
+// build artifact, not prose" section already gates NUMBER claims with
+// reproduction commands (scripts/check-doc-claims-all.mjs) and TEST-LINK
+// claims (scripts/verify-invariant-test-links.mjs). Neither covers the third
+// shape: a prose claim that something is fixed/closed/resolved/shipped,
+// naming a specific file (optionally `#functionName` or `:lineNumber`). That
+// claim can drift exactly like a number can — the file gets renamed, the
+// function gets removed in a later refactor, or (the sharper failure mode)
+// the fix described was reverted and the doc never caught up.
+//
+// This detector does NOT verify the SEMANTIC claim (whether the fix is still
+// correct) — that's undecidable statically. It verifies the CHEAPER, honest
+// precondition: does the referenced file still exist, and if a function name
+// was named, does that identifier still appear in the file at all. A claim
+// that fails even this weak check is definitely stale; a claim that passes
+// it might still be substantively wrong, which is why findings here are
+// "verify this claim", not "this claim is false".
+
+import path from "node:path";
+import { readSafe, makeReport, makeError, walk } from "./_framework.js";
+
+const FIXED_KEYWORDS = /\b(fixed|closed|resolved|patched|shipped)\b/i;
+// Backticked `path/to/file.ext` or `path/to/file.ext:123` or
+// `path/to/file.ext#functionName` — requires a slash so bare identifiers
+// (`isSafePathSegment`) and prose (`config`) don't false-positive.
+const FILE_REF_RE = /`([\w./-]+\/[\w.-]+\.(?:js|ts|tsx|jsx|mjs|py))(?:[:#]([A-Za-z_][\w]*))?`/g;
+const PLACEHOLDER_RE = /path\/to\/|yourname|\.\.\.\//;
+
+// A line that cites another project's GitHub repo (e.g. verifying a macro's
+// field names against "github.com/freelawproject/courtlistener" because the
+// real API was network-blocked) is citing THAT repo's own source file, not
+// claiming a path in OUR tree — the "fixed/closed" keyword on the line
+// describes the Concord macro, not the cited external file. This repo's own
+// GitHub org (ConcordDev) is excluded from the "external" set so a citation
+// of Concord's own repo URL still counts normally. Confirmed real instance:
+// docs/lens-specs/law-capability-map.md citing CourtListener's
+// `cl/search/forms.py` — without this guard it false-positives as stale
+// every run, and a blunter "ref must start with a real top-level dir" filter
+// would also have swallowed genuine findings like a bare `register/page.tsx`
+// shorthand reference that really has gone stale.
+// Three idioms actually observed in this repo's own docs for citing an
+// external project's source (all found running this detector for real, on
+// docs/{FRONTEND_REBUILD_PROGRAM,WAVE4_INVENTORY}.md + lens-specs/law-
+// capability-map.md — each a DIFFERENT phrasing of the same CourtListener
+// citation): a full github.com/owner/repo URL, a raw.githubusercontent.com
+// fetch, and a bare "owner/repo" shorthand token sitting near the word
+// "GitHub" with no URL at all. All three exclude this project's own org.
+// githubusercontent.com alone (no trailing path) is already a strong enough
+// external-source signal on its own; github.com specifically still requires
+// a path so a bare mention of "github.com" in passing doesn't over-trigger.
+const EXTERNAL_GITHUB_URL_RE = /githubusercontent\.com\b|github\.com\/(?!concorddev\/)[\w-]+(?:\/[\w.-]+)?/i;
+const EXTERNAL_OWNER_REPO_NEAR_GITHUB_RE = /\bGitHub\b[\s\S]{0,80}?\b(?!concorddev\/)([\w-]+)\/([\w.-]+)\b|\b([\w-]+)\/([\w.-]+)\b[\s\S]{0,80}?\bGitHub\b/i;
+
+function citesExternalRepo(line) {
+  if (EXTERNAL_GITHUB_URL_RE.test(line)) return true;
+  const m = EXTERNAL_OWNER_REPO_NEAR_GITHUB_RE.exec(line);
+  if (!m) return false;
+  const owner = (m[1] || m[3] || "").toLowerCase();
+  return owner !== "concorddev" && owner !== "";
+}
+
+const BASES = ["server", "concord-frontend", "."];
+
+async function resolveFile(root, ref) {
+  for (const base of BASES) {
+    const p = path.join(root, base, ref);
+    const c = await readSafe(p);
+    if (c) return { path: p, content: c };
+    // Also try the ref as already-rooted (e.g. "server/lib/x.js").
+    const p2 = path.join(root, ref);
+    const c2 = await readSafe(p2);
+    if (c2) return { path: p2, content: c2 };
+  }
+  return null;
+}
+
+export async function runDocClaimResolutionDetector({ root, opts = {} } = {}) {
+  const t0 = Date.now();
+  if (!root) return makeError("doc-claim-resolution", "no_root", null, t0);
+  try {
+    const docFiles = [path.join(root, "CLAUDE.md")];
+    const docsDir = path.join(root, "docs");
+    for (const f of await walk(docsDir, [".md"])) docFiles.push(f);
+
+    const findings = [];
+    let claimsChecked = 0, staleClaims = 0;
+
+    for (const docFile of docFiles) {
+      const content = await readSafe(docFile);
+      if (!content) continue;
+      const lines = content.split("\n");
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (!FIXED_KEYWORDS.test(line)) continue;
+        if (citesExternalRepo(line)) continue; // citing another project's own source, not ours
+
+        FILE_REF_RE.lastIndex = 0;
+        let m;
+        while ((m = FILE_REF_RE.exec(line)) != null) {
+          const ref = m[1];
+          const symbol = m[2] && /^\d+$/.test(m[2]) ? null : m[2]; // a pure digit is a line number, not a symbol
+          if (PLACEHOLDER_RE.test(ref)) continue;
+          claimsChecked++;
+
+          const resolved = await resolveFile(root, ref);
+          const docRel = path.relative(root, docFile);
+          if (!resolved) {
+            staleClaims++;
+            findings.push({
+              id: "doc_claim_file_not_found",
+              severity: "medium",
+              kind: "static",
+              category: "docs",
+              subject: { kind: "doc", path: docRel, line: i + 1 },
+              message: `${docRel}:${i + 1} claims something is fixed/closed, referencing "${ref}", but that file no longer exists — verify the claim is still true and update or remove the stale reference`,
+              location: `${docRel}:${i + 1}`,
+              evidence: { ref, docFile: docRel },
+              fixHint: "verify_and_update_stale_doc_claim",
+            });
+            continue;
+          }
+          if (symbol && !new RegExp(`\\b${symbol.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`).test(resolved.content)) {
+            staleClaims++;
+            findings.push({
+              id: "doc_claim_symbol_not_found",
+              severity: "medium",
+              kind: "static",
+              category: "docs",
+              subject: { kind: "doc", path: docRel, line: i + 1 },
+              message: `${docRel}:${i + 1} claims something is fixed/closed at "${ref}#${symbol}", but "${symbol}" no longer appears in that file — verify the claim is still true`,
+              location: `${docRel}:${i + 1}`,
+              evidence: { ref, symbol, docFile: docRel },
+              fixHint: "verify_and_update_stale_doc_claim",
+            });
+          }
+        }
+      }
+    }
+
+    findings.unshift({
+      id: "doc_claim_resolution_summary",
+      severity: "info",
+      kind: "static",
+      category: "docs",
+      message: `Checked ${claimsChecked} "fixed/closed"-adjacent file reference(s) across ${docFiles.length} doc file(s); ${staleClaims} no longer resolve`,
+      evidence: { docFiles: docFiles.length, claimsChecked, staleClaims },
+    });
+
+    return makeReport("doc-claim-resolution", findings, t0);
+  } catch (err) {
+    return makeError("doc-claim-resolution", "exception", err, t0);
+  }
+}

--- a/server/lib/detectors/index.js
+++ b/server/lib/detectors/index.js
@@ -67,6 +67,11 @@ import { runHardcodedLiteralDataPropDetector } from "./hardcoded-literal-data-pr
 import { runDomainReachabilityDetector } from "./domain-reachability-detector.js";
 import { runLensManifestCapabilityDetector } from "./lens-manifest-capability-detector.js";
 import { runConstantTimeDetector } from "./constant-time-detector.js";
+import { runPublicReadWriteVerbDetector } from "./public-read-write-verb-detector.js";
+import { runWorldShardWriteBoundaryDetector } from "./world-shard-write-boundary-detector.js";
+import { runInternalActorStampDetector } from "./internal-actor-stamp-detector.js";
+import { runCheckerSelfCoverageDetector } from "./checker-self-coverage-detector.js";
+import { runDocClaimResolutionDetector } from "./doc-claim-resolution-detector.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -696,6 +701,64 @@ registerDetector({
   dataNeeds: ["fs"],
   description: "AST-based: flags secret-dependent branches, secret-dependent array/object indexing, and secret-dependent loop bounds/early-exits (the classic non-constant-time-compare pattern) across server/ — the timing-side-channel precondition, not a hardware-level proof.",
   run: runConstantTimeDetector,
+});
+
+// ── "What other bugs could there even be" wave (2026-07-31) ────────────────
+// Five detectors for the five specific bug categories identified while
+// debugging PR #875's CI: (1) an auth surface trusted to self-police that
+// might not, matching the exact shape of the SEC-3 RBAC bug; (2) a
+// production write happening from the wrong process boundary, a class
+// invisible in every normal test run because CONCORD_SHARD_WORLDS defaults
+// off; (3) the exact `{ ...actor, internal: true }` shape that let
+// jobs.enqueue grant privileges it shouldn't have (fixed 2026-07-27; this is
+// the permanent regression guard for the pattern, not a re-check of that one
+// site); (4) a meta-detector for checkers with no test proving they work in
+// either direction — seeded by two real instances found this same session
+// (the ssrf-guard/no-egress bypass, the emit-subscribe-pairing regex bug);
+// (5) a doc claiming something is fixed/closed while referencing a file or
+// symbol that no longer resolves, seeded by a stale external-fetch.js claim
+// found this session. Security-relevant but NOT tagged consumer:"security"
+// pending a measured false-positive pass on the real tree, same promotion
+// discipline documented above for secret-leak/constant-time.
+registerDetector({
+  id: "public-read-write-verb",
+  label: "PublicReadWriteVerbDetector",
+  consumers: ["code-quality", "repair-cortex"],
+  dataNeeds: ["fs"],
+  description: "A write-shaped macro name (create/update/delete/transfer/...) sitting in publicReadDomains (Gate 2, anonymous-callable) whose handler shows no ownership-check idiom.",
+  run: runPublicReadWriteVerbDetector,
+});
+registerDetector({
+  id: "world-shard-write-boundary",
+  label: "WorldShardWriteBoundaryDetector",
+  consumers: ["code-quality", "repair-cortex"],
+  dataNeeds: ["fs"],
+  description: "A route or scope:'global' heartbeat writing directly to a PER_WORLD_WRITE_TABLES table — invisible with CONCORD_SHARD_WORLDS off, a real race once sharding is enabled.",
+  run: runWorldShardWriteBoundaryDetector,
+});
+registerDetector({
+  id: "internal-actor-stamp",
+  label: "InternalActorStampDetector",
+  consumers: ["code-quality", "repair-cortex", "security"],
+  dataNeeds: ["fs"],
+  description: "`{ ...var, internal: true }` or `x.internal = true` on a non-literal target — the jobs.enqueue privilege-escalation shape (fixed 2026-07-27; permanent regression guard).",
+  run: runInternalActorStampDetector,
+});
+registerDetector({
+  id: "checker-self-coverage",
+  label: "CheckerSelfCoverageDetector",
+  consumers: ["code-quality", "repair-cortex"],
+  dataNeeds: ["fs"],
+  description: "A detector or gate script with no test anywhere referencing it — nothing proves it's correct in either direction (false-positive or false-negative).",
+  run: runCheckerSelfCoverageDetector,
+});
+registerDetector({
+  id: "doc-claim-resolution",
+  label: "DocClaimResolutionDetector",
+  consumers: ["code-quality", "repair-cortex"],
+  dataNeeds: ["fs"],
+  description: "A 'fixed/closed/resolved' doc claim naming a specific file or symbol that no longer exists in the tree.",
+  run: runDocClaimResolutionDetector,
 });
 
 // Shared across modules so repair-cortex / Concordia / HUD see the same

--- a/server/lib/detectors/internal-actor-stamp-detector.js
+++ b/server/lib/detectors/internal-actor-stamp-detector.js
@@ -1,0 +1,168 @@
+// server/lib/detectors/internal-actor-stamp-detector.js
+//
+// Seeded by a real, confirmed vulnerability (SECURITY audit 2026-07-27,
+// server.js#runJob): `jobs.enqueue` is a user-reachable macro that accepts an
+// arbitrary domain.name job kind. The job runner used to build the execution
+// ctx by spreading the job's caller-supplied actor and then unconditionally
+// stamping `internal: true` on top — `{ ...j.actor, internal: true }` — which
+// let any authenticated user route ANY macro through the job queue to pick up
+// internal-context privileges (council-gate skip, HTTP-layer-gate bypass)
+// they would never have calling the macro directly. Fixed by gating the
+// internal stamp behind an explicit isSystemJob check.
+//
+// The FIX for that one call site is real and confirmed in the current tree.
+// This detector is the permanent regression guard for the SHAPE of the bug,
+// not a re-check of that one site: `{ ...IDENTIFIER, internal: true }` (or the
+// equivalent `.internal = true` assignment on an object built from a
+// non-literal source) is exactly the pattern that turns "internal" from a
+// hardcoded system-context marker into something a caller-influenced value
+// can carry along for the ride. A hardcoded actor literal
+// (`{ userId: "system", role: "owner", internal: true }`) is the legitimate,
+// safe shape — it can't be influenced by any request. Spreading a variable
+// into the same object is the risky shape, because nothing in a static scan
+// can prove the spread source is genuinely trustworthy at that point — that
+// requires the kind of manual trace this bug needed. Every instance is
+// therefore a required-review finding, allowlisted individually once
+// verified guarded (same posture as authz-coverage's bypass-path pinning).
+
+import path from "node:path";
+import { readSafe, makeReport, makeError, relPath, lineOf, walk } from "./_framework.js";
+
+// `{ ...ident, internal: true }` / `{...ident,internal:true}` — spread-then-stamp.
+const SPREAD_STAMP_RE = /\{\s*\.\.\.([A-Za-z_$][\w$.?]*)\s*,\s*internal\s*:\s*true/g;
+// `target.internal = true` where target isn't obviously a hardcoded local
+// built entirely from a literal on the same statement (heuristic: flag all,
+// then exempt via ALLOWLIST — same "surface everything, allowlist reviewed"
+// posture as the rest of the suite rather than trying to prove safety here).
+const ASSIGN_STAMP_RE = /\b([A-Za-z_$][\w$.]*)\s*\.\s*internal\s*=\s*true\b/g;
+
+// Reviewed, confirmed-guarded instances. Each entry names the exact site
+// (file substring + nearby text) so a moved/renamed guard re-surfaces as a
+// finding rather than silently staying allowlisted after the code around it
+// changed shape.
+const ALLOWLIST = [
+  {
+    file: "server.js",
+    nearText: "isSystemJob",
+    reason:
+      "runJob() gates this stamp behind an explicit isSystemJob check (job.actor.internal===true or role in {system,owner,founder}); a user-enqueued job takes the OTHER branch and gets ctx.internal=false + actor.internal=false. Fixed + reviewed 2026-07-27.",
+  },
+];
+
+function isAllowlisted(rel, content, matchIndex) {
+  const windowStart = Math.max(0, matchIndex - 800);
+  const window = content.slice(windowStart, matchIndex);
+  return ALLOWLIST.some((a) => rel.endsWith(a.file) && window.includes(a.nearText));
+}
+
+/**
+ * Strip `//` line comments and `/* *\/` block comments, replacing removed
+ * characters with spaces (never newlines) so every match index / line number
+ * computed against the result still lines up with the ORIGINAL source.
+ * Load-bearing for this detector specifically: its own source file explains
+ * the bug shape it looks for by quoting the exact risky pattern in prose
+ * (`{ ...j.actor, internal: true }`, `x.internal = true`) — without this,
+ * the detector matches its own documentation and flags itself. Same
+ * self-inflicted-false-positive class CLAUDE.md documents for the UX-polish
+ * grader's generic-scaffold detector, fixed here the same way rather than
+ * softening the pattern.
+ */
+export function stripComments(src) {
+  let out = "";
+  let i = 0;
+  const n = src.length;
+  while (i < n) {
+    if (src[i] === "/" && src[i + 1] === "/") {
+      while (i < n && src[i] !== "\n") { out += " "; i++; }
+      continue;
+    }
+    if (src[i] === "/" && src[i + 1] === "*") {
+      out += "  "; i += 2;
+      while (i < n && !(src[i] === "*" && src[i + 1] === "/")) {
+        out += src[i] === "\n" ? "\n" : " ";
+        i++;
+      }
+      if (i < n) { out += "  "; i += 2; }
+      continue;
+    }
+    out += src[i]; i++;
+  }
+  return out;
+}
+
+export async function runInternalActorStampDetector({ root, opts = {} } = {}) {
+  const t0 = Date.now();
+  if (!root) return makeError("internal-actor-stamp", "no_root", null, t0);
+  try {
+    const files = [
+      path.join(root, "server", "server.js"),
+      ...(await walk(path.join(root, "server", "domains"), [".js"])),
+      ...(await walk(path.join(root, "server", "routes"), [".js"])),
+      ...(await walk(path.join(root, "server", "lib"), [".js"])),
+    ];
+
+    const findings = [];
+    let scanned = 0, flagged = 0, exempted = 0;
+    for (const f of files) {
+      const content = await readSafe(f);
+      if (!content) continue;
+      scanned++;
+      const rel = relPath(root, f);
+      // Match against a comment-stripped view — see stripComments' doc
+      // comment for why this is load-bearing, not cosmetic, for this
+      // specific detector. Positions/line numbers stay valid against
+      // `content` because stripComments preserves length and newlines.
+      const scan = stripComments(content);
+
+      SPREAD_STAMP_RE.lastIndex = 0;
+      let m;
+      while ((m = SPREAD_STAMP_RE.exec(scan)) != null) {
+        const lineNo = lineOf(content, m.index);
+        if (isAllowlisted(rel, content, m.index)) { exempted++; continue; }
+        flagged++;
+        findings.push({
+          id: "internal_actor_stamp_spread",
+          severity: "high",
+          kind: "static",
+          category: "security",
+          subject: { kind: "file", path: rel, line: lineNo },
+          message: `${rel}:${lineNo} builds an actor/ctx via "{ ...${m[1]}, internal: true }" — spreading a non-literal source while stamping internal:true is the exact shape that let jobs.enqueue grant internal-context privileges to user-triggered calls (SEC audit 2026-07-27). Verify the spread source cannot be caller-influenced at this point, then allowlist with a reason.`,
+          location: `${rel}:${lineNo}`,
+          evidence: { spreadSource: m[1] },
+          fixHint: "verify_spread_source_is_system_only_or_gate_before_stamping",
+        });
+      }
+
+      ASSIGN_STAMP_RE.lastIndex = 0;
+      while ((m = ASSIGN_STAMP_RE.exec(scan)) != null) {
+        const lineNo = lineOf(content, m.index);
+        if (isAllowlisted(rel, content, m.index)) { exempted++; continue; }
+        flagged++;
+        findings.push({
+          id: "internal_actor_stamp_assign",
+          severity: "medium",
+          kind: "static",
+          category: "security",
+          subject: { kind: "file", path: rel, line: lineNo },
+          message: `${rel}:${lineNo} sets "${m[1]}.internal = true" — verify this target was constructed from a trusted, non-caller-influenced source before this point.`,
+          location: `${rel}:${lineNo}`,
+          evidence: { target: m[1] },
+          fixHint: "verify_target_is_system_only_or_gate_before_stamping",
+        });
+      }
+    }
+
+    findings.unshift({
+      id: "internal_actor_stamp_summary",
+      severity: "info",
+      kind: "static",
+      category: "security",
+      message: `Scanned ${scanned} file(s) for internal:true stamps built from a non-literal source; ${flagged} require review, ${exempted} already reviewed+allowlisted`,
+      evidence: { scanned, flagged, exempted },
+    });
+
+    return makeReport("internal-actor-stamp", findings, t0);
+  } catch (err) {
+    return makeError("internal-actor-stamp", "exception", err, t0);
+  }
+}

--- a/server/lib/detectors/internal-actor-stamp-detector.js
+++ b/server/lib/detectors/internal-actor-stamp-detector.js
@@ -47,6 +47,12 @@ const ALLOWLIST = [
     reason:
       "runJob() gates this stamp behind an explicit isSystemJob check (job.actor.internal===true or role in {system,owner,founder}); a user-enqueued job takes the OTHER branch and gets ctx.internal=false + actor.internal=false. Fixed + reviewed 2026-07-27.",
   },
+  {
+    file: "server.js",
+    nearText: "function makeInternalCtx(source",
+    reason:
+      "This IS the canonical, single, trusted factory that mints an internal ctx (`makeInternalCtx`) — not a caller-influenced spread/assign. It unconditionally marks the context as internal regardless of its `source` parameter; `source` only ever becomes the actor's userId (an attribution string), never the internal-flag's value, so a caller cannot toggle whether internal status is granted by calling this function. The real question for this pattern is REACHABILITY — which code paths call makeInternalCtx(), not what its own definition does — and that's a call-site-by-call-site review question this static detector can't answer generically (the same reason the jobs.enqueue bug was a reachability bug, not a value-control bug). Reviewed 2026-07-31 (public-read-write-verb-detector pass).",
+  },
 ];
 
 function isAllowlisted(rel, content, matchIndex) {
@@ -94,11 +100,21 @@ export async function runInternalActorStampDetector({ root, opts = {} } = {}) {
   const t0 = Date.now();
   if (!root) return makeError("internal-actor-stamp", "no_root", null, t0);
   try {
+    // server/lib/detectors/*.js is excluded: this whole suite is static
+    // analysis code that never constructs a privileged runtime ctx, and its
+    // own ALLOWLIST entries necessarily quote the risky pattern in prose
+    // (a `reason:` STRING, which stripComments() correctly does not touch —
+    // stripping string content would be wrong in general). This detector
+    // self-matched its own allowlist reason text twice this session before
+    // this exclusion was added; excluding the directory is the durable fix,
+    // not just careful wording (which the next added ALLOWLIST entry could
+    // just as easily reintroduce).
+    const detectorsDir = path.join(root, "server", "lib", "detectors") + path.sep;
     const files = [
       path.join(root, "server", "server.js"),
       ...(await walk(path.join(root, "server", "domains"), [".js"])),
       ...(await walk(path.join(root, "server", "routes"), [".js"])),
-      ...(await walk(path.join(root, "server", "lib"), [".js"])),
+      ...(await walk(path.join(root, "server", "lib"), [".js"])).filter((f) => !f.startsWith(detectorsDir)),
     ];
 
     const findings = [];

--- a/server/lib/detectors/public-read-write-verb-detector.js
+++ b/server/lib/detectors/public-read-write-verb-detector.js
@@ -12,19 +12,59 @@
 // same class can hide here: a write-shaped macro name (create/update/delete/
 // transfer/...) sitting in the PUBLIC READ allowlist, whose handler either
 // can't be found or shows no sign of checking the caller's identity before
-// mutating. A live instance already exists in the tree at the time this
-// detector was written: `dtu: new Set([..., "create", "update", "delete",
-// "bulkCreate", ...])` — flagged here for human review, not silently fixed,
-// since the handler may in fact self-scope correctly and this detector can
-// only prove "no ownership idiom found", never "definitely unsafe".
+// mutating.
 //
 // This detector does NOT replace a real security review of each flagged
 // macro. It converts "nobody has looked" into "here is the exact list to
 // look at" — the same posture as authz-coverage-detector's bypass-allowlist
 // pinning.
+//
+// Two real bugs were found and fixed in THIS detector by running it against
+// the live tree (not just synthetic fixtures) and reading what it flagged:
+//
+// 1. Every finding shared the exact same `location` string (the fixed line
+//    where `const publicReadDomains = {` starts), regardless of which
+//    domain/macro it was about. The ratchet's fingerprint is
+//    sha256(detector|ruleId|location|severity) — with `location` constant,
+//    ALL "no_ownership_idiom" findings collapsed onto ONE fingerprint (and
+//    all "handler_not_found" findings onto another), so out of 36 real
+//    findings only 2 survived into the baseline/ratchet bookkeeping. Once
+//    one of the two got baselined, every future distinct occurrence of that
+//    ruleId — a genuinely different, unreviewed macro — would have silently
+//    read as "already known" forever. Fixed: location is now the resolved
+//    handler's real file:line when found, and a `domain.macro`-qualified
+//    fallback when not (see `locationFor`).
+//
+// 2. OWNERSHIP_IDIOM_RE required a literal `ctx.actor` (no `?` between `ctx`
+//    and `.actor`), but this codebase's dominant idiom is `ctx?.actor?.userId`
+//    (optional-chaining right after `ctx` too). This produced 9 false
+//    positives out of 12 "no_ownership_idiom" findings — including
+//    `dtu.update`, whose handler turned out to have a careful, correct
+//    ownership check the regex simply couldn't see. Fixed by allowing `?`
+//    after `ctx` as well as after `.actor`.
+//
+// After both fixes, manual review of the 3 real remaining
+// "no_ownership_idiom" findings confirmed: `agent.create` and
+// `scope.promote` were genuine anonymous-write gaps (fixed in server.js,
+// same commit as this detector fix); `collab.join` is intentional by
+// design (a session-link-based Live-Share-style join — the neighboring
+// `_collabActorId` comment in server.js documents that edit/merge already
+// require prior participation, and join is necessarily the entry point
+// that can't require it) — allowlisted below with that citation.
+//
+// `handler_not_found` findings turned out to be dominated by a different,
+// non-adversarial pattern: many publicReadDomains entries name a generic
+// CRUD verb (create/update/delete) that was never the real macro name for
+// that domain (e.g. `goals` uses propose/approve/activate/complete/abandon,
+// never bare "create"; `creative` uses "create_work", not "create"). A
+// macro that doesn't exist can't be called via `/api/lens/run` at all — the
+// dispatcher returns macro_not_found — so this is real, confirmed doc/config
+// drift (misleading, worth cleaning up) rather than a live anonymous-write
+// path. Downgraded from "high" to "medium" to reflect that it is inert, not
+// exploitable, while still being worth surfacing and fixing.
 
 import path from "node:path";
-import { readSafe, makeReport, makeError, relPath, lineOf } from "./_framework.js";
+import { readSafe, makeReport, makeError, relPath, lineOf, walk } from "./_framework.js";
 
 // Verb-prefix heuristic for "this macro name implies a mutation" — mirrors
 // scripts/audit-wiring-gate.mjs's SYSTEM_VERB list plus the domain-economy
@@ -38,8 +78,32 @@ const WRITE_VERB_RE = /^(create|update|delete|remove|destroy|transfer|tip|follow
 const SELF_SCOPING_NAME_RE = /mine\b|_own\b|^my/i;
 
 // Ownership-check idioms this codebase actually uses in handler bodies.
+// `ctx\??\.actor\??\.` (not `ctx\.actor\??\.`) — this codebase's dominant
+// idiom is optional-chaining right after `ctx` too (`ctx?.actor?.userId`,
+// confirmed in server/domains/land-claims.js, routes/worlds.js, and the
+// dtu.update handler itself), which the tighter pattern missed entirely —
+// a real false-negative source found by manually reading a flagged
+// handler (dtu.update) that turned out to have a careful, correct
+// ownership check my regex simply couldn't see.
 const OWNERSHIP_IDIOM_RE =
-  /ctx\.actor\??\.userId|ctx\.userId|ctx\.actor\??\.id\b|aidCk\s*\(|req\.user\??\.id|reason:\s*['"]no_user['"]|ok:\s*false.{0,40}no_user|creator_id\s*[=!]==?\s*|user_id\s*[=!]==?\s*|owner_id\s*[=!]==?\s*|creatorId\s*[=!]==?\s*|ownerId\s*[=!]==?\s*/;
+  /ctx\??\.actor\??\.userId|ctx\??\.userId|ctx\??\.actor\??\.id\b|ctx\??\.actor\??\.odId|aidCk\s*\(|req\.user\??\.id|reason:\s*['"]no_user['"]|ok:\s*false.{0,40}no_user|creator_id\s*[=!]==?\s*|user_id\s*[=!]==?\s*|owner_id\s*[=!]==?\s*|creatorId\s*[=!]==?\s*|ownerId\s*[=!]==?\s*|ownerField\s*[=!]==?\s*|owner[A-Z]\w*\s*[=!]==?\s*/;
+
+// Reviewed, confirmed-intentional instances — same posture as
+// internal-actor-stamp-detector.js's ALLOWLIST: named exact site + reason,
+// so a moved/renamed guard re-surfaces as a finding instead of silently
+// staying allowlisted after the code around it changed shape.
+const ALLOWLIST = [
+  {
+    domain: "collab",
+    macro: "join",
+    reason:
+      "Session-link-based Live-Share-style join — knowing the sessionId IS the authorization (matches the code lens's real Yjs CRDT collab pattern). The neighboring _collabActorId comment in server.js documents that a WORSE bug (userId spoofing) was already found and fixed here, and that edit()/merge() now require the caller to already be a participant — join is necessarily the entry point that adds a participant, so it can't require pre-existing participation without being circular. An anonymous caller collapses onto the fixed 'anonymous' identity shared by all anonymous callers, which is a UX quirk, not a privilege gain.",
+  },
+];
+
+function isAllowlisted(domain, macro) {
+  return ALLOWLIST.some((a) => a.domain === domain && a.macro === macro);
+}
 
 /** Parse `const publicReadDomains = { key: new Set([...]), ... };` from server.js. */
 export function parsePublicReadDomains(content) {
@@ -72,17 +136,23 @@ export function parsePublicReadDomains(content) {
 
 /** Locate a macro handler's body: register("domain","name",(ctx,...)=>{...}) or registerLensAction(...). Returns a bounded body string or null. */
 export function findHandlerBody(allSourceBlob, domain, macro) {
-  const patterns = [
-    new RegExp(`register(?:LensAction)?\\s*\\(\\s*["'\`]${escapeRe(domain)}["'\`]\\s*,\\s*["'\`]${escapeRe(macro)}["'\`]\\s*,`),
-  ];
-  for (const re of patterns) {
-    const m = re.exec(allSourceBlob);
-    if (!m) continue;
-    // Grab a bounded window after the match (function bodies here run well
-    // under 4000 chars; this is a heuristic scan, not a parser).
-    return allSourceBlob.slice(m.index, m.index + 4000);
-  }
-  return null;
+  const found = findHandlerMatch(allSourceBlob, domain, macro);
+  return found ? found.body : null;
+}
+
+/**
+ * Same lookup as findHandlerBody, but also returns the match index so the
+ * caller can compute a real, finding-specific line number instead of a
+ * shared placeholder. See the file header for why a shared location broke
+ * the ratchet's fingerprinting.
+ */
+function findHandlerMatch(allSourceBlob, domain, macro) {
+  const re = new RegExp(`register(?:LensAction)?\\s*\\(\\s*["'\`]${escapeRe(domain)}["'\`]\\s*,\\s*["'\`]${escapeRe(macro)}["'\`]\\s*,`);
+  const m = re.exec(allSourceBlob);
+  if (!m) return null;
+  // Grab a bounded window after the match (function bodies here run well
+  // under 4000 chars; this is a heuristic scan, not a parser).
+  return { index: m.index, body: allSourceBlob.slice(m.index, m.index + 4000) };
 }
 
 function escapeRe(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); }
@@ -98,49 +168,67 @@ export async function runPublicReadWriteVerbDetector({ root, opts = {} } = {}) {
     const parsed = parsePublicReadDomains(serverSrc);
     if (!parsed) return makeError("public-read-write-verb", "public_read_domains_not_found", null, t0);
 
-    // Also load every server/domains/*.js file's source so handler lookup
-    // isn't limited to server.js inline registrations.
-    const { walk } = await import("./_framework.js");
+    // Load every server/domains/*.js file individually (not concatenated)
+    // so a resolved handler's location can name the real file it lives in.
     const domainFiles = await walk(path.join(root, "server", "domains"), [".js"]);
-    let domainsBlob = "";
-    for (const f of domainFiles) domainsBlob += "\n" + (await readSafe(f));
+    const domainSources = [];
+    for (const f of domainFiles) {
+      const c = await readSafe(f);
+      if (c) domainSources.push({ rel: relPath(root, f), content: c });
+    }
+
+    const serverRel = relPath(root, serverPath);
+    const allowlistBlockLine = lineOf(serverSrc, serverSrc.indexOf("const publicReadDomains = {"));
 
     const findings = [];
-    let flagged = 0, checked = 0;
+    let flagged = 0, checked = 0, allowlistedCount = 0;
     for (const { domain, macro } of parsed.entries) {
       if (!WRITE_VERB_RE.test(macro)) continue;
       if (SELF_SCOPING_NAME_RE.test(macro)) continue;
       checked++;
+      if (isAllowlisted(domain, macro)) { allowlistedCount++; continue; }
 
-      const body = findHandlerBody(serverSrc, domain, macro) || findHandlerBody(domainsBlob, domain, macro);
-      const rel = relPath(root, serverPath);
-      const lineNo = lineOf(serverSrc, serverSrc.indexOf("const publicReadDomains = {"));
+      let match = findHandlerMatch(serverSrc, domain, macro);
+      let matchRel = serverRel, matchSrc = serverSrc;
+      if (!match) {
+        for (const ds of domainSources) {
+          match = findHandlerMatch(ds.content, domain, macro);
+          if (match) { matchRel = ds.rel; matchSrc = ds.content; break; }
+        }
+      }
 
-      if (!body) {
+      if (!match) {
         flagged++;
+        // No real registration site exists to point at — the location is
+        // the allowlist entry's own line, qualified with domain.macro so
+        // distinct not-found macros still fingerprint distinctly (a bare
+        // shared line number would repeat the exact collision bug this
+        // detector was rewritten to fix).
         findings.push({
           id: "public_read_write_verb_handler_not_found",
-          severity: "high",
+          severity: "medium",
           kind: "static",
           category: "security",
           subject: { kind: "macro", domain, macro },
-          message: `publicReadDomains lists write-shaped macro "${domain}.${macro}" (anonymous-callable) but its handler could not be located to verify self-scoping`,
-          location: `${rel}:${lineNo}`,
+          message: `publicReadDomains lists write-shaped macro "${domain}.${macro}" (anonymous-callable) but no register()/registerLensAction() call for it could be located anywhere in server.js or server/domains/*.js — it cannot actually be invoked via /api/lens/run (dispatch returns macro_not_found), so this is confirmed-stale allowlist drift, not a live anonymous-write path. Remove the dead entry, or add the real macro if it was meant to exist.`,
+          location: `${serverRel}:${allowlistBlockLine}:${domain}.${macro}`,
           evidence: { domain, macro },
-          fixHint: "verify_macro_handler_self_scopes_or_remove_from_public_read_domains",
+          fixHint: "remove_dead_entry_or_register_the_missing_macro",
         });
         continue;
       }
-      if (!OWNERSHIP_IDIOM_RE.test(body)) {
+
+      if (!OWNERSHIP_IDIOM_RE.test(match.body)) {
         flagged++;
+        const realLine = lineOf(matchSrc, match.index);
         findings.push({
           id: "public_read_write_verb_no_ownership_idiom",
           severity: "high",
           kind: "static",
           category: "security",
           subject: { kind: "macro", domain, macro },
-          message: `publicReadDomains lists write-shaped macro "${domain}.${macro}" (anonymous-callable) but its handler shows no ownership-check idiom (ctx.actor.userId / no_user rejection / owner-id comparison) — verify it can't be used to mutate another user's data anonymously`,
-          location: `${rel}:${lineNo}`,
+          message: `publicReadDomains lists write-shaped macro "${domain}.${macro}" (anonymous-callable) but its handler at ${matchRel}:${realLine} shows no ownership-check idiom (ctx.actor.userId / no_user rejection / owner-id comparison) — verify it can't be used to mutate another user's data anonymously`,
+          location: `${matchRel}:${realLine}`,
           evidence: { domain, macro },
           fixHint: "verify_macro_handler_self_scopes_or_remove_from_public_read_domains",
         });
@@ -152,8 +240,8 @@ export async function runPublicReadWriteVerbDetector({ root, opts = {} } = {}) {
       severity: "info",
       kind: "static",
       category: "security",
-      message: `publicReadDomains: ${checked} write-shaped macro name(s) found in the anonymous-read allowlist; ${flagged} flagged for missing/unverifiable ownership checks`,
-      evidence: { checked, flagged, totalEntries: parsed.entries.length },
+      message: `publicReadDomains: ${checked} write-shaped macro name(s) found in the anonymous-read allowlist; ${flagged} flagged for missing/unverifiable ownership checks, ${allowlistedCount} already reviewed+allowlisted`,
+      evidence: { checked, flagged, allowlistedCount, totalEntries: parsed.entries.length },
     });
 
     return makeReport("public-read-write-verb", findings, t0);

--- a/server/lib/detectors/public-read-write-verb-detector.js
+++ b/server/lib/detectors/public-read-write-verb-detector.js
@@ -1,0 +1,163 @@
+// server/lib/detectors/public-read-write-verb-detector.js
+//
+// Gate 2 (`publicReadDomains` in server.js) is a domain -> Set(macro names)
+// allowlist of macros safe to call WITHOUT authentication. Every entry is an
+// assertion that the listed macro is genuinely read-only, OR that its handler
+// self-scopes correctly when the caller is anonymous. Nothing has ever
+// verified that assertion against the real handler code — it's been trust on
+// the honor system since the allowlist was first written.
+//
+// Seeded by the exact bug shape found and fixed this session (SEC-3): a
+// mutating endpoint (RBAC role update) trusted to self-gate that didn't. The
+// same class can hide here: a write-shaped macro name (create/update/delete/
+// transfer/...) sitting in the PUBLIC READ allowlist, whose handler either
+// can't be found or shows no sign of checking the caller's identity before
+// mutating. A live instance already exists in the tree at the time this
+// detector was written: `dtu: new Set([..., "create", "update", "delete",
+// "bulkCreate", ...])` — flagged here for human review, not silently fixed,
+// since the handler may in fact self-scope correctly and this detector can
+// only prove "no ownership idiom found", never "definitely unsafe".
+//
+// This detector does NOT replace a real security review of each flagged
+// macro. It converts "nobody has looked" into "here is the exact list to
+// look at" — the same posture as authz-coverage-detector's bypass-allowlist
+// pinning.
+
+import path from "node:path";
+import { readSafe, makeReport, makeError, relPath, lineOf } from "./_framework.js";
+
+// Verb-prefix heuristic for "this macro name implies a mutation" — mirrors
+// scripts/audit-wiring-gate.mjs's SYSTEM_VERB list plus the domain-economy
+// verbs this codebase actually uses (transfer/tip/follow/mint/...).
+const WRITE_VERB_RE = /^(create|update|delete|remove|destroy|transfer|tip|follow|unfollow|join|leave|invite|revoke|grant|ban|unban|kick|mint|withdraw|deposit|pay|spend|credit|debit|approve|reject|cancel|refund|mute|unmute|block|unblock|report|vote|bid|claim|redeem|purchase|buy|sell|list_on_market|publish|unpublish|post|comment|reply|edit|rename|move|assign|unassign|promote|demote|lock|unlock|archive|restore|merge|split|bulkCreate|bulkUpdate|bulkDelete|set[A-Z]|add[A-Z]|drop[A-Z])/;
+
+// Handlers whose OWN name/shape already implies self-scoping (list_mine,
+// *_mine, get_own, ...) are exempt — the "mine" suffix is this codebase's own
+// established idiom for "scoped to ctx.actor by construction" (see dtu/drafts/
+// sessions comments in server.js right next to publicReadDomains itself).
+const SELF_SCOPING_NAME_RE = /mine\b|_own\b|^my/i;
+
+// Ownership-check idioms this codebase actually uses in handler bodies.
+const OWNERSHIP_IDIOM_RE =
+  /ctx\.actor\??\.userId|ctx\.userId|ctx\.actor\??\.id\b|aidCk\s*\(|req\.user\??\.id|reason:\s*['"]no_user['"]|ok:\s*false.{0,40}no_user|creator_id\s*[=!]==?\s*|user_id\s*[=!]==?\s*|owner_id\s*[=!]==?\s*|creatorId\s*[=!]==?\s*|ownerId\s*[=!]==?\s*/;
+
+/** Parse `const publicReadDomains = { key: new Set([...]), ... };` from server.js. */
+export function parsePublicReadDomains(content) {
+  const startIdx = content.indexOf("const publicReadDomains = {");
+  if (startIdx < 0) return null;
+  // Balance braces from the opening `{` to find the literal's extent.
+  const braceStart = content.indexOf("{", startIdx);
+  let depth = 0, i = braceStart, end = -1;
+  for (; i < content.length; i++) {
+    if (content[i] === "{") depth++;
+    else if (content[i] === "}") { depth--; if (depth === 0) { end = i; break; } }
+  }
+  if (end < 0) return null;
+  const block = content.slice(braceStart, end + 1);
+
+  const out = []; // { domain, macro, offsetInBlock }
+  const entryRe = /(["'`]?)([A-Za-z][\w-]*)\1\s*:\s*new Set\(\s*\[([^\]]*)\]\s*\)/g;
+  let m;
+  while ((m = entryRe.exec(block)) != null) {
+    const domain = m[2];
+    const listBlob = m[3];
+    const macroRe = /['"`]([\w.-]+)['"`]/g;
+    let mm;
+    while ((mm = macroRe.exec(listBlob)) != null) {
+      out.push({ domain, macro: mm[1], offsetInBlock: m.index });
+    }
+  }
+  return { entries: out, blockStartOffset: braceStart };
+}
+
+/** Locate a macro handler's body: register("domain","name",(ctx,...)=>{...}) or registerLensAction(...). Returns a bounded body string or null. */
+export function findHandlerBody(allSourceBlob, domain, macro) {
+  const patterns = [
+    new RegExp(`register(?:LensAction)?\\s*\\(\\s*["'\`]${escapeRe(domain)}["'\`]\\s*,\\s*["'\`]${escapeRe(macro)}["'\`]\\s*,`),
+  ];
+  for (const re of patterns) {
+    const m = re.exec(allSourceBlob);
+    if (!m) continue;
+    // Grab a bounded window after the match (function bodies here run well
+    // under 4000 chars; this is a heuristic scan, not a parser).
+    return allSourceBlob.slice(m.index, m.index + 4000);
+  }
+  return null;
+}
+
+function escapeRe(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); }
+
+export async function runPublicReadWriteVerbDetector({ root, opts = {} } = {}) {
+  const t0 = Date.now();
+  if (!root) return makeError("public-read-write-verb", "no_root", null, t0);
+  try {
+    const serverPath = path.join(root, "server", "server.js");
+    const serverSrc = await readSafe(serverPath);
+    if (!serverSrc) return makeError("public-read-write-verb", "server_js_unreadable", null, t0);
+
+    const parsed = parsePublicReadDomains(serverSrc);
+    if (!parsed) return makeError("public-read-write-verb", "public_read_domains_not_found", null, t0);
+
+    // Also load every server/domains/*.js file's source so handler lookup
+    // isn't limited to server.js inline registrations.
+    const { walk } = await import("./_framework.js");
+    const domainFiles = await walk(path.join(root, "server", "domains"), [".js"]);
+    let domainsBlob = "";
+    for (const f of domainFiles) domainsBlob += "\n" + (await readSafe(f));
+
+    const findings = [];
+    let flagged = 0, checked = 0;
+    for (const { domain, macro } of parsed.entries) {
+      if (!WRITE_VERB_RE.test(macro)) continue;
+      if (SELF_SCOPING_NAME_RE.test(macro)) continue;
+      checked++;
+
+      const body = findHandlerBody(serverSrc, domain, macro) || findHandlerBody(domainsBlob, domain, macro);
+      const rel = relPath(root, serverPath);
+      const lineNo = lineOf(serverSrc, serverSrc.indexOf("const publicReadDomains = {"));
+
+      if (!body) {
+        flagged++;
+        findings.push({
+          id: "public_read_write_verb_handler_not_found",
+          severity: "high",
+          kind: "static",
+          category: "security",
+          subject: { kind: "macro", domain, macro },
+          message: `publicReadDomains lists write-shaped macro "${domain}.${macro}" (anonymous-callable) but its handler could not be located to verify self-scoping`,
+          location: `${rel}:${lineNo}`,
+          evidence: { domain, macro },
+          fixHint: "verify_macro_handler_self_scopes_or_remove_from_public_read_domains",
+        });
+        continue;
+      }
+      if (!OWNERSHIP_IDIOM_RE.test(body)) {
+        flagged++;
+        findings.push({
+          id: "public_read_write_verb_no_ownership_idiom",
+          severity: "high",
+          kind: "static",
+          category: "security",
+          subject: { kind: "macro", domain, macro },
+          message: `publicReadDomains lists write-shaped macro "${domain}.${macro}" (anonymous-callable) but its handler shows no ownership-check idiom (ctx.actor.userId / no_user rejection / owner-id comparison) — verify it can't be used to mutate another user's data anonymously`,
+          location: `${rel}:${lineNo}`,
+          evidence: { domain, macro },
+          fixHint: "verify_macro_handler_self_scopes_or_remove_from_public_read_domains",
+        });
+      }
+    }
+
+    findings.unshift({
+      id: "public_read_write_verb_summary",
+      severity: "info",
+      kind: "static",
+      category: "security",
+      message: `publicReadDomains: ${checked} write-shaped macro name(s) found in the anonymous-read allowlist; ${flagged} flagged for missing/unverifiable ownership checks`,
+      evidence: { checked, flagged, totalEntries: parsed.entries.length },
+    });
+
+    return makeReport("public-read-write-verb", findings, t0);
+  } catch (err) {
+    return makeError("public-read-write-verb", "exception", err, t0);
+  }
+}

--- a/server/lib/detectors/world-shard-write-boundary-detector.js
+++ b/server/lib/detectors/world-shard-write-boundary-detector.js
@@ -22,6 +22,39 @@
 // Both scanned for a write statement (INSERT/UPDATE/DELETE, or a bare
 // db.prepare(...).run(...) built from a template containing the table name)
 // targeting a table in PER_WORLD_WRITE_TABLES.
+//
+// Severity + fingerprinting, corrected after running this detector against
+// the live tree (not just synthetic fixtures):
+//
+// - `world_shard_write_from_global_heartbeat` never set a `location` field
+//   at all. The ratchet fingerprints on sha256(detector|ruleId|location|
+//   severity), and an absent location becomes the empty string — so EVERY
+//   finding of this ruleId collapsed onto ONE shared fingerprint regardless
+//   of which heartbeat/table it was about, hiding all but the first from
+//   baseline/ratchet tracking (the exact bug class public-read-write-verb-
+//   detector was independently found and fixed for). Fixed: every finding
+//   now resolves the handler's real defining file, and `location` is that
+//   file's `path:line`, which is unique per handler.
+//
+// - Both finding severities were downgraded from "high" to "medium" after
+//   running against the live tree: CONCORD_SHARD_WORLDS defaults off, and —
+//   confirmed by reading world-shard-manager.js and grepping every call site
+//   of shardingEnabled() — NO write-forwarding plumbing exists anywhere in
+//   this codebase for HTTP routes today (the manager only forks child
+//   processes to run scope:"world" HEARTBEATS; there is no mechanism for a
+//   synchronous Express route to defer its write to a shard and wait for
+//   the result). That means virtually every per-world-table write in the
+//   ENTIRE codebase currently originates from the parent process — this is
+//   the app's actual, universal, working architecture today, not a
+//   localized bug in freshly-written code. A "high" severity blocking gate
+//   on a condition this systemic and this far from exploitable (sharding
+//   isn't live anywhere) would never be clearable without either building
+//   the (currently nonexistent) route-to-shard forwarding infrastructure
+//   for the whole app in one pass, or systematically muting the detector —
+//   neither of which this pass does. "Medium" keeps the signal — real,
+//   worth fixing when Phase F write-forwarding is actually built — without
+//   miscalibrating a first-time severity guess as an actionable blocker for
+//   debt that predates this detector and spans the whole write layer.
 
 import path from "node:path";
 import { readSafe, makeReport, makeError, relPath, lineOf, walk } from "./_framework.js";
@@ -51,6 +84,25 @@ export function findFunctionBody(blob, name) {
   return null;
 }
 function escapeRe(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); }
+
+// Reviewed, confirmed-intentional instances — same posture as
+// internal-actor-stamp-detector.js's ALLOWLIST: named exact site + reason.
+const ALLOWLIST = [
+  {
+    heartbeat: "npc-ambition-cycle",
+    reason:
+      "Deliberately scope:'global' per the adjacent server.js comment (Phase T, right above the registerHeartbeat call): its top-N-ambitious query is a single cross-world budget with no world_id filter, and sharding it per-world would either duplicate-process the same rows on every shard or silently never run at all — the same documented tradeoff already made for its two sibling heartbeats (npc-travel-cycle, npc-vs-npc-combat). This is a reviewed, load-bearing design choice, not an oversight.",
+  },
+  {
+    heartbeat: "npc-travel-cycle",
+    reason:
+      "Same adjacent server.js comment as npc-ambition-cycle (Phase T): explicitly moves NPCs BETWEEN worlds in one operation and its candidate query has no world_id filter — sharding it per-world would either duplicate-process the same rows on every shard or silently never run at all. Reviewed, load-bearing design choice, not an oversight.",
+  },
+];
+
+function isAllowlisted(heartbeatName) {
+  return ALLOWLIST.some((a) => a.heartbeat === heartbeatName);
+}
 
 export async function runWorldShardWriteBoundaryDetector({ root, opts = {} } = {}) {
   const t0 = Date.now();
@@ -82,11 +134,11 @@ export async function runWorldShardWriteBoundaryDetector({ root, opts = {} } = {
         const lineNo = lineOf(content, m.index);
         findings.push({
           id: "world_shard_write_from_route",
-          severity: "high",
+          severity: "medium",
           kind: "static",
           category: "correctness",
           subject: { kind: "file", path: rel, table },
-          message: `${rel}:${lineNo} writes to per-world table "${table}" from a route (parent-process-only) — will race the world-shard writer once CONCORD_SHARD_WORLDS=true`,
+          message: `${rel}:${lineNo} writes to per-world table "${table}" from a route (parent-process-only) — will race the world-shard writer once CONCORD_SHARD_WORLDS=true. No route-to-shard write forwarding exists anywhere in this codebase yet (sharding only forks scope:'world' heartbeats), so this reflects the app's current universal architecture, not a localized new-code bug.`,
           location: `${rel}:${lineNo}`,
           evidence: { table, surface: "route" },
           fixHint: "move_write_into_world_shard_or_tag_scope_world",
@@ -95,19 +147,21 @@ export async function runWorldShardWriteBoundaryDetector({ root, opts = {} } = {
     }
 
     // (b) scope:"global" heartbeat handlers — resolve the handler function's
-    // definition anywhere under server/ and scan its body.
+    // definition anywhere under server/ and scan its body. Search each file
+    // individually (not one concatenated blob) so a resolved handler's
+    // location can point at its real defining file:line — a shared/absent
+    // location collapses every finding of this ruleId onto one fingerprint
+    // (see file header).
     const serverFiles = [
       path.join(root, "server", "server.js"),
       ...(await walk(path.join(root, "server", "emergent"), [".js"])),
       ...(await walk(path.join(root, "server", "lib"), [".js"])),
     ];
-    let wholeBlob = "";
     const blobByFile = [];
     for (const f of serverFiles) {
       const c = await readSafe(f);
       if (!c) continue;
-      blobByFile.push({ file: f, content: c });
-      wholeBlob += "\n" + c;
+      blobByFile.push({ rel: relPath(root, f), content: c });
     }
 
     const globalHeartbeats = [];
@@ -121,22 +175,31 @@ export async function runWorldShardWriteBoundaryDetector({ root, opts = {} } = {
       }
     }
 
-    let scanned = 0;
+    let scanned = 0, allowlistedCount = 0;
     for (const { name, handlerIdent } of globalHeartbeats) {
-      const found = findFunctionBody(wholeBlob, handlerIdent);
+      let found = null, foundRel = null, foundContent = null;
+      for (const bf of blobByFile) {
+        found = findFunctionBody(bf.content, handlerIdent);
+        if (found) { foundRel = bf.rel; foundContent = bf.content; break; }
+      }
       if (!found) continue; // can't locate — not a finding, just unresolved (info-level noise avoided)
       scanned++;
       writeRe.lastIndex = 0;
       let m;
       while ((m = writeRe.exec(found.body)) != null) {
         const table = m[1];
+        if (isAllowlisted(name)) { allowlistedCount++; continue; }
+        // Absolute offset within the real file = where the function body
+        // started + how far into that body the write statement is.
+        const lineNo = lineOf(foundContent, found.offset + m.index);
         findings.push({
           id: "world_shard_write_from_global_heartbeat",
-          severity: "high",
+          severity: "medium",
           kind: "static",
           category: "correctness",
           subject: { kind: "heartbeat", name, table },
-          message: `heartbeat "${name}" (scope:"global", handler ${handlerIdent}) writes to per-world table "${table}" — global-scope heartbeats run on the parent process and will race the world-shard writer once CONCORD_SHARD_WORLDS=true`,
+          message: `heartbeat "${name}" (scope:"global", handler ${handlerIdent} at ${foundRel}) writes to per-world table "${table}" — global-scope heartbeats run on the parent process and will race the world-shard writer once CONCORD_SHARD_WORLDS=true.`,
+          location: `${foundRel}:${lineNo}:${name}`,
           evidence: { heartbeat: name, handlerIdent, table, surface: "global-heartbeat" },
           fixHint: "retag_heartbeat_scope_world_or_move_write_into_shard",
         });
@@ -148,8 +211,8 @@ export async function runWorldShardWriteBoundaryDetector({ root, opts = {} } = {
       severity: "info",
       kind: "static",
       category: "correctness",
-      message: `Scanned ${routeFiles.length} route file(s) + ${scanned}/${globalHeartbeats.length} resolvable global-scope heartbeat handler(s) against ${tables.size} per-world write-owned table(s)`,
-      evidence: { routeFiles: routeFiles.length, globalHeartbeats: globalHeartbeats.length, resolved: scanned, tableCount: tables.size },
+      message: `Scanned ${routeFiles.length} route file(s) + ${scanned}/${globalHeartbeats.length} resolvable global-scope heartbeat handler(s) against ${tables.size} per-world write-owned table(s); ${allowlistedCount} write(s) already reviewed+allowlisted`,
+      evidence: { routeFiles: routeFiles.length, globalHeartbeats: globalHeartbeats.length, resolved: scanned, tableCount: tables.size, allowlistedCount },
     });
 
     return makeReport("world-shard-write-boundary", findings, t0);

--- a/server/lib/detectors/world-shard-write-boundary-detector.js
+++ b/server/lib/detectors/world-shard-write-boundary-detector.js
@@ -1,0 +1,159 @@
+// server/lib/detectors/world-shard-write-boundary-detector.js
+//
+// CLAUDE.md's "DB write-ownership rules (Phase F)" invariant: once
+// CONCORD_SHARD_WORLDS=true, each per-world table (lib/world-shard-protocol.js
+// PER_WORLD_WRITE_TABLES) is write-owned by that world's forked child process.
+// "New code that writes to a per-world table from an HTTP route or from a
+// scope:'global' module is wrong: it will work in single-process mode but
+// will race the shard writer once Phase F is enabled."
+//
+// That invariant has never had an automated check — CONCORD_SHARD_WORLDS
+// defaults OFF, so a violation is invisible in every normal test run and
+// would only surface as real data corruption the first time an operator
+// flips the flag in production. This detector makes the invariant checkable
+// without ever needing to actually boot a sharded cluster: it's pure static
+// text analysis, same posture as the other write-ownership-shaped detectors
+// in this suite (authz-coverage, money-txn-hygiene).
+//
+// Two surfaces, per the documented rule:
+//   (a) server/routes/*.js — these only ever run on the parent process.
+//   (b) any heartbeat module registered with `scope: "global"` — the
+//       handler function runs on the parent, not a world shard.
+// Both scanned for a write statement (INSERT/UPDATE/DELETE, or a bare
+// db.prepare(...).run(...) built from a template containing the table name)
+// targeting a table in PER_WORLD_WRITE_TABLES.
+
+import path from "node:path";
+import { readSafe, makeReport, makeError, relPath, lineOf, walk } from "./_framework.js";
+
+const HEARTBEAT_GLOBAL_RE = /registerHeartbeat\s*\(\s*["'`]([\w-]+)["'`]\s*,\s*\{[^}]*?scope\s*:\s*["'`]global["'`][^}]*?\}/gs;
+const HANDLER_IDENT_RE = /handler\s*:\s*([A-Za-z_$][\w$]*)/;
+
+// Matches an INSERT/UPDATE/DELETE statement (typically inside a db.prepare(`...`)
+// template literal) naming one of the given tables. Table name must appear
+// right after INTO/UPDATE, or as the FROM target of a DELETE.
+function buildTableWriteRe(tables) {
+  const alt = Array.from(tables).map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
+  return new RegExp(`\\b(?:INSERT\\s+(?:OR\\s+\\w+\\s+)?INTO|UPDATE|DELETE\\s+FROM)\\s+(${alt})\\b`, "gi");
+}
+
+/** Locate a named function's definition body (function decl or const-arrow) — bounded heuristic scan, same convention as public-read-write-verb-detector. */
+export function findFunctionBody(blob, name) {
+  const patterns = [
+    new RegExp(`function\\s+${escapeRe(name)}\\s*\\(`),
+    new RegExp(`(?:const|let)\\s+${escapeRe(name)}\\s*=\\s*(?:async\\s*)?(?:function\\s*)?\\(`),
+    new RegExp(`(?:const|let)\\s+${escapeRe(name)}\\s*=\\s*async\\s*[\\w(]`),
+  ];
+  for (const re of patterns) {
+    const m = re.exec(blob);
+    if (m) return { body: blob.slice(m.index, m.index + 6000), offset: m.index };
+  }
+  return null;
+}
+function escapeRe(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); }
+
+export async function runWorldShardWriteBoundaryDetector({ root, opts = {} } = {}) {
+  const t0 = Date.now();
+  if (!root) return makeError("world-shard-write-boundary", "no_root", null, t0);
+  try {
+    const protocolPath = path.join(root, "server", "lib", "world-shard-protocol.js");
+    const protocolSrc = await readSafe(protocolPath);
+    if (!protocolSrc) return makeError("world-shard-write-boundary", "world_shard_protocol_unreadable", null, t0);
+
+    const tableSetMatch = /PER_WORLD_WRITE_TABLES\s*=\s*Object\.freeze\(new Set\(\[([^\]]*)\]\)\)/s.exec(protocolSrc);
+    if (!tableSetMatch) return makeError("world-shard-write-boundary", "per_world_write_tables_not_found", null, t0);
+    const tables = new Set();
+    for (const m of tableSetMatch[1].matchAll(/["'`]([\w]+)["'`]/g)) tables.add(m[1]);
+    if (tables.size === 0) return makeError("world-shard-write-boundary", "per_world_write_tables_empty", null, t0);
+
+    const writeRe = buildTableWriteRe(tables);
+    const findings = [];
+
+    // (a) server/routes/*.js — parent-process-only surface.
+    const routeFiles = await walk(path.join(root, "server", "routes"), [".js"]);
+    for (const f of routeFiles) {
+      const content = await readSafe(f);
+      if (!content) continue;
+      const rel = relPath(root, f);
+      writeRe.lastIndex = 0;
+      let m;
+      while ((m = writeRe.exec(content)) != null) {
+        const table = m[1];
+        const lineNo = lineOf(content, m.index);
+        findings.push({
+          id: "world_shard_write_from_route",
+          severity: "high",
+          kind: "static",
+          category: "correctness",
+          subject: { kind: "file", path: rel, table },
+          message: `${rel}:${lineNo} writes to per-world table "${table}" from a route (parent-process-only) — will race the world-shard writer once CONCORD_SHARD_WORLDS=true`,
+          location: `${rel}:${lineNo}`,
+          evidence: { table, surface: "route" },
+          fixHint: "move_write_into_world_shard_or_tag_scope_world",
+        });
+      }
+    }
+
+    // (b) scope:"global" heartbeat handlers — resolve the handler function's
+    // definition anywhere under server/ and scan its body.
+    const serverFiles = [
+      path.join(root, "server", "server.js"),
+      ...(await walk(path.join(root, "server", "emergent"), [".js"])),
+      ...(await walk(path.join(root, "server", "lib"), [".js"])),
+    ];
+    let wholeBlob = "";
+    const blobByFile = [];
+    for (const f of serverFiles) {
+      const c = await readSafe(f);
+      if (!c) continue;
+      blobByFile.push({ file: f, content: c });
+      wholeBlob += "\n" + c;
+    }
+
+    const globalHeartbeats = [];
+    for (const { content } of blobByFile) {
+      HEARTBEAT_GLOBAL_RE.lastIndex = 0;
+      let m;
+      while ((m = HEARTBEAT_GLOBAL_RE.exec(content)) != null) {
+        const name = m[1];
+        const handlerM = HANDLER_IDENT_RE.exec(m[0]);
+        if (handlerM) globalHeartbeats.push({ name, handlerIdent: handlerM[1] });
+      }
+    }
+
+    let scanned = 0;
+    for (const { name, handlerIdent } of globalHeartbeats) {
+      const found = findFunctionBody(wholeBlob, handlerIdent);
+      if (!found) continue; // can't locate — not a finding, just unresolved (info-level noise avoided)
+      scanned++;
+      writeRe.lastIndex = 0;
+      let m;
+      while ((m = writeRe.exec(found.body)) != null) {
+        const table = m[1];
+        findings.push({
+          id: "world_shard_write_from_global_heartbeat",
+          severity: "high",
+          kind: "static",
+          category: "correctness",
+          subject: { kind: "heartbeat", name, table },
+          message: `heartbeat "${name}" (scope:"global", handler ${handlerIdent}) writes to per-world table "${table}" — global-scope heartbeats run on the parent process and will race the world-shard writer once CONCORD_SHARD_WORLDS=true`,
+          evidence: { heartbeat: name, handlerIdent, table, surface: "global-heartbeat" },
+          fixHint: "retag_heartbeat_scope_world_or_move_write_into_shard",
+        });
+      }
+    }
+
+    findings.unshift({
+      id: "world_shard_write_boundary_summary",
+      severity: "info",
+      kind: "static",
+      category: "correctness",
+      message: `Scanned ${routeFiles.length} route file(s) + ${scanned}/${globalHeartbeats.length} resolvable global-scope heartbeat handler(s) against ${tables.size} per-world write-owned table(s)`,
+      evidence: { routeFiles: routeFiles.length, globalHeartbeats: globalHeartbeats.length, resolved: scanned, tableCount: tables.size },
+    });
+
+    return makeReport("world-shard-write-boundary", findings, t0);
+  } catch (err) {
+    return makeError("world-shard-write-boundary", "exception", err, t0);
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -12962,7 +12962,11 @@ async function runMacro(domain, name, input, ctx) {
     // douse mutate and require an actor, so they're NOT here).
     elements: new Set(["matrix"]),
     emergent: new Set(["status", "get", "list", "schema", "patterns", "reputation", "scope.metrics", "bridge.heartbeatTick"]),
-    dtu: new Set(["list", "get", "search", "recent", "stats", "count", "export", "paginated", "create", "update", "delete", "bulkCreate", "promote"]),
+    // "bulkCreate"/"promote" removed (public-read-write-verb-detector,
+    // confirmed dead 2026-07-31): no register("dtu","bulkCreate"|"promote",...)
+    // exists anywhere — these names were never real macros, so listing them
+    // here was inert allowlist drift, not a live anonymous-write path.
+    dtu: new Set(["list", "get", "search", "recent", "stats", "count", "export", "paginated", "create", "update", "delete"]),
     // Phase 1 (UX completeness sprint) — per-lens auto-save drafts.
     // Handlers self-scope by ctx.actor.userId; anonymous callers return
     // {ok:false,reason:'no_user'}. Listing here bypasses the heavy
@@ -13051,7 +13055,11 @@ async function runMacro(domain, name, input, ctx) {
     graph: new Set(["visual", "visualData", "forceGraph", "edges", "stats", "neighbors"]),
     events: new Set(["list", "recent", "log", "paginated"]),
     worldmodel: new Set(["list_relations", "get", "status", "entities", "simulations"]),
-    goals: new Set(["list", "get", "status", "config", "create", "update", "delete", "complete"]),
+    // "create"/"update"/"delete" removed (public-read-write-verb-detector,
+    // confirmed dead 2026-07-31): the real goals macros are
+    // propose/approve/activate/complete/abandon — bare create/update/delete
+    // were never registered, so these entries were inert allowlist drift.
+    goals: new Set(["list", "get", "status", "config", "complete"]),
     council: new Set(["tally", "status", "list"]),
     hypothesis: new Set(["list", "get", "status"]),
     analytics: new Set(["dashboard", "growth", "density", "citations", "marketplace", "personal"]),
@@ -13133,10 +13141,28 @@ async function runMacro(domain, name, input, ctx) {
       "upsert_shadow", "list_shadows", "get_weight",
     ]),
     messaging: new Set(["status", "bindings", "connect", "verify", "messages"]),
-    sandbox: new Set(["create", "status", "action", "list", "pause", "resume", "provision", "kill"]),
-    collab: new Set(["comments", "revisions", "workspace", "edit-session", "create", "update", "delete", "join"]),
-    social: new Set(["profile", "followers", "following", "discover", "cited-by", "post", "react", "share", "comment", "follow", "unfollow"]),
-    economy: new Set(["status", "balance", "transactions", "withdrawals", "transfer", "tip"]),
+    // "create" removed (public-read-write-verb-detector, confirmed dead
+    // 2026-07-31): the real sandbox macros are provision/kill/list/status/
+    // action/pause/resume — bare "create" was never registered.
+    sandbox: new Set(["status", "action", "list", "pause", "resume", "provision", "kill"]),
+    // "comments"/"edit-session"/"create"/"update"/"delete" removed
+    // (public-read-write-verb-detector, confirmed dead 2026-07-31): the real
+    // write macros are createSession/edit/merge — these bare names were
+    // never registered. "join" stays and is reviewed+allowlisted in the
+    // detector (session-link-based join, not an ownership-check gap).
+    collab: new Set(["revisions", "workspace", "join"]),
+    // "followers"/"following"/"post"/"comment"/"follow"/"unfollow" removed
+    // (public-read-write-verb-detector, confirmed dead 2026-07-31): the real
+    // functionality is the authenticated HTTP routes /api/social/follow,
+    // /api/social/unfollow, etc. — no register("social", ...) macro of
+    // these names was ever wired, so calling them via /api/lens/run was a
+    // harmless no-op (macro_not_found), never a live anonymous-write path.
+    social: new Set(["profile", "discover", "cited-by", "react", "share"]),
+    // "withdrawals"/"transfer"/"tip" removed (public-read-write-verb-detector,
+    // confirmed dead 2026-07-31): the real functionality is the authenticated
+    // HTTP routes /api/economy/transfer etc. — no matching macro was ever
+    // registered.
+    economy: new Set(["status", "balance", "transactions"]),
     marketplace: new Set(["listings", "list", "get", "browse", "submit", "install", "review", "purchase"]),
     credits: new Set(["balance", "status"]),
     hive: new Set(["status", "list"]),
@@ -13159,7 +13185,10 @@ async function runMacro(domain, name, input, ctx) {
     // Extended domains (three-gate audit)
     quest: new Set(["list", "get", "active", "progress", "metrics"]),
     teaching: new Set(["list", "get", "profile", "metrics", "expertise"]),
-    creative: new Set(["list", "get", "exhibition", "metrics", "profile", "masterworks", "registry", "domains", "generate", "create", "run"]),
+    // "create" removed (public-read-write-verb-detector, confirmed dead
+    // 2026-07-31): the real macro is "create_work" (underscore), never
+    // bare "create" — this entry was never callable.
+    creative: new Set(["list", "get", "exhibition", "metrics", "profile", "masterworks", "registry", "domains", "generate", "run"]),
     culture: new Set(["status", "traditions", "values", "stories", "metrics", "identity"]),
     trust: new Set(["get", "network", "metrics"]),
     federation: new Set(["status", "peers", "commune_list", "commune_status", "peer_list", "outbox", "actor", "inbox"]),
@@ -13187,7 +13216,13 @@ async function runMacro(domain, name, input, ctx) {
     experience: new Set(["status", "patterns", "recent", "strategies", "consolidate", "retrieve"]),
     explore: new Set(["history"]),
     flywheel: new Set(["history", "metrics"]),
-    inheritance: new Set(["bequests", "claim", "create-bequest", "revoke", "list_open"]),
+    // "claim"/"create-bequest"/"revoke" removed (public-read-write-verb-
+    // detector, confirmed dead 2026-07-31): the real inheritance macros are
+    // open_listing/claim_slot/list_open — these three names were never
+    // registered; the real functionality for "revoke" lives at the
+    // authenticated HTTP route /api/inheritance/revoke, entirely separate
+    // from the macro dispatcher, so this entry never actually bypassed auth.
+    inheritance: new Set(["bequests", "list_open"]),
     pipeline: new Set(["execute", "executions"]),
     quality: new Set(["stats", "domain", "thresholds"]),
     sovereignty: new Set(["status", "audit", "setup", "preferences"]),
@@ -31572,12 +31607,21 @@ register("jobs","get", (ctx, input) => {
 
 // ---- Agents ----
 register("agent","create", (ctx, input) => {
+  // SECURITY: this macro is anonymous-callable (publicReadDomains lists
+  // "agent" -> "create"), and the handler previously had no ownership gate
+  // at all — any unauthenticated caller could mint persistent, unscoped
+  // records in the shared STATE.personas map with an attacker-controlled
+  // allowedMacros list. Require a real caller identity; the created agent
+  // is now stamped with it so a future ownership check (enable/tick/list)
+  // has something to check against. Flagged by public-read-write-verb-detector.
+  const userId = ctx?.actor?.userId;
+  if (!userId) return { ok: false, reason: "no_user" };
   const name = normalizeText(input.name || "Agent");
   const goal = normalizeText(input.goal || "");
   const cadenceMs = clamp(Number(input.cadenceMs||60000), 5000, 86400000);
   const allowed = Array.isArray(input.allowedMacros) ? input.allowedMacros.map(String) : ["dtu.create","dtu.list","system.synthesize"];
   const id = uid("agent");
-  const agent = { id, orgId: ctx.actor.orgId, name, goal, cadenceMs, allowedMacros: allowed, enabled: false, createdAt: nowISO(), lastTickAt: null };
+  const agent = { id, orgId: ctx.actor.orgId, ownerId: userId, name, goal, cadenceMs, allowedMacros: allowed, enabled: false, createdAt: nowISO(), lastTickAt: null };
   STATE.queues.agents = Array.isArray(STATE.queues.agents) ? STATE.queues.agents : [];
   STATE.queues.agents.push(id);
   STATE.personas.set(id, agent); // store in personas map as lightweight agent record (no new map needed)
@@ -40843,6 +40887,14 @@ function computeRoyaltyCascade(dtu) {
 // ── Scope Promotion Macro (Dual Global) ─────────────────────────────────────
 
 register("scope", "promote", async (ctx, input) => {
+  // SECURITY: anonymous-callable (publicReadDomains lists "scope" ->
+  // "promote") but operates on an arbitrary caller-supplied dtuId with no
+  // ownership check on the requester — the actual admission decision is
+  // made by the pre-submission + council/review gates below, not by who's
+  // asking, so "any logged-in community member can nominate a DTU for
+  // promotion" is the intended shape. Require real authentication only,
+  // not DTU ownership. Flagged by public-read-write-verb-detector.
+  if (!ctx?.actor?.userId) return { ok: false, reason: "no_user" };
   const { dtuId, targetScope } = input || {};
   const dtu = STATE.dtus.get(dtuId);
 

--- a/server/tests/checker-self-coverage-detector.test.js
+++ b/server/tests/checker-self-coverage-detector.test.js
@@ -1,0 +1,81 @@
+// tests/checker-self-coverage-detector.test.js
+//
+// Bidirectional pin: a detector/gate-script with no referencing test must be
+// flagged; the same one WITH a referencing test must not be.
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm, mkdir } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { runCheckerSelfCoverageDetector } from "../lib/detectors/checker-self-coverage-detector.js";
+
+async function tmpRepo() {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "csc-"));
+  await mkdir(path.join(dir, "server", "lib", "detectors"), { recursive: true });
+  await mkdir(path.join(dir, "server", "tests"), { recursive: true });
+  await mkdir(path.join(dir, "scripts"), { recursive: true });
+  // Infra files that must be excluded from the checker set.
+  await writeFile(path.join(dir, "server", "lib", "detectors", "_framework.js"), "// infra", "utf8");
+  await writeFile(path.join(dir, "server", "lib", "detectors", "index.js"), "// infra", "utf8");
+  return dir;
+}
+
+describe("checker-self-coverage detector — end to end", () => {
+  let dir;
+  afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
+
+  it("FLAGS a detector file with no referencing test anywhere", async () => {
+    dir = await tmpRepo();
+    await writeFile(path.join(dir, "server", "lib", "detectors", "orphan-detector.js"), "export function runOrphanDetector(){}", "utf8");
+    await writeFile(path.join(dir, "server", "tests", "unrelated.test.js"), "// nothing referencing orphan-detector here", "utf8");
+    const r = await runCheckerSelfCoverageDetector({ root: dir });
+    assert.equal(r.ok, true);
+    const hit = r.findings.find((f) => f.id === "checker_no_pinning_test_detector");
+    assert.ok(hit, "orphan-detector.js must be flagged");
+    assert.equal(hit.evidence.detector, "orphan-detector");
+  });
+
+  it("does NOT flag a detector file a real test file imports", async () => {
+    dir = await tmpRepo();
+    await writeFile(path.join(dir, "server", "lib", "detectors", "covered-detector.js"), "export function runCoveredDetector(){}", "utf8");
+    await writeFile(
+      path.join(dir, "server", "tests", "covered.test.js"),
+      `import { runCoveredDetector } from "../lib/detectors/covered-detector.js";`,
+      "utf8"
+    );
+    const r = await runCheckerSelfCoverageDetector({ root: dir });
+    const hit = r.findings.find((f) => f.evidence?.detector === "covered-detector");
+    assert.equal(hit, undefined, "a detector a test file imports must not be flagged");
+  });
+
+  it("FLAGS a gate script (audit-/check-/verify-/grade- prefixed) with no referencing test", async () => {
+    dir = await tmpRepo();
+    await writeFile(path.join(dir, "scripts", "audit-orphan-gate.mjs"), "// gate script", "utf8");
+    await writeFile(path.join(dir, "server", "tests", "unrelated2.test.js"), "// nothing here either", "utf8");
+    const r = await runCheckerSelfCoverageDetector({ root: dir });
+    const hit = r.findings.find((f) => f.id === "checker_no_pinning_test_script");
+    assert.ok(hit);
+    assert.equal(hit.evidence.script, "audit-orphan-gate");
+  });
+
+  it("does NOT flag a gate script a test file's execFileSync path references", async () => {
+    dir = await tmpRepo();
+    await writeFile(path.join(dir, "scripts", "check-covered-gate.mjs"), "// gate script", "utf8");
+    await writeFile(
+      path.join(dir, "server", "tests", "gate.test.js"),
+      `const SCRIPT = path.resolve(HERE, "../../../scripts/check-covered-gate.mjs");`,
+      "utf8"
+    );
+    const r = await runCheckerSelfCoverageDetector({ root: dir });
+    const hit = r.findings.find((f) => f.evidence?.script === "check-covered-gate");
+    assert.equal(hit, undefined);
+  });
+
+  it("does NOT treat a non-gate-shaped script (e.g. a plain helper) as a checker requiring coverage", async () => {
+    dir = await tmpRepo();
+    await writeFile(path.join(dir, "scripts", "unrelated-helper.mjs"), "// not a gate script", "utf8");
+    const r = await runCheckerSelfCoverageDetector({ root: dir });
+    const hit = r.findings.find((f) => f.evidence?.script === "unrelated-helper");
+    assert.equal(hit, undefined, "only audit-/check-/verify-/grade- prefixed scripts count as gate scripts");
+  });
+});

--- a/server/tests/doc-claim-resolution-detector.test.js
+++ b/server/tests/doc-claim-resolution-detector.test.js
@@ -1,0 +1,115 @@
+// tests/doc-claim-resolution-detector.test.js
+//
+// Bidirectional pin: a "fixed"-adjacent claim naming a file/symbol that no
+// longer exists must be flagged; the same claim naming a real, still-present
+// file/symbol must not be.
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm, mkdir } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { runDocClaimResolutionDetector } from "../lib/detectors/doc-claim-resolution-detector.js";
+
+async function tmpRepo({ claudeMd = "", serverFiles = {} }) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "dcr-"));
+  await mkdir(path.join(dir, "server", "lib"), { recursive: true });
+  await mkdir(path.join(dir, "docs"), { recursive: true });
+  await writeFile(path.join(dir, "CLAUDE.md"), claudeMd, "utf8");
+  for (const [name, content] of Object.entries(serverFiles)) {
+    await writeFile(path.join(dir, "server", "lib", name), content, "utf8");
+  }
+  return dir;
+}
+
+describe("doc-claim-resolution detector — end to end", () => {
+  let dir;
+  afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
+
+  it("FLAGS a fixed-claim referencing a file that no longer exists", async () => {
+    const claudeMd = `The SSRF gap in \`server/lib/gone-now.js\` was fixed last week.`;
+    dir = await tmpRepo({ claudeMd });
+    const r = await runDocClaimResolutionDetector({ root: dir });
+    assert.equal(r.ok, true);
+    const hit = r.findings.find((f) => f.id === "doc_claim_file_not_found");
+    assert.ok(hit, "a fixed-claim on a nonexistent file must be flagged");
+    assert.equal(hit.evidence.ref, "server/lib/gone-now.js");
+  });
+
+  it("does NOT flag a fixed-claim referencing a file that exists", async () => {
+    const claudeMd = `The SSRF gap in \`server/lib/real-file.js\` was fixed last week.`;
+    dir = await tmpRepo({ claudeMd, serverFiles: { "real-file.js": "// real content" } });
+    const r = await runDocClaimResolutionDetector({ root: dir });
+    const hit = r.findings.find((f) => f.evidence?.ref === "server/lib/real-file.js");
+    assert.equal(hit, undefined, "a real, existing file must not be flagged");
+  });
+
+  it("FLAGS a fixed-claim naming a function symbol no longer present in the file", async () => {
+    const claudeMd = `\`server/lib/real-file.js#missingFn\` was patched.`;
+    dir = await tmpRepo({ claudeMd, serverFiles: { "real-file.js": "export function otherFn() {}" } });
+    const r = await runDocClaimResolutionDetector({ root: dir });
+    const hit = r.findings.find((f) => f.id === "doc_claim_symbol_not_found");
+    assert.ok(hit);
+    assert.equal(hit.evidence.symbol, "missingFn");
+  });
+
+  it("does NOT flag a fixed-claim naming a symbol that IS present in the file", async () => {
+    const claudeMd = `\`server/lib/real-file.js#realFn\` was resolved.`;
+    dir = await tmpRepo({ claudeMd, serverFiles: { "real-file.js": "export function realFn() {}" } });
+    const r = await runDocClaimResolutionDetector({ root: dir });
+    const hit = r.findings.find((f) => f.evidence?.symbol === "realFn");
+    assert.equal(hit, undefined);
+  });
+
+  it("does NOT flag a file reference with no fixed/closed/resolved keyword nearby", async () => {
+    const claudeMd = `See \`server/lib/gone-now.js\` for the pattern.`;
+    dir = await tmpRepo({ claudeMd });
+    const r = await runDocClaimResolutionDetector({ root: dir });
+    const hit = r.findings.find((f) => f.evidence?.ref === "server/lib/gone-now.js");
+    assert.equal(hit, undefined, "no fixed-adjacent keyword on this line — not a resolution claim");
+  });
+
+  it("does NOT flag a file reference on a line citing a DIFFERENT project's GitHub repo", async () => {
+    // Real instance found running this detector against the live tree:
+    // docs/lens-specs/law-capability-map.md cites CourtListener's own
+    // `cl/search/forms.py` as evidence for an API field name — the
+    // "fixed/closed" keyword on that line describes the Concord macro, not
+    // a claim that cl/search/forms.py exists in this repo.
+    const claudeMd = `CLOSED — verified against github.com/freelawproject/courtlistener's \`cl/search/forms.py\` SearchForm.`;
+    dir = await tmpRepo({ claudeMd });
+    const r = await runDocClaimResolutionDetector({ root: dir });
+    const hit = r.findings.find((f) => f.evidence?.ref === "cl/search/forms.py");
+    assert.equal(hit, undefined, "a citation of another project's own file must not be flagged as a stale Concord reference");
+  });
+
+  it("does NOT flag a file reference cited via raw.githubusercontent.com (no github.com/ URL)", async () => {
+    const claudeMd = `CLOSED — re-fetched \`cl/search/forms.py\` from raw.githubusercontent.com and confirmed the field.`;
+    dir = await tmpRepo({ claudeMd });
+    const r = await runDocClaimResolutionDetector({ root: dir });
+    const hit = r.findings.find((f) => f.evidence?.ref === "cl/search/forms.py");
+    assert.equal(hit, undefined, "a raw.githubusercontent.com citation is still an external-repo citation");
+  });
+
+  it("does NOT flag a file reference cited via a bare owner/repo shorthand near the word GitHub (no URL at all)", async () => {
+    const claudeMd = `CLOSED — source: \`freelawproject/courtlistener\` GitHub — \`cl/search/forms.py\`.`;
+    dir = await tmpRepo({ claudeMd });
+    const r = await runDocClaimResolutionDetector({ root: dir });
+    const hit = r.findings.find((f) => f.evidence?.ref === "cl/search/forms.py");
+    assert.equal(hit, undefined, "a bare owner/repo + GitHub mention is still an external-repo citation");
+  });
+
+  it("STILL flags a stale bare-shorthand ref even though it also has no repo-top-level-dir prefix (the fix must not be a blunt path-prefix filter)", async () => {
+    const claudeMd = `The onboarding flow was fixed in \`register/page.tsx\`.`;
+    dir = await tmpRepo({ claudeMd }); // no such file created — genuinely stale
+    const r = await runDocClaimResolutionDetector({ root: dir });
+    const hit = r.findings.find((f) => f.evidence?.ref === "register/page.tsx");
+    assert.ok(hit, "a genuinely stale shorthand ref with no external-repo citation nearby must still be flagged");
+  });
+
+  it("does NOT flag a `path:123` reference where 123 is a line number, not a symbol", async () => {
+    const claudeMd = `Fixed at \`server/lib/real-file.js:42\`.`;
+    dir = await tmpRepo({ claudeMd, serverFiles: { "real-file.js": "line1\nline2" } });
+    const r = await runDocClaimResolutionDetector({ root: dir });
+    const symbolHit = r.findings.find((f) => f.id === "doc_claim_symbol_not_found");
+    assert.equal(symbolHit, undefined, "a pure digit after : is a line number, never treated as a missing symbol");
+  });
+});

--- a/server/tests/doc-claim-resolution-detector.test.js
+++ b/server/tests/doc-claim-resolution-detector.test.js
@@ -105,6 +105,31 @@ describe("doc-claim-resolution detector — end to end", () => {
     assert.ok(hit, "a genuinely stale shorthand ref with no external-repo citation nearby must still be flagged");
   });
 
+  it("STILL flags a claim citing a lookalike host that is NOT github.com (host-anchoring — CodeQL alert #4772)", async () => {
+    // "notgithub.com/x" and "evilgithubusercontent.com" contain the strings
+    // "github.com/" and "githubusercontent.com" as unanchored substrings —
+    // the pre-fix regex (no left-boundary) would have treated these as a
+    // real external-repo citation and wrongly suppressed the finding.
+    const claudeMd = `CLOSED — verified against notgithub.com/freelawproject/courtlistener \`cl/search/forms.py\`.`;
+    dir = await tmpRepo({ claudeMd });
+    const r = await runDocClaimResolutionDetector({ root: dir });
+    const hit = r.findings.find((f) => f.evidence?.ref === "cl/search/forms.py");
+    assert.ok(hit, "a lookalike host (notgithub.com) must NOT be treated as the real github.com");
+  });
+
+  it("does NOT flag a file reference cited via a genuine dot-separated GitHub subdomain other than raw.", async () => {
+    // The host-anchor must allow ANY dot-separated subdomain of
+    // githubusercontent.com/github.com (real CDN/API hosts use several),
+    // not just the one literal fixture string "raw." — distinguishing a
+    // real subdomain (preceded by ".") from a glued-on lookalike prefix
+    // (preceded by a word character, no separator) is the actual fix.
+    const claudeMd = `CLOSED — re-fetched \`cl/search/forms.py\` from media.githubusercontent.com and confirmed the field.`;
+    dir = await tmpRepo({ claudeMd });
+    const r = await runDocClaimResolutionDetector({ root: dir });
+    const hit = r.findings.find((f) => f.evidence?.ref === "cl/search/forms.py");
+    assert.equal(hit, undefined, "any dot-separated githubusercontent.com subdomain is a real external-source signal");
+  });
+
   it("does NOT flag a `path:123` reference where 123 is a line number, not a symbol", async () => {
     const claudeMd = `Fixed at \`server/lib/real-file.js:42\`.`;
     dir = await tmpRepo({ claudeMd, serverFiles: { "real-file.js": "line1\nline2" } });

--- a/server/tests/internal-actor-stamp-detector.test.js
+++ b/server/tests/internal-actor-stamp-detector.test.js
@@ -1,0 +1,104 @@
+// tests/internal-actor-stamp-detector.test.js
+//
+// Bidirectional pin: `{ ...var, internal: true }` and `x.internal = true`
+// must be flagged; the confirmed-guarded jobs.enqueue site (isSystemJob check
+// nearby) must be allowlisted and NOT flagged.
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm, mkdir } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { runInternalActorStampDetector } from "../lib/detectors/internal-actor-stamp-detector.js";
+
+async function tmpRepo({ serverJs = "" }) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "ias-"));
+  await mkdir(path.join(dir, "server"), { recursive: true });
+  await writeFile(path.join(dir, "server", "server.js"), serverJs, "utf8");
+  return dir;
+}
+
+describe("internal-actor-stamp detector — end to end", () => {
+  let dir;
+  afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
+
+  it("FLAGS a spread-then-stamp actor built from a variable", async () => {
+    const serverJs = `
+function runSomeJob(j) {
+  const ctx = { actor: { ...j.actor, internal: true } };
+  return ctx;
+}
+`;
+    dir = await tmpRepo({ serverJs });
+    const r = await runInternalActorStampDetector({ root: dir });
+    assert.equal(r.ok, true);
+    const hit = r.findings.find((f) => f.id === "internal_actor_stamp_spread");
+    assert.ok(hit, "spread-then-stamp from j.actor must be flagged");
+    assert.equal(hit.evidence.spreadSource, "j.actor");
+    assert.equal(hit.severity, "high");
+  });
+
+  it("FLAGS a bare .internal = true assignment", async () => {
+    const serverJs = `
+function attach(ctx) {
+  ctx.internal = true;
+}
+`;
+    dir = await tmpRepo({ serverJs });
+    const r = await runInternalActorStampDetector({ root: dir });
+    const hit = r.findings.find((f) => f.id === "internal_actor_stamp_assign");
+    assert.ok(hit);
+    assert.equal(hit.evidence.target, "ctx");
+    assert.equal(hit.severity, "medium");
+  });
+
+  it("does NOT flag the reviewed jobs.enqueue site (isSystemJob guard present nearby)", async () => {
+    const serverJs = `
+async function runJob(j) {
+  const actorRole = String(j.actor?.role || "");
+  const isSystemJob = !j.actor || j.actor.internal === true || actorRole === "system" || actorRole === "owner" || actorRole === "founder";
+  let ctx;
+  if (isSystemJob) {
+    ctx = makeInternalCtx("job_runner");
+    if (j.actor) { ctx.actor = { ...j.actor, internal: true }; }
+  } else {
+    ctx = makeCtx(null);
+    ctx.internal = false;
+    ctx.actor = { ...j.actor, internal: false };
+  }
+}
+`;
+    dir = await tmpRepo({ serverJs });
+    const r = await runInternalActorStampDetector({ root: dir });
+    const hit = r.findings.find((f) => f.id === "internal_actor_stamp_spread");
+    assert.equal(hit, undefined, "the reviewed, isSystemJob-guarded site must be allowlisted");
+    const summary = r.findings.find((f) => f.id === "internal_actor_stamp_summary");
+    assert.ok(summary.evidence.exempted >= 1, "the allowlisted site must still be counted");
+  });
+
+  it("does NOT flag the pattern when it only appears inside a comment (self-inflicted false-positive guard)", async () => {
+    // This detector's OWN source file explains the bug shape by quoting it
+    // in prose ("{ ...j.actor, internal: true }") — without comment-
+    // stripping, the detector would flag its own documentation. Pin that
+    // directly rather than relying on eyeballing the real-tree run.
+    const serverJs = `
+// Seeded by a bug where code did { ...j.actor, internal: true } and also
+// somewhere did x.internal = true without checking anything first.
+function realCode() {
+  return { userId: "system", role: "owner", internal: true };
+}
+`;
+    dir = await tmpRepo({ serverJs });
+    const r = await runInternalActorStampDetector({ root: dir });
+    const nonInfo = r.findings.filter((f) => f.severity !== "info");
+    assert.equal(nonInfo.length, 0, "a comment-only mention of the risky shape must not be flagged");
+  });
+
+  it("does NOT flag a fully-literal system actor with no spread/variable", async () => {
+    const serverJs = `
+const ctx = { actor: { userId: "system", role: "owner", scopes: ["*"], internal: true } };
+`;
+    dir = await tmpRepo({ serverJs });
+    const r = await runInternalActorStampDetector({ root: dir });
+    assert.equal(r.findings.filter((f) => f.severity !== "info").length, 0, "a hardcoded literal actor is the safe shape");
+  });
+});

--- a/server/tests/internal-actor-stamp-detector.test.js
+++ b/server/tests/internal-actor-stamp-detector.test.js
@@ -10,10 +10,14 @@ import os from "node:os";
 import path from "node:path";
 import { runInternalActorStampDetector } from "../lib/detectors/internal-actor-stamp-detector.js";
 
-async function tmpRepo({ serverJs = "" }) {
+async function tmpRepo({ serverJs = "", detectorFiles = {} }) {
   const dir = await mkdtemp(path.join(os.tmpdir(), "ias-"));
   await mkdir(path.join(dir, "server"), { recursive: true });
+  await mkdir(path.join(dir, "server", "lib", "detectors"), { recursive: true });
   await writeFile(path.join(dir, "server", "server.js"), serverJs, "utf8");
+  for (const [name, content] of Object.entries(detectorFiles)) {
+    await writeFile(path.join(dir, "server", "lib", "detectors", name), content, "utf8");
+  }
   return dir;
 }
 
@@ -91,6 +95,28 @@ function realCode() {
     const r = await runInternalActorStampDetector({ root: dir });
     const nonInfo = r.findings.filter((f) => f.severity !== "info");
     assert.equal(nonInfo.length, 0, "a comment-only mention of the risky shape must not be flagged");
+  });
+
+  it("does NOT scan server/lib/detectors/*.js at all (self-match guard: an ALLOWLIST reason string quoting the risky pattern in prose must not self-flag)", async () => {
+    // Real bug found twice this session: a detector's own ALLOWLIST entry
+    // explains WHY a site is safe by describing the pattern in prose inside
+    // a `reason:` string — which stripComments() correctly does NOT strip
+    // (it's real string data, not a comment) — so the detector flagged its
+    // own explanatory text as a fresh violation. The durable fix is
+    // excluding server/lib/detectors/ from the scan entirely (this whole
+    // directory is static-analysis code that never constructs a privileged
+    // runtime ctx), not just careful wording.
+    const detectorFiles = {
+      "some-other-detector.js": `
+const ALLOWLIST = [{
+  reason: "this site sets ctx.internal = true safely because of a guard",
+}];
+`,
+    };
+    dir = await tmpRepo({ serverJs: "", detectorFiles });
+    const r = await runInternalActorStampDetector({ root: dir });
+    const nonInfo = r.findings.filter((f) => f.severity !== "info");
+    assert.equal(nonInfo.length, 0, "server/lib/detectors/*.js must never be scanned by this detector");
   });
 
   it("does NOT flag a fully-literal system actor with no spread/variable", async () => {

--- a/server/tests/project-continuation-initiative.test.js
+++ b/server/tests/project-continuation-initiative.test.js
@@ -35,6 +35,27 @@ function backdateProject(db, projectId, secondsAgo) {
   db.prepare(`UPDATE projects SET updated_at = unixepoch() - ? WHERE id = ?`).run(secondsAgo, projectId);
 }
 
+/**
+ * Pre-existing bug found running this file's tests for real (not just at a
+ * convenient moment): initiative-engine.js's DEFAULT quiet-hours window is
+ * 22:00-08:00 (server/lib/initiative-engine.js:503-504) — a ~10h/day
+ * overnight span covering ~42% of any given day. Any subtest that expects
+ * `proposed: 1` runs straight into checkRateLimits()'s quiet-hours gate and
+ * fails with reason:"quiet_hours" whenever CI happens to execute during that
+ * window (confirmed live: 23:58 UTC, `_isQuietHours("22:00","08:00")` true).
+ * This has nothing to do with any of this test file's actual assertions —
+ * it's a wall-clock-time-of-day dependency the tests never neutralized.
+ * quietStart===quietEnd="00:00" makes _isQuietHours's same-day-range branch
+ * evaluate `currentMinutes >= 0 && currentMinutes < 0`, which is always
+ * false — a permanent, deterministic "never quiet" override, not a clock
+ * mock. The engine persists settings in `db`, so a second
+ * createInitiativeEngine(db) instance (e.g. the one project-continuation-
+ * initiative.js's own engineFor() lazily creates) reads the same override.
+ */
+function disableQuietHours(db, userId) {
+  createInitiativeEngine(db).updateSettings(userId, { quietStart: "00:00", quietEnd: "00:00" });
+}
+
 /** Build a project with a real goal tree + one actionable subgoal, backdated
  *  past the idle threshold. */
 function makeIdleActionableProject(db, userId, name) {
@@ -60,6 +81,7 @@ test("Project continuation initiative — suggestion-only, gated pass", async (t
     db.pragma("foreign_keys = ON");
     return runMigrations(db).then(() => {
       const { project } = makeIdleActionableProject(db, "u1", "Ship the R&D engine");
+      disableQuietHours(db, "u1");
       const engine = createInitiativeEngine(db);
       const r = runProjectContinuationPass(db, { engine });
 
@@ -81,6 +103,7 @@ test("Project continuation initiative — suggestion-only, gated pass", async (t
     db.pragma("foreign_keys = ON");
     return runMigrations(db).then(() => {
       makeIdleActionableProject(db, "u2", "Second gating project");
+      disableQuietHours(db, "u2");
       const engine = createInitiativeEngine(db);
 
       const first = runProjectContinuationPass(db, { engine });
@@ -144,6 +167,7 @@ test("Project continuation initiative — suggestion-only, gated pass", async (t
       linkMarathonToProject(db, project.id, mar.sessionId); // bumps projects.updated_at — real activity
       db.prepare(`UPDATE agent_marathon_sessions SET status = 'paused' WHERE id = ?`).run(mar.sessionId);
       backdateProject(db, project.id, 3600); // re-idle it AFTER the link, so only `paused` is under test
+      disableQuietHours(db, "u5");
 
       const engine = createInitiativeEngine(db);
       const r = runProjectContinuationPass(db, { engine });
@@ -185,6 +209,7 @@ test("Project continuation initiative — suggestion-only, gated pass", async (t
     db.pragma("foreign_keys = ON");
     return runMigrations(db).then(() => {
       makeIdleActionableProject(db, "u7", "Via heartbeat wrapper");
+      disableQuietHours(db, "u7");
       _resetProjectContinuationEngine();
       const r = runProjectContinuationCycle({ db });
       assert.equal(r.ok, true);

--- a/server/tests/public-read-write-verb-detector.test.js
+++ b/server/tests/public-read-write-verb-detector.test.js
@@ -89,13 +89,14 @@ register("demo", "list_mine", (ctx) => { return []; });
     assert.equal(flagged.length, 0, "list_mine is read-shaped/self-scoping by naming convention");
   });
 
-  it("FLAGS with handler_not_found when the macro has no locatable registration", async () => {
+  it("FLAGS with handler_not_found (medium — inert, not a live anonymous-write path) when the macro has no locatable registration", async () => {
     const serverJs = PRELUDE; // demo.create is declared public but never registered anywhere
     dir = await tmpRepo({ serverJs });
     const r = await runPublicReadWriteVerbDetector({ root: dir });
     const hit = r.findings.find((f) => f.evidence?.domain === "demo" && f.evidence?.macro === "create");
     assert.ok(hit);
     assert.equal(hit.id, "public_read_write_verb_handler_not_found");
+    assert.equal(hit.severity, "medium", "a macro that can't be called at all is confirmed drift, not a live risk");
   });
 
   it("finds a handler registered in server/domains/*.js, not just server.js", async () => {
@@ -107,5 +108,82 @@ register("demo", "list_mine", (ctx) => { return []; });
     const r = await runPublicReadWriteVerbDetector({ root: dir });
     const hit = r.findings.find((f) => f.evidence?.domain === "demo" && f.evidence?.macro === "create");
     assert.equal(hit, undefined, "handler found in domains/demo.js with an ownership idiom must not be flagged");
+  });
+
+  it("finds a real ctx?.actor?.userId (optional-chained after ctx too, not just after .actor)", async () => {
+    // Real false-negative this exact pattern caused against the live tree:
+    // dtu.update's handler uses `ctx?.actor?.userId` and was wrongly flagged
+    // until OWNERSHIP_IDIOM_RE was widened to allow the `?` after `ctx`.
+    const serverJs = PRELUDE + `
+register("demo", "create", (ctx, input) => {
+  const userId = ctx?.actor?.userId;
+  if (!userId) return { ok: false, reason: "no_user" };
+  return { ok: true };
+});
+`;
+    dir = await tmpRepo({ serverJs });
+    const r = await runPublicReadWriteVerbDetector({ root: dir });
+    const hit = r.findings.find((f) => f.evidence?.domain === "demo" && f.evidence?.macro === "create");
+    assert.equal(hit, undefined, "ctx?.actor?.userId must be recognized as a real ownership idiom");
+  });
+
+  it("gives two DIFFERENT not-found macros distinct, fingerprint-safe locations (regression: shared-location fingerprint collision)", async () => {
+    // Real bug found running the pre-fix detector against the live tree:
+    // every finding shared one fixed `location` (the publicReadDomains
+    // block's start line), so the ratchet's sha256(detector|rule|location|
+    // severity) fingerprint collapsed 36 distinct findings down to 2 —
+    // silently losing 34 from baseline/ratchet tracking forever. Two
+    // different dead macros must never produce the same `location`.
+    const serverJs = `
+const publicReadDomains = {
+  demo: new Set(["create", "delete"]),
+};
+`; // neither macro is registered anywhere
+    dir = await tmpRepo({ serverJs });
+    const r = await runPublicReadWriteVerbDetector({ root: dir });
+    const create = r.findings.find((f) => f.evidence?.domain === "demo" && f.evidence?.macro === "create");
+    const del = r.findings.find((f) => f.evidence?.domain === "demo" && f.evidence?.macro === "delete");
+    assert.ok(create && del);
+    assert.notEqual(create.location, del.location, "distinct macros must fingerprint distinctly, never share a location");
+  });
+
+  it("gives two DIFFERENT resolved (no-ownership-idiom) macros distinct locations pointing at their real registration line", async () => {
+    const serverJs = `
+const publicReadDomains = {
+  demo: new Set(["create", "update"]),
+};
+register("demo", "create", (ctx, input) => { return STATE.things.set(input.id, input.value); });
+
+register("demo", "update", (ctx, input) => { return STATE.other.set(input.id, input.value); });
+`;
+    dir = await tmpRepo({ serverJs });
+    const r = await runPublicReadWriteVerbDetector({ root: dir });
+    const create = r.findings.find((f) => f.evidence?.domain === "demo" && f.evidence?.macro === "create");
+    const update = r.findings.find((f) => f.evidence?.domain === "demo" && f.evidence?.macro === "update");
+    assert.ok(create && update);
+    assert.equal(create.id, "public_read_write_verb_no_ownership_idiom");
+    assert.equal(update.id, "public_read_write_verb_no_ownership_idiom");
+    assert.notEqual(create.location, update.location, "each resolved handler's location must point at ITS OWN real registration line");
+  });
+
+  it("does NOT flag an allowlisted, reviewed-intentional macro (collab.join)", async () => {
+    // Mirrors the real live-tree instance: collab.join has no ownership
+    // idiom by design (session-link-based join), reviewed and allowlisted
+    // in the detector's own ALLOWLIST rather than patched around.
+    const serverJs = `
+const publicReadDomains = {
+  collab: new Set(["join"]),
+};
+register("collab", "join", (ctx, input) => {
+  const userId = ctx?.actor?.userId || "anonymous";
+  return { ok: true, userId };
+});
+`;
+    dir = await tmpRepo({ serverJs });
+    const r = await runPublicReadWriteVerbDetector({ root: dir });
+    const hit = r.findings.find((f) => f.evidence?.domain === "collab" && f.evidence?.macro === "join");
+    assert.equal(hit, undefined, "collab.join is allowlisted as a reviewed, intentional design");
+    const summary = r.findings.find((f) => f.id === "public_read_write_verb_summary");
+    assert.equal(summary.evidence.allowlistedCount, 1);
   });
 });

--- a/server/tests/public-read-write-verb-detector.test.js
+++ b/server/tests/public-read-write-verb-detector.test.js
@@ -1,0 +1,111 @@
+// tests/public-read-write-verb-detector.test.js
+//
+// Bidirectional pin for public-read-write-verb-detector: a write-shaped
+// macro name in publicReadDomains whose handler has no ownership-check idiom
+// must be flagged; the SAME macro with a real ctx.actor.userId guard (or a
+// read-shaped/"_mine"-suffixed name) must NOT be flagged.
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm, mkdir } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  runPublicReadWriteVerbDetector,
+  parsePublicReadDomains,
+  findHandlerBody,
+} from "../lib/detectors/public-read-write-verb-detector.js";
+
+async function tmpRepo({ serverJs, domainFiles = {} }) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "prwv-"));
+  await mkdir(path.join(dir, "server", "domains"), { recursive: true });
+  await writeFile(path.join(dir, "server", "server.js"), serverJs, "utf8");
+  for (const [name, content] of Object.entries(domainFiles)) {
+    await writeFile(path.join(dir, "server", "domains", name), content, "utf8");
+  }
+  return dir;
+}
+
+const PRELUDE = `
+const publicReadDomains = {
+  lore: new Set(["list", "get"]),
+  demo: new Set(["create", "list_mine"]),
+};
+`;
+
+describe("public-read-write-verb detector — pure parser", () => {
+  it("parses domain->macro pairs out of the publicReadDomains literal", () => {
+    const parsed = parsePublicReadDomains(PRELUDE);
+    assert.ok(parsed);
+    const pairs = parsed.entries.map((e) => `${e.domain}.${e.macro}`).sort();
+    assert.deepEqual(pairs, ["demo.create", "demo.list_mine", "lore.get", "lore.list"]);
+  });
+
+  it("finds a register()-registered handler body by domain+macro", () => {
+    const src = `register("demo", "create", (ctx, artifact, params) => { return ctx.actor.userId; });`;
+    const body = findHandlerBody(src, "demo", "create");
+    assert.ok(body && body.includes("ctx.actor.userId"));
+  });
+});
+
+describe("public-read-write-verb detector — end to end", () => {
+  let dir;
+  afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
+
+  it("FLAGS a write-verb macro whose handler has no ownership idiom", async () => {
+    const serverJs = PRELUDE + `
+register("demo", "create", (ctx, artifact, params) => {
+  return STATE.things.set(params.id, params.value);
+});
+`;
+    dir = await tmpRepo({ serverJs });
+    const r = await runPublicReadWriteVerbDetector({ root: dir });
+    assert.equal(r.ok, true);
+    const hit = r.findings.find((f) => f.evidence?.domain === "demo" && f.evidence?.macro === "create");
+    assert.ok(hit, "demo.create should be flagged");
+    assert.equal(hit.id, "public_read_write_verb_no_ownership_idiom");
+    assert.equal(hit.severity, "high");
+  });
+
+  it("does NOT flag a write-verb macro whose handler checks ctx.actor.userId", async () => {
+    const serverJs = PRELUDE + `
+register("demo", "create", (ctx, artifact, params) => {
+  if (!ctx.actor?.userId) return { ok: false, reason: "no_user" };
+  return STATE.things.set(params.id, { ...params.value, owner_id: ctx.actor.userId });
+});
+`;
+    dir = await tmpRepo({ serverJs });
+    const r = await runPublicReadWriteVerbDetector({ root: dir });
+    const hit = r.findings.find((f) => f.evidence?.domain === "demo" && f.evidence?.macro === "create");
+    assert.equal(hit, undefined, "a real ownership-check idiom must not be flagged");
+  });
+
+  it("does NOT flag a read-shaped or _mine-suffixed macro (verb heuristic scoped correctly)", async () => {
+    const serverJs = PRELUDE + `
+register("demo", "list_mine", (ctx) => { return []; });
+`;
+    dir = await tmpRepo({ serverJs });
+    const r = await runPublicReadWriteVerbDetector({ root: dir });
+    const flagged = r.findings.filter((f) => f.evidence?.macro === "list_mine");
+    assert.equal(flagged.length, 0, "list_mine is read-shaped/self-scoping by naming convention");
+  });
+
+  it("FLAGS with handler_not_found when the macro has no locatable registration", async () => {
+    const serverJs = PRELUDE; // demo.create is declared public but never registered anywhere
+    dir = await tmpRepo({ serverJs });
+    const r = await runPublicReadWriteVerbDetector({ root: dir });
+    const hit = r.findings.find((f) => f.evidence?.domain === "demo" && f.evidence?.macro === "create");
+    assert.ok(hit);
+    assert.equal(hit.id, "public_read_write_verb_handler_not_found");
+  });
+
+  it("finds a handler registered in server/domains/*.js, not just server.js", async () => {
+    const serverJs = PRELUDE;
+    const domainFiles = {
+      "demo.js": `register("demo", "create", (ctx) => { if (!ctx.actor?.userId) return {ok:false}; return {}; });`,
+    };
+    dir = await tmpRepo({ serverJs, domainFiles });
+    const r = await runPublicReadWriteVerbDetector({ root: dir });
+    const hit = r.findings.find((f) => f.evidence?.domain === "demo" && f.evidence?.macro === "create");
+    assert.equal(hit, undefined, "handler found in domains/demo.js with an ownership idiom must not be flagged");
+  });
+});

--- a/server/tests/world-shard-write-boundary-detector.test.js
+++ b/server/tests/world-shard-write-boundary-detector.test.js
@@ -58,7 +58,12 @@ describe("world-shard-write-boundary detector — end to end", () => {
     const hit = r.findings.find((f) => f.id === "world_shard_write_from_route");
     assert.ok(hit, "route write to world_npcs must be flagged");
     assert.equal(hit.evidence.table, "world_npcs");
-    assert.equal(hit.severity, "high");
+    // Severity is "medium", not "high" — CONCORD_SHARD_WORLDS defaults off
+    // and no route-to-shard write-forwarding infrastructure exists anywhere
+    // in this codebase yet, so this reflects the app's current universal
+    // architecture (confirmed by grepping every shardingEnabled() call
+    // site against the live tree), not a localized new-code bug.
+    assert.equal(hit.severity, "medium");
   });
 
   it("does NOT flag a route writing to a user-global table", async () => {
@@ -72,18 +77,28 @@ describe("world-shard-write-boundary detector — end to end", () => {
   });
 
   it("FLAGS a scope:'global' heartbeat handler writing to a per-world table", async () => {
+    // Deliberately NOT named "npc-travel-cycle"/"npc-ambition-cycle" — both
+    // are real, reviewed ALLOWLIST entries, and this fixture must exercise
+    // the un-allowlisted flag path.
     const serverJs = `
-registerHeartbeat("npc-travel-cycle", { frequency: 60, handler: runNpcTravelCycle, scope: "global" });
+registerHeartbeat("npc-migration-cycle", { frequency: 60, handler: runNpcMigrationCycle, scope: "global" });
 `;
     const emergentFiles = {
-      "npc-travel.js": `function runNpcTravelCycle() { db.prepare("INSERT INTO city_presence (id) VALUES (?)").run(1); }`,
+      "npc-migration.js": `function runNpcMigrationCycle() { db.prepare("INSERT INTO city_presence (id) VALUES (?)").run(1); }`,
     };
     dir = await tmpRepo({ serverJs, emergentFiles });
     const r = await runWorldShardWriteBoundaryDetector({ root: dir });
     const hit = r.findings.find((f) => f.id === "world_shard_write_from_global_heartbeat");
     assert.ok(hit, "global-scope heartbeat writing city_presence must be flagged");
-    assert.equal(hit.evidence.heartbeat, "npc-travel-cycle");
+    assert.equal(hit.evidence.heartbeat, "npc-migration-cycle");
     assert.equal(hit.evidence.table, "city_presence");
+    assert.equal(hit.severity, "medium");
+    // Regression pin: this finding used to never set `location` at all
+    // (falls back to "" in the fingerprint), which collapsed every
+    // global-heartbeat finding onto ONE shared fingerprint regardless of
+    // which heartbeat/table it was about.
+    assert.ok(hit.location && hit.location.length > 0, "location must be set and non-empty");
+    assert.match(hit.location, /npc-migration\.js:\d+:npc-migration-cycle$/);
   });
 
   it("does NOT flag a scope:'world' heartbeat handler writing to a per-world table", async () => {
@@ -97,5 +112,37 @@ registerHeartbeat("per-world-thing", { frequency: 60, handler: runPerWorldThing,
     const r = await runWorldShardWriteBoundaryDetector({ root: dir });
     const hit = r.findings.find((f) => f.id === "world_shard_write_from_global_heartbeat");
     assert.equal(hit, undefined, "scope:'world' heartbeats are the correct place for per-world writes");
+  });
+
+  it("gives two DIFFERENT global heartbeats distinct locations (regression: missing-location fingerprint collision)", async () => {
+    const serverJs = `
+registerHeartbeat("heartbeat-a", { frequency: 60, handler: runHeartbeatA, scope: "global" });
+registerHeartbeat("heartbeat-b", { frequency: 60, handler: runHeartbeatB, scope: "global" });
+`;
+    const emergentFiles = {
+      "heartbeat-a.js": `function runHeartbeatA() { db.prepare("INSERT INTO world_npcs (id) VALUES (?)").run(1); }`,
+      "heartbeat-b.js": `function runHeartbeatB() { db.prepare("INSERT INTO city_presence (id) VALUES (?)").run(1); }`,
+    };
+    dir = await tmpRepo({ serverJs, emergentFiles });
+    const r = await runWorldShardWriteBoundaryDetector({ root: dir });
+    const a = r.findings.find((f) => f.evidence?.heartbeat === "heartbeat-a");
+    const b = r.findings.find((f) => f.evidence?.heartbeat === "heartbeat-b");
+    assert.ok(a && b);
+    assert.notEqual(a.location, b.location, "distinct heartbeats must fingerprint distinctly, never share a location");
+  });
+
+  it("does NOT flag an allowlisted, reviewed-intentional heartbeat (npc-ambition-cycle)", async () => {
+    const serverJs = `
+registerHeartbeat("npc-ambition-cycle", { frequency: 80, handler: runNpcAmbitionCycle, scope: "global" });
+`;
+    const emergentFiles = {
+      "npc-ambition-cycle.js": `function runNpcAmbitionCycle() { db.prepare("UPDATE world_npcs SET ambition_score = 1 WHERE id = ?").run(1); }`,
+    };
+    dir = await tmpRepo({ serverJs, emergentFiles });
+    const r = await runWorldShardWriteBoundaryDetector({ root: dir });
+    const hit = r.findings.find((f) => f.evidence?.heartbeat === "npc-ambition-cycle");
+    assert.equal(hit, undefined, "npc-ambition-cycle is a reviewed, documented cross-world-budget exception");
+    const summary = r.findings.find((f) => f.id === "world_shard_write_boundary_summary");
+    assert.equal(summary.evidence.allowlistedCount, 1);
   });
 });

--- a/server/tests/world-shard-write-boundary-detector.test.js
+++ b/server/tests/world-shard-write-boundary-detector.test.js
@@ -1,0 +1,101 @@
+// tests/world-shard-write-boundary-detector.test.js
+//
+// Bidirectional pin: a route or scope:"global" heartbeat writing to a
+// PER_WORLD_WRITE_TABLES table must be flagged; the same code writing to a
+// user-global table (not in the set) must NOT be flagged.
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm, mkdir } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  runWorldShardWriteBoundaryDetector,
+  findFunctionBody,
+} from "../lib/detectors/world-shard-write-boundary-detector.js";
+
+const PROTOCOL_SRC = `
+export const PER_WORLD_WRITE_TABLES = Object.freeze(new Set([
+  "world_npcs",
+  "city_presence",
+]));
+`;
+
+async function tmpRepo({ routeFiles = {}, serverJs = "", emergentFiles = {} }) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "wswb-"));
+  await mkdir(path.join(dir, "server", "lib"), { recursive: true });
+  await mkdir(path.join(dir, "server", "routes"), { recursive: true });
+  await mkdir(path.join(dir, "server", "emergent"), { recursive: true });
+  await writeFile(path.join(dir, "server", "lib", "world-shard-protocol.js"), PROTOCOL_SRC, "utf8");
+  await writeFile(path.join(dir, "server", "server.js"), serverJs, "utf8");
+  for (const [name, content] of Object.entries(routeFiles)) {
+    await writeFile(path.join(dir, "server", "routes", name), content, "utf8");
+  }
+  for (const [name, content] of Object.entries(emergentFiles)) {
+    await writeFile(path.join(dir, "server", "emergent", name), content, "utf8");
+  }
+  return dir;
+}
+
+describe("world-shard-write-boundary detector — pure helpers", () => {
+  it("finds a function-declaration body by identifier", () => {
+    const blob = `function runFoo(a,b) { db.prepare("INSERT INTO world_npcs (id) VALUES (?)").run(a); }`;
+    const found = findFunctionBody(blob, "runFoo");
+    assert.ok(found && found.body.includes("world_npcs"));
+  });
+});
+
+describe("world-shard-write-boundary detector — end to end", () => {
+  let dir;
+  afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
+
+  it("FLAGS a route writing to a per-world table", async () => {
+    const routeFiles = {
+      "worlds.js": `router.post("/x", (req,res) => { db.prepare("UPDATE world_npcs SET hp = ? WHERE id = ?").run(1, 2); });`,
+    };
+    dir = await tmpRepo({ routeFiles });
+    const r = await runWorldShardWriteBoundaryDetector({ root: dir });
+    assert.equal(r.ok, true);
+    const hit = r.findings.find((f) => f.id === "world_shard_write_from_route");
+    assert.ok(hit, "route write to world_npcs must be flagged");
+    assert.equal(hit.evidence.table, "world_npcs");
+    assert.equal(hit.severity, "high");
+  });
+
+  it("does NOT flag a route writing to a user-global table", async () => {
+    const routeFiles = {
+      "users.js": `router.post("/x", (req,res) => { db.prepare("UPDATE users SET name = ? WHERE id = ?").run("a", 2); });`,
+    };
+    dir = await tmpRepo({ routeFiles });
+    const r = await runWorldShardWriteBoundaryDetector({ root: dir });
+    const hit = r.findings.find((f) => f.id === "world_shard_write_from_route");
+    assert.equal(hit, undefined, "users is not a per-world table");
+  });
+
+  it("FLAGS a scope:'global' heartbeat handler writing to a per-world table", async () => {
+    const serverJs = `
+registerHeartbeat("npc-travel-cycle", { frequency: 60, handler: runNpcTravelCycle, scope: "global" });
+`;
+    const emergentFiles = {
+      "npc-travel.js": `function runNpcTravelCycle() { db.prepare("INSERT INTO city_presence (id) VALUES (?)").run(1); }`,
+    };
+    dir = await tmpRepo({ serverJs, emergentFiles });
+    const r = await runWorldShardWriteBoundaryDetector({ root: dir });
+    const hit = r.findings.find((f) => f.id === "world_shard_write_from_global_heartbeat");
+    assert.ok(hit, "global-scope heartbeat writing city_presence must be flagged");
+    assert.equal(hit.evidence.heartbeat, "npc-travel-cycle");
+    assert.equal(hit.evidence.table, "city_presence");
+  });
+
+  it("does NOT flag a scope:'world' heartbeat handler writing to a per-world table", async () => {
+    const serverJs = `
+registerHeartbeat("per-world-thing", { frequency: 60, handler: runPerWorldThing, scope: "world" });
+`;
+    const emergentFiles = {
+      "per-world-thing.js": `function runPerWorldThing() { db.prepare("INSERT INTO city_presence (id) VALUES (?)").run(1); }`,
+    };
+    dir = await tmpRepo({ serverJs, emergentFiles });
+    const r = await runWorldShardWriteBoundaryDetector({ root: dir });
+    const hit = r.findings.find((f) => f.id === "world_shard_write_from_global_heartbeat");
+    assert.equal(hit, undefined, "scope:'world' heartbeats are the correct place for per-world writes");
+  });
+});


### PR DESCRIPTION
## Summary

Five new detectors in `server/lib/detectors/`, each operationalizing one concrete bug category identified while debugging PR #875's CI (real regression classes this codebase's own docs/invariants already flag as unverified, or bugs directly found this session):

- **`public-read-write-verb-detector.js`** — flags a write-shaped macro name (`create`/`update`/`delete`/etc.) sitting in the Gate-2 `publicReadDomains` allowlist whose handler has no ownership-check idiom (e.g. `ctx.actor.userId`) — the shape of an anonymous-writable macro slipping into a "read" allowlist.
- **`world-shard-write-boundary-detector.js`** — flags an HTTP route or a `scope:"global"` heartbeat writing to a `PER_WORLD_WRITE_TABLES` table, violating the Phase-F world-sharding write-ownership invariant (invisible in normal testing since `CONCORD_SHARD_WORLDS` defaults off).
- **`internal-actor-stamp-detector.js`** — permanent regression guard for the `jobs.enqueue` privilege-escalation shape (`{ ...actor, internal: true }` spread-then-stamp) fixed 2026-07-27; flags the pattern anywhere else in the tree, allowlisting only reviewed-safe instances.
- **`checker-self-coverage-detector.js`** — meta-detector: flags a detector or gate script (`scripts/{audit,check,verify,grade}-*.mjs`) with no referencing test anywhere, closing the "who checks the checkers" gap.
- **`doc-claim-resolution-detector.js`** — flags stale "fixed/closed" doc claims that no longer resolve to a real file/test, while explicitly excluding citations of third-party repos' own source (verified against real false-positive instances in `docs/lens-specs/law-capability-map.md` etc.).

Each detector follows the existing `server/lib/detectors/_framework.js` contract (`DetectorReport`/`Finding` shape, `registerDetector`) and ships with a bidirectional pinning test (positive + negative fixture cases). Two detectors caught genuine self-inflicted false positives against the real live tree during verification (matching in their own explanatory comments / matching third-party citations) — both fixed via comment-stripping / external-citation detection rather than softening the pattern, per this repo's own anti-cheat convention.

Registered in `server/lib/detectors/index.js` alongside the existing ~50-detector suite.

## Test plan
- [x] `node --test` on all 5 new test files (`server/tests/{public-read-write-verb,world-shard-write-boundary,internal-actor-stamp,checker-self-coverage,doc-claim-resolution}-detector.test.js`) — all green
- [x] Each detector independently run against the real live repo tree (not just synthetic fixtures) to confirm sane, correct findings
- [ ] Full `node scripts/run-detectors.js` (all ~55 detectors together) — not yet confirmed to completion in this environment; watching CI for this

---
_Generated by [Claude Code](https://claude.ai/code/session_01S33herYGdAwwdRgSeLFvyo)_