### PR TITLE
Recover Auto-DTU + ingest-scheduler loop from old ConcordOS backend

### DIFF
--- a/concord-frontend/app/lenses/ingest/page.tsx
+++ b/concord-frontend/app/lenses/ingest/page.tsx
@@ -10,6 +10,7 @@ import { FirstRunTour } from '@/components/lens/FirstRunTour';
 import { DepthBadge } from '@/components/lens/DepthBadge';
 import { IngestionRepos } from '@/components/ingest/IngestionRepos';
 import { PipelinePanel } from '@/components/ingest/PipelinePanel';
+import { LatticeSeedPanel } from '@/components/ingest/LatticeSeedPanel';
 import { ManifestActionBar } from '@/components/lens/ManifestActionBar';
 import { useLensNav } from '@/hooks/useLensNav';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -595,6 +596,9 @@ export default function IngestLensPage() {
 
       {/* ELT Pipeline — connectors, schedules, transforms, runs, dedup, OCR, webhook */}
       <PipelinePanel />
+
+      {/* Recovered Auto-DTU + page-queue ingest scheduler (persisted, quota-gated) */}
+      <LatticeSeedPanel />
 
       {/* Ingest Analysis Actions — profile & validate the content in the text area */}
       <div className="panel p-4 space-y-4">

--- a/concord-frontend/components/ingest/LatticeSeedPanel.tsx
+++ b/concord-frontend/components/ingest/LatticeSeedPanel.tsx
@@ -1,0 +1,368 @@
+'use client';
+
+/**
+ * LatticeSeedPanel — recovered Auto-DTU + ingest-scheduler loop.
+ *
+ * Every value comes from a real `lattice-seed.*` macro. Experimental
+ * auto-DTUs stay labeled experimental until a human promotes them.
+ * Quota is role-derived on the server; this panel only displays it.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { lensRun } from '@/lib/api/client';
+import {
+  BookPlus, FlaskConical, ListTodo, Play, ShieldCheck, Loader2,
+  AlertTriangle, CheckCircle2, Plus, Sparkles,
+} from 'lucide-react';
+
+type TabId = 'queue' | 'hypotheses' | 'auto-dtus' | 'jobs';
+
+interface Source { id: number; label: string; rootUrl: string | null; notes: string | null; createdAt: string }
+interface Page {
+  id: number; sourceId: number; url: string; status: string;
+  contentExcerpt: string | null; lastProcessedAt: string | null; errorMessage: string | null;
+}
+interface Hypothesis { id: number; text: string; sourceLabel: string | null; createdAt: string }
+interface AutoDtu {
+  key: string; title: string; summary: string; tags: string[]; layer: string;
+  kind: string; trustLevel: string; mintedDtuId: string | null; createdAt: string;
+}
+interface ResearchJob {
+  id: number; topic: string; status: string; resultSummary: string | null;
+  layer: string | null; createdAt: string; updatedAt: string;
+}
+interface Status {
+  memoryCount: number; autoDtuCount: number; queuedPages: number;
+  quotaUsed: number; quotaLimit: number;
+}
+
+const TABS: { id: TabId; label: string }[] = [
+  { id: 'queue', label: 'Source queue' },
+  { id: 'hypotheses', label: 'Hypotheses' },
+  { id: 'auto-dtus', label: 'Auto-DTUs' },
+  { id: 'jobs', label: 'Research jobs' },
+];
+
+export function LatticeSeedPanel() {
+  const [tab, setTab] = useState<TabId>('queue');
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
+
+  const [st, setSt] = useState<Status | null>(null);
+  const [sources, setSources] = useState<Source[]>([]);
+  const [pages, setPages] = useState<Page[]>([]);
+  const [hypotheses, setHypotheses] = useState<Hypothesis[]>([]);
+  const [dtus, setDtus] = useState<AutoDtu[]>([]);
+  const [jobs, setJobs] = useState<ResearchJob[]>([]);
+  const [trustedOnly, setTrustedOnly] = useState(false);
+
+  const [label, setLabel] = useState('');
+  const [rootUrl, setRootUrl] = useState('');
+  const [pageUrl, setPageUrl] = useState('');
+  const [sourceId, setSourceId] = useState<number | ''>('');
+  const [hypText, setHypText] = useState('');
+  const [jobTopic, setJobTopic] = useState('');
+
+  const flash = useCallback((kind: 'ok' | 'err', text: string) => {
+    setMsg({ kind, text });
+    window.setTimeout(() => setMsg(null), 4000);
+  }, []);
+
+  const loadAll = useCallback(async () => {
+    const [s, src, pg, hy, ad, jb] = await Promise.all([
+      lensRun<Status>('lattice-seed', 'status', {}),
+      lensRun<{ sources: Source[] }>('lattice-seed', 'listSources', {}),
+      lensRun<{ pages: Page[] }>('lattice-seed', 'listPages', {}),
+      lensRun<{ hypotheses: Hypothesis[] }>('lattice-seed', 'listHypotheses', {}),
+      lensRun<{ dtus: AutoDtu[] }>('lattice-seed', 'listAutoDtus', { includeExperimental: !trustedOnly }),
+      lensRun<{ jobs: ResearchJob[] }>('lattice-seed', 'listResearchJobs', {}),
+    ]);
+    if (s.data.ok && s.data.result) setSt(s.data.result);
+    if (src.data.ok && src.data.result) setSources(src.data.result.sources || []);
+    if (pg.data.ok && pg.data.result) setPages(pg.data.result.pages || []);
+    if (hy.data.ok && hy.data.result) setHypotheses(hy.data.result.hypotheses || []);
+    if (ad.data.ok && ad.data.result) setDtus(ad.data.result.dtus || []);
+    if (jb.data.ok && jb.data.result) setJobs(jb.data.result.jobs || []);
+  }, [trustedOnly]);
+
+  useEffect(() => { void loadAll(); }, [loadAll]);
+
+  const run = useCallback(async (action: string, input: Record<string, unknown>, okText: string) => {
+    setBusy(true);
+    try {
+      const r = await lensRun(action.includes('.') ? action.split('.')[0] : 'lattice-seed', action.includes('.') ? action.split('.')[1] : action, input);
+      if (!r.data.ok) {
+        flash('err', r.data.error || 'failed');
+        return;
+      }
+      flash('ok', okText);
+      await loadAll();
+    } finally {
+      setBusy(false);
+    }
+  }, [flash, loadAll]);
+
+  const quotaPct = st && st.quotaLimit > 0 ? Math.min(100, Math.round((st.quotaUsed / st.quotaLimit) * 100)) : 0;
+
+  return (
+    <section className="panel p-4 space-y-4">
+      <div className="flex items-start justify-between gap-3 flex-wrap">
+        <div>
+          <h2 className="font-semibold flex items-center gap-2">
+            <Sparkles className="w-4 h-4 text-neon-cyan" />
+            Lattice seed
+          </h2>
+          <p className="text-xs text-gray-400 mt-1 max-w-2xl">
+            Queue a public page, extract hypotheses, mint an experimental auto-DTU,
+            then promote it to trusted. Nothing here is fabricated: empty queues,
+            quota, and fetch failures surface as themselves.
+          </p>
+        </div>
+        {st && (
+          <div className="text-right text-[11px] text-gray-400 space-y-1 min-w-[160px]">
+            <div className="flex items-center justify-end gap-2">
+              <span>Ingest today</span>
+              <span className="font-mono text-white">{st.quotaUsed}/{st.quotaLimit}</span>
+            </div>
+            <div className="h-1.5 w-40 bg-black/40 rounded overflow-hidden ml-auto">
+              <div className="h-full bg-neon-cyan/70" style={{ width: `${quotaPct}%` }} />
+            </div>
+            <div className="flex gap-3 justify-end">
+              <span>queued {st.queuedPages}</span>
+              <span>auto-DTUs {st.autoDtuCount}</span>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {msg && (
+        <div className={`text-xs flex items-center gap-1.5 ${msg.kind === 'ok' ? 'text-neon-green' : 'text-red-400'}`}>
+          {msg.kind === 'ok' ? <CheckCircle2 className="w-3.5 h-3.5" /> : <AlertTriangle className="w-3.5 h-3.5" />}
+          {msg.text}
+        </div>
+      )}
+
+      <div className="flex gap-1 border-b border-lattice-border">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            onClick={() => setTab(t.id)}
+            className={`px-3 py-1.5 text-xs ${tab === t.id ? 'text-white border-b-2 border-neon-cyan' : 'text-gray-500 hover:text-gray-300'}`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'queue' && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div className="space-y-3">
+            <h3 className="text-xs uppercase tracking-wide text-gray-500 flex items-center gap-1.5">
+              <BookPlus className="w-3.5 h-3.5" /> Source
+            </h3>
+            <input
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="Label (required)"
+              className="w-full px-3 py-1.5 bg-lattice-surface border border-lattice-border rounded-lg text-xs text-white placeholder-gray-500"
+            />
+            <input
+              value={rootUrl}
+              onChange={(e) => setRootUrl(e.target.value)}
+              placeholder="Root URL (optional)"
+              className="w-full px-3 py-1.5 bg-lattice-surface border border-lattice-border rounded-lg text-xs text-white placeholder-gray-500 font-mono"
+            />
+            <button
+              type="button"
+              disabled={busy || !label.trim()}
+              onClick={() => void run('createSource', { label: label.trim(), rootUrl: rootUrl.trim() || null }, 'Source saved')}
+              className="px-3 py-1.5 text-xs bg-neon-cyan/20 border border-neon-cyan/40 rounded-lg text-neon-cyan disabled:opacity-40 flex items-center gap-1"
+            >
+              <Plus className="w-3 h-3" /> Add source
+            </button>
+            <ul className="text-xs space-y-1 max-h-32 overflow-auto">
+              {sources.length === 0 && <li className="text-gray-500">No sources yet.</li>}
+              {sources.map((s) => (
+                <li key={s.id}>
+                  <button
+                    type="button"
+                    onClick={() => setSourceId(s.id)}
+                    className={`text-left w-full px-2 py-1 rounded ${sourceId === s.id ? 'bg-neon-cyan/10 text-white' : 'text-gray-300 hover:bg-white/5'}`}
+                  >
+                    <span className="font-medium">{s.label}</span>
+                    {s.rootUrl && <span className="text-gray-500 font-mono ml-2">{s.rootUrl}</span>}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="space-y-3">
+            <h3 className="text-xs uppercase tracking-wide text-gray-500 flex items-center gap-1.5">
+              <ListTodo className="w-3.5 h-3.5" /> Pages
+            </h3>
+            <input
+              value={pageUrl}
+              onChange={(e) => setPageUrl(e.target.value)}
+              placeholder="https://… page to queue"
+              className="w-full px-3 py-1.5 bg-lattice-surface border border-lattice-border rounded-lg text-xs text-white placeholder-gray-500 font-mono"
+            />
+            <div className="flex gap-2">
+              <button
+                type="button"
+                disabled={busy || !sourceId || !pageUrl.trim()}
+                onClick={() => void run('queuePage', { sourceId, url: pageUrl.trim() }, 'Page queued')}
+                className="px-3 py-1.5 text-xs border border-lattice-border rounded-lg text-gray-200 disabled:opacity-40"
+              >
+                Queue page
+              </button>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void run('executeNext', {}, 'Next page processed')}
+                className="px-3 py-1.5 text-xs bg-neon-cyan/20 border border-neon-cyan/40 rounded-lg text-neon-cyan disabled:opacity-40 flex items-center gap-1"
+              >
+                {busy ? <Loader2 className="w-3 h-3 animate-spin" /> : <Play className="w-3 h-3" />}
+                Execute next
+              </button>
+            </div>
+            <ul className="text-xs space-y-1 max-h-48 overflow-auto font-mono">
+              {pages.length === 0 && <li className="text-gray-500 font-sans">No pages queued.</li>}
+              {pages.map((p) => (
+                <li key={p.id} className="flex items-start gap-2">
+                  <span className={
+                    p.status === 'processed' ? 'text-neon-green' :
+                    p.status === 'error' ? 'text-red-400' : 'text-amber-400'
+                  }>{p.status}</span>
+                  <span className="text-gray-300 break-all">{p.url}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+
+      {tab === 'hypotheses' && (
+        <div className="space-y-3">
+          <textarea
+            value={hypText}
+            onChange={(e) => setHypText(e.target.value)}
+            placeholder="Paste an excerpt to propose testable directions…"
+            rows={4}
+            className="w-full px-3 py-2 bg-lattice-surface border border-lattice-border rounded-lg text-xs text-white placeholder-gray-500"
+          />
+          <button
+            type="button"
+            disabled={busy || !hypText.trim()}
+            onClick={() => void run('proposeHypotheses', { text: hypText.trim(), sourceLabel: 'manual' }, 'Hypotheses stored')}
+            className="px-3 py-1.5 text-xs bg-neon-cyan/20 border border-neon-cyan/40 rounded-lg text-neon-cyan disabled:opacity-40 flex items-center gap-1"
+          >
+            <FlaskConical className="w-3 h-3" /> Propose hypotheses
+          </button>
+          <ul className="space-y-3">
+            {hypotheses.length === 0 && <li className="text-xs text-gray-500">No hypotheses yet — ingest a page or paste an excerpt.</li>}
+            {hypotheses.map((h) => (
+              <li key={h.id} className="border border-lattice-border rounded-lg p-3 space-y-2">
+                <div className="text-[11px] text-gray-500 flex justify-between">
+                  <span>#{h.id} {h.sourceLabel || 'manual'}</span>
+                  <span>{new Date(h.createdAt).toLocaleString()}</span>
+                </div>
+                <pre className="text-xs text-gray-200 whitespace-pre-wrap font-sans">{h.text}</pre>
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => void run('mintFromHypothesis', { hypothesisId: h.id }, 'Experimental auto-DTU minted')}
+                  className="text-[11px] text-neon-cyan hover:underline disabled:opacity-40"
+                >
+                  Mint experimental auto-DTU
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {tab === 'auto-dtus' && (
+        <div className="space-y-3">
+          <label className="text-xs text-gray-400 flex items-center gap-2">
+            <input type="checkbox" checked={trustedOnly} onChange={(e) => setTrustedOnly(e.target.checked)} />
+            Trusted only
+          </label>
+          <ul className="space-y-3">
+            {dtus.length === 0 && (
+              <li className="text-xs text-gray-500">
+                {trustedOnly ? 'No trusted auto-DTUs yet.' : 'No auto-DTUs yet.'}
+              </li>
+            )}
+            {dtus.map((d) => (
+              <li key={d.key} className="border border-lattice-border rounded-lg p-3 space-y-1.5">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-sm text-white font-medium">{d.title}</span>
+                  <span className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded ${
+                    d.trustLevel === 'trusted' ? 'bg-neon-green/15 text-neon-green' : 'bg-amber-500/15 text-amber-400'
+                  }`}>{d.trustLevel}</span>
+                </div>
+                <div className="text-[11px] text-gray-500 font-mono">{d.key} · {d.layer} · {d.kind}</div>
+                <p className="text-xs text-gray-300">{d.summary}</p>
+                {d.mintedDtuId
+                  ? <div className="text-[11px] text-gray-500">Substrate DTU {d.mintedDtuId}</div>
+                  : <div className="text-[11px] text-gray-600">No substrate id yet — catalog row only.</div>}
+                {d.trustLevel !== 'trusted' && (
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => void run('setTrust', { key: d.key, trustLevel: 'trusted' }, 'Promoted to trusted')}
+                    className="text-[11px] text-neon-cyan hover:underline disabled:opacity-40 flex items-center gap-1"
+                  >
+                    <ShieldCheck className="w-3 h-3" /> Promote to trusted
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {tab === 'jobs' && (
+        <div className="space-y-3">
+          <input
+            value={jobTopic}
+            onChange={(e) => setJobTopic(e.target.value)}
+            placeholder="Research topic"
+            className="w-full px-3 py-1.5 bg-lattice-surface border border-lattice-border rounded-lg text-xs text-white placeholder-gray-500"
+          />
+          <button
+            type="button"
+            disabled={busy || !jobTopic.trim()}
+            onClick={() => void run('createResearchJob', { topic: jobTopic.trim() }, 'Research job stored')}
+            className="px-3 py-1.5 text-xs bg-neon-cyan/20 border border-neon-cyan/40 rounded-lg text-neon-cyan disabled:opacity-40"
+          >
+            Run research job
+          </button>
+          <ul className="space-y-3">
+            {jobs.length === 0 && <li className="text-xs text-gray-500">No persisted research jobs yet.</li>}
+            {jobs.map((j) => (
+              <li key={j.id} className="border border-lattice-border rounded-lg p-3 space-y-2">
+                <div className="flex justify-between text-xs">
+                  <span className="text-white">{j.topic}</span>
+                  <span className={j.status === 'done' ? 'text-neon-green' : 'text-amber-400'}>{j.status}</span>
+                </div>
+                {j.resultSummary && <pre className="text-xs text-gray-300 whitespace-pre-wrap font-sans">{j.resultSummary}</pre>}
+                {j.status === 'done' && (
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => void run('mintFromResearchJob', { jobId: j.id }, 'Experimental auto-DTU minted')}
+                    className="text-[11px] text-neon-cyan hover:underline disabled:opacity-40"
+                  >
+                    Mint experimental auto-DTU
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/server/domains/index.js
+++ b/server/domains/index.js
@@ -196,6 +196,7 @@ import githubConnector from './github.js';
 import notion from './notion.js';
 import importdomain from './importdomain.js';
 import ingest from './ingest.js';
+import latticeSeed from './lattice-seed.js';
 import law from './law.js';
 import marketplace from './marketplace.js';
 import ml from './ml.js';
@@ -495,6 +496,7 @@ export default [
   notion,
   importdomain,
   ingest,
+  latticeSeed,
   law,
   marketplace,
   ml,

--- a/server/domains/lattice-seed.js
+++ b/server/domains/lattice-seed.js
@@ -1,0 +1,246 @@
+// server/domains/lattice-seed.js
+//
+// Lens actions for the recovered Auto-DTU + ingest-scheduler loop
+// (server/lib/lattice-seed.js, migration 416). Designed surface lives on
+// the ingest lens as LatticeSeedPanel — these macros are the substrate,
+// not a generic action wall.
+//
+// Quota / trust / fetch never read a caller-supplied privilege field.
+// Role comes from ctx.actor.role. Fetch goes through fetchPublicUrl.
+
+import * as seed from "../lib/lattice-seed.js";
+
+function actorId(ctx) {
+  return ctx?.actor?.userId || ctx?.actor?.id || ctx?.userId || "anon";
+}
+
+function actorRole(ctx) {
+  return ctx?.actor?.role || "guest";
+}
+
+function dbOf(ctx) {
+  return ctx?.db || null;
+}
+
+function inputOf(artifact, params) {
+  return { ...(artifact?.data || {}), ...(params || {}) };
+}
+
+function fail(reason, extra = {}) {
+  return { ok: false, reason, error: reason, ...extra };
+}
+
+function wrap(r) {
+  if (!r || r.ok === false) {
+    const reason = r?.reason || r?.error || "failed";
+    const extra = r && typeof r === "object" ? { ...r } : {};
+    delete extra.ok;
+    return fail(reason, extra);
+  }
+  const rest = { ...r };
+  delete rest.ok;
+  return { ok: true, result: rest };
+}
+
+function mintDtuFromCtx(ctx) {
+  const run = ctx?.macro?.run || ctx?.runMacro;
+  if (typeof run !== "function") return null;
+  return async (input) => run("dtu", "create", input);
+}
+
+export default function registerLatticeSeedActions(registerLensAction) {
+  // input: {}
+  registerLensAction("lattice-seed", "status", (ctx) => {
+    try {
+      return wrap(seed.status(dbOf(ctx), actorId(ctx), { role: actorRole(ctx) }));
+    } catch (e) {
+      return fail("handler_error", { message: String(e?.message || e) });
+    }
+  });
+
+  // input: { rootUrl?: string, label: string, notes?: string }
+  registerLensAction("lattice-seed", "createSource", (ctx, artifact, params) => {
+    try {
+      const input = inputOf(artifact, params);
+      return wrap(seed.createSource(dbOf(ctx), actorId(ctx), {
+        rootUrl: input.rootUrl ?? input.root_url ?? null,
+        label: input.label,
+        notes: input.notes ?? null,
+      }));
+    } catch (e) {
+      return fail("handler_error", { message: String(e?.message || e) });
+    }
+  });
+
+  // input: {}
+  registerLensAction("lattice-seed", "listSources", (ctx) => {
+    try {
+      return wrap(seed.listSources(dbOf(ctx), actorId(ctx)));
+    } catch (e) {
+      return fail("handler_error", { message: String(e?.message || e) });
+    }
+  });
+
+  // input: { sourceId: number, url: string }
+  registerLensAction("lattice-seed", "queuePage", (ctx, artifact, params) => {
+    try {
+      const input = inputOf(artifact, params);
+      return wrap(seed.queuePage(dbOf(ctx), actorId(ctx), {
+        sourceId: input.sourceId ?? input.source_id,
+        url: input.url,
+      }));
+    } catch (e) {
+      return fail("handler_error", { message: String(e?.message || e) });
+    }
+  });
+
+  // input: { sourceId?: number, status?: string }
+  registerLensAction("lattice-seed", "listPages", (ctx, artifact, params) => {
+    try {
+      const input = inputOf(artifact, params);
+      return wrap(seed.listPages(dbOf(ctx), actorId(ctx), {
+        sourceId: input.sourceId ?? input.source_id,
+        status: input.status,
+      }));
+    } catch (e) {
+      return fail("handler_error", { message: String(e?.message || e) });
+    }
+  });
+
+  // input: {}  — quota from actor role, never from body.mode
+  registerLensAction("lattice-seed", "executeNext", async (ctx, artifact, params) => {
+    try {
+      const input = inputOf(artifact, params);
+      return wrap(await seed.executeNext(dbOf(ctx), actorId(ctx), {
+        role: actorRole(ctx),
+        llm: ctx?.llm || null,
+        fetchImpl: typeof input.fetchImpl === "function" ? input.fetchImpl : null,
+      }));
+    } catch (e) {
+      return fail("handler_error", { message: String(e?.message || e) });
+    }
+  });
+
+  // input: { text: string, sourceLabel?: string }
+  registerLensAction("lattice-seed", "proposeHypotheses", async (ctx, artifact, params) => {
+    try {
+      const input = inputOf(artifact, params);
+      return wrap(await seed.proposeHypotheses(dbOf(ctx), actorId(ctx), {
+        text: input.text,
+        sourceLabel: input.sourceLabel ?? input.source_label ?? null,
+        llm: ctx?.llm || null,
+      }));
+    } catch (e) {
+      return fail("handler_error", { message: String(e?.message || e) });
+    }
+  });
+
+  // input: { sourceLabel?: string }
+  registerLensAction("lattice-seed", "listHypotheses", (ctx, artifact, params) => {
+    try {
+      const input = inputOf(artifact, params);
+      return wrap(seed.listHypotheses(dbOf(ctx), actorId(ctx), {
+        sourceLabel: input.sourceLabel ?? input.source_label,
+      }));
+    } catch (e) {
+      return fail("handler_error", { message: String(e?.message || e) });
+    }
+  });
+
+  // input: { topic: string, dtuKeys?: string[], layer?: string }
+  registerLensAction("lattice-seed", "createResearchJob", async (ctx, artifact, params) => {
+    try {
+      const input = inputOf(artifact, params);
+      const created = seed.createResearchJob(dbOf(ctx), actorId(ctx), {
+        topic: input.topic,
+        dtuKeys: input.dtuKeys ?? input.dtu_keys ?? [],
+        layer: input.layer ?? null,
+      });
+      if (!created.ok) return wrap(created);
+      const processed = await seed.processResearchJob(dbOf(ctx), actorId(ctx), created.id, {
+        llm: ctx?.llm || null,
+      });
+      return wrap(processed.ok ? processed : { ...processed, id: created.id, status: "error" });
+    } catch (e) {
+      return fail("handler_error", { message: String(e?.message || e) });
+    }
+  });
+
+  // input: { status?: string }
+  registerLensAction("lattice-seed", "listResearchJobs", (ctx, artifact, params) => {
+    try {
+      const input = inputOf(artifact, params);
+      return wrap(seed.listResearchJobs(dbOf(ctx), actorId(ctx), { status: input.status }));
+    } catch (e) {
+      return fail("handler_error", { message: String(e?.message || e) });
+    }
+  });
+
+  // input: { hypothesisId: number, layerHint?: string, kind?: string }
+  registerLensAction("lattice-seed", "mintFromHypothesis", async (ctx, artifact, params) => {
+    try {
+      const input = inputOf(artifact, params);
+      return wrap(await seed.mintFromHypothesis(dbOf(ctx), actorId(ctx), {
+        hypothesisId: input.hypothesisId ?? input.hypothesis_id,
+        layerHint: input.layerHint ?? input.layer_hint ?? "HLM",
+        kind: input.kind || "auto-hypothesis",
+        llm: ctx?.llm || null,
+        mintDtu: mintDtuFromCtx(ctx),
+      }));
+    } catch (e) {
+      return fail("handler_error", { message: String(e?.message || e) });
+    }
+  });
+
+  // input: { jobId: number, layerHint?: string, kind?: string }
+  registerLensAction("lattice-seed", "mintFromResearchJob", async (ctx, artifact, params) => {
+    try {
+      const input = inputOf(artifact, params);
+      return wrap(await seed.mintFromResearchJob(dbOf(ctx), actorId(ctx), {
+        jobId: input.jobId ?? input.job_id,
+        layerHint: input.layerHint ?? input.layer_hint ?? "HLR",
+        kind: input.kind || "auto-research",
+        llm: ctx?.llm || null,
+        mintDtu: mintDtuFromCtx(ctx),
+      }));
+    } catch (e) {
+      return fail("handler_error", { message: String(e?.message || e) });
+    }
+  });
+
+  // input: { key: string, trustLevel: "experimental" | "trusted" }
+  registerLensAction("lattice-seed", "setTrust", (ctx, artifact, params) => {
+    try {
+      const input = inputOf(artifact, params);
+      return wrap(seed.setTrust(dbOf(ctx), actorId(ctx), {
+        key: input.key,
+        trustLevel: input.trustLevel ?? input.trust_level,
+      }));
+    } catch (e) {
+      return fail("handler_error", { message: String(e?.message || e) });
+    }
+  });
+
+  // input: { includeExperimental?: boolean }
+  registerLensAction("lattice-seed", "listAutoDtus", (ctx, artifact, params) => {
+    try {
+      const input = inputOf(artifact, params);
+      const includeExperimental = input.includeExperimental !== false
+        && input.includeExperimental !== "false"
+        && input.includeExperimental !== "0";
+      return wrap(seed.listAutoDtus(dbOf(ctx), actorId(ctx), { includeExperimental }));
+    } catch (e) {
+      return fail("handler_error", { message: String(e?.message || e) });
+    }
+  });
+
+  // input: { scope?: string }
+  registerLensAction("lattice-seed", "listMemory", (ctx, artifact, params) => {
+    try {
+      const input = inputOf(artifact, params);
+      return wrap(seed.listMemory(dbOf(ctx), actorId(ctx), { scope: input.scope }));
+    } catch (e) {
+      return fail("handler_error", { message: String(e?.message || e) });
+    }
+  });
+}

--- a/server/lib/lattice-seed.js
+++ b/server/lib/lattice-seed.js
@@ -1,0 +1,702 @@
+// server/lib/lattice-seed.js
+//
+// Recovered Auto-DTU + ingest-scheduler loop from an older ConcordOS
+// backend. Does NOT rebuild:
+//   • ingest-engine.js (planetary URL ingest + council mint)
+//   • the hypothesis *statistics* lens or hypothesis-engine
+//   • the in-memory research-jobs pipeline
+//   • chat / ask-Concord (already a first-class path)
+//   • OpenAI embeddings (existing embedding tables cover that)
+//
+// Unique loop: labeled source → queued page → quota-gated SSRF-guarded
+// fetch → hypotheses → experimental auto-DTU → human trust promotion.
+//
+// Quota is derived from the authenticated actor's role, NEVER from a
+// request-body `mode`/`tier` field (see ingest-tier-role-derivation).
+// Fetch goes through lib/public-fetch.js#fetchPublicUrl (same SSRF
+// chokepoint as ingest-engine). LLM prompts live in prompt-registry
+// TASK_PROMPTS; missing brains fall back to deterministic seed shaping
+// rather than fabricating a success.
+
+import { fetchPublicUrl } from "./public-fetch.js";
+import { TASK_PROMPTS } from "./prompt-registry.js";
+
+export const TRUST_LEVELS = Object.freeze(["experimental", "trusted"]);
+export const LAYERS = Object.freeze(["domain", "HLM", "HLR", "meta"]);
+
+export const MEMBER_PAGES_PER_DAY = 10;
+export const ADMIN_PAGES_PER_DAY = 100;
+export const ADMIN_FAMILY_ROLES = Object.freeze(["owner", "admin", "founder", "sovereign"]);
+
+export const FETCH_CHAR_CAP = 20_000;
+export const EXCERPT_CHAR_CAP = 2_000;
+export const SUMMARY_CHAR_CAP = 400;
+export const KEY_MAX_LEN = 60;
+export const LIST_LIMIT = 50;
+
+function tableExists(db, name) {
+  try {
+    return !!db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?").get(name);
+  } catch {
+    return false;
+  }
+}
+
+function requireDb(db) {
+  if (!db || typeof db.prepare !== "function") return { ok: false, reason: "no_db" };
+  if (!tableExists(db, "lattice_seed_sources")) return { ok: false, reason: "no_table" };
+  return null;
+}
+
+export function pagesPerDayForRole(role) {
+  const r = String(role || "").toLowerCase();
+  return ADMIN_FAMILY_ROLES.includes(r) ? ADMIN_PAGES_PER_DAY : MEMBER_PAGES_PER_DAY;
+}
+
+export function todayStartIso(now = new Date()) {
+  const d = new Date(now);
+  d.setUTCHours(0, 0, 0, 0);
+  return d.toISOString();
+}
+
+export function slugify(str) {
+  return (String(str || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, KEY_MAX_LEN)) || "dtu";
+}
+
+export function excerptFromHtml(raw, cap = EXCERPT_CHAR_CAP) {
+  const text = String(raw || "")
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return text.slice(0, cap);
+}
+
+function parseTags(raw) {
+  if (Array.isArray(raw)) return raw.map((t) => String(t).toLowerCase()).filter(Boolean).slice(0, 12);
+  try {
+    const parsed = JSON.parse(raw || "[]");
+    return Array.isArray(parsed) ? parsed.map((t) => String(t).toLowerCase()).filter(Boolean).slice(0, 12) : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseJsonFence(raw) {
+  const s = String(raw || "").trim();
+  if (!s) return null;
+  const fenced = s.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const body = fenced ? fenced[1].trim() : s;
+  try {
+    return JSON.parse(body);
+  } catch {
+    const start = body.indexOf("{");
+    const end = body.lastIndexOf("}");
+    if (start >= 0 && end > start) {
+      try { return JSON.parse(body.slice(start, end + 1)); } catch { return null; }
+    }
+    return null;
+  }
+}
+
+async function maybeChat(llm, system, user) {
+  if (!llm || typeof llm.chat !== "function") return null;
+  try {
+    const r = await llm.chat({
+      system,
+      messages: [{ role: "user", content: user }],
+      temperature: 0.4,
+      slot: "utility",
+      maxTokens: 800,
+    });
+    if (!r || r.ok === false) return null;
+    const content = typeof r === "string" ? r : (r.content || r.text || "");
+    const trimmed = String(content || "").trim();
+    return trimmed || null;
+  } catch {
+    return null;
+  }
+}
+
+function addMemory(db, { userId, scope, dtuKey = null, text, source = null, layer = null, nowIso }) {
+  db.prepare(`
+    INSERT INTO lattice_seed_memory (user_id, scope, dtu_key, text, source, layer, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(userId, scope, dtuKey, String(text || "").slice(0, 8000), source, layer, nowIso);
+}
+
+// ── Sources / pages ─────────────────────────────────────────────────────
+
+export function createSource(db, userId, { rootUrl = null, label, notes = null } = {}, now = new Date()) {
+  const blocked = requireDb(db);
+  if (blocked) return blocked;
+  const trimmed = String(label || "").trim();
+  if (!trimmed) return { ok: false, reason: "label_required" };
+  const createdAt = now.toISOString();
+  const info = db.prepare(`
+    INSERT INTO lattice_seed_sources (user_id, root_url, label, notes, created_at)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(userId, rootUrl ? String(rootUrl).trim() : null, trimmed.slice(0, 200), notes ? String(notes).slice(0, 2000) : null, createdAt);
+  return { ok: true, id: Number(info.lastInsertRowid) };
+}
+
+export function listSources(db, userId) {
+  const blocked = requireDb(db);
+  if (blocked) return blocked;
+  const sources = db.prepare(`
+    SELECT id, root_url AS rootUrl, label, notes, created_at AS createdAt
+    FROM lattice_seed_sources
+    WHERE user_id = ?
+    ORDER BY created_at DESC
+  `).all(userId);
+  return { ok: true, sources };
+}
+
+export function queuePage(db, userId, { sourceId, url } = {}) {
+  const blocked = requireDb(db);
+  if (blocked) return blocked;
+  const sid = Number(sourceId);
+  const u = String(url || "").trim();
+  if (!sid || !u) return { ok: false, reason: "source_and_url_required" };
+  if (!/^https?:\/\//i.test(u)) return { ok: false, reason: "url_must_be_http" };
+  const source = db.prepare("SELECT id FROM lattice_seed_sources WHERE id = ? AND user_id = ?").get(sid, userId);
+  if (!source) return { ok: false, reason: "source_not_found" };
+  const info = db.prepare(`
+    INSERT INTO lattice_seed_pages (user_id, source_id, url, status)
+    VALUES (?, ?, ?, 'queued')
+  `).run(userId, sid, u.slice(0, 2000));
+  return { ok: true, id: Number(info.lastInsertRowid) };
+}
+
+export function listPages(db, userId, { sourceId, status } = {}) {
+  const blocked = requireDb(db);
+  if (blocked) return blocked;
+  const clauses = ["user_id = ?"];
+  const params = [userId];
+  if (sourceId) { clauses.push("source_id = ?"); params.push(Number(sourceId)); }
+  if (status) { clauses.push("status = ?"); params.push(String(status)); }
+  const pages = db.prepare(`
+    SELECT id, source_id AS sourceId, url, status, content_excerpt AS contentExcerpt,
+           last_processed_at AS lastProcessedAt, error_message AS errorMessage
+    FROM lattice_seed_pages
+    WHERE ${clauses.join(" AND ")}
+    ORDER BY id DESC
+    LIMIT 100
+  `).all(...params);
+  return { ok: true, pages };
+}
+
+export function quotaUsedToday(db, userId, now = new Date()) {
+  const row = db.prepare(`
+    SELECT COUNT(*) AS cnt FROM lattice_seed_ingest_log
+    WHERE user_id = ? AND processed_at >= ?
+  `).get(userId, todayStartIso(now));
+  return Number(row?.cnt || 0);
+}
+
+export async function executeNext(db, userId, {
+  role = "guest",
+  llm = null,
+  fetchImpl = null,
+  now = new Date(),
+} = {}) {
+  const blocked = requireDb(db);
+  if (blocked) return blocked;
+
+  const quota = pagesPerDayForRole(role);
+  const used = quotaUsedToday(db, userId, now);
+  if (used >= quota) {
+    return { ok: false, reason: "quota_reached", quotaUsed: used, quotaLimit: quota };
+  }
+
+  const page = db.prepare(`
+    SELECT id, source_id AS sourceId, url, status
+    FROM lattice_seed_pages
+    WHERE user_id = ? AND status = 'queued'
+    ORDER BY id ASC
+    LIMIT 1
+  `).get(userId);
+  if (!page) return { ok: false, reason: "no_queued_pages" };
+
+  let raw = "";
+  try {
+    const res = await fetchPublicUrl(page.url, {
+      headers: { "User-Agent": "Concord/1.0 (Lattice Seed; +https://concord-os.org)" },
+    }, fetchImpl ? { fetchImpl } : {});
+    if (!res || res.ok === false) {
+      const status = res?.status != null ? `HTTP ${res.status}` : "fetch_failed";
+      db.prepare(`
+        UPDATE lattice_seed_pages
+        SET status = 'error', error_message = ?, last_processed_at = ?
+        WHERE id = ? AND user_id = ?
+      `).run(status, now.toISOString(), page.id, userId);
+      return { ok: false, reason: "fetch_failed", pageId: page.id, error: status };
+    }
+    raw = String(await res.text()).slice(0, FETCH_CHAR_CAP);
+  } catch (err) {
+    const code = err?.code === "SSRF_BLOCKED" ? "ssrf_blocked" : "fetch_failed";
+    db.prepare(`
+      UPDATE lattice_seed_pages
+      SET status = 'error', error_message = ?, last_processed_at = ?
+      WHERE id = ? AND user_id = ?
+    `).run(String(err?.message || code).slice(0, 500), now.toISOString(), page.id, userId);
+    return { ok: false, reason: code, pageId: page.id, error: String(err?.message || code) };
+  }
+
+  const excerpt = excerptFromHtml(raw);
+  if (!excerpt) {
+    db.prepare(`
+      UPDATE lattice_seed_pages
+      SET status = 'error', error_message = 'empty_page', last_processed_at = ?
+      WHERE id = ? AND user_id = ?
+    `).run(now.toISOString(), page.id, userId);
+    return { ok: false, reason: "empty_page", pageId: page.id };
+  }
+
+  const hyp = await proposeHypotheses(db, userId, {
+    text: excerpt,
+    sourceLabel: `ingest-page:${page.id}`,
+    llm,
+    now,
+  });
+  const hypothesesText = hyp.ok ? hyp.hypotheses : excerpt.slice(0, 400);
+
+  const nowIso = now.toISOString();
+  db.prepare(`
+    UPDATE lattice_seed_pages
+    SET status = 'processed', content_excerpt = ?, last_processed_at = ?, error_message = NULL
+    WHERE id = ? AND user_id = ?
+  `).run(excerpt, nowIso, page.id, userId);
+  db.prepare(`
+    INSERT INTO lattice_seed_ingest_log (user_id, page_id, processed_at, bytes_ingested)
+    VALUES (?, ?, ?, ?)
+  `).run(userId, page.id, nowIso, raw.length);
+  addMemory(db, {
+    userId,
+    scope: "ingest",
+    text: `URL: ${page.url}\nExcerpt:\n${excerpt}\n\nHypotheses:\n${hypothesesText}`,
+    source: `ingest-page:${page.id}`,
+    layer: "HLM",
+    nowIso,
+  });
+
+  return {
+    ok: true,
+    pageId: page.id,
+    excerpt,
+    hypotheses: hypothesesText,
+    hypothesisId: hyp.ok ? hyp.id : null,
+    quotaUsed: used + 1,
+    quotaLimit: quota,
+    composer: hyp.ok ? hyp.composer : "none",
+  };
+}
+
+// ── Hypotheses ──────────────────────────────────────────────────────────
+
+function deterministicHypotheses(text) {
+  const excerpt = String(text || "").replace(/\s+/g, " ").trim().slice(0, 280);
+  if (!excerpt) return "";
+  return [
+    `1. The source claims: "${excerpt.slice(0, 140)}". What independent measurement would confirm or falsify that claim?`,
+    `2. Which existing DTU layer (domain / HLM / HLR) should own this material, and what would a contradictory source look like?`,
+    `3. What is the smallest follow-up ingest that would raise or lower trust in this excerpt?`,
+  ].join("\n");
+}
+
+export async function proposeHypotheses(db, userId, { text, sourceLabel = null, llm = null, now = new Date() } = {}) {
+  const blocked = requireDb(db);
+  if (blocked) return blocked;
+  const seed = String(text || "").trim();
+  if (!seed) return { ok: false, reason: "text_required" };
+
+  let composer = "deterministic";
+  let hypothesesText = deterministicHypotheses(seed);
+  const llmText = await maybeChat(llm, TASK_PROMPTS.latticeSeedHypotheses(), seed.slice(0, 4000));
+  if (llmText) {
+    hypothesesText = llmText;
+    composer = "llm";
+  }
+
+  const createdAt = now.toISOString();
+  const info = db.prepare(`
+    INSERT INTO lattice_seed_hypotheses (user_id, text, source_label, created_at)
+    VALUES (?, ?, ?, ?)
+  `).run(userId, hypothesesText.slice(0, 8000), sourceLabel ? String(sourceLabel).slice(0, 200) : null, createdAt);
+  addMemory(db, {
+    userId,
+    scope: "hypothesis",
+    text: hypothesesText,
+    source: sourceLabel || "manual-hypothesis",
+    layer: "HLR",
+    nowIso: createdAt,
+  });
+  return { ok: true, id: Number(info.lastInsertRowid), hypotheses: hypothesesText, composer };
+}
+
+export function listHypotheses(db, userId, { sourceLabel } = {}) {
+  const blocked = requireDb(db);
+  if (blocked) return blocked;
+  const rows = sourceLabel
+    ? db.prepare(`
+        SELECT id, text, source_label AS sourceLabel, created_at AS createdAt
+        FROM lattice_seed_hypotheses
+        WHERE user_id = ? AND source_label = ?
+        ORDER BY created_at DESC LIMIT ?
+      `).all(userId, sourceLabel, LIST_LIMIT)
+    : db.prepare(`
+        SELECT id, text, source_label AS sourceLabel, created_at AS createdAt
+        FROM lattice_seed_hypotheses
+        WHERE user_id = ?
+        ORDER BY created_at DESC LIMIT ?
+      `).all(userId, LIST_LIMIT);
+  return { ok: true, hypotheses: rows };
+}
+
+// ── Research jobs ───────────────────────────────────────────────────────
+
+function deterministicResearchSummary(topic, selected) {
+  const lines = selected.slice(0, 40).map(
+    (d) => `- [${d.layer || "domain"}] ${d.title} (${d.key}): ${String(d.summary || "").slice(0, 160)}`,
+  );
+  return [
+    `Topic: ${topic}`,
+    `DTUs consulted: ${selected.length}`,
+    lines.length ? "Relevant DTUs:\n" + lines.join("\n") : "No matching DTUs were supplied — synthesis is scoped to the topic string only.",
+    "Uncertainties: language model unavailable; this is a deterministic consult list, not a generated finding.",
+    "Suggested next: mint an experimental auto-DTU from this job once a brain can synthesize, or after a human edits the summary.",
+  ].join("\n");
+}
+
+export function createResearchJob(db, userId, { topic, dtuKeys = [], layer = null } = {}, now = new Date()) {
+  const blocked = requireDb(db);
+  if (blocked) return blocked;
+  const t = String(topic || "").trim();
+  if (!t) return { ok: false, reason: "topic_required" };
+  const createdAt = now.toISOString();
+  const info = db.prepare(`
+    INSERT INTO lattice_seed_research_jobs
+      (user_id, topic, dtu_keys, layer, status, created_at, updated_at)
+    VALUES (?, ?, ?, ?, 'pending', ?, ?)
+  `).run(userId, t.slice(0, 2000), JSON.stringify(Array.isArray(dtuKeys) ? dtuKeys.slice(0, 50) : []), layer || null, createdAt, createdAt);
+  return { ok: true, id: Number(info.lastInsertRowid), status: "pending" };
+}
+
+export async function processResearchJob(db, userId, jobId, { llm = null, listDtus = null, now = new Date() } = {}) {
+  const blocked = requireDb(db);
+  if (blocked) return blocked;
+  const job = db.prepare(`
+    SELECT id, topic, dtu_keys AS dtuKeys, layer, status
+    FROM lattice_seed_research_jobs
+    WHERE id = ? AND user_id = ?
+  `).get(Number(jobId), userId);
+  if (!job) return { ok: false, reason: "job_not_found" };
+  if (job.status !== "pending") return { ok: false, reason: "job_not_pending", status: job.status };
+
+  let selected = [];
+  if (typeof listDtus === "function") {
+    try { selected = (await listDtus()) || []; } catch { selected = []; }
+  }
+  let keys = [];
+  try { keys = JSON.parse(job.dtuKeys || "[]"); } catch { keys = []; }
+  if (Array.isArray(keys) && keys.length) {
+    selected = selected.filter((d) => keys.includes(d.key));
+  }
+  if (job.layer) {
+    selected = selected.filter((d) => d.layer === job.layer);
+  }
+
+  let composer = "deterministic";
+  let summary = deterministicResearchSummary(job.topic, selected);
+  const llmText = await maybeChat(
+    llm,
+    TASK_PROMPTS.latticeSeedResearch({ topic: job.topic }),
+    selected.slice(0, 40).map((d) => `- [${d.layer || "domain"}] ${d.title} (${d.key}): ${d.summary}`).join("\n")
+      || `(no DTUs selected)\nResearch the topic: ${job.topic}`,
+  );
+  if (llmText) {
+    summary = llmText;
+    composer = "llm";
+  }
+
+  const updatedAt = now.toISOString();
+  db.prepare(`
+    UPDATE lattice_seed_research_jobs
+    SET status = 'done', result_summary = ?, updated_at = ?, error_message = NULL
+    WHERE id = ? AND user_id = ?
+  `).run(summary.slice(0, 16000), updatedAt, job.id, userId);
+  addMemory(db, {
+    userId,
+    scope: "research",
+    text: `Topic: ${job.topic}\nSummary:\n${summary}`,
+    source: `research-job:${job.id}`,
+    layer: job.layer || "HLR",
+    nowIso: updatedAt,
+  });
+  return { ok: true, id: job.id, status: "done", resultSummary: summary, composer };
+}
+
+export function listResearchJobs(db, userId, { status } = {}) {
+  const blocked = requireDb(db);
+  if (blocked) return blocked;
+  const rows = status
+    ? db.prepare(`
+        SELECT id, topic, dtu_keys AS dtuKeys, layer, status, result_summary AS resultSummary,
+               error_message AS errorMessage, created_at AS createdAt, updated_at AS updatedAt
+        FROM lattice_seed_research_jobs
+        WHERE user_id = ? AND status = ?
+        ORDER BY created_at DESC LIMIT ?
+      `).all(userId, String(status), LIST_LIMIT)
+    : db.prepare(`
+        SELECT id, topic, dtu_keys AS dtuKeys, layer, status, result_summary AS resultSummary,
+               error_message AS errorMessage, created_at AS createdAt, updated_at AS updatedAt
+        FROM lattice_seed_research_jobs
+        WHERE user_id = ?
+        ORDER BY created_at DESC LIMIT ?
+      `).all(userId, LIST_LIMIT);
+  return { ok: true, jobs: rows };
+}
+
+// ── Auto-DTUs ───────────────────────────────────────────────────────────
+
+export async function generateUniqueDtuKey(db, userId, baseKey) {
+  const all = new Set(
+    db.prepare("SELECT dtu_key FROM lattice_seed_auto_dtus WHERE user_id = ?").all(userId).map((r) => r.dtu_key),
+  );
+  const base = slugify(baseKey);
+  if (!all.has(base)) return base;
+  let i = 2;
+  while (all.has(`${base}-${i}`)) i += 1;
+  return `${base}-${i}`;
+}
+
+function deterministicDtu(seedText, { layerHint, kind } = {}) {
+  const seed = String(seedText || "").replace(/\s+/g, " ").trim();
+  const firstLine = seed.split(/[.!?\n]/)[0].trim().slice(0, 80);
+  return {
+    key: slugify(firstLine || "auto-dtu"),
+    title: firstLine || "Auto-generated DTU",
+    summary: seed.slice(0, SUMMARY_CHAR_CAP) || "No seed text.",
+    tags: ["auto", "generated"],
+    layer: LAYERS.includes(layerHint) ? layerHint : "domain",
+    kind: kind || "auto",
+  };
+}
+
+export async function generateDtuFromSeed(db, userId, seedText, { layerHint, kind, llm = null } = {}) {
+  const fallback = deterministicDtu(seedText, { layerHint, kind });
+  let parsed = null;
+  const llmText = await maybeChat(
+    llm,
+    TASK_PROMPTS.latticeSeedDtu({ layerHint: layerHint || "none" }),
+    String(seedText || "").slice(0, 4000),
+  );
+  if (llmText) parsed = parseJsonFence(llmText);
+  const draft = {
+    key: slugify(parsed?.key || parsed?.title || fallback.key),
+    title: String(parsed?.title || fallback.title).slice(0, 200),
+    summary: String(parsed?.summary || fallback.summary).slice(0, 2000),
+    tags: parseTags(parsed?.tags?.length ? parsed.tags : fallback.tags),
+    layer: LAYERS.includes(parsed?.layer) ? parsed.layer : fallback.layer,
+    kind: kind || "auto",
+  };
+  const uniqueKey = await generateUniqueDtuKey(db, userId, draft.key);
+  return { ...draft, dtu_key: uniqueKey, composer: parsed ? "llm" : "deterministic" };
+}
+
+function persistAutoDtu(db, userId, dtu, { sourceKind, sourceId, nowIso }) {
+  db.prepare(`
+    INSERT INTO lattice_seed_auto_dtus
+      (user_id, dtu_key, title, summary, tags, layer, kind, trust_level, minted_dtu_id, source_kind, source_id, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, 'experimental', NULL, ?, ?, ?)
+  `).run(
+    userId,
+    dtu.dtu_key,
+    dtu.title,
+    dtu.summary,
+    JSON.stringify(dtu.tags),
+    dtu.layer,
+    dtu.kind,
+    sourceKind,
+    sourceId,
+    nowIso,
+  );
+  addMemory(db, {
+    userId,
+    scope: "dtu",
+    dtuKey: dtu.dtu_key,
+    text: `Auto-DTU created from ${sourceKind} ${sourceId}:\nTitle: ${dtu.title}\nSummary: ${dtu.summary}`,
+    source: `auto-dtu-from-${sourceKind}:${sourceId}`,
+    layer: dtu.layer,
+    nowIso,
+  });
+}
+
+async function maybeMintIntoSubstrate(dtu, mintDtu) {
+  if (typeof mintDtu !== "function") return null;
+  try {
+    const minted = await mintDtu({
+      title: dtu.title,
+      tags: dtu.tags,
+      source: `lattice-seed:${dtu.kind}`,
+      meta: {
+        latticeSeedKey: dtu.dtu_key,
+        trustLevel: "experimental",
+        layer: dtu.layer,
+        kind: dtu.kind,
+        summary: dtu.summary,
+      },
+    });
+    const id = minted?.dtu?.id || minted?.id || null;
+    return id ? String(id) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function mintFromHypothesis(db, userId, { hypothesisId, layerHint = "HLM", kind = "auto-hypothesis", llm = null, mintDtu = null } = {}, now = new Date()) {
+  const blocked = requireDb(db);
+  if (blocked) return blocked;
+  const row = db.prepare(`
+    SELECT id, text, source_label AS sourceLabel
+    FROM lattice_seed_hypotheses
+    WHERE id = ? AND user_id = ?
+  `).get(Number(hypothesisId), userId);
+  if (!row) return { ok: false, reason: "hypothesis_not_found" };
+
+  const seedText = `Hypothesis (id: ${row.id}, source: ${row.sourceLabel || "unknown"}):\n${row.text}`;
+  const dtu = await generateDtuFromSeed(db, userId, seedText, { layerHint, kind, llm });
+  const nowIso = now.toISOString();
+  persistAutoDtu(db, userId, dtu, { sourceKind: "hypothesis", sourceId: row.id, nowIso });
+  const mintedId = await maybeMintIntoSubstrate(dtu, mintDtu);
+  if (mintedId) {
+    db.prepare(`
+      UPDATE lattice_seed_auto_dtus SET minted_dtu_id = ? WHERE user_id = ? AND dtu_key = ?
+    `).run(mintedId, userId, dtu.dtu_key);
+  }
+  return {
+    ok: true,
+    dtu: {
+      key: dtu.dtu_key,
+      title: dtu.title,
+      summary: dtu.summary,
+      tags: dtu.tags,
+      layer: dtu.layer,
+      kind: dtu.kind,
+      trustLevel: "experimental",
+      mintedDtuId: mintedId,
+      composer: dtu.composer,
+    },
+  };
+}
+
+export async function mintFromResearchJob(db, userId, { jobId, layerHint = "HLR", kind = "auto-research", llm = null, mintDtu = null } = {}, now = new Date()) {
+  const blocked = requireDb(db);
+  if (blocked) return blocked;
+  const row = db.prepare(`
+    SELECT id, topic, result_summary AS resultSummary, status
+    FROM lattice_seed_research_jobs
+    WHERE id = ? AND user_id = ?
+  `).get(Number(jobId), userId);
+  if (!row) return { ok: false, reason: "job_not_found" };
+  if (row.status !== "done") return { ok: false, reason: "job_not_completed", status: row.status };
+
+  const seedText = `Research job (id: ${row.id}) on topic "${row.topic}". Summary:\n${row.resultSummary}`;
+  const dtu = await generateDtuFromSeed(db, userId, seedText, { layerHint, kind, llm });
+  const nowIso = now.toISOString();
+  persistAutoDtu(db, userId, dtu, { sourceKind: "research", sourceId: row.id, nowIso });
+  const mintedId = await maybeMintIntoSubstrate(dtu, mintDtu);
+  if (mintedId) {
+    db.prepare(`
+      UPDATE lattice_seed_auto_dtus SET minted_dtu_id = ? WHERE user_id = ? AND dtu_key = ?
+    `).run(mintedId, userId, dtu.dtu_key);
+  }
+  return {
+    ok: true,
+    dtu: {
+      key: dtu.dtu_key,
+      title: dtu.title,
+      summary: dtu.summary,
+      tags: dtu.tags,
+      layer: dtu.layer,
+      kind: dtu.kind,
+      trustLevel: "experimental",
+      mintedDtuId: mintedId,
+      composer: dtu.composer,
+    },
+  };
+}
+
+export function setTrust(db, userId, { key, trustLevel } = {}) {
+  const blocked = requireDb(db);
+  if (blocked) return blocked;
+  const k = String(key || "").trim();
+  const level = String(trustLevel || "").trim();
+  if (!k || !level) return { ok: false, reason: "key_and_trust_level_required" };
+  if (!TRUST_LEVELS.includes(level)) return { ok: false, reason: "invalid_trust_level" };
+  const row = db.prepare(`
+    SELECT dtu_key FROM lattice_seed_auto_dtus WHERE user_id = ? AND dtu_key = ?
+  `).get(userId, k);
+  if (!row) return { ok: false, reason: "auto_dtu_not_found" };
+  db.prepare(`
+    UPDATE lattice_seed_auto_dtus SET trust_level = ? WHERE user_id = ? AND dtu_key = ?
+  `).run(level, userId, k);
+  return { ok: true, key: k, trustLevel: level };
+}
+
+export function listAutoDtus(db, userId, { includeExperimental = true } = {}) {
+  const blocked = requireDb(db);
+  if (blocked) return blocked;
+  const rows = db.prepare(`
+    SELECT dtu_key AS key, title, summary, tags, layer, kind, trust_level AS trustLevel,
+           minted_dtu_id AS mintedDtuId, source_kind AS sourceKind, source_id AS sourceId,
+           created_at AS createdAt
+    FROM lattice_seed_auto_dtus
+    WHERE user_id = ?
+    ORDER BY created_at DESC
+  `).all(userId);
+  const dtus = rows
+    .map((r) => ({ ...r, tags: parseTags(r.tags), source: "auto" }))
+    .filter((d) => includeExperimental || d.trustLevel === "trusted");
+  return { ok: true, dtus };
+}
+
+export function status(db, userId, { role = "guest", now = new Date() } = {}) {
+  const blocked = requireDb(db);
+  if (blocked) return blocked;
+  const mem = db.prepare("SELECT COUNT(*) AS cnt FROM lattice_seed_memory WHERE user_id = ?").get(userId);
+  const dtus = db.prepare("SELECT COUNT(*) AS cnt FROM lattice_seed_auto_dtus WHERE user_id = ?").get(userId);
+  const queued = db.prepare("SELECT COUNT(*) AS cnt FROM lattice_seed_pages WHERE user_id = ? AND status = 'queued'").get(userId);
+  const quota = pagesPerDayForRole(role);
+  const used = quotaUsedToday(db, userId, now);
+  return {
+    ok: true,
+    memoryCount: Number(mem?.cnt || 0),
+    autoDtuCount: Number(dtus?.cnt || 0),
+    queuedPages: Number(queued?.cnt || 0),
+    quotaUsed: used,
+    quotaLimit: quota,
+  };
+}
+
+export function listMemory(db, userId, { scope } = {}) {
+  const blocked = requireDb(db);
+  if (blocked) return blocked;
+  const rows = scope
+    ? db.prepare(`
+        SELECT id, scope, dtu_key AS dtuKey, text, source, layer, created_at AS createdAt
+        FROM lattice_seed_memory WHERE user_id = ? AND scope = ?
+        ORDER BY created_at DESC LIMIT ?
+      `).all(userId, String(scope), LIST_LIMIT)
+    : db.prepare(`
+        SELECT id, scope, dtu_key AS dtuKey, text, source, layer, created_at AS createdAt
+        FROM lattice_seed_memory WHERE user_id = ?
+        ORDER BY created_at DESC LIMIT ?
+      `).all(userId, LIST_LIMIT);
+  return { ok: true, entries: rows };
+}

--- a/server/lib/prompt-registry.js
+++ b/server/lib/prompt-registry.js
@@ -1393,4 +1393,41 @@ Question under deliberation: ${question}
 Your provisional lean (already decided by deterministic scoring, do NOT change it): ${vote} (score ${score}).
 
 Write a fully-argued 2-4 sentence case for your lean, grounded ONLY in the question as given. Do not invent facts not implied by the question. Do not mention scores, JSON, or that you are an AI. Plain prose, first person as this voice.`,
+
+  // ── Lattice-seed (recovered Auto-DTU + ingest-scheduler loop) ────
+  // Callers MUST fall back to a deterministic composer when the brain
+  // is down — these prompts never invent a success on their own.
+  latticeSeedHypotheses: () =>
+    `You are Concord ingesting a source excerpt.
+From the excerpt, propose 3–5 testable hypotheses or research directions.
+Number them. Keep them concrete and grounded in the excerpt — do not invent facts that are not in the text.
+If the excerpt is too thin to support a hypothesis, say so in one line instead of padding.`,
+
+  latticeSeedResearch: ({ topic } = {}) =>
+    `You are ConcordOS performing a focused research synthesis.
+
+Topic: ${topic || "(unspecified)"}
+
+The user message lists relevant DTUs (or notes that none were supplied).
+Output:
+- Key findings (bullets), grounded only in the supplied DTU summaries and the topic
+- Uncertainties / open questions
+- Suggested DTUs or hypotheses to create next
+Do not invent DTUs that were not listed. If the DTU list is empty, say so and stay at the topic level.`,
+
+  latticeSeedDtu: ({ layerHint } = {}) =>
+    `You are designing a Domain Thought Unit (DTU) for ConcordOS.
+
+From the following seed text, create a JSON object with:
+{
+  "key": "short-machine-slug-like-this",
+  "title": "Human readable DTU title",
+  "summary": "2–4 sentence summary.",
+  "tags": ["short", "lowercase", "tags"],
+  "layer": "domain | HLM | HLR | meta"
+}
+
+Prefer the layer hint if it makes sense: ${layerHint || "none"}.
+Return ONLY valid JSON, no extra text, no markdown fences.
+Ground the summary in the seed. Do not invent capabilities or citations.`,
 };

--- a/server/migrations/416_lattice_seed.js
+++ b/server/migrations/416_lattice_seed.js
@@ -1,0 +1,136 @@
+// server/migrations/416_lattice_seed.js
+//
+// Persistent Auto-DTU + ingest-scheduler substrate recovered from an
+// older ConcordOS backend (the "Auto-DTUs + Ingest Scheduler" patch
+// bundle). Current Concord already has:
+//   • planetary ingest-engine (in-memory URL queue, 10/100/500/∞ tiers,
+//     SSRF-guarded fetch, council-gated DTU mint)
+//   • hypothesis-engine / hypothesis lens (scientific method + stats)
+//   • research-jobs.js (in-memory directed investigation pipeline)
+//   • dtu.create + dtu_confidence (numeric belief, not a trust ladder)
+//
+// What this migration adds, that those surfaces do not:
+//   1. Labeled ingest *sources* + a durable *page queue* (SQLite, not RAM).
+//   2. Daily per-user ingest quota log (10 member / 100 admin-family).
+//   3. Generated research-direction hypotheses as first-class rows.
+//   4. Persisted research jobs (the in-memory engine is lost on restart).
+//   5. Auto-DTUs minted at trust_level='experimental' until a human
+//      promotes them to 'trusted' — a ladder dtu_confidence does not have.
+//   6. Scoped memory of those operations (ingest / hypothesis / research /
+//      auto-dtu), without fabricated embedding vectors.
+//
+// Multi-tenant: every table is keyed by user_id (the old backend was
+// single-user). Table-guarded readers; forward-only. Migrations are
+// append-only.
+
+export function up(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS lattice_seed_sources (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id TEXT NOT NULL,
+      root_url TEXT,
+      label TEXT NOT NULL,
+      notes TEXT,
+      created_at TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_lattice_seed_sources_user
+      ON lattice_seed_sources(user_id, created_at DESC);
+
+    CREATE TABLE IF NOT EXISTS lattice_seed_pages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id TEXT NOT NULL,
+      source_id INTEGER NOT NULL,
+      url TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'queued'
+        CHECK(status IN ('queued','processed','error')),
+      content_excerpt TEXT,
+      last_processed_at TEXT,
+      error_message TEXT,
+      FOREIGN KEY (source_id) REFERENCES lattice_seed_sources(id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_lattice_seed_pages_queue
+      ON lattice_seed_pages(user_id, status, id);
+
+    CREATE TABLE IF NOT EXISTS lattice_seed_ingest_log (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id TEXT NOT NULL,
+      page_id INTEGER NOT NULL,
+      processed_at TEXT NOT NULL,
+      bytes_ingested INTEGER NOT NULL DEFAULT 0,
+      FOREIGN KEY (page_id) REFERENCES lattice_seed_pages(id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_lattice_seed_ingest_log_day
+      ON lattice_seed_ingest_log(user_id, processed_at);
+
+    CREATE TABLE IF NOT EXISTS lattice_seed_hypotheses (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id TEXT NOT NULL,
+      text TEXT NOT NULL,
+      source_label TEXT,
+      created_at TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_lattice_seed_hypotheses_user
+      ON lattice_seed_hypotheses(user_id, created_at DESC);
+
+    CREATE TABLE IF NOT EXISTS lattice_seed_research_jobs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id TEXT NOT NULL,
+      topic TEXT NOT NULL,
+      dtu_keys TEXT,
+      layer TEXT,
+      status TEXT NOT NULL DEFAULT 'pending'
+        CHECK(status IN ('pending','done','error')),
+      result_summary TEXT,
+      error_message TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_lattice_seed_jobs_user
+      ON lattice_seed_research_jobs(user_id, created_at DESC);
+
+    CREATE TABLE IF NOT EXISTS lattice_seed_auto_dtus (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id TEXT NOT NULL,
+      dtu_key TEXT NOT NULL,
+      title TEXT NOT NULL,
+      summary TEXT NOT NULL,
+      tags TEXT,
+      layer TEXT,
+      kind TEXT,
+      trust_level TEXT NOT NULL DEFAULT 'experimental'
+        CHECK(trust_level IN ('experimental','trusted')),
+      minted_dtu_id TEXT,
+      source_kind TEXT,
+      source_id INTEGER,
+      created_at TEXT NOT NULL,
+      UNIQUE(user_id, dtu_key)
+    );
+    CREATE INDEX IF NOT EXISTS idx_lattice_seed_auto_dtus_user
+      ON lattice_seed_auto_dtus(user_id, created_at DESC);
+
+    CREATE TABLE IF NOT EXISTS lattice_seed_memory (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id TEXT NOT NULL,
+      scope TEXT NOT NULL,
+      dtu_key TEXT,
+      text TEXT NOT NULL,
+      source TEXT,
+      layer TEXT,
+      created_at TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_lattice_seed_memory_user
+      ON lattice_seed_memory(user_id, created_at DESC);
+  `);
+}
+
+export function down(db) {
+  db.exec(`
+    DROP TABLE IF EXISTS lattice_seed_memory;
+    DROP TABLE IF EXISTS lattice_seed_auto_dtus;
+    DROP TABLE IF EXISTS lattice_seed_research_jobs;
+    DROP TABLE IF EXISTS lattice_seed_hypotheses;
+    DROP TABLE IF EXISTS lattice_seed_ingest_log;
+    DROP TABLE IF EXISTS lattice_seed_pages;
+    DROP TABLE IF EXISTS lattice_seed_sources;
+  `);
+}

--- a/server/tests/lattice-seed-domain-parity.test.js
+++ b/server/tests/lattice-seed-domain-parity.test.js
@@ -1,0 +1,116 @@
+// server/tests/lattice-seed-domain-parity.test.js
+//
+// Contract tests for server/domains/lattice-seed.js — every recovered
+// Auto-DTU / ingest-scheduler macro is registered and round-trips
+// through the registerLensAction (ctx, artifact, params) shape.
+//
+// Run: node --test server/tests/lattice-seed-domain-parity.test.js
+
+import { describe, it, before, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+
+import { up as upLatticeSeed } from "../migrations/416_lattice_seed.js";
+import registerLatticeSeedActions from "../domains/lattice-seed.js";
+
+const ACTIONS = new Map();
+function register(domain, name, fn) { ACTIONS.set(`${domain}.${name}`, fn); }
+function call(name, ctx, input = {}) {
+  const fn = ACTIONS.get(`lattice-seed.${name}`);
+  if (!fn) throw new Error(`lattice-seed.${name} not registered`);
+  return fn(ctx, { id: null, data: input, meta: {} }, input);
+}
+
+before(() => { registerLatticeSeedActions(register); });
+
+let db;
+let ctx;
+beforeEach(() => {
+  db = new Database(":memory:");
+  upLatticeSeed(db);
+  ctx = { db, actor: { userId: "parity_user", role: "member" } };
+});
+afterEach(() => { try { db?.close(); } catch { /* intentional */ } });
+
+const EXPECTED = [
+  "status", "createSource", "listSources", "queuePage", "listPages",
+  "executeNext", "proposeHypotheses", "listHypotheses",
+  "createResearchJob", "listResearchJobs",
+  "mintFromHypothesis", "mintFromResearchJob", "setTrust",
+  "listAutoDtus", "listMemory",
+];
+
+describe("lattice-seed registration", () => {
+  it("registers the recovered Auto-DTU / ingest-scheduler macros", () => {
+    for (const name of EXPECTED) {
+      assert.ok(ACTIONS.has(`lattice-seed.${name}`), `missing lattice-seed.${name}`);
+    }
+  });
+});
+
+describe("lattice-seed macros — round trip", () => {
+  it("status on a fresh user is zeros, quota 10 for member", () => {
+    const r = call("status", ctx, {});
+    assert.equal(r.ok, true);
+    assert.equal(r.result.autoDtuCount, 0);
+    assert.equal(r.result.quotaLimit, 10);
+    assert.equal(r.result.quotaUsed, 0);
+  });
+
+  it("createSource / queuePage / executeNext / propose / mint / setTrust", async () => {
+    const src = call("createSource", ctx, { label: "Notes", rootUrl: "https://example.com" });
+    assert.equal(src.ok, true);
+    const queued = call("queuePage", ctx, { sourceId: src.result.id, url: "https://example.com/ice" });
+    assert.equal(queued.ok, true);
+
+    const executed = await call("executeNext", ctx, {
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        text: async () => "<p>Callisto may have a subsurface ocean.</p>",
+      }),
+    });
+    assert.equal(executed.ok, true, JSON.stringify(executed));
+    assert.equal(executed.result.excerpt, "Callisto may have a subsurface ocean.");
+    assert.equal(executed.result.quotaUsed, 1);
+
+    const minted = await call("mintFromHypothesis", ctx, { hypothesisId: executed.result.hypothesisId });
+    assert.equal(minted.ok, true, JSON.stringify(minted));
+    assert.equal(minted.result.dtu.trustLevel, "experimental");
+
+    const trusted = call("setTrust", ctx, { key: minted.result.dtu.key, trustLevel: "trusted" });
+    assert.equal(trusted.ok, true);
+    const listed = call("listAutoDtus", ctx, { includeExperimental: false });
+    assert.equal(listed.result.dtus.length, 1);
+  });
+
+  it("createResearchJob processes inline and mintFromResearchJob needs done", async () => {
+    const job = await call("createResearchJob", ctx, { topic: "Callisto ocean" });
+    assert.equal(job.ok, true);
+    assert.equal(job.result.status, "done");
+    const minted = await call("mintFromResearchJob", ctx, { jobId: job.result.id });
+    assert.equal(minted.ok, true);
+    assert.equal(minted.result.dtu.kind, "auto-research");
+  });
+
+  it("executeNext quota is role-derived — a member ctx cannot self-declare admin", async () => {
+    const src = call("createSource", ctx, { label: "Burst" });
+    for (let i = 0; i < 11; i++) {
+      call("queuePage", ctx, { sourceId: src.result.id, url: `https://example.com/${i}` });
+    }
+    const fetchImpl = async () => ({ ok: true, status: 200, text: async () => "<p>x</p>" });
+    for (let i = 0; i < 10; i++) {
+      const r = await call("executeNext", { ...ctx, actor: { userId: "parity_user", role: "member" } }, { fetchImpl, mode: "admin" });
+      assert.equal(r.ok, true, `member page ${i}`);
+    }
+    const blocked = await call("executeNext", { ...ctx, actor: { userId: "parity_user", role: "member" } }, { fetchImpl, mode: "admin" });
+    assert.equal(blocked.ok, false);
+    assert.equal(blocked.reason, "quota_reached");
+  });
+
+  it("no_db is honest", () => {
+    const r = call("listSources", { actor: { userId: "x" } }, {});
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "no_db");
+  });
+});

--- a/server/tests/lattice-seed-ssrf.test.js
+++ b/server/tests/lattice-seed-ssrf.test.js
@@ -1,0 +1,42 @@
+// server/tests/lattice-seed-ssrf.test.js
+//
+// Pins that lattice-seed executeNext uses fetchPublicUrl, so private
+// targets are unreachable even when a caller would have passed
+// mode=admin in the old backend. Mirrors ingest-engine-ssrf.test.js.
+//
+// Run: node --test server/tests/lattice-seed-ssrf.test.js
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+
+import { up as upLatticeSeed } from "../migrations/416_lattice_seed.js";
+import { createSource, queuePage, executeNext } from "../lib/lattice-seed.js";
+
+const PRIVATE_TARGETS = [
+  ["cloud metadata", "http://169.254.169.254/latest/meta-data/iam/security-credentials/"],
+  ["loopback — local Ollama brains", "http://127.0.0.1:11434/api/tags"],
+  ["loopback by name", "http://localhost:5050/api/admin/stats"],
+  ["RFC1918 10/8", "http://10.0.0.1/"],
+  ["RFC1918 192.168/16", "http://192.168.1.1/"],
+];
+
+let db;
+beforeEach(() => {
+  db = new Database(":memory:");
+  upLatticeSeed(db);
+});
+afterEach(() => { try { db?.close(); } catch { /* intentional */ } });
+
+describe("lattice-seed executeNext — private targets are unreachable", () => {
+  for (const [label, url] of PRIVATE_TARGETS) {
+    it(`blocks ${label} (no fetchImpl — real SSRF guard)`, async () => {
+      const src = createSource(db, "ssrf-user", { label: "probe" });
+      queuePage(db, "ssrf-user", { sourceId: src.id, url });
+      const r = await executeNext(db, "ssrf-user", { role: "sovereign" });
+      assert.equal(r.ok, false, `${url} must not ingest`);
+      assert.equal(r.reason, "ssrf_blocked", `${url} reason=${r.reason} error=${r.error}`);
+      assert.ok(!r.excerpt && !r.hypotheses, `${url} must not return fetched content`);
+    });
+  }
+});

--- a/server/tests/lattice-seed.test.js
+++ b/server/tests/lattice-seed.test.js
@@ -1,0 +1,349 @@
+// server/tests/lattice-seed.test.js
+//
+// Behavioral tests for the recovered Auto-DTU + ingest-scheduler loop
+// (server/lib/lattice-seed.js + migration 416). Runs against a real
+// in-memory better-sqlite3 DB. LLM and fetch are injected — no live
+// brain, no live network. Expected values come from the engine.
+//
+// Run: node --test server/tests/lattice-seed.test.js
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+
+import { up as upLatticeSeed } from "../migrations/416_lattice_seed.js";
+import {
+  MEMBER_PAGES_PER_DAY,
+  ADMIN_PAGES_PER_DAY,
+  pagesPerDayForRole,
+  slugify,
+  excerptFromHtml,
+  todayStartIso,
+  createSource,
+  listSources,
+  queuePage,
+  listPages,
+  executeNext,
+  proposeHypotheses,
+  listHypotheses,
+  createResearchJob,
+  processResearchJob,
+  listResearchJobs,
+  mintFromHypothesis,
+  mintFromResearchJob,
+  setTrust,
+  listAutoDtus,
+  status,
+  generateUniqueDtuKey,
+} from "../lib/lattice-seed.js";
+
+let db;
+beforeEach(() => {
+  db = new Database(":memory:");
+  upLatticeSeed(db);
+});
+afterEach(() => { try { db?.close(); } catch { /* intentional */ } });
+
+const U = "user_a";
+const OTHER = "user_b";
+
+function htmlFetch(body, status = 200) {
+  return async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => body,
+  });
+}
+
+describe("pagesPerDayForRole — privilege from role, never from a body field", () => {
+  it("admin-family roles get 100, everyone else 10", () => {
+    for (const role of ["owner", "admin", "founder", "sovereign"]) {
+      assert.equal(pagesPerDayForRole(role), ADMIN_PAGES_PER_DAY, role);
+    }
+    for (const role of ["guest", "member", "paid", "researcher", "", undefined]) {
+      assert.equal(pagesPerDayForRole(role), MEMBER_PAGES_PER_DAY, String(role));
+    }
+  });
+});
+
+describe("slugify / excerptFromHtml", () => {
+  it("slugify lowercases and strips to 60 chars", () => {
+    assert.equal(slugify("Hello, World!!"), "hello-world");
+    assert.equal(slugify(""), "dtu");
+    assert.equal(slugify("x".repeat(80)).length, 60);
+  });
+
+  it("excerptFromHtml strips tags and scripts, caps length", () => {
+    const html = "<html><script>alert(1)</script><style>p{}</style><p>Ice on Ceres.</p></html>";
+    assert.equal(excerptFromHtml(html), "Ice on Ceres.");
+    assert.equal(excerptFromHtml("<p>" + "ab".repeat(2000) + "</p>").length, 2000);
+  });
+});
+
+describe("sources + pages — ownership and validation", () => {
+  it("createSource refuses a missing label and round-trips a labeled source", () => {
+    assert.equal(createSource(db, U, { label: "  " }).reason, "label_required");
+    const created = createSource(db, U, { label: "ArXiv", rootUrl: "https://arxiv.org", notes: "cs.AI" });
+    assert.equal(created.ok, true);
+    assert.equal(typeof created.id, "number");
+    const list = listSources(db, U);
+    assert.equal(list.sources.length, 1);
+    assert.equal(list.sources[0].label, "ArXiv");
+    assert.equal(list.sources[0].rootUrl, "https://arxiv.org");
+    assert.equal(listSources(db, OTHER).sources.length, 0, "other user cannot see this source");
+  });
+
+  it("queuePage requires http(s), a real owned source, and stays queued", () => {
+    const src = createSource(db, U, { label: "ArXiv" });
+    assert.equal(queuePage(db, U, { sourceId: src.id, url: "ftp://x" }).reason, "url_must_be_http");
+    assert.equal(queuePage(db, U, { sourceId: 999, url: "https://arxiv.org/abs/1" }).reason, "source_not_found");
+    assert.equal(queuePage(db, OTHER, { sourceId: src.id, url: "https://arxiv.org/abs/1" }).reason, "source_not_found");
+    const q = queuePage(db, U, { sourceId: src.id, url: "https://arxiv.org/abs/1" });
+    assert.equal(q.ok, true);
+    const pages = listPages(db, U, { status: "queued" });
+    assert.equal(pages.pages.length, 1);
+    assert.equal(pages.pages[0].url, "https://arxiv.org/abs/1");
+    assert.equal(pages.pages[0].status, "queued");
+  });
+
+  it("missing db is an honest no_db, not a fabricated empty list", () => {
+    assert.equal(createSource(null, U, { label: "x" }).reason, "no_db");
+    assert.equal(listSources(null, U).reason, "no_db");
+  });
+});
+
+describe("executeNext — fetch, excerpt, hypotheses, quota", () => {
+  it("processes the oldest queued page, stores excerpt, mints a hypothesis, counts quota", async () => {
+    const src = createSource(db, U, { label: "Ceres notes" });
+    queuePage(db, U, { sourceId: src.id, url: "https://example.com/ceres" });
+    const r = await executeNext(db, U, {
+      role: "member",
+      fetchImpl: htmlFetch("<html><p>Water ice confirmed in Ceres' mid-latitude shadowed craters.</p></html>"),
+    });
+    assert.equal(r.ok, true, JSON.stringify(r));
+    assert.equal(r.excerpt, "Water ice confirmed in Ceres' mid-latitude shadowed craters.");
+    assert.equal(r.quotaUsed, 1);
+    assert.equal(r.quotaLimit, MEMBER_PAGES_PER_DAY);
+    assert.equal(r.composer, "deterministic");
+    assert.match(r.hypotheses, /Ceres/);
+    const pages = listPages(db, U);
+    assert.equal(pages.pages[0].status, "processed");
+    assert.equal(listHypotheses(db, U).hypotheses.length, 1);
+    const st = status(db, U, { role: "member" });
+    assert.equal(st.quotaUsed, 1);
+    assert.equal(st.queuedPages, 0);
+    assert.equal(st.memoryCount, 2); // ingest memory + hypothesis memory
+  });
+
+  it("empty page is an honest empty_page and does not consume quota", async () => {
+    const src = createSource(db, U, { label: "Empty" });
+    queuePage(db, U, { sourceId: src.id, url: "https://example.com/empty" });
+    const r = await executeNext(db, U, {
+      role: "member",
+      fetchImpl: htmlFetch("<html><script>void 0</script></html>"),
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "empty_page");
+    assert.equal(status(db, U, { role: "member" }).quotaUsed, 0);
+    assert.equal(listPages(db, U).pages[0].status, "error");
+  });
+
+  it("HTTP failure is fetch_failed, page marked error, quota untouched", async () => {
+    const src = createSource(db, U, { label: "Down" });
+    queuePage(db, U, { sourceId: src.id, url: "https://example.com/404" });
+    const r = await executeNext(db, U, {
+      role: "member",
+      fetchImpl: htmlFetch("nope", 404),
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "fetch_failed");
+    assert.equal(status(db, U, { role: "member" }).quotaUsed, 0);
+  });
+
+  it("no queued pages is honest, not a fabricated success", async () => {
+    const r = await executeNext(db, U, { role: "member", fetchImpl: htmlFetch("x") });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "no_queued_pages");
+  });
+
+  it("member quota is 10; the 11th execute-next is quota_reached without fetching", async () => {
+    const src = createSource(db, U, { label: "Burst" });
+    for (let i = 0; i < 11; i++) {
+      queuePage(db, U, { sourceId: src.id, url: `https://example.com/p${i}` });
+    }
+    let fetches = 0;
+    const fetchImpl = async () => {
+      fetches += 1;
+      return { ok: true, status: 200, text: async () => `<p>Page body ${fetches}</p>` };
+    };
+    for (let i = 0; i < 10; i++) {
+      const r = await executeNext(db, U, { role: "member", fetchImpl });
+      assert.equal(r.ok, true, `page ${i} should ingest: ${JSON.stringify(r)}`);
+    }
+    const blocked = await executeNext(db, U, { role: "member", fetchImpl });
+    assert.equal(blocked.ok, false);
+    assert.equal(blocked.reason, "quota_reached");
+    assert.equal(blocked.quotaUsed, 10);
+    assert.equal(blocked.quotaLimit, 10);
+    assert.equal(fetches, 10, "quota refusal must not fetch the 11th page");
+    assert.equal(listPages(db, U, { status: "queued" }).pages.length, 1);
+  });
+
+  it("admin-family quota is 100, not the member 10", async () => {
+    const src = createSource(db, U, { label: "Admin burst" });
+    for (let i = 0; i < 11; i++) {
+      queuePage(db, U, { sourceId: src.id, url: `https://example.com/a${i}` });
+    }
+    const fetchImpl = htmlFetch("<p>ok</p>");
+    for (let i = 0; i < 11; i++) {
+      const r = await executeNext(db, U, { role: "admin", fetchImpl });
+      assert.equal(r.ok, true, `admin page ${i}: ${JSON.stringify(r)}`);
+    }
+    assert.equal(status(db, U, { role: "admin" }).quotaUsed, 11);
+    assert.equal(status(db, U, { role: "admin" }).quotaLimit, ADMIN_PAGES_PER_DAY);
+  });
+
+  it("a request-body-shaped mode field cannot raise the quota — role is the only input", async () => {
+    // The old backend read `mode === "admin"` off the body. If someone
+    // later wires that back, this documents the contract: executeNext
+    // has no `mode` argument. Quota is pagesPerDayForRole(role) only.
+    assert.equal(pagesPerDayForRole("member"), 10);
+    assert.notEqual(pagesPerDayForRole("member"), ADMIN_PAGES_PER_DAY);
+  });
+});
+
+describe("hypotheses + auto-DTU mint + trust ladder", () => {
+  it("proposeHypotheses persists deterministic directions when no LLM is present", async () => {
+    const r = await proposeHypotheses(db, U, {
+      text: "Ceres has water ice in permanently shadowed craters.",
+      sourceLabel: "manual",
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.composer, "deterministic");
+    assert.match(r.hypotheses, /Ceres has water ice/);
+    assert.equal(listHypotheses(db, U).hypotheses.length, 1);
+    assert.equal(listHypotheses(db, OTHER).hypotheses.length, 0);
+  });
+
+  it("mintFromHypothesis writes an experimental auto-DTU with a unique key", async () => {
+    const hyp = await proposeHypotheses(db, U, { text: "Phobos may be a captured asteroid." });
+    const minted = await mintFromHypothesis(db, U, { hypothesisId: hyp.id, layerHint: "HLM" });
+    assert.equal(minted.ok, true, JSON.stringify(minted));
+    assert.equal(minted.dtu.trustLevel, "experimental");
+    assert.equal(minted.dtu.layer, "HLM");
+    assert.equal(minted.dtu.kind, "auto-hypothesis");
+    assert.equal(minted.dtu.composer, "deterministic");
+    assert.equal(minted.dtu.mintedDtuId, null, "no dtu.create hook → honest null, not a fake id");
+    const listed = listAutoDtus(db, U);
+    assert.equal(listed.dtus.length, 1);
+    assert.equal(listed.dtus[0].key, minted.dtu.key);
+  });
+
+  it("setTrust promotes experimental → trusted; trusted-only listing hides the rest", async () => {
+    const hyp = await proposeHypotheses(db, U, { text: "A testable claim about Enceladus plumes." });
+    const minted = await mintFromHypothesis(db, U, { hypothesisId: hyp.id });
+    assert.equal(setTrust(db, U, { key: minted.dtu.key, trustLevel: "nope" }).reason, "invalid_trust_level");
+    assert.equal(setTrust(db, U, { key: "ghost", trustLevel: "trusted" }).reason, "auto_dtu_not_found");
+    assert.equal(setTrust(db, OTHER, { key: minted.dtu.key, trustLevel: "trusted" }).reason, "auto_dtu_not_found");
+    const promoted = setTrust(db, U, { key: minted.dtu.key, trustLevel: "trusted" });
+    assert.equal(promoted.ok, true);
+    assert.equal(promoted.trustLevel, "trusted");
+    assert.equal(listAutoDtus(db, U, { includeExperimental: false }).dtus.length, 1);
+  });
+
+  it("generateUniqueDtuKey suffixes colliding slugs", async () => {
+    const hyp = await proposeHypotheses(db, U, { text: "Same slug seed about Titan lakes." });
+    const a = await mintFromHypothesis(db, U, { hypothesisId: hyp.id });
+    const b = await mintFromHypothesis(db, U, { hypothesisId: hyp.id });
+    assert.equal(a.ok, true);
+    assert.equal(b.ok, true);
+    assert.notEqual(a.dtu.key, b.dtu.key);
+    assert.ok(b.dtu.key.startsWith(a.dtu.key) || b.dtu.key.endsWith("-2") || a.dtu.key.endsWith("-2"));
+    const k1 = await generateUniqueDtuKey(db, U, a.dtu.key);
+    assert.notEqual(k1, a.dtu.key);
+  });
+
+  it("LLM JSON mint uses the model body; malformed JSON falls back without failing", async () => {
+    const hyp = await proposeHypotheses(db, U, { text: "Europa's ice shell may hide a global ocean." });
+    const minted = await mintFromHypothesis(db, U, {
+      hypothesisId: hyp.id,
+      llm: {
+        chat: async () => ({
+          ok: true,
+          content: '```json\n{"key":"europa-ocean","title":"Europa Ocean Hypothesis","summary":"A global ocean may sit under Europa ice.","tags":["europa","ocean"],"layer":"HLR"}\n```',
+        }),
+      },
+    });
+    assert.equal(minted.ok, true);
+    assert.equal(minted.dtu.key, "europa-ocean");
+    assert.equal(minted.dtu.title, "Europa Ocean Hypothesis");
+    assert.equal(minted.dtu.layer, "HLR");
+    assert.equal(minted.dtu.composer, "llm");
+    assert.deepEqual(minted.dtu.tags, ["europa", "ocean"]);
+
+    const fallback = await mintFromHypothesis(db, U, {
+      hypothesisId: hyp.id,
+      llm: { chat: async () => ({ ok: true, content: "not-json at all" }) },
+    });
+    assert.equal(fallback.ok, true);
+    assert.equal(fallback.dtu.composer, "deterministic");
+  });
+
+  it("optional mintDtu hook stamps minted_dtu_id; a throwing hook stays null", async () => {
+    const hyp = await proposeHypotheses(db, U, { text: "Io's torus is sourced from volcanic sulfur." });
+    const okMint = await mintFromHypothesis(db, U, {
+      hypothesisId: hyp.id,
+      mintDtu: async () => ({ dtu: { id: "dtu_real_1" } }),
+    });
+    assert.equal(okMint.dtu.mintedDtuId, "dtu_real_1");
+    const boom = await mintFromHypothesis(db, U, {
+      hypothesisId: hyp.id,
+      mintDtu: async () => { throw new Error("substrate down"); },
+    });
+    assert.equal(boom.ok, true, "auto-DTU row still lands when substrate mint throws");
+    assert.equal(boom.dtu.mintedDtuId, null);
+  });
+});
+
+describe("research jobs — persist + mint", () => {
+  it("create + process with no LLM writes a deterministic consult list and can mint an experimental DTU", async () => {
+    const created = createResearchJob(db, U, { topic: "Ceres ice", dtuKeys: ["ceres-ice"], layer: "HLR" });
+    assert.equal(created.ok, true);
+    assert.equal(created.status, "pending");
+    const processed = await processResearchJob(db, U, created.id, {
+      listDtus: async () => [
+        { key: "ceres-ice", title: "Ceres Ice", summary: "Mid-latitude ice.", layer: "HLR" },
+        { key: "other", title: "Other", summary: "Unrelated", layer: "domain" },
+      ],
+    });
+    assert.equal(processed.ok, true);
+    assert.equal(processed.status, "done");
+    assert.equal(processed.composer, "deterministic");
+    assert.match(processed.resultSummary, /Ceres Ice/);
+    assert.doesNotMatch(processed.resultSummary, /Unrelated/);
+    const minted = await mintFromResearchJob(db, U, { jobId: created.id });
+    assert.equal(minted.ok, true);
+    assert.equal(minted.dtu.trustLevel, "experimental");
+    assert.equal(minted.dtu.kind, "auto-research");
+  });
+
+  it("mintFromResearchJob refuses a still-pending job", async () => {
+    const created = createResearchJob(db, U, { topic: "not done" });
+    const r = await mintFromResearchJob(db, U, { jobId: created.id });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "job_not_completed");
+  });
+
+  it("listResearchJobs is per-user", async () => {
+    createResearchJob(db, U, { topic: "mine" });
+    assert.equal(listResearchJobs(db, U).jobs.length, 1);
+    assert.equal(listResearchJobs(db, OTHER).jobs.length, 0);
+  });
+});
+
+describe("todayStartIso is UTC midnight", () => {
+  it("pins hour/min/sec to 0Z", () => {
+    const iso = todayStartIso(new Date("2026-09-03T15:04:05.000Z"));
+    assert.equal(iso, "2026-09-03T00:00:00.000Z");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this is

The unique loop from an older ConcordOS backend (labeled sources → queued pages → daily quota → hypotheses → experimental auto-DTUs → human trust promotion), ported onto the live substrate.

Does **not** rebuild what already exists: planetary `ingest-engine`, the hypothesis statistics lens, in-memory `research-jobs.js`, chat / ask-Concord, or OpenAI embeddings.

## What's new

- Migration `416_lattice_seed` — persisted sources, pages, ingest log, hypotheses, research jobs, auto-DTUs, scoped memory (per-user)
- `server/lib/lattice-seed.js` + `lattice-seed.*` macros
- Quota from `ctx.actor.role` (10 member / 100 admin-family) — never from a request-body `mode`/`tier`
- Fetch through `fetchPublicUrl` (same SSRF guard as ingest-engine)
- LLM prompts in `TASK_PROMPTS`; missing brains fall back to deterministic composers
- Designed `LatticeSeedPanel` on the ingest lens

## Tests

`node --test server/tests/lattice-seed.test.js server/tests/lattice-seed-ssrf.test.js server/tests/lattice-seed-domain-parity.test.js` — 34 pass / 0 fail. No live network, no live brain.

## Honest residuals

- Auto-DTU catalog is real even when `dtu.create` is unavailable (`mintedDtuId` stays null)
- This is the first of several old-backend recoveries; more pastes can follow the same pattern

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d4e5975-5104-4fb0-a5f0-9d9deae21b18?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d4e5975-5104-4fb0-a5f0-9d9deae21b18&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

