### PR TITLE
fix(chat): external references are on-demand, not a promoted always-open panel

### DIFF
--- a/concord-frontend/app/lenses/chat/page.tsx
+++ b/concord-frontend/app/lenses/chat/page.tsx
@@ -7,6 +7,7 @@ import { LensShell } from '@/components/lens/LensShell';
 import { FirstRunTour } from '@/components/lens/FirstRunTour';
 import { DepthBadge } from '@/components/lens/DepthBadge';
 import { HackerNewsReference } from '@/components/chat/HackerNewsReference';
+import { ExternalReferenceLocale } from '@/components/lens/ExternalReferenceLocale';
 import { useLensCommand } from '@/hooks/useLensCommand';
 import { useTilePush } from '@/hooks/useTilePush';
 import { MobileTabBar } from '@/components/mobile/MobileTabBar';
@@ -4821,9 +4822,9 @@ export default function ChatLensPage() {
           </motion.div>
         )}
       </AnimatePresence>
-      <section className="mt-6 rounded-xl border border-zinc-800 bg-zinc-950/40 p-4">
+      <ExternalReferenceLocale label="Hacker News" source="hn.algolia.com" className="mt-6">
         <HackerNewsReference />
-      </section>
+      </ExternalReferenceLocale>
     </div>
     {/* Phase 12 (C4) — mobile pane switcher. Chat has multiple overlays
         (sidebar, thread-search, tool-palette, scheduled, projects) that

--- a/concord-frontend/components/lens/ExternalReferenceLocale.tsx
+++ b/concord-frontend/components/lens/ExternalReferenceLocale.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+// concord-frontend/components/lens/ExternalReferenceLocale.tsx
+//
+// The one, consistent place a lens puts a link out to an external information
+// provider (Hacker News, GitHub, etc.) — collapsed by default, opened on
+// demand. Concord's own answer for "I need outside context" is ConKay/chat
+// (tools.web_search + citation), not a permanently-mounted third-party feed
+// competing for the same screen real estate as the lens's own work — a
+// promoted, always-visible external panel reads as free advertising for
+// someone else's product on Concord's own page, not a designed feature.
+//
+// This is the "designed locale": every lens that needs one mounts THIS
+// component in the same collapsed, search-on-demand shape, instead of each
+// lens inventing its own always-open block. Content lives in `children` —
+// this component only owns the disclosure chrome.
+
+import { useState, type ReactNode } from 'react';
+import { ChevronDown, ChevronUp, Globe2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface ExternalReferenceLocaleProps {
+  /** e.g. "Hacker News", "GitHub" — shown in the collapsed pill. */
+  label: string;
+  /** e.g. "hn.algolia.com" — small provenance hint next to the label. */
+  source?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function ExternalReferenceLocale({ label, source, children, className }: ExternalReferenceLocaleProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <section
+      className={cn('rounded-lg border border-zinc-800/80 bg-zinc-950/40', className)}
+      data-testid="external-reference-locale"
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-zinc-400 hover:text-zinc-200 transition-colors"
+        aria-expanded={open}
+      >
+        <Globe2 className="h-3.5 w-3.5 text-zinc-500" />
+        <span>Look up {label}</span>
+        {source && <span className="font-mono text-[10px] text-zinc-600">{source}</span>}
+        {open ? <ChevronUp className="ml-auto h-3.5 w-3.5" /> : <ChevronDown className="ml-auto h-3.5 w-3.5" />}
+      </button>
+      {open && <div className="px-3 pb-3 pt-1 border-t border-zinc-800/60">{children}</div>}
+    </section>
+  );
+}
+
+export default ExternalReferenceLocale;

--- a/concord-frontend/lib/panel-affinity.ts
+++ b/concord-frontend/lib/panel-affinity.ts
@@ -15,7 +15,10 @@
 // (their own rich page is the depth) — that's fine.
 export const PANEL_AFFINITY: Record<string, string[]> = {
   // ── Core 6 ──
-  chat: ['research.academic-search'],
+  // chat intentionally has no cross-mounted panel — DTU citation/piping
+  // already covers cross-lens composition for chat, and a second
+  // "Cross-lens panels" strip on top of that was redundant screen space,
+  // not a distinct capability (owner feedback, 2026-08-06).
   board: ['projects.portfolio'],
   graph: ['research.academic-search'],
   code: ['code-quality.pr-decoration', 'observe.action'],

--- a/concord-frontend/tests/components/ExternalReferenceLocale.test.tsx
+++ b/concord-frontend/tests/components/ExternalReferenceLocale.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { ExternalReferenceLocale } from '@/components/lens/ExternalReferenceLocale';
+
+describe('ExternalReferenceLocale — collapsed-by-default external reference locale', () => {
+  it('starts collapsed: the label pill renders but the content does not', () => {
+    render(
+      <ExternalReferenceLocale label="Hacker News" source="hn.algolia.com">
+        <div data-testid="hn-search-form">search form</div>
+      </ExternalReferenceLocale>
+    );
+    expect(screen.getByText(/Look up Hacker News/i)).toBeInTheDocument();
+    expect(screen.getByText('hn.algolia.com')).toBeInTheDocument();
+    expect(screen.queryByTestId('hn-search-form')).not.toBeInTheDocument();
+  });
+
+  it('clicking the pill expands it and reveals the content, on demand', () => {
+    render(
+      <ExternalReferenceLocale label="Hacker News">
+        <div data-testid="hn-search-form">search form</div>
+      </ExternalReferenceLocale>
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Look up Hacker News/i }));
+    expect(screen.getByTestId('hn-search-form')).toBeInTheDocument();
+
+    // Collapses again on a second click — never a permanently-mounted panel.
+    fireEvent.click(screen.getByRole('button', { name: /Look up Hacker News/i }));
+    expect(screen.queryByTestId('hn-search-form')).not.toBeInTheDocument();
+  });
+
+  it('renders without a source hint when none is given', () => {
+    render(
+      <ExternalReferenceLocale label="GitHub">
+        <div>content</div>
+      </ExternalReferenceLocale>
+    );
+    expect(screen.getByText(/Look up GitHub/i)).toBeInTheDocument();
+  });
+});

--- a/concord-frontend/tests/world-page-explore-mode-layout.test.ts
+++ b/concord-frontend/tests/world-page-explore-mode-layout.test.ts
@@ -5,24 +5,29 @@
 // Root cause, confirmed by measuring COMPUTED layout in a live Playwright
 // session (not a guess from reading source): the 3D Explore-mode container
 // (`<div ref={exploreShellRef} className="flex-1 relative min-h-0">`, which
-// holds the Three.js canvas) is a flex-column sibling of four other,
+// holds the Three.js canvas) was a flex-column sibling of several other,
 // unconditionally-rendered blocks that don't belong to the 3D game view:
 //   - "World Actions Panel" (country-compare / indicator-track / trade-flow
 //     / demographic-profile — 2D district-inspection tools)
-//   - "Lens Features" (generic feature-icon scaffold, LensFeaturePanel)
+//   - "Lens Features" (a generic feature-icon scaffold, LensFeaturePanel —
+//     since removed from this page entirely as part of the zero-generic-
+//     tendencies cleanup, rather than kept and viewMode-gated; its absence
+//     is strictly better than the original fix, so this file now asserts
+//     that instead of a gate around a panel that no longer exists)
 //   - the Factions/Quests/Marketplace/Adventure-kit affordance bar
 //   - the EarthEventsLive NASA-EONET "Earth events" dashboard section
 //     (by far the single biggest, measured at ~200px alone)
-// None of these are gated on `viewMode`, so they always claim their full
+// None of these were gated on `viewMode`, so they always claimed their full
 // content height in the flex column — leaving the `flex-1` 3D container
-// only whatever space is left over. Measured before the fix: the 3D canvas
+// only whatever space was left over. Measured before the fix: the 3D canvas
 // rendered at 114px tall out of a 572px content area. After hiding the
-// three purely-2D-dashboard blocks (World Actions, Lens Features, Earth
-// events) while `viewMode === 'explore'`, the same content area gave the
-// 3D canvas 452px — a 4x increase, confirmed live. The Factions/Quests/
-// Marketplace/Adventure-kit affordance bar was deliberately KEPT visible in
-// 3D mode (only ~39px, and its buttons open genuinely useful slide-over
-// panels — quest log, marketplace — while exploring in 3D).
+// remaining 2D-dashboard blocks (World Actions, Earth events) while
+// `viewMode === 'explore'` — and removing Lens Features outright — the same
+// content area gave the 3D canvas 452px — a 4x increase, confirmed live.
+// The Factions/Quests/Marketplace/Adventure-kit affordance bar was
+// deliberately KEPT visible in 3D mode (only ~39px, and its buttons open
+// genuinely useful slide-over panels — quest log, marketplace — while
+// exploring in 3D).
 //
 // The page is too large (9000+ lines) to render in a unit test — this file
 // follows the same source-pin convention already used for this page
@@ -44,11 +49,12 @@ describe('world lens page — 2D dashboard panels hidden in 3D Explore mode', ()
     expect(slice).toMatch(/\{viewMode !== 'explore' && \(/);
   });
 
-  it('hides the Lens Features panel while viewMode is explore', () => {
-    const idx = src.indexOf('{/* Lens Features (collapsible)');
-    expect(idx).toBeGreaterThan(-1);
-    const slice = src.slice(idx, idx + 400);
-    expect(slice).toMatch(/\{viewMode !== 'explore' && \(/);
+  it('never mounts the generic Lens Features scaffold panel at all (removed, not just hidden)', () => {
+    // LensFeaturePanel was fully removed from this page (zero-generic-
+    // tendencies cleanup) rather than kept and gated on viewMode — its
+    // absence is the stronger guarantee the original bug fix was after.
+    expect(src).not.toMatch(/<LensFeaturePanel\b/);
+    expect(src).not.toContain('{/* Lens Features (collapsible)');
   });
 
   it('hides the EarthEventsLive dashboard section while viewMode is explore', () => {


### PR DESCRIPTION
## Summary

The chat lens permanently mounted a full "Hacker News reference" block directly in the page flow — always visible, competing for screen space with the actual conversation, and effectively free promotion for a third-party product sitting front-and-center on Concord's own page. Concord's real answer for "I need outside context" is asking ConKay/chat (`tools.web_search` + citation), not a permanently-open third-party feed widget bolted onto a lens.

- **New `components/lens/ExternalReferenceLocale.tsx`** — the one consistent, collapsed-by-default disclosure a lens uses when it needs to link out to an external provider (Hacker News, GitHub, etc.). Search-on-demand, never promoted. This is the "designed locale" every lens should reuse instead of each lens inventing its own always-open external panel.
- **Chat lens**: `HackerNewsReference` now renders inside `ExternalReferenceLocale` instead of an always-open `<section>`.
- **Removed chat's entry from `lib/panel-affinity.ts`** (the "Cross-lens panels" strip). DTU citation/piping already covers cross-lens composition for chat, and a second, largely-unused mechanism stacked on top of that was pure screen space with no distinct value. The other ~15 lenses using `PANEL_AFFINITY` are untouched — each of those was independently curated, not evidenced as the same problem.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` — 0 new errors (2433 pre-existing warnings, unrelated)
- [x] `panel-registry integrity` — 12/12 passing
- [x] existing chat-lens ConKay-backport test — 4/4 passing
- [x] new `ExternalReferenceLocale` test — 3/3 passing, 100% statement/branch/func/line coverage

---
_Generated by [Claude Code](https://claude.ai/code/session_01S33herYGdAwwdRgSeLFvyo)_