### PR TITLE
Present Concordia's existing simulation in Unity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -295,6 +295,21 @@ apps/concordia-living-world/unity-client/Assets/_Recovery/
 apps/concordia-living-world/unity-client/Assets/ADG_Textures/
 apps/concordia-living-world/unity-client/Assets/_Creepy_Cat/
 apps/concordia-living-world/unity-client/Assets/3DGamekit/
+apps/concordia-living-world/unity-client/Assets/NatureStarterKit/
+apps/concordia-living-world/unity-client/Assets/Free Island Collection/
+apps/concordia-living-world/unity-client/Assets/Free Pack/
+apps/concordia-living-world/unity-client/Assets/3DForge/
+apps/concordia-living-world/unity-client/Assets/ALP_Assets/
+apps/concordia-living-world/unity-client/Assets/BodyGuards/
+apps/concordia-living-world/unity-client/Assets/Cartoon_Texture_Pack/
+apps/concordia-living-world/unity-client/Assets/InnerverseInteractive/
+apps/concordia-living-world/unity-client/Assets/Medieval Action - FX Pack 2.0/
+apps/concordia-living-world/unity-client/Assets/RPG_FPS_game_assets_industrial/
+apps/concordia-living-world/unity-client/Assets/Rocks and Boulders 2/
+apps/concordia-living-world/unity-client/Assets/TreePackVol.1/
+apps/concordia-living-world/unity-client/Assets/RPG_inventory_icons/
+apps/concordia-living-world/unity-client/Assets/YughuesFreeMetalMaterials/
+apps/concordia-living-world/unity-client/Assets/Plugins/Demigiant/
 # Third-party rocketbox human textures (~584MB) + shot dumps — not script SoT
 apps/concordia-living-world/unity-client/Assets/Concordia/Models/
 apps/concordia-living-world/unity-client/Assets/Concordia/Shots/
@@ -334,6 +349,21 @@ apps/concordia-living-world/unity-client/Assets/_Recovery.meta
 apps/concordia-living-world/unity-client/Assets/ADG_Textures.meta
 apps/concordia-living-world/unity-client/Assets/_Creepy_Cat.meta
 apps/concordia-living-world/unity-client/Assets/3DGamekit.meta
+apps/concordia-living-world/unity-client/Assets/NatureStarterKit.meta
+apps/concordia-living-world/unity-client/Assets/Free Island Collection.meta
+apps/concordia-living-world/unity-client/Assets/Free Pack.meta
+apps/concordia-living-world/unity-client/Assets/3DForge.meta
+apps/concordia-living-world/unity-client/Assets/ALP_Assets.meta
+apps/concordia-living-world/unity-client/Assets/BodyGuards.meta
+apps/concordia-living-world/unity-client/Assets/Cartoon_Texture_Pack.meta
+apps/concordia-living-world/unity-client/Assets/InnerverseInteractive.meta
+apps/concordia-living-world/unity-client/Assets/Medieval Action - FX Pack 2.0.meta
+apps/concordia-living-world/unity-client/Assets/RPG_FPS_game_assets_industrial.meta
+apps/concordia-living-world/unity-client/Assets/Rocks and Boulders 2.meta
+apps/concordia-living-world/unity-client/Assets/TreePackVol.1.meta
+apps/concordia-living-world/unity-client/Assets/RPG_inventory_icons.meta
+apps/concordia-living-world/unity-client/Assets/YughuesFreeMetalMaterials.meta
+apps/concordia-living-world/unity-client/Assets/Plugins/Demigiant.meta
 apps/concordia-living-world/unity-client/Assets/Concordia/Models.meta
 apps/concordia-living-world/unity-client/Assets/Concordia/Shots.meta
 apps/concordia-living-world/unity-client/Assets/StreamingAssets/LlamaLib-v2.0.5.meta

--- a/.gitignore
+++ b/.gitignore
@@ -292,6 +292,9 @@ apps/concordia-living-world/unity-client/Assets/Gizmos/
 apps/concordia-living-world/unity-client/Assets/Packages/
 apps/concordia-living-world/unity-client/Assets/_TerrainAutoUpgrade/
 apps/concordia-living-world/unity-client/Assets/_Recovery/
+apps/concordia-living-world/unity-client/Assets/ADG_Textures/
+apps/concordia-living-world/unity-client/Assets/_Creepy_Cat/
+apps/concordia-living-world/unity-client/Assets/3DGamekit/
 # Third-party rocketbox human textures (~584MB) + shot dumps — not script SoT
 apps/concordia-living-world/unity-client/Assets/Concordia/Models/
 apps/concordia-living-world/unity-client/Assets/Concordia/Shots/
@@ -328,6 +331,9 @@ apps/concordia-living-world/unity-client/Assets/Gizmos.meta
 apps/concordia-living-world/unity-client/Assets/Packages.meta
 apps/concordia-living-world/unity-client/Assets/_TerrainAutoUpgrade.meta
 apps/concordia-living-world/unity-client/Assets/_Recovery.meta
+apps/concordia-living-world/unity-client/Assets/ADG_Textures.meta
+apps/concordia-living-world/unity-client/Assets/_Creepy_Cat.meta
+apps/concordia-living-world/unity-client/Assets/3DGamekit.meta
 apps/concordia-living-world/unity-client/Assets/Concordia/Models.meta
 apps/concordia-living-world/unity-client/Assets/Concordia/Shots.meta
 apps/concordia-living-world/unity-client/Assets/StreamingAssets/LlamaLib-v2.0.5.meta

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,498 +1,188 @@
-# UX Completeness Sprint — Handoff
-
-Branch: `claude/add-api-wires-onboarding-EWvZC` (built on top of merged
-`claude/audit-app-completeness-GwBlp`, PR #759 — pushed to origin)
-Plan: `/root/.claude/plans/make-a-new-plan-nifty-crayon.md` (Phase 11
-17-item backlog; commit `eba0a3d` is the last push)
-Last update: 2026-05-17 (sessions 9–11 — branch now at **236 lens dirs**,
-all 10 UX-completeness dimensions complete + **pan-social hub** at
-`/lenses/social` with React/Share/Bookmark/Follow/Comment/Story/UserLink
-primitives + Saved tab + **@mention autocomplete** + **social:notification
-toast** + **/admin/endpoints** 2,400-route inventory + **useTilePush**
-hook + 41 REAL_FREE no-key wire panels + 0 type errors + 25/25 social
-contract tests + server tests green with two pre-existing failures fixed)
-
-## Session 11 additions (Phase 11 — 17-item backlog, parts 1-5)
-
-```
-1eb6d81 Phase 11 Items 5 + 10 sweep: 4 more hero lenses get MobileTabBar, 6 more DraftedTextarea swaps
-0e95008 Phase 11 Items 5 + 10 partial: MobileTabBar on council/sim + DraftedTextarea swaps
-5598765 Phase 11 Item 7 (substrate + roster): Spaces (live audio rooms)
-4a049bc Phase 11 Item 6 (substrate + feed): Reels short-form video
-a38889e Phase 11 Items 12 + 8-part-3: federation push for social + useTilePush mount
-9ec5f65 Phase 11 Item 13: WebPush notifications — migration 197 + dispatcher + hook + service worker + 8/8 tests
-e18face Phase 11 Item 9 finish: 4 panels for the key-required wires
-67658a6 Phase 11 Stage B (Item 9): 4 key-required REAL_FREE wires + 6/6 contract tests
-5cdd5dd Phase 11 Stage A: HANDOFF refresh + 25/25 social tests green
-eba0a3d Phase 11 part 2 (in-flight): useTilePush + FlashHighlight + 7 social contract tests + realtimeEvents
-1970f29 Phase 11 part 1: admin/endpoints, bookmarks lens, mention autocomplete, notification toast, two pre-existing test fixes
-fe31813 chore: refresh macro telemetry artifact
-```
-
-### Phase 11 final tally — 15 of 17 backlog items fully shipped, 2 partial
-
-| # | Item | Status |
-|---|---|---|
-| 1 | /admin/endpoints inventory | ✅ |
-| 2 | Bookmarks lens (Saved) | ✅ |
-| 3 | @mention autocomplete | ✅ |
-| 4 | Notification toast | ✅ |
-| 5 | Mobile polish hero lenses | 🟡 9/20 (kingdoms, sessions, social, council, sim, food, education, legal, healthcare) |
-| 6 | Reels short-form video | ✅ Substrate + feed |
-| 7 | Spaces live audio rooms | ✅ Substrate + roster |
-| 8 | useTilePush + FlashHighlight | ✅ Hook + marketplace mount |
-| 9 | 4 REAL_FREE key-required wires (FRED/EPA/NPS/OpenWeatherMap) | ✅ |
-| 10 | DraftedTextarea hand-swaps | 🟡 10 swapped (astronomy, game-design, environment, insurance, fitness, calendar, realestate ×2, healthcare, education ×2) |
-| 11 | Migrations 195-200 deployed | ✅ Locally; prod = human action |
-| 12 | Federation push (ActivityPub) | ✅ Substrate + outbox + heartbeat + visibility selector |
-| 13 | Push notifications (WebPush) | ✅ |
-| 14 | HANDOFF.md refresh | ✅ This file |
-| 15 | Tier-2 social contract tests | ✅ 25/25 |
-| 16 | Server test baseline | ✅ Plus 2 pre-existing fixes |
-| 17 | README pan-social section | ✅ |
-
-### New tests landed this phase (all green)
-
-- `tests/route-inventory.test.js` — 5/5
-- `tests/key-required-live-registration.test.js` — 6/6
-- `tests/push-tokens.test.js` — 8/8
-- `tests/federation-outbox.test.js` — 8/8
-- `tests/reels.test.js` — 9/9
-- `tests/audio-rooms.test.js` — 10/10
-- `tests/components/social/{ReactionBar,BookmarkButton,FollowButton,UserLink,QuickPostComposer,ShareButton,CommentThread}.test.tsx` — 25/25 (vitest)
-
-### New migrations landed this phase
-
-- 197 `push_tokens` — WebPush + Expo device registry
-- 198 `social_federation` — federation_outbox + federation_inbox + federation_peer_actors
-- 199 `reels` — reels + reel_views
-- 200 `audio_rooms` — audio_rooms + audio_room_speakers + audio_room_listeners
-
-
-
-### Session 11 highlights
-
-**`/admin/endpoints` — full HTTP route inventory.** Companion to
-`/admin/wires`. Static-parses `server.js` + every `routes/*.js` for
-`(method, path, file, line, auth)` tuples; caches result; renders
-~2,400 rows grouped by base path with one-click Test buttons. Auth
-posture (public / required / gated) derived from real source. POST /
-PUT / DELETE buttons confirm before firing.
-New: `server/lib/route-inventory.js` + `concord-frontend/app/admin/endpoints/page.tsx` + 5/5 contract tests.
-
-**Saved lens.** `BookmarkButton` was mounted in every `DTUEmbed` but
-there was no surface to SEE saved posts. Fixed: new `BookmarksList.tsx`
-that pulls `/api/social/bookmarks` then parallel-fetches each post via
-`/api/social/post/:postId`; new `/lenses/saved` page + new "Saved"
-tab on `/lenses/social`; manifest entry `category: 'social'`,
-`dataTier: 'REAL_LIVE'`. "Post unavailable" placeholder + one-click
-Remove for deleted posts.
-
-**@mention autocomplete.** `createPost` was already accepting a
-`mentionedUsers` array but no UI wired it. Fixed: new endpoint
-`GET /api/social/mention-search?q=&limit=` ranked followed > followers
-> citation count + prefix matches; new `MentionAutocomplete.tsx`
-render-prop wrapper (debounced 200ms, arrow keys, Enter/Tab/Escape);
-wired into both `QuickPostComposer` and `CommentThread`; `addComment`
-now persists `mentionedUsers` and fires `type: 'mention'` notifications.
-
-**Social notification toast.** `NotificationBell` polls every 60s but
-reactions/comments/follows fired no real-time UI. Fixed:
-`setSocialEmitter(fn)` exported from `social-layer.js`, called once
-at boot to thread `emitToUser` in; `createNotification` now also
-fires a `social:notification` socket event to the recipient's
-`user:${userId}` room; new `useSocialNotificationToast.ts` hook
-subscribes via `subscribe()` and pushes through `useUIStore.addToast`.
-Mounted in `AppShell.tsx` — app-wide. Dedupes against an in-memory
-seen-set so poll + socket race doesn't double-toast.
-
-**useTilePush + FlashHighlight (in-flight).** Manifest already
-declared `realtimeEvents?: string[]` but no lens populated it. Fixed:
-new `useTilePush.ts` reads the manifest, subscribes to events,
-invalidates the supplied query keys + flips `flashKey`; new
-`FlashHighlight.tsx` pulses an indigo ring for 900ms. `realtimeEvents`
-populated on world (building-state, refusal-field, season-transition,
-sign-placed, weather:update, combat:hit/stagger), chat (chat:status/
-token/complete + message:saved), finance, marketplace, crypto. **TODO
-Phase 11 part 3**: codemod-mount `useTilePush` + wrap primary list
-renders with `<FlashHighlight>`.
-
-**7 social contract test files** (25/25 green):
-`ReactionBar`, `BookmarkButton`, `FollowButton`, `UserLink`,
-`QuickPostComposer`, `ShareButton`, `CommentThread` — Tier-2 vitest
-coverage of the pan-social primitives.
-
-**Two pre-existing server-test regressions fixed:**
-- `three-gate-consistency`: `/api/lens-actions` was in Gate 1 but not
-  Gate 3 — added it to `_safeReadPaths`.
-- `social-dm-recall: rejects recall after the window has elapsed`:
-  `ageSec > windowSeconds` let `windowSeconds=0` through when ageSec
-  was 0. Changed to `>=` so "zero window = no recall" is honest.
-
-**README updated**: 236 lens dirs, 196 migrations, new "Pan-Social
-Hub" section listing every primitive.
-
-## Sessions 9–10 highlights (pan-social hub)
-
-- **Session 9**: promoted 41 "light vertical" lenses → solid via
-  `LensVerticalHero` codemod.
-- **Session 10**: pan-social hub at `/lenses/social` mounting
-  StoriesBar / Discovery / NotificationCenter / UserProfile /
-  SuggestedFollows / TrendingTopics / TrendingDomains /
-  PresenceIndicator / DMIndicator / StreakIndicator /
-  CreatorAnalytics / QuickPostComposer / MobileTabBar.
-- **Session 10 primitives** (new): `ReactionBar` (6 canonical
-  reaction types matching backend `VALID_REACTIONS`), `CommentThread`
-  (threaded, collapsed mode, maxDepth=2), `QuickPostComposer`
-  (Post / 24h Story modes, 500-char cap), `ShareButton`
-  (`POST /api/social/share` with commentary), `BookmarkButton`
-  (toggle endpoint, shared cache), `FollowButton` (hides for self
-  and anon), `UserLink` (routes to `/profile/:username`).
-- **Session 10 wiring**: `DTUEmbed.tsx` composes ReactionBar +
-  ShareButton + BookmarkButton + CommentThread + DownstreamBadge so
-  every cross-lens DTU embed has social context.
-- **Session 10 production fixes**: groupId fall-through in
-  `routes/social-groups.js` (was unconditionally blocking generic
-  createPost); reaction-type rename to match backend canonical set.
-
----
-
-## Original session 8 summary (carried for context)
-
-
-## Session 8 additions (3 new commits)
-
-```
-83a0a1b Phase 8: contract test for /api/lens-actions classifier + dedup logic
-366f3fc Phase 7: lift dtu_surface.record into 3 hot DTU rendering callsites
-51f447e Phase 8c: /admin/wires — REAL wires status dashboard
-2934013 Phase 8b: AutoActionStrip in 75 more lenses (bespoke ActionPanel companions) + JSON-param input mode
-```
-
-### Session 8 highlights
-
-**AutoActionStrip coverage rose 151 → 226 lenses (96.5%)**: additive
-codemod mounted `<AutoActionStrip title="More actions" />` BELOW the
-bespoke `<XActionPanel/>` in 75 lenses so the highlight computes stay
-in their custom forms but the long tail (typically 20-40 additional
-registered actions per lens) becomes clickable.
-
-**JSON-param input mode**: every action button now has a `{}` sibling
-that opens an inline JSON editor. User edits input, clicks Run, sees
-the real result envelope. Default click still fires with empty input
-(most engineering computes return useful default-driven output).
-
-**`/admin/wires` status dashboard**: top-level page that auto-discovers
-every `live_*` macro across 39 known live-wire domains via parallel
-`/api/lens-actions/<domain>` fetches, then fires each with curated
-sample inputs and renders per-row status + latency + expandable raw
-envelope. Counters at top: total / ok / failed / running / untested.
-
-**dtu_surface.record lifted into 3 callsites**:
-  - CitationChips (chat + code) — citation_chip surface per dtuId
-  - OracleResponse DtuChip — same
-  - DTUEmpireCard (home) — recent_card surface
-
-DownstreamBadge counts will populate as users browse.
-
-**Contract test**: tests/lens-actions-endpoint.test.js pins classifier
-logic (10/10). Sprint total: 191 → 201 / 57 suites / 0 failures.
-
-## Session 7 additions (4 new commits — close the depth gap)
-
-```
-52c4677 Phase 8: AutoActionStrip — auto-discover every registered lens action + button-strip UI
-c981b77 Fix the 2 pre-existing server test failures (concord-link RNG flake + macro-tests auth)
-dc7cd33 Phase 5: sessions manifest entry follows lens.<domain>.* macro convention
-5c53eab Phase 5: fix useLensSession advance() narrowing — r.session possibly undefined
-```
-
-### Session 7 — the depth-gap closer
-
-**The user flagged**: "trades follow a simple pattern cuz they're mostly
-compute but we gotta make sure every compute call that needs to get
-called actually works and is wired so people can do stuff."
-
-**Audit**: 251 orphan compute actions across 34 trades-style verticals
-(accounting, aviation, healthcare, electrical, plumbing, HVAC, masonry,
-welding, carpentry, landscaping, mining, food, retail, logistics, etc.)
-had `registerLensAction(domain, name, handler)` on the backend but
-zero UI buttons calling them.
-
-**Fix**:
-- New backend endpoint `GET /api/lens-actions/:domain` returns the
-  union of LENS_ACTIONS + MACROS for any domain, annotated with
-  isCompute / isAnalysis / isGenerative / isAi / isLive flags.
-- New `<AutoActionStrip domain="X" />` component auto-discovers via
-  the endpoint, groups by kind, renders ONE BUTTON PER ACTION with
-  kind-tinted icons, fires `useRunArtifact(domain).mutateAsync` on
-  click, and inline-renders the result envelope. Honest empty/error
-  states; raw JSON view.
-- Filter strips noise: generic CRUD, social engagement chips,
-  generic AI catch-alls, and `live_*` (surfaced by per-API panels).
-- Codemod mounted AutoActionStrip in **151 lens pages** (75 skipped
-  because they already mount a bespoke `<XActionPanel/>`, 7 have no
-  RecentMineCard anchor). Report at
-  `audit/codemod-reports/auto-action-strip-codemod.json`.
-
-**Verified**:
-- `electrical.voltageDropCalc` → returns NEC-compliant wire-drop math
-  + upgrade recommendation. Click the button, see the answer.
-- `plumbing.pipeSize` → recommended pipe diameter + material.
-- `welding.heatInput` → kJ/mm + distortion-risk recommendation.
-- 49 actions on aviation, 48 on accounting, 29 on electrical now have
-  callable buttons in the strip.
-
-**Also fixed** (the 2 pre-existing server-test failures the user asked
-me to close out):
-- `concord-link.test.js` "emits realtime to recipient when delivered +
-  online" was flaking 1-in-25 runs because rollCorruption() used
-  Math.random() directly. Threaded `rng` injection through
-  rollCorruption + sendMessage; test now passes `corruptionRng=()=>0.99`
-  to force no-corruption deterministically.
-- `tests/macro-tests.js` was a legacy standalone runner hitting a live
-  authful server anonymously. Added preflight probe that skips with
-  exit 0 + clear message when endpoints 401/403; force-runs locally
-  with `CONCORD_MACRO_TESTS=1`.
-
-**Pre-merge state**:
-- 13876 / 13883 server tests passing (was 99.95%, now closer to 100%
-  once the 2 above land in the upstream suite)
-- 2475 / 2475 vitest passing (162 files)
-- 0 type errors
-- 191 / 191 sprint contract tests
-- 33 + lens pages rendering 200 OK with auth cookie
-
-## Session 6 additions (5 new commits)
-
-## Session 6 additions (5 new commits)
-
-```
-97d9995 Phase 5: SessionRail mounted in marketplace + music + forge + foundry + projects
-5810110 Phase 4 (fourth wave): mount WikipediaSearchPanel in desert/ocean/neuro/geology
-f9d08a9 Phase 4 (sixth wave): mount ZippopotamPanel + IssPassPanel in travel + astronomy
-71d1936 Phase 4 (sixth wave): 5 more REAL free-API wires — World Bank, Open Brewery, Dog CEO, Zippopotam, Open Notify
-```
-
-### Session 6 wires (37 REAL_FREE panels total)
-- World Bank country indicators (global + finance) with SVG sparkline
-- Open Brewery DB (food + cooking)
-- Dog CEO API random dog images (pets)
-- Zippopotam.us postal-code lookup (retail + logistics + travel)
-- Open Notify ISS pass times (astronomy + space)
-- WikipediaSearchPanel mounted in 4 more lenses (desert / ocean / neuro / geology)
-- IssPassPanel mounted in /lenses/astronomy
-- ZippopotamPanel mounted in /lenses/travel
-
-### Session 6 frontend panels
-- WorldBankPanel (country/indicator selectors, big-number latest, sparkline)
-- BreweryPanel (city filter, type chips, address + website links)
-- DogPanel (4-col grid of random dog images, refresh)
-- ZippopotamPanel (country picker + postal lookup with lat/lon)
-- IssPassPanel (city picker + 5 upcoming overpass times)
-
-### Session 6 SessionRail mounts
-marketplace, music, forge, foundry, projects → 5 more lenses
-surface caller's open sessions. Total SessionRail-aware lenses: 13.
-
-Sprint contract suite now: **176 / 176 passing across 56 suites.**
-
-## Session 5 additions (3 commits)
-
-```
-5fd3be4 Phase 4 (fifth wave): mount CatFactsPanel in pets lens
-e0161b5 Phase 5+4: SessionRail in code/studio/agents + TriviaPanel in game
-e787fab Phase 4 (fifth wave): 6 more REAL free-API wires — Spaceflight News, Launch Library, PoetryDB, Open Trivia, Quotable, Cat Facts
-```
-
-### Session 5 wires (26 REAL_FREE panels total)
-- Spaceflight News v4 (astronomy + space)
-- Launch Library 2 (astronomy + space)
-- PoetryDB (poetry) — poetry lens dataTier bumped SIM_GRADE_A → REAL_FREE
-- Open Trivia DB (game)
-- Quotable (daily + reflection)
-- Cat Facts (pets)
-
-### Session 5 frontend panels
-- SpaceflightNewsPanel, UpcomingLaunchesPanel, QuotablePanel,
-  PoetryDbPanel, TriviaPanel, CatFactsPanel — all drop-in REAL data
-  chips with refresh + error handling, no fake placeholders.
-
-### Session 5 mounts
-- /lenses/space — Spaceflight News + Launches side-by-side
-- /lenses/astronomy — Spaceflight News + Launches side-by-side
-- /lenses/poetry — PoetryDB next to Datamuse
-- /lenses/daily — Quotable (wisdom tag) above journal
-- /lenses/pets — Cat Facts above pet workflow
-- /lenses/game — TriviaPanel with difficulty filter
-- /lenses/code — SessionRail (debugging sessions)
-- /lenses/studio — SessionRail (mixdown sessions)
-- /lenses/agents — SessionRail (marathon sessions)
-
-Sprint contract suite now: **161 / 161 passing across 51 suites.**
-
-## Session 4 additions
-
-7 commits closing the polish loop:
-
-```
-1d71699 Phase 7: mount ProvenanceTrail + DownstreamBadge in DTUDetailView
-2d7b789 Phase 5: SessionRail mounted in paper + research lenses
-9f7f4be Phase 4 (fourth wave): Wikipedia REST search wired across 10 reference lenses
-3e1fb7a Phase 5 (mobile): mount MobileTabBar in kingdoms + sessions lenses
-10f7b4a Phase 5 (mobile): ResponsiveModal + MobileTabBar primitives
-942cec3 Phase 5: WarCampaignSession — kingdoms uses the sessions substrate end-to-end
-1cbeb6b Phase 4 (third wave): 4 more REAL free-API wires — CrossRef, OpenAlex, Datamuse, Free Dictionary
-```
-
-### What's new this session
-
-- **REAL_FREE wires (20 → 22 panels)**:
-  - CrossRef DOI metadata (paper + research)
-  - OpenAlex academic graph (paper + research)
-  - Datamuse word relationships (linguistics + creative-writing + poetry)
-  - Free Dictionary (linguistics + education)
-  - Wikipedia REST search + summary (10 reference lenses)
-- **Marquee session use case**: `WarCampaignSession` in kingdoms with
-  declare→muster→engage→resolve step graph, SessionStepper UI, and
-  DraftedTextarea-backed state fields.
-- **Mobile primitives expanded**: ResponsiveModal (auto-picks desktop
-  modal vs. BottomSheet) + MobileTabBar (fixed-bottom thumb nav). Both
-  mounted in kingdoms + sessions lenses as exemplars.
-- **Cross-lens narrative visible at every level**: DTUEmbed shows compact
-  DownstreamBadge + auto-records on mount; DTUDetailView mounts full
-  ProvenanceTrail walking the citation graph upstream.
-- **Test totals (sprint-specific)**: 150 / 150 across 47 suites.
-
----
-
-## What landed across all sessions
-
-37 commits total. Session 3 added 9 commits closing the remaining
-dimensions. All work pushed.
-
-### Per-dimension status (post-session 3)
-
-| # | Dimension | Status | What landed |
-|---|---|---|---|
-| 1 | **Persistence (auto-save drafts)** | ✅ infra + 14 production uses | Migration 194, drafts domain (4 macros), draft-gc-cycle heartbeat. DraftedTextarea now in production at pharmacy/paper/accounting/podcast/kingdoms/legal/mental-health/daily/goals (12 specific fields). Close-the-tab-lose-the-work is closed everywhere it matters. |
-| 2 | **Load-from-substrate** | ✅ all lenses | useListMine hook + RecentMineCard mounted in 226 lens pages (6 hero lenses skipped — bespoke recents). |
-| 3 | **Cross-session list views** | ✅ all ~150 domains | `<domain>.recent_mine` + `<domain>.list_mine` registered across ~150 lens domains. Standard return shape pinned. |
-| 4 | **Bespoke widgets** | partial — DepthBadge + shells visible | DepthBadge live on all 232 lenses. 5 rival shells defaultOpen={true}. 42 bare lenses still need hand-polish. |
-| 5 | **Realtime push** | partial — auto-refresh wired | useListMine integrates socket revalidation; live panels auto-refresh on intervals. |
-| 6 | **Multi-step workflows** | ✅ substrate + 2 mounts | **NEW session 3.** Migration 195 + sessions domain (6 macros) + useLensSession hook + SessionRail + SessionStepper components. Mounted in app/hub (global) and kingdoms (lens-scoped). 20/20 contract tests. |
-| 7 | **Mobile responsiveness** | ✅ primitives shipped | **NEW session 3.** BottomSheet (drag-to-dismiss + snap points), SwipeNav (horizontal swipe + chevrons), useViewport (SSR-safe, real pointer:coarse detection). Per-lens hand-polish to follow. |
-| 8 | **Onboarding per lens** | ✅ 208/208 | **NEW session 3 codegen.** All 208 manifest entries now have firstRunGuide + emptyState (43 hand-authored + 165 metadata-driven). FirstRunTour fires automatically on first visit for every lens. |
-| 9 | **Depth bar (real data)** | ✅ infra + 16 live wires | **NEW session 3 wires.** Added PubChem (chem), PubMed (bio/neuro), MedlinePlus (mental-health), iTunes podcasts, REST Countries (global), GBIF (env/forestry/agriculture), Open Library (paper/education) — 11 new REAL_FREE (domain, macro) pairs. Wire count rose 9 → 16. |
-| 10 | **Cross-lens narrative** | ✅ substrate + 226-lens mount | **NEW session 3.** Migration 196 + dtu_surface domain (4 macros) + useDtuSurface hook + DownstreamBadge (in DTUEmbed header) + ProvenanceTrail component + CrossLensRecentsPanel (codemodded into 226 lenses). DTUEmbed auto-records surfaces on mount. 15/15 contract tests. |
-
-### Session 3 commits
-
-```
-b8be21e Phase 5: mobile primitives — BottomSheet + SwipeNav + useViewport
-c246c88 Phase 7: codemod mounts CrossLensRecentsPanel + auto-record in DTUEmbed
-493db84 Phase 7: cross-lens narrative substrate (dtu_surface domain)
-f33db91 Phase 3: hand-swap DraftedTextarea into 8 form-heavy lenses
-05ad776 Phase 5: multi-step workflow sessions (useLensSession + sessions domain)
-648ab4a Phase 4: 7 more REAL free-API wire-ups (PubChem, PubMed, MedlinePlus, …)
-0fe1896 Phase 5: author firstRunGuide + emptyState for all remaining 165 lenses
-```
-
-### Test totals (sprint-specific)
-
-`cd server && node --test tests/sessions-domain.test.js tests/dtu-surface-domain.test.js tests/more-free-apis-registration.test.js tests/free-api-live-registration.test.js tests/drafts-domain.test.js tests/integration-registry.test.js tests/recent-mine-helper.test.js tests/research-live-arxiv.test.js tests/dtu-recent-mine.test.js`
-
-→ **128 / 128 passing** across 42 suites.
-
-The full server suite has not been re-run end-to-end this session.
-Do `cd server && npm test` before merging.
-
----
-
-## File map (cumulative, post-session 3)
-
-### Backend new (session 3)
-
-- `server/migrations/195_lens_sessions.js` — lens_sessions + lens_session_events
-- `server/migrations/196_dtu_surface_log.js` — dtu_surface_log
-- `server/domains/sessions.js` — 6 macros for multi-step workflows
-- `server/domains/dtu-surface.js` — 4 macros for cross-lens narrative
-- `server/domains/more-free-apis.js` — 11 macros across 9 lenses
-- `server/tests/sessions-domain.test.js` (20)
-- `server/tests/dtu-surface-domain.test.js` (15)
-- `server/tests/more-free-apis-registration.test.js` (22)
-
-### Frontend new (session 3)
-
-- `concord-frontend/hooks/useLensSession.ts`
-- `concord-frontend/hooks/useDtuSurface.ts`
-- `concord-frontend/hooks/useViewport.ts`
-- `concord-frontend/components/lens/SessionRail.tsx`
-- `concord-frontend/components/lens/SessionStepper.tsx`
-- `concord-frontend/components/lens/CrossLensRecentsPanel.tsx`
-- `concord-frontend/components/dtu/DownstreamBadge.tsx`
-- `concord-frontend/components/dtu/ProvenanceTrail.tsx`
-- `concord-frontend/components/mobile/BottomSheet.tsx`
-- `concord-frontend/components/mobile/SwipeNav.tsx`
-- `concord-frontend/components/research/PubMedPanel.tsx`
-- `concord-frontend/components/chem/PubChemPanel.tsx`
-- `concord-frontend/components/podcast/ItunesPodcastPanel.tsx`
-- `concord-frontend/components/paper/OpenLibraryPanel.tsx`
-- `concord-frontend/components/environment/GbifPanel.tsx`
-- `concord-frontend/components/health/MedlinePlusPanel.tsx`
-- `concord-frontend/scripts/codemod-cross-lens-recents.mjs`
-
-### Modified (session 3, summary)
-
-- `concord-frontend/lib/lenses/manifest.ts` — 165 new firstRunGuide + emptyState entries
-- `server/server.js` — registers sessions, dtu-surface, more-free-apis + publicReadDomains entries
-- `concord-frontend/components/dtu/DTUEmbed.tsx` — auto-record surface on mount + DownstreamBadge chip
-- 9 lens pages with DraftedTextarea swaps
-- 9 lens pages with PubMedPanel / PubChemPanel / OpenLibraryPanel / GbifPanel / MedlinePlusPanel mounts
-- 226 lens pages with CrossLensRecentsPanel codemod
-- 2 lens pages with SessionRail mount (hub + kingdoms)
-
----
-
-## Next up (in priority order)
-
-### Highest leverage
-
-1. **Per-lens mobile hand-polish** — pick 10–20 hero lenses, wrap their
-   modals in BottomSheet via useViewport. Pattern is one helper render.
-2. **Use the sessions substrate** — kingdoms war-campaign, research
-   marathon, podcast multi-episode arc. Each lens needs only 2–3 lines
-   to start a session and a stepper to drive it.
-3. **Lift surface_kind on more lens code paths** — pass
-   `recordSurfaceFromLens="<lens>"` into every DTUEmbed mount across
-   the chat / message / feed / paper lenses so the substrate populates
-   broadly within a week of deploy.
-
-### Medium leverage
-
-4. **42 bare lenses** → ≥6/10 widget density (Phase 6, hand work).
-5. **useTilePush codemod** for `realtimeEvents` manifest field.
-6. **More REAL_FREE wires**: FRED (needs free API key, US economic
-   data — good for global + accounting), EPA AirNow (needs free key,
-   environment air quality), Khan Academy (education).
-
-### Pre-merge verification
-
-- [ ] `cd server && npm test` (full suite — only sprint subset run this session; 128/128 there)
-- [ ] `cd concord-frontend && npm run type-check`
-- [ ] `cd concord-frontend && npm run test:run`
-- [ ] `cd server && node migrate.js --status` (should show 195 + 196 applied)
-- [ ] Manual: visit /lenses/chem → PubChem panel renders; type "caffeine".
-- [ ] Manual: visit /lenses/bio → PubMed panel renders; type "CRISPR".
-- [ ] Manual: visit /lenses/paper → Open Library panel renders.
-- [ ] Manual: visit /hub → SessionRail empty (no sessions yet); start one in kingdoms, return → SessionRail shows it.
-- [ ] Manual: open any DTU embed → DownstreamBadge chip absent (no surfaces yet); navigate around → counts populate.
-
----
-
-## Trust-but-verify
-
-This document describes what was committed. The diff is the ground truth.
-Read `git log --stat` on the branch to confirm. Some inserted text
-references use `—` for em-dashes (codemod side-effect from json.dumps)
-— they are valid TS and render correctly; they are not bugs.
+# Handoff — Concordia Unity pivot (2026-09-12)
+
+Written by Claude for whoever (Cursor included) picks this up next. Everything
+below is verified, not guessed — where I couldn't verify something, it's
+labeled as such.
+
+## Where things stand right now
+
+**PR #970 is fully merged/green.** Nothing pending there — 37 checks pass, 0
+fail, 4 intentional deploy-gated skips. Not part of this handoff's scope.
+
+**Uncommitted local changes (3 files, all real, all intentional — nothing
+else in the working tree, editor-churn noise already reverted):**
+- `apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ModularPerson.cs` — two root-caused fixes, both live-verified in Play mode (see below).
+- `docs/ART_STYLE_GUIDE.md` — retirement notice added at the top (see "Architecture decision" below).
+- `docs/ART_DIRECTION_UNITY_WEB.md` — new file, the current canonical art-direction doc.
+
+None of these are committed yet. Review the diff, then commit — I didn't push
+anything since it wasn't asked for this round.
+
+**Unity Editor**: was left open and running (project at
+`apps/concordia-living-world/unity-client`, Unity 6000.5.9f1) with the
+MCPForUnity bridge live and working. If you're picking this up in a fresh
+session, it may or may not still be running — check before assuming.
+
+## Architecture decision (owner call, this session — canonical, don't relitigate)
+
+- **Unity, exported to WebGL, is now the canonical World Lens web client.**
+  Not a new idea — `scripts/export-unity-web.mjs` (full Unity 6→WebGL
+  pipeline, mirrors Godot's serving shape) and `mountUnityGateway`
+  (`server/lib/unity-bridge.js`, already mounted in `server.js`) both already
+  existed and work. The project's own Editor/WebGL code splits
+  (`ConcordClient.cs`, `FreePacks.cs`, `HubKit.cs`, `Assets/Plugins/WebGL/ConcordWs.jslib`)
+  confirm it was built with this target in mind from early on.
+- **Godot (`world-lens-godot/`) is the presenter/spectator role** — its
+  existing read-only spectator viewer, not a full interactive client.
+- **Three.js's World Lens renderer (`concord-frontend/lib/world-lens/`,
+  `components/world/`, `components/world-lens/`) is retired as canonical.**
+  Its `docs/ART_STYLE_GUIDE.md` stylized-BotW/Palworld mandate governed ONLY
+  that renderer (confirmed by grep — zero references outside those
+  directories + this doc's own tests) and is retired with it. The file still
+  exists with a retirement banner at the top — don't delete it, don't revive
+  its mandate for Unity.
+- **The direction for Unity is photorealistic**, reversing the old
+  `ART_DIRECTION_AUDIT.md` "photorealism explicitly rejected" call — that
+  call was scoped to the Three.js renderer specifically, for reasons that
+  don't bind Unity. See `docs/ART_DIRECTION_UNITY_WEB.md` for the full
+  reasoning and the acquisition-list audit.
+- **The game's systems are untouched by any of this.** Quests, combat,
+  economy, NPC AI all live server-side (`server/emergent/`, `server/domains/`)
+  and are client-agnostic. This pivot only changes which client draws the
+  pixels.
+
+## What's fixed and verified live tonight
+
+Both of these were root-caused and confirmed by actually running the game in
+Unity Play mode (`ConcordiaHub.unity` scene), not just reasoned about from
+source. Verification steps are worth reading if either regresses.
+
+### 1. Hero/NPC world-appropriate body casting (`ModularPerson.cs:265`, `LoadPersonPrefab`)
+
+- **Bug**: `ModularPerson.CastingWorld` was set per-world by `WorldBuilder.cs`
+  but never *read* anywhere — every world (Fantasy, Tunya, Ruins, all of
+  them) got the same Rocketbox photoreal adult body, whose baked texture is
+  business-casual civilian wear (it's a Microsoft crowd-sim asset). That's
+  the actual mechanism behind the "polo-shirt hero" complaint.
+- **Why not just tint it**: checked live — Rocketbox bakes skin AND clothing
+  into one continuous texture with no separate cloth UV region, so a
+  multiplied color tint would also discolor visible skin. Real dead end, not
+  a shortcut I skipped.
+- **Fix**: `LoadPersonPrefab` now branches on `CastingWorld` — `Hub` keeps
+  Rocketbox (the one world with textual grounding as "modern/neutral" per
+  the retired style guide's own saturation table), every other world prefers
+  the already-in-project, already-painted **KayKit Knight**
+  (`Models/kaykit/adventures/gltf/Knight.glb`), falling back to Rocketbox
+  honestly if Knight is ever missing. Resolves via `FreePacks.Mesh`, which
+  works in both Editor and the real WebGL build.
+- **Caveat, in the code comment too**: whether every non-Hub world is
+  genuinely "knight-coded" is a first-pass call, not verified lore — Cyber
+  and Crime in particular could plausibly want a modern body too. Worth a
+  tuning pass once there's real per-world casting content.
+- **Verified live**: entered Play mode on `ConcordiaHub`, confirmed the Hub
+  hero still renders as Rocketbox (correct — Hub is the one exception) and
+  that `ModularPerson.CastingWorld != WorldId.Hub` path compiles/resolves
+  cleanly. Did **not** yet verify the Knight path visually (would need to
+  force-spawn in a non-Hub world) — that's a real next step if you want full
+  confidence on this fix.
+
+### 2. Oversized-sword bug (`ModularPerson.cs:1249`, `MakeSword`)
+
+- **Bug**: not a scale-math bug — `FreePacks.FitMax`'s uniform-scale-to-1.05m
+  logic is correct. The Kenney `weapon-sword.glb` mesh it fell back to is
+  chibi-proportioned (width = 52% of its length); scaling that up to a
+  realistic 1.05m length drags the already-fat width/thickness up with it,
+  reading as a giant slab.
+- Also confirmed live: `FreePacks.Mesh("longsword")` — tried first in the
+  original code — **resolves to nothing**. Every hero was silently falling
+  through to the Kenney mesh.
+- **Fix**: added `FreePacks.Mesh("Sword16")` to the fallback chain before the
+  Kenney mesh. `Sword16` is a real, already-in-project mesh from `MYFG-Weapon
+  Pack Lite` (`Assets/MYFG-Weapon Pack Lite/Meshes/Sword16.FBX`) — measured
+  live at a 0.14 width/length ratio vs. Kenney's 0.52.
+- **Verified live**: screenshot confirms a properly-proportioned blade
+  hanging at the hero's side; live component inspection confirmed
+  `sharedMesh` = `Sword16.FBX` and `localScale` settled to ~0.97 (near 1:1,
+  since Sword16's native size is already close to the 1.05m target).
+
+### 3. "Floating NPCs" — investigated, NOT a real bug (false alarm, self-corrected)
+
+A screenshot early in the session looked like every NPC/the player was
+floating above the ground (shadows offset from feet). Before reporting it as
+a bug I measured it directly:
+- `CharacterController.isGrounded = true`
+- The mesh's actual world-space bounds bottom sat right at the terrain
+  surface (matching `Grounding.Snap`'s deliberate 4cm skin offset exactly)
+- A follow-up screenshot after physics settled showed feet and shadow
+  correctly planted
+
+Conclusion: the first screenshot caught a mid-stride animation pose or a
+spawn-frame transient, not a structural bug. **Don't "fix" `Grounding.cs` —
+it's working correctly**, confirmed by direct measurement, not just a second
+look.
+
+## Open items / next steps, prioritized
+
+1. **Weather-visuals binding** — the third named Tier-1 item, not started
+   this session. No investigation done yet.
+2. **Verify the Knight-casting fix visually** in a non-Hub world (force
+   `ModularPerson.CastingWorld` to e.g. `WorldId.Fantasy` and check the
+   spawned body/outfit actually looks right, not just that it compiles).
+3. **Unidentified small floating dark object** — appeared consistently in
+   two screenshots near the player in the Hub plaza. Filtered ~1,241 world
+   renderers for small+elevated+nearby matches; only hit was a `LanternGlow`
+   prop whose position doesn't match what was visible on screen. Left
+   unresolved — minor, likely VFX, but not confirmed.
+4. **World-count discrepancy**: `Canon.cs`'s `WorldId` enum has **10** worlds
+   (Hub, Ruins, Tunya, Fantasy, Crime, Cyber, Frontier, Superhero, Crucible,
+   **Sere**). The retired Three.js style guide's own saturation table only
+   lists **9** — `Sere` is missing from it entirely. Not urgent now that the
+   guide is retired, but worth a note if anyone later mines that doc for a
+   world list.
+5. **Acquisition list** (see `docs/ART_DIRECTION_UNITY_WEB.md` for full
+   detail): 4 of ~20 named packages spot-checked and confirmed real (Kevin
+   Iglesias Human Basic Motions FREE, Synty Sidekick Starter Pack FREE, KHS
+   Korean-heritage architecture family, Slavic Medieval Environment). Two
+   numeric claims in the original doc were wrong (9 vs 10 worlds; "200+ Hub
+   buildings" vs. the code's real 100-per-city target with the Hub itself
+   having ~zero). ~16 more named packages are still **unverified** — don't
+   treat the rest of that list as vetted.
+
+## Environment gotchas worth knowing about
+
+- **MCPForUnity stale-registration bug**: if `mcpforunity://instances` flaps
+  between "found it" and "not found" / returns a project you're not even
+  running, check `~/.unity-mcp/` for leftover `unity-mcp-status-<hash>.json`
+  / `unity-mcp-port-<hash>.json` files from OTHER projects with dead
+  heartbeats, and a stale `unity-mcp-port.json` (no hash) pointing at one of
+  them. Delete the dead ones; the live Editor regenerates its own
+  registration fine. This cost real time tonight before being root-caused.
+- **Don't edit a `.cs` file while Unity is mid-compile.** Did this once
+  tonight and it wedged the Editor's domain-reload pipeline hard enough that
+  a full process kill + relaunch was needed (confirmed via 0% CPU across all
+  shader-compiler/import-worker processes for 45+ minutes with zero log
+  growth — genuinely hung, not just slow).
+- **`tsc --noEmit` without memory headroom can OOM-crash** on this codebase
+  (`EXIT_CODE=134`, V8 heap fatal error at ~4GB) — that's an environment
+  artifact, not a real type error. Use the project's own
+  `NODE_OPTIONS='--max-old-space-size=8192' tsc --noEmit`
+  (matches `concord-frontend/package.json`'s `type-check:ci` script) before
+  concluding anything about type-check status.
+- **execute_code (UnityMCP) needs CodeDom-compatible C# 6 syntax** unless
+  Roslyn is installed in this project (it isn't) — no `using` directives (the
+  snippet runs as a method body), no `default` literal, no local functions
+  after a `return`. Explicit types and old-style `new Bounds()` instead.
+
+## Useful facts for resuming live verification
+
+- Scene to load: `Assets/Scenes/ConcordiaHub.unity`. Its only authored roots
+  are `Directional Light` and `ConcordiaGame` — everything else (Player,
+  World with ~900 children, NPCs, etc.) is built procedurally at Play-mode
+  start by `WorldBuilder`/`ConcordiaGame`.
+- Hero body: `find_gameobjects` for `"Person"` → its `ModularPerson`
+  component exposes `rightHand`/`leftHand`/`sword` object references
+  directly (useful — no need to walk the hierarchy by hand).
+- Screenshots: use `manage_camera` action `screenshot` with `output_folder`
+  set to something OUTSIDE `Assets/` (e.g. `Captures`) — saving into
+  `Assets/Screenshots` triggers an asset-database reimport that can look
+  like another hang.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -152,8 +152,17 @@ look.
 `PlaceWeather("rain"|"snow")` in `WorldBuilder.DressSky` / `WorldKit.Accents`
 was one-shot from `Canon.WorldDef.weather`, so Crime rained forever and the
 kernel's "weather shifted" line was HUD-only. Identity fireflies (Hub / Tunya
-/ Fantasy) are unchanged. Play-mode visual confirm still outstanding — Hub
-starts `clear`, so either travel to Crime or force `WorldClock.Weather`.
+/ Fantasy) are unchanged.
+
+Play-mode visual confirm did **not** complete this pass. Entered Play on
+`ConcordiaHub` while the Editor was still serving the **pre-change**
+`Assembly-CSharp` (`ApplyWeatherVisuals` was not on `WorldClock` via
+reflection; Hub weather read `clear` as expected). After exiting Play and
+force-reimporting `WorldBook.cs`, MCP `execute_code` started TCS-timing-out
+and the Editor main process sat at ~0% CPU — same class of hang as the
+mid-compile-edit gotcha below. Do not assume the weather bind is visually
+proven; next session should let the Editor finish a clean domain reload,
+then force rain (or travel to Crime) and look for a `World/WeatherFx` child.
 
 ## Environment gotchas worth knowing about
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -123,23 +123,21 @@ look.
 
 ## Open items / next steps, prioritized
 
-1. **Weather-visuals binding** — the third named Tier-1 item, not started
-   this session. No investigation done yet.
-2. **Verify the Knight-casting fix visually** in a non-Hub world (force
+1. **Verify the Knight-casting fix visually** in a non-Hub world (force
    `ModularPerson.CastingWorld` to e.g. `WorldId.Fantasy` and check the
    spawned body/outfit actually looks right, not just that it compiles).
-3. **Unidentified small floating dark object** — appeared consistently in
+2. **Unidentified small floating dark object** — appeared consistently in
    two screenshots near the player in the Hub plaza. Filtered ~1,241 world
    renderers for small+elevated+nearby matches; only hit was a `LanternGlow`
    prop whose position doesn't match what was visible on screen. Left
    unresolved — minor, likely VFX, but not confirmed.
-4. **World-count discrepancy**: `Canon.cs`'s `WorldId` enum has **10** worlds
+3. **World-count discrepancy**: `Canon.cs`'s `WorldId` enum has **10** worlds
    (Hub, Ruins, Tunya, Fantasy, Crime, Cyber, Frontier, Superhero, Crucible,
    **Sere**). The retired Three.js style guide's own saturation table only
    lists **9** — `Sere` is missing from it entirely. Not urgent now that the
    guide is retired, but worth a note if anyone later mines that doc for a
    world list.
-5. **Acquisition list** (see `docs/ART_DIRECTION_UNITY_WEB.md` for full
+4. **Acquisition list** (see `docs/ART_DIRECTION_UNITY_WEB.md` for full
    detail): 4 of ~20 named packages spot-checked and confirmed real (Kevin
    Iglesias Human Basic Motions FREE, Synty Sidekick Starter Pack FREE, KHS
    Korean-heritage architecture family, Slavic Medieval Environment). Two
@@ -147,6 +145,15 @@ look.
    buildings" vs. the code's real 100-per-city target with the Hub itself
    having ~zero). ~16 more named packages are still **unverified** — don't
    treat the rest of that list as vetted.
+
+### Weather-visuals binding (done this continuation)
+
+`WorldClock.Weather` now drives precip + fog + sun dim. Build-time
+`PlaceWeather("rain"|"snow")` in `WorldBuilder.DressSky` / `WorldKit.Accents`
+was one-shot from `Canon.WorldDef.weather`, so Crime rained forever and the
+kernel's "weather shifted" line was HUD-only. Identity fireflies (Hub / Tunya
+/ Fantasy) are unchanged. Play-mode visual confirm still outstanding — Hub
+starts `clear`, so either travel to Crime or force `WorldClock.Weather`.
 
 ## Environment gotchas worth knowing about
 

--- a/apps/concordia-living-world/unity-client/.gitignore
+++ b/apps/concordia-living-world/unity-client/.gitignore
@@ -50,3 +50,18 @@ Assets/Concordia/Models/**
 Assets/ADG_Textures/
 Assets/_Creepy_Cat/
 Assets/3DGamekit/
+Assets/NatureStarterKit/
+Assets/Free Island Collection/
+Assets/Free Pack/
+Assets/3DForge/
+Assets/ALP_Assets/
+Assets/BodyGuards/
+Assets/Cartoon_Texture_Pack/
+Assets/InnerverseInteractive/
+Assets/Medieval Action - FX Pack 2.0/
+Assets/RPG_FPS_game_assets_industrial/
+Assets/Rocks and Boulders 2/
+Assets/TreePackVol.1/
+Assets/RPG_inventory_icons/
+Assets/YughuesFreeMetalMaterials/
+Assets/Plugins/Demigiant/

--- a/apps/concordia-living-world/unity-client/.gitignore
+++ b/apps/concordia-living-world/unity-client/.gitignore
@@ -35,6 +35,7 @@ sysinfo.txt
 # Editor debug captures (p0 Hub shots) — never commit
 [Aa]ssets/[Ss]creenshots/
 Assets/Concordia/Shots/
+Captures/
 
 # Mixamo / character FBX (~587MB). Restore locally from the kitchen tree.
 Assets/Concordia/Models/**

--- a/apps/concordia-living-world/unity-client/.gitignore
+++ b/apps/concordia-living-world/unity-client/.gitignore
@@ -45,3 +45,8 @@ Assets/Concordia/Models/**
 # Live editor scripts:   Assets/Editor/
 /Scripts/
 /Editor/
+
+# Asset Store My Assets imports (reinstall from Package Manager; never vendor)
+Assets/ADG_Textures/
+Assets/_Creepy_Cat/
+Assets/3DGamekit/

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Editor/ImportAllMyAssets.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Editor/ImportAllMyAssets.cs
@@ -258,6 +258,8 @@ namespace Concordia.Editor
                     var t = Ed("UnityEditor.PackageManager.UI.Internal.IAssetStorePackageInstaller");
                     t.GetMethod("Install").Invoke(installer, new object[] { id, false });
                     Log("Install(" + id + ", interactive=false)");
+                    // Install of an already-cached pack can finish with no domain reload.
+                    EditorApplication.delayCall += Kick;
                 }
                 catch (Exception ex)
                 {

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Editor/ImportAllMyAssets.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Editor/ImportAllMyAssets.cs
@@ -1,0 +1,605 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+using Concordia;
+
+namespace Concordia.Editor
+{
+    /// <summary>
+    /// Downloads + installs every My Assets pack into this project except Demo City (269772).
+    /// Uses Unity 6 Package Manager internals via reflection (those types are CS0122).
+    /// State lives in /tmp so domain reload after each Install can resume.
+    /// </summary>
+    [InitializeOnLoad]
+    public static class ImportAllMyAssets
+    {
+        const long SkipDemoCity = 269772L;
+        const int Batch = 3;
+        const string StatePath = "/tmp/concordia-import-state.txt";
+        const string NamesPath = "/tmp/concordia-import-names.txt";
+        const string ProgressPath = "/tmp/concordia-import-progress.txt";
+        const string EditorAsmName = "UnityEditor.CoreModule";
+
+        static readonly string[] LocalUrpPackages =
+        {
+            "Assets/Barking_Dog/3D Free Modular Kit - URP.unitypackage",
+            "Assets/EasyRoads3D/SRP Support Packages/URP_17_0_3.unitypackage",
+            "Assets/GabrielAguiarProductions/FreeQuickEffectsVol1_2022_URP_v1.0.unitypackage"
+        };
+
+        // productId -> folder needle already in this project
+        static readonly Dictionary<long, string[]> KnownFolders = new Dictionary<long, string[]>
+        {
+            { 85732, new[] { "Barking_Dog" } },
+            { 107400, new[] { "BOXOPHOBIC" } },
+            { 235621, new[] { "Convai" } },
+            { 56841, new[] { "Earth" } },
+            { 987, new[] { "EasyRoads3D" } },
+            { 65284, new[] { "ExplosiveLLC" } },
+            { 35361, new[] { "Fantasy Forest" } },
+            { 304424, new[] { "GabrielAguiar" } },
+            { 154271, new[] { "Kevin Iglesias" } },
+            { 178395, new[] { "Kevin Iglesias" } },
+            { 99131, new[] { "KinematicCharacterController" } },
+            { 15649, new[] { "living birds" } },
+            { 273604, new[] { "LLMUnity" } },
+            { 87811, new[] { "Mega Fantasy Props" } },
+            { 14360, new[] { "MYFG-Weapon" } },
+            { 188357, new[] { "ProceduralTerrainPainter" } },
+            { 34938, new[] { "RainMaker" } },
+            { 267961, new[] { "Starter Assets" } },
+            { 4387, new[] { "SUIMONO" } },
+            { 95986, new[] { "UMotionEditor", "UMotionExamples" } },
+            { 127325, new[] { "UnityTechnologies" } },
+            { 28647, new[] { "3rdPerson+Fly" } },
+            { 116144, new[] { "SlimUI" } },
+            { 18353, new[] { "Skybox" } },
+            { 61217, new[] { "Skybox" } }
+        };
+
+        static bool _hooked;
+        static bool _listing;
+        static Type _editorAsmCached;
+
+        static ImportAllMyAssets()
+        {
+            EditorApplication.delayCall += ResumeIfNeeded;
+        }
+
+        [MenuItem("Concordia/Asset Store/Import all My Assets")]
+        public static void StartImport()
+        {
+            if (EditorApplication.isPlaying)
+            {
+                EditorApplication.isPlaying = false;
+                EditorApplication.delayCall += StartImport;
+                Log("stopped Play — starting import");
+                return;
+            }
+            if (EditorApplication.isCompiling || EditorApplication.isUpdating)
+            {
+                EditorApplication.delayCall += StartImport;
+                return;
+            }
+            WriteProgress("listing My Assets…");
+            _listing = true;
+            HookDownloadEvents();
+            ListPurchasesThenQueue();
+        }
+
+        [MenuItem("Concordia/Asset Store/Import local URP support packs")]
+        public static void ImportLocalUrp()
+        {
+            var imported = 0;
+            foreach (var rel in LocalUrpPackages)
+            {
+                var abs = Path.Combine(Directory.GetParent(Application.dataPath).FullName, rel);
+                if (!File.Exists(abs))
+                {
+                    Log("URP pack missing: " + rel);
+                    continue;
+                }
+                AssetDatabase.ImportPackage(rel, false);
+                imported++;
+                Log("imported URP support " + rel);
+            }
+            WriteProgress("urp local packs imported=" + imported);
+        }
+
+        [MenuItem("Concordia/Asset Store/Stop My Assets import")]
+        public static void StopImport()
+        {
+            try { if (File.Exists(StatePath)) File.Delete(StatePath); } catch { }
+            WriteProgress("stopped");
+            Log("import stopped — state cleared");
+        }
+
+        static void ResumeIfNeeded()
+        {
+            if (!File.Exists(StatePath)) return;
+            var st = ReadState();
+            if (st.Phase == "idle" || st.Phase == "done") return;
+            if (EditorApplication.isPlaying) return;
+            HookDownloadEvents();
+            EditorApplication.delayCall += Kick;
+        }
+
+        static void ListPurchasesThenQueue()
+        {
+            var restType = Ed("UnityEditor.PackageManager.UI.Internal.IAssetStoreRestAPI");
+            var purchasesType = Ed("UnityEditor.PackageManager.UI.Internal.AssetStorePurchases");
+            var infoType = Ed("UnityEditor.PackageManager.UI.Internal.AssetStorePurchaseInfo");
+            var errorType = Ed("UnityEditor.PackageManager.UI.Internal.UIError");
+            var queryType = Ed("UnityEditor.PackageManager.UI.Internal.PurchasesQueryArgs");
+            var api = Resolve("UnityEditor.PackageManager.UI.Internal.IAssetStoreRestAPI");
+            var query = Activator.CreateInstance(queryType, new object[] { 0, 1000, "", null });
+
+            Action<object> onOk = purchases =>
+            {
+                try
+                {
+                    var list = purchasesType.GetField("list").GetValue(purchases) as System.Collections.IEnumerable;
+                    var total = Convert.ToInt64(purchasesType.GetField("total").GetValue(purchases));
+                    var names = new Dictionary<long, string>();
+                    if (list != null)
+                    {
+                        foreach (var item in list)
+                        {
+                            var id = Convert.ToInt64(infoType.GetField("productId").GetValue(item));
+                            var name = "" + infoType.GetField("displayName").GetValue(item);
+                            names[id] = name;
+                        }
+                    }
+                    Log("My Assets total=" + total + " listed=" + names.Count);
+                    QueueFromCatalog(names);
+                }
+                catch (Exception ex)
+                {
+                    WriteProgress("list failed: " + ex.Message);
+                    Debug.LogException(ex);
+                }
+                finally { _listing = false; }
+            };
+            Action<object> onErr = err =>
+            {
+                _listing = false;
+                var msg = ReadUiError(err);
+                WriteProgress("GetPurchases error: " + msg);
+                Log("GetPurchases error: " + msg);
+            };
+
+            var okDel = BoxAction(purchasesType, onOk);
+            var errDel = BoxAction(errorType, onErr);
+            restType.GetMethod("GetPurchases").Invoke(api, new object[] { query, okDel, errDel });
+        }
+
+        static void QueueFromCatalog(Dictionary<long, string> names)
+        {
+            WriteNames(names);
+            var download = new List<long>();
+            var install = new List<long>();
+            var done = new List<long>();
+            var failed = new List<long>();
+            foreach (var kv in names.OrderBy(k => k.Value, StringComparer.OrdinalIgnoreCase))
+            {
+                var id = kv.Key;
+                var name = kv.Value;
+                if (id == SkipDemoCity)
+                {
+                    Log("skip Demo City " + id);
+                    done.Add(id);
+                    continue;
+                }
+                if (AlreadyInProject(id, name))
+                {
+                    Log("already in project " + id + " " + name);
+                    done.Add(id);
+                    continue;
+                }
+                if (HasLocalPackage(id))
+                {
+                    Log("cached, will install " + id + " " + name);
+                    install.Add(id);
+                    continue;
+                }
+                download.Add(id);
+            }
+            var st = new State
+            {
+                Phase = download.Count > 0 ? "download" : (install.Count > 0 ? "install" : "urp"),
+                PendingDownload = download,
+                PendingInstall = install,
+                Done = done,
+                Failed = failed
+            };
+            WriteState(st);
+            WriteProgress("queued download=" + download.Count + " install=" + install.Count + " already=" + done.Count);
+            Kick();
+        }
+
+        static void Kick()
+        {
+            if (EditorApplication.isCompiling || EditorApplication.isUpdating)
+            {
+                EditorApplication.delayCall += Kick;
+                return;
+            }
+            if (!File.Exists(StatePath))
+            {
+                WriteProgress("idle — no state");
+                return;
+            }
+            var st = ReadState();
+            if (st.Phase == "done" || st.Phase == "idle") return;
+
+            if (st.Installing != 0)
+            {
+                if (!st.Done.Contains(st.Installing)) st.Done.Add(st.Installing);
+                st.PendingInstall.Remove(st.Installing);
+                st.Installing = 0;
+                WriteState(st);
+            }
+
+            if (st.PendingInstall.Count > 0)
+            {
+                st.Phase = "install";
+                var id = st.PendingInstall[0];
+                st.Installing = id;
+                WriteState(st);
+                WriteProgress("installing " + id + " " + NameOf(id) + " remainingInstall=" + st.PendingInstall.Count);
+                try
+                {
+                    var installer = Resolve("UnityEditor.PackageManager.UI.Internal.IAssetStorePackageInstaller");
+                    var t = Ed("UnityEditor.PackageManager.UI.Internal.IAssetStorePackageInstaller");
+                    t.GetMethod("Install").Invoke(installer, new object[] { id, false });
+                    Log("Install(" + id + ", interactive=false)");
+                }
+                catch (Exception ex)
+                {
+                    st.Failed.Add(id);
+                    st.PendingInstall.Remove(id);
+                    st.Installing = 0;
+                    WriteState(st);
+                    Log("Install failed " + id + " " + ex.Message);
+                    EditorApplication.delayCall += Kick;
+                }
+                return;
+            }
+
+            if (st.PendingDownload.Count > 0)
+            {
+                st.Phase = "download";
+                WriteState(st);
+                var n = Math.Min(Batch, st.PendingDownload.Count);
+                var batch = st.PendingDownload.GetRange(0, n);
+                WriteProgress("download batch " + string.Join(",", batch.ConvertAll(x => x + ":" + NameOf(x)).ToArray()) + " remaining=" + st.PendingDownload.Count);
+                try
+                {
+                    HookDownloadEvents();
+                    var mgr = Resolve("UnityEditor.PackageManager.UI.Internal.IAssetStoreDownloadManager");
+                    var t = Ed("UnityEditor.PackageManager.UI.Internal.IAssetStoreDownloadManager");
+                    var ok = (bool)t.GetMethod("Download", new[] { typeof(IEnumerable<long>) }).Invoke(mgr, new object[] { batch });
+                    Log("Download batch ok=" + ok + " n=" + batch.Count);
+                    if (!ok)
+                    {
+                        foreach (var id in batch)
+                        {
+                            st.Failed.Add(id);
+                            st.PendingDownload.Remove(id);
+                        }
+                        WriteState(st);
+                        EditorApplication.delayCall += Kick;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    WriteProgress("download threw: " + ex.Message);
+                    Log("download threw: " + ex);
+                }
+                return;
+            }
+
+            if (st.Phase != "done")
+            {
+                st.Phase = "urp";
+                WriteState(st);
+                WriteProgress("importing local URP support packs");
+                ImportLocalUrp();
+                Finish(st);
+            }
+        }
+
+        static void Finish(State st)
+        {
+            st.Phase = "done";
+            st.Installing = 0;
+            WriteState(st);
+            try
+            {
+                FreePacks.Reindex();
+                var audit = DressVocab.Audit();
+                File.WriteAllText("/tmp/concordia-visual.txt", audit);
+            }
+            catch (Exception ex) { Log("reindex/audit: " + ex.Message); }
+            WriteProgress("DONE done=" + st.Done.Count + " failed=" + st.Failed.Count + " " + string.Join(",", st.Failed));
+            Log("My Assets import finished. failed=" + st.Failed.Count);
+        }
+
+        static void HookDownloadEvents()
+        {
+            if (_hooked) return;
+            var mgrType = Ed("UnityEditor.PackageManager.UI.Internal.IAssetStoreDownloadManager");
+            var opType = Ed("UnityEditor.PackageManager.UI.Internal.AssetStoreDownloadOperation");
+            var errType = Ed("UnityEditor.PackageManager.UI.Internal.UIError");
+            var mgr = Resolve("UnityEditor.PackageManager.UI.Internal.IAssetStoreDownloadManager");
+            var doneEvt = mgrType.GetEvent("onDownloadFinalized");
+            var errEvt = mgrType.GetEvent("onDownloadError");
+            var progEvt = mgrType.GetEvent("onDownloadProgress");
+            doneEvt.AddEventHandler(mgr, BoxAction(opType, OnDownloadFinalized));
+            errEvt.AddEventHandler(mgr, BoxAction2(opType, errType, OnDownloadError));
+            progEvt.AddEventHandler(mgr, BoxAction(opType, OnDownloadProgress));
+            _hooked = true;
+        }
+
+        static void OnDownloadFinalized(object op)
+        {
+            var opType = op.GetType();
+            var id = Convert.ToInt64(opType.GetProperty("productId").GetValue(op, null));
+            var state = opType.GetProperty("state").GetValue(op, null);
+            var stateName = state != null ? state.ToString() : "?";
+            var err = "" + opType.GetProperty("errorMessage").GetValue(op, null);
+            var path = "" + opType.GetProperty("packageNewPath").GetValue(op, null);
+            Log("download finalized id=" + id + " state=" + stateName + " path=" + path + " err=" + err);
+            if (!File.Exists(StatePath)) return;
+            var st = ReadState();
+            st.PendingDownload.Remove(id);
+            var completed = stateName.IndexOf("Completed", StringComparison.OrdinalIgnoreCase) >= 0
+                            || (!string.IsNullOrEmpty(path) && File.Exists(path));
+            var failed = stateName.IndexOf("Error", StringComparison.OrdinalIgnoreCase) >= 0
+                         || stateName.IndexOf("Aborted", StringComparison.OrdinalIgnoreCase) >= 0;
+            if (failed && !completed)
+            {
+                if (!st.Failed.Contains(id)) st.Failed.Add(id);
+                WriteState(st);
+                WriteProgress("download failed " + id + " " + NameOf(id) + " " + err);
+            }
+            else
+            {
+                if (!st.PendingInstall.Contains(id) && !st.Done.Contains(id))
+                    st.PendingInstall.Add(id);
+                WriteState(st);
+                WriteProgress("download ok " + id + " " + NameOf(id) + " → install queue");
+            }
+            EditorApplication.delayCall += Kick;
+        }
+
+        static void OnDownloadError(object op, object err)
+        {
+            long id = 0;
+            try { id = Convert.ToInt64(op.GetType().GetProperty("productId").GetValue(op, null)); } catch { }
+            var msg = ReadUiError(err);
+            Log("download error id=" + id + " " + msg);
+            if (!File.Exists(StatePath)) return;
+            var st = ReadState();
+            st.PendingDownload.Remove(id);
+            if (!st.Failed.Contains(id)) st.Failed.Add(id);
+            WriteState(st);
+            WriteProgress("download error " + id + " " + NameOf(id) + " " + msg);
+            EditorApplication.delayCall += Kick;
+        }
+
+        static void OnDownloadProgress(object op)
+        {
+            try
+            {
+                var id = Convert.ToInt64(op.GetType().GetProperty("productId").GetValue(op, null));
+                var pct = Convert.ToSingle(op.GetType().GetProperty("progressPercentage").GetValue(op, null));
+                WriteProgress("downloading " + id + " " + NameOf(id) + " " + (pct * 100f).ToString("0") + "%");
+            }
+            catch { }
+        }
+
+        static bool AlreadyInProject(long id, string displayName)
+        {
+            try
+            {
+                var cache = Resolve("UnityEditor.PackageManager.UI.Internal.IAssetStoreCache");
+                var t = Ed("UnityEditor.PackageManager.UI.Internal.IAssetStoreCache");
+                var imported = t.GetMethod("GetImportedPackage").Invoke(cache, new object[] { ToNullableLong(id) });
+                if (imported != null) return true;
+            }
+            catch { }
+            string[] needles;
+            if (KnownFolders.TryGetValue(id, out needles) && FolderPresent(needles)) return true;
+            if (!string.IsNullOrEmpty(displayName) && FolderPresent(new[] { displayName })) return true;
+            return false;
+        }
+
+        static bool HasLocalPackage(long id)
+        {
+            try
+            {
+                var cache = Resolve("UnityEditor.PackageManager.UI.Internal.IAssetStoreCache");
+                var t = Ed("UnityEditor.PackageManager.UI.Internal.IAssetStoreCache");
+                var local = t.GetMethod("GetLocalInfo").Invoke(cache, new object[] { ToNullableLong(id) });
+                if (local == null) return false;
+                var path = "" + local.GetType().GetField("packagePath").GetValue(local);
+                return !string.IsNullOrEmpty(path) && File.Exists(path);
+            }
+            catch { return false; }
+        }
+
+        static bool FolderPresent(string[] needles)
+        {
+            if (needles == null) return false;
+            var assets = Application.dataPath;
+            if (!Directory.Exists(assets)) return false;
+            var dirs = Directory.GetDirectories(assets);
+            for (var i = 0; i < dirs.Length; i++)
+            {
+                var name = Path.GetFileName(dirs[i]);
+                for (var n = 0; n < needles.Length; n++)
+                {
+                    var needle = needles[n];
+                    if (string.IsNullOrEmpty(needle)) continue;
+                    if (name.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0) return true;
+                }
+            }
+            return false;
+        }
+
+        static object ToNullableLong(long id)
+        {
+            return Activator.CreateInstance(typeof(long?), id);
+        }
+
+        static Delegate BoxAction(Type argType, Action<object> handler)
+        {
+            var p = Expression.Parameter(argType, "x");
+            var body = Expression.Invoke(Expression.Constant(handler), Expression.Convert(p, typeof(object)));
+            return Expression.Lambda(typeof(Action<>).MakeGenericType(argType), body, p).Compile();
+        }
+
+        static Delegate BoxAction2(Type a, Type b, Action<object, object> handler)
+        {
+            var p1 = Expression.Parameter(a, "x");
+            var p2 = Expression.Parameter(b, "y");
+            var body = Expression.Invoke(Expression.Constant(handler),
+                Expression.Convert(p1, typeof(object)),
+                Expression.Convert(p2, typeof(object)));
+            return Expression.Lambda(typeof(Action<,>).MakeGenericType(a, b), body, p1, p2).Compile();
+        }
+
+        static Type Ed(string fullName)
+        {
+            if (_editorAsmCached == null)
+            {
+                _editorAsmCached = typeof(UnityEditor.Editor);
+            }
+            var t = _editorAsmCached.Assembly.GetType(fullName);
+            if (t == null) throw new InvalidOperationException("missing type " + fullName);
+            return t;
+        }
+
+        static object Resolve(string fullName)
+        {
+            var want = Ed(fullName);
+            var scType = Ed("UnityEditor.PackageManager.UI.Internal.ServicesContainer");
+            var inst = scType.GetProperty("instance", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy).GetValue(null, null);
+            return scType.GetMethod("Resolve").MakeGenericMethod(want).Invoke(inst, null);
+        }
+
+        static string ReadUiError(object err)
+        {
+            if (err == null) return "null";
+            try
+            {
+                var p = err.GetType().GetProperty("message");
+                if (p != null) return "" + p.GetValue(err, null);
+            }
+            catch { }
+            return err.ToString();
+        }
+
+        static string NameOf(long id)
+        {
+            try
+            {
+                if (!File.Exists(NamesPath)) return "";
+                foreach (var line in File.ReadAllLines(NamesPath))
+                {
+                    var tab = line.IndexOf('\t');
+                    if (tab <= 0) continue;
+                    long parsed;
+                    if (long.TryParse(line.Substring(0, tab), out parsed) && parsed == id)
+                        return line.Substring(tab + 1);
+                }
+            }
+            catch { }
+            return "";
+        }
+
+        static void WriteNames(Dictionary<long, string> names)
+        {
+            var sb = new System.Text.StringBuilder();
+            foreach (var kv in names)
+                sb.Append(kv.Key).Append('\t').Append(kv.Value).Append('\n');
+            File.WriteAllText(NamesPath, sb.ToString());
+        }
+
+        class State
+        {
+            public string Phase = "idle";
+            public long Installing;
+            public List<long> PendingDownload = new List<long>();
+            public List<long> PendingInstall = new List<long>();
+            public List<long> Done = new List<long>();
+            public List<long> Failed = new List<long>();
+        }
+
+        static void WriteState(State st)
+        {
+            var sb = new System.Text.StringBuilder();
+            sb.Append("phase=").Append(st.Phase).Append('\n');
+            sb.Append("installing=").Append(st.Installing).Append('\n');
+            sb.Append("pendingDownload=").Append(string.Join(",", st.PendingDownload)).Append('\n');
+            sb.Append("pendingInstall=").Append(string.Join(",", st.PendingInstall)).Append('\n');
+            sb.Append("done=").Append(string.Join(",", st.Done)).Append('\n');
+            sb.Append("failed=").Append(string.Join(",", st.Failed)).Append('\n');
+            File.WriteAllText(StatePath, sb.ToString());
+        }
+
+        static State ReadState()
+        {
+            var st = new State();
+            if (!File.Exists(StatePath)) return st;
+            foreach (var raw in File.ReadAllLines(StatePath))
+            {
+                var eq = raw.IndexOf('=');
+                if (eq <= 0) continue;
+                var k = raw.Substring(0, eq);
+                var v = raw.Substring(eq + 1);
+                if (k == "phase") st.Phase = v;
+                else if (k == "installing") long.TryParse(v, out st.Installing);
+                else if (k == "pendingDownload") st.PendingDownload = ParseIds(v);
+                else if (k == "pendingInstall") st.PendingInstall = ParseIds(v);
+                else if (k == "done") st.Done = ParseIds(v);
+                else if (k == "failed") st.Failed = ParseIds(v);
+            }
+            return st;
+        }
+
+        static List<long> ParseIds(string v)
+        {
+            var list = new List<long>();
+            if (string.IsNullOrEmpty(v)) return list;
+            var parts = v.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+            for (var i = 0; i < parts.Length; i++)
+            {
+                long id;
+                if (long.TryParse(parts[i], out id)) list.Add(id);
+            }
+            return list;
+        }
+
+        static void WriteProgress(string line)
+        {
+            try
+            {
+                File.WriteAllText(ProgressPath, DateTime.Now.ToString("HH:mm:ss") + " " + line + "\n");
+            }
+            catch { }
+            Debug.Log("[Concordia import] " + line);
+        }
+
+        static void Log(string line)
+        {
+            Debug.Log("[Concordia import] " + line);
+        }
+    }
+}

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Editor/ImportAllMyAssets.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Editor/ImportAllMyAssets.cs
@@ -59,16 +59,32 @@ namespace Concordia.Editor
             { 28647, new[] { "3rdPerson+Fly" } },
             { 116144, new[] { "SlimUI" } },
             { 18353, new[] { "Skybox" } },
-            { 61217, new[] { "Skybox" } }
+            { 61217, new[] { "Skybox" } },
+            { 12567, new[] { "ADG_Textures" } },
+            { 42285, new[] { "_Creepy_Cat" } },
+            { 115747, new[] { "3DGamekit" } }
         };
 
         static bool _hooked;
-        static bool _listing;
         static Type _editorAsmCached;
+        static double _lastKickAt;
 
         static ImportAllMyAssets()
         {
             EditorApplication.delayCall += ResumeIfNeeded;
+            EditorApplication.update += WatchdogKick;
+        }
+
+        static void WatchdogKick()
+        {
+            if (!File.Exists(StatePath)) return;
+            if (EditorApplication.isCompiling || EditorApplication.isUpdating || EditorApplication.isPlaying) return;
+            var now = EditorApplication.timeSinceStartup;
+            if (now - _lastKickAt < 4.0) return;
+            var st = ReadState();
+            if (st.Phase == "idle" || st.Phase == "done") return;
+            _lastKickAt = now;
+            Kick();
         }
 
         [MenuItem("Concordia/Asset Store/Import all My Assets")]
@@ -87,7 +103,6 @@ namespace Concordia.Editor
                 return;
             }
             WriteProgress("listing My Assets…");
-            _listing = true;
             HookDownloadEvents();
             ListPurchasesThenQueue();
         }
@@ -163,11 +178,9 @@ namespace Concordia.Editor
                     WriteProgress("list failed: " + ex.Message);
                     Debug.LogException(ex);
                 }
-                finally { _listing = false; }
             };
             Action<object> onErr = err =>
             {
-                _listing = false;
                 var msg = ReadUiError(err);
                 WriteProgress("GetPurchases error: " + msg);
                 Log("GetPurchases error: " + msg);

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Editor/ImportAllMyAssets.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Editor/ImportAllMyAssets.cs
@@ -20,6 +20,20 @@ namespace Concordia.Editor
     {
         const long SkipDemoCity = 269772L;
         const int Batch = 3;
+        // Huge sample/tool packs that refill the disk or mutate ProjectSettings.
+        // 115747 3D Game Kit already blew Safe Mode + 2.5GB — never re-import.
+        static readonly long[] SkipForever =
+        {
+            SkipDemoCity,
+            115747L, // 3D Game Kit
+            20282L,  // Huge FBX Mocap Library part 2
+            234361L, // Any(MMO)RPG
+            45568L,  // Item & Inventory System
+            73563L,  // Lighting Optimisation sample
+            272450L, // Meta MR Utility Kit
+            213197L, // Unity URP Terrain sample
+            12555L   // Outdoor Ground — failed twice on this disk
+        };
         const string StatePath = "/tmp/concordia-import-state.txt";
         const string NamesPath = "/tmp/concordia-import-names.txt";
         const string ProgressPath = "/tmp/concordia-import-progress.txt";
@@ -62,7 +76,18 @@ namespace Concordia.Editor
             { 61217, new[] { "Skybox" } },
             { 12567, new[] { "ADG_Textures" } },
             { 42285, new[] { "_Creepy_Cat" } },
-            { 115747, new[] { "3DGamekit" } }
+            { 115747, new[] { "3DGamekit" } },
+            { 17785, new[] { "3DForge" } },
+            { 279431, new[] { "ALP_Assets" } },
+            { 104753, new[] { "Free Island Collection" } },
+            { 155776, new[] { "Free Pack" } },
+            { 49962, new[] { "NatureStarterKit" } },
+            { 76974, new[] { "TreePackVol" } },
+            { 6947, new[] { "Rocks and Boulders" } },
+            { 86679, new[] { "RPG_FPS_game_assets_industrial" } },
+            { 31711, new[] { "BodyGuards" } },
+            { 111778, new[] { "Cartoon_Texture_Pack" } },
+            { 54030, new[] { "Medieval Action" } }
         };
 
         static bool _hooked;
@@ -202,9 +227,9 @@ namespace Concordia.Editor
             {
                 var id = kv.Key;
                 var name = kv.Value;
-                if (id == SkipDemoCity)
+                if (ShouldSkip(id))
                 {
-                    Log("skip Demo City " + id);
+                    Log("skip forever " + id + " " + name);
                     done.Add(id);
                     continue;
                 }
@@ -250,6 +275,11 @@ namespace Concordia.Editor
             var st = ReadState();
             if (st.Phase == "done" || st.Phase == "idle") return;
 
+            var skipped = 0;
+            skipped += st.PendingDownload.RemoveAll(ShouldSkip);
+            skipped += st.PendingInstall.RemoveAll(ShouldSkip);
+            if (skipped > 0) WriteState(st);
+
             if (st.Installing != 0)
             {
                 if (!st.Done.Contains(st.Installing)) st.Done.Add(st.Installing);
@@ -260,6 +290,11 @@ namespace Concordia.Editor
 
             if (st.PendingInstall.Count > 0)
             {
+                if (AnyDownloadInProgress())
+                {
+                    WriteProgress("waiting — download in flight before install remainingInstall=" + st.PendingInstall.Count);
+                    return;
+                }
                 st.Phase = "install";
                 var id = st.PendingInstall[0];
                 st.Installing = id;
@@ -288,6 +323,11 @@ namespace Concordia.Editor
 
             if (st.PendingDownload.Count > 0)
             {
+                if (AnyDownloadInProgress())
+                {
+                    WriteProgress("waiting — download already in progress remaining=" + st.PendingDownload.Count);
+                    return;
+                }
                 st.Phase = "download";
                 WriteState(st);
                 var n = Math.Min(Batch, st.PendingDownload.Count);
@@ -417,6 +457,31 @@ namespace Concordia.Editor
                 WriteProgress("downloading " + id + " " + NameOf(id) + " " + (pct * 100f).ToString("0") + "%");
             }
             catch { }
+        }
+
+        static bool ShouldSkip(long id)
+        {
+            for (var i = 0; i < SkipForever.Length; i++)
+            {
+                if (SkipForever[i] == id) return true;
+            }
+            return false;
+        }
+
+        static bool AnyDownloadInProgress()
+        {
+            try
+            {
+                var mgr = Resolve("UnityEditor.PackageManager.UI.Internal.IAssetStoreDownloadManager");
+                var t = Ed("UnityEditor.PackageManager.UI.Internal.IAssetStoreDownloadManager");
+                var m = t.GetMethod("IsAnyDownloadInProgress");
+                if (m == null) return false;
+                return (bool)m.Invoke(mgr, null);
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         static bool AlreadyInProject(long id, string displayName)

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Editor/ImportAllMyAssets.cs.meta
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Editor/ImportAllMyAssets.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 953eb01b60a4242c784202bb06c47add

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/Canon.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/Canon.cs
@@ -8,6 +8,13 @@ namespace Concordia
     Hub, Ruins, Tunya, Fantasy, Crime, Cyber, Frontier, Superhero, Crucible, Sere
 }
 
+    /// <summary>
+    /// Five fighting styles from style-sets.ts. Presentation of the existing
+    /// combat engine — not a second one. Stance / anticipation / strike read
+    /// differently on sight.
+    /// </summary>
+    public enum FightStyle { Karate, MuayThai, WingChun, Capoeira, Sword }
+
     [Serializable]
     public class GateDef
     {
@@ -129,6 +136,43 @@ namespace Concordia
                 default:
                     return new WorldDef { id = WorldId.Crucible, title = "The Crucible", refusal = "A system that refuses to close can never rest.", theNo = "There is no ninth.", fantasy = "rules that refuse to stay", traversal = "unstable ground", combat = "drift", weather = "drift", ground = Hex("204040"), sun = Hex("20ffd0"), steelLive = true, law = "If it would end, un-end it.", style = S("drift", "Open Lattice", "Shard", "Recycle", "Refuse completion", "Un-end", 1.15f, 1f, 1.1f), fauna = new[] { "drift", "wraith", "construct" } };
             }
+        }
+
+        /// <summary>
+        /// Port of pickStyle({factionId, archetype, preferredStyleId}) plus a
+        /// world default so Hub karate and Crime wing chun actually read apart.
+        /// </summary>
+        public static FightStyle PickFight(string factionId, string archetype, WorldId world)
+        {
+            if (!string.IsNullOrEmpty(factionId))
+            {
+                if (factionId == "iron_wardens") return FightStyle.Sword;
+                if (factionId == "scholars_guild") return FightStyle.WingChun;
+                if (factionId == "shadow_network") return FightStyle.Capoeira;
+                if (factionId == "merchant_collective") return FightStyle.MuayThai;
+            }
+            if (!string.IsNullOrEmpty(archetype))
+            {
+                var a = archetype.ToLowerInvariant();
+                if (a.Contains("warrior") || a.Contains("guard")) return FightStyle.Sword;
+                if (a.Contains("scholar") || a.Contains("mystic")) return FightStyle.WingChun;
+                if (a.Contains("hunter") || a.Contains("acrobat")) return FightStyle.Capoeira;
+                if (a.Contains("trader")) return FightStyle.MuayThai;
+                if (a.Contains("monk")) return FightStyle.Karate;
+            }
+            return world switch
+            {
+                WorldId.Hub => FightStyle.Karate,
+                WorldId.Crime => FightStyle.WingChun,
+                WorldId.Sere => FightStyle.WingChun,
+                WorldId.Cyber => FightStyle.Capoeira,
+                WorldId.Tunya => FightStyle.Capoeira,
+                WorldId.Frontier => FightStyle.MuayThai,
+                WorldId.Fantasy => FightStyle.Sword,
+                WorldId.Ruins => FightStyle.Sword,
+                WorldId.Superhero => FightStyle.Karate,
+                _ => FightStyle.Sword
+            };
         }
 
         public static bool InArena(Vector3 p) => Vector3.Distance(new Vector3(p.x, 0, p.z), Arena) < 8f;

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ChaseCamera.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ChaseCamera.cs
@@ -95,7 +95,7 @@ namespace Concordia
 
             var feetY = Mathf.Clamp(target.position.y, 0f, 3.5f);
             var focus = new Vector3(target.position.x, feetY + 1.35f, target.position.z);
-            var fov = creatorFraming ? 52f : (sprinting ? PovFov[pov] + 6f : inCombat ? PovFov[pov] - 3f : PovFov[pov]);
+            var fov = creatorFraming ? 52f : (sprinting ? PovFov[pov] + 6f : inCombat ? PovFov[pov] - 5f : PovFov[pov]);
 
             if (creatorFraming)
             {
@@ -108,7 +108,7 @@ namespace Concordia
             ReadZoomAndPov();
             var dist = PovDist[Mathf.Clamp(pov, 0, 2)];
             if (sprinting) dist += 0.7f;
-            if (inCombat) dist -= 0.6f;
+            if (inCombat) dist -= 0.85f;
             dist = Mathf.Clamp(dist + (distance - 6.2f), 2.4f, 14f);
 
             if (_vcam && _orbit)

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/CombatFeel.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/CombatFeel.cs
@@ -27,6 +27,9 @@ namespace Concordia
             if (hit && body && knockback > 0)
                 body.Move(-transform.forward * Mathf.Min(knockback, 2.4f) * 0.15f);
             _shake = hit ? 0.16f : 0.05f;
+            var av = GetComponentInChildren<MixamoAvatar>();
+            if (hit) av?.Hit();
+            if (knockback > 1.1f) av?.Stagger();
             if (brokenArm) Debug.Log("limb: broken arm — strikes weakened");
             if (brokenLeg) Debug.Log("limb: broken leg — dodge locked");
         }

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/CombatFeel.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/CombatFeel.cs
@@ -13,10 +13,11 @@ namespace Concordia
         float _shake;
         float _fovKick;
 
-        public void Strike(bool heavy, bool connected)
+        public void Strike(bool heavy, bool connected, float kickMul = 1f)
         {
-            _shake = connected ? (heavy ? 0.22f : 0.12f) : 0.05f;
-            _fovKick = connected ? (heavy ? 7f : 3.5f) : 1.2f;
+            var k = Mathf.Clamp(kickMul, 0.4f, 2.6f);
+            _shake = (connected ? (heavy ? 0.22f : 0.12f) : 0.05f) * k;
+            _fovKick = (connected ? (heavy ? 7f : 3.5f) : 1.2f) * k;
         }
 
         public void ApplyAck(bool hit, float knockback, bool brokenArm, bool brokenLeg)

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/CombatFeel.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/CombatFeel.cs
@@ -3,7 +3,8 @@ using UnityEngine;
 namespace Concordia
 {
     /// <summary>
-    /// Camera kick + FOV punch. ChaseCamera writes pose first; we offset after.
+    /// Camera kick + FOV punch + owned-pack combat VFX.
+    /// ChaseCamera writes pose first; we offset after.
     /// </summary>
     [DefaultExecutionOrder(80)]
     public class CombatFeel : MonoBehaviour
@@ -13,11 +14,12 @@ namespace Concordia
         float _shake;
         float _fovKick;
 
-        public void Strike(bool heavy, bool connected, float kickMul = 1f)
+        public void Strike(bool heavy, bool connected, float kickMul = 1f, string skillType = null)
         {
             var k = Mathf.Clamp(kickMul, 0.4f, 2.6f);
             _shake = (connected ? (heavy ? 0.22f : 0.12f) : 0.05f) * k;
             _fovKick = (connected ? (heavy ? 7f : 3.5f) : 1.2f) * k;
+            if (connected) Burst(skillType);
         }
 
         public void ApplyAck(bool hit, float knockback, bool brokenArm, bool brokenLeg)
@@ -27,6 +29,14 @@ namespace Concordia
             _shake = hit ? 0.16f : 0.05f;
             if (brokenArm) Debug.Log("limb: broken arm — strikes weakened");
             if (brokenLeg) Debug.Log("limb: broken leg — dodge locked");
+        }
+
+        void Burst(string skillType)
+        {
+            var path = SkillLattice.VfxPath(skillType);
+            var at = transform.position + transform.forward * 1.5f + Vector3.up * 1.1f;
+            var go = FreePacks.Prefab(path, transform, at, transform.eulerAngles.y);
+            if (go) Object.Destroy(go, 1.25f);
         }
 
         void LateUpdate()

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/CombatFeel.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/CombatFeel.cs
@@ -29,7 +29,8 @@ namespace Concordia
             _shake = hit ? 0.16f : 0.05f;
             var av = GetComponentInChildren<MixamoAvatar>();
             if (hit) av?.Hit();
-            if (knockback > 1.1f) av?.Stagger();
+            if (knockback > 1.8f) av?.Knockdown();
+            else if (knockback > 1.1f) av?.Stagger();
             if (brokenArm) Debug.Log("limb: broken arm — strikes weakened");
             if (brokenLeg) Debug.Log("limb: broken leg — dodge locked");
         }

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
@@ -37,6 +37,9 @@ namespace Concordia
         public static string LastReason { get; private set; } = "no_gateway";
         public static string HudLine { get; private set; } = "";
         public static string SnapshotJson { get; private set; } = "";
+        public static string PartyLine { get; private set; } = "PARTY  ·  you";
+        public static int PartyCount { get; private set; } = 1;
+        public static string DungeonLine { get; private set; } = "";
         public static ConcordClient Live { get; private set; }
 
         public string WorldId => worldId;
@@ -210,6 +213,8 @@ namespace Concordia
                 await SendEvt("auth", "{\"token\":\"" + Escape(token) + "\"}");
                 await SendEvt("scene:request", "{\"worldId\":\"" + Escape(worldId) + "\"}");
                 await SendEvt("kingdom:request", "{\"worldId\":\"" + Escape(worldId) + "\"}");
+                await SendEvt("room:join", "{\"room\":\"world:" + Escape(worldId) + "\"}");
+                await SendEvt("party:request", "{\"worldId\":\"" + Escape(worldId) + "\"}");
                 LastReason = "awaiting_kingdom";
                 StatusJson = "{\"ok\":false,\"reason\":\"awaiting_kingdom\"}";
 #if !(UNITY_WEBGL && !UNITY_EDITOR)
@@ -229,6 +234,9 @@ namespace Concordia
             StatusJson = "{\"ok\":false,\"reason\":\"no_gateway\"}";
             HudLine = "";
             SnapshotJson = "";
+            PartyLine = "PARTY  ·  you";
+            PartyCount = 1;
+            DungeonLine = "";
         }
 
         void HandleFrame(string evt, string text)
@@ -276,8 +284,53 @@ namespace Concordia
                 else if (!string.IsNullOrEmpty(plotter))
                     line = plotter + " · " + kind;
                 WorldClock.NoteAct("scheme nearby — " + line);
+                Plots.Seed(line);
                 return;
             }
+            if (evt == "gift:result")
+            {
+                var npcId = JsonString(text, "npcId");
+                var aff = JsonFloat(text, "affinity", -1f);
+                if (aff >= 0f && !string.IsNullOrEmpty(npcId)) Bonds.Set(npcId, aff);
+                var reaction = JsonString(text, "reaction");
+                if (!string.IsNullOrEmpty(reaction))
+                    WorldClock.NoteAct("gift · " + reaction);
+                return;
+            }
+            if (evt == "scheme:intervened")
+            {
+                if (!JsonFlagFalse(text, "ok"))
+                    WorldClock.NoteAct("the kernel named the plot");
+                return;
+            }
+            if (evt == "party:data")
+            {
+                ApplyParty(text);
+                return;
+            }
+            if (evt == "inheritance:data")
+            {
+                var heir = JsonString(text, "heirName");
+                if (string.IsNullOrEmpty(heir)) heir = JsonString(text, "heir_name");
+                if (!string.IsNullOrEmpty(heir))
+                {
+                    WorldClock.NoteAct(heir + " carries the thread");
+                    ConcordiaHUD.Announce("Heir rose", heir + " inherited");
+                }
+                return;
+            }
+            if (evt == "dungeon:data")
+            {
+                var name = JsonNestedString(text, "name");
+                if (string.IsNullOrEmpty(name)) name = JsonString(text, "name");
+                var phase = JsonString(text, "phase");
+                if (string.IsNullOrEmpty(name)) name = "the hold";
+                DungeonLine = name + (string.IsNullOrEmpty(phase) ? "" : " · " + phase);
+                ConcordiaHUD.Announce(name, string.IsNullOrEmpty(phase) ? "the hold opened" : phase);
+                return;
+            }
+            if (evt == "combat:dodge:ack")
+                return;
             if (evt == "auth:error" || (evt == "error" && text.Contains("auth_required")))
                 MarkDisconnected();
         }
@@ -362,6 +415,8 @@ namespace Concordia
             if (!string.IsNullOrEmpty(nextWorldId)) worldId = nextWorldId;
             await SendEvt("scene:request", "{\"worldId\":\"" + Escape(worldId) + "\"}");
             await SendEvt("kingdom:request", "{\"worldId\":\"" + Escape(worldId) + "\"}");
+            await SendEvt("room:join", "{\"room\":\"world:" + Escape(worldId) + "\"}");
+            await SendEvt("party:request", "{\"worldId\":\"" + Escape(worldId) + "\"}");
         }
 
         public Task SendMove(float x, float y, float z, string cityId) =>
@@ -372,6 +427,27 @@ namespace Concordia
 
         public Task SendDodge(bool parry = false) =>
             SendEvt("combat:dodge", "{\"wasParry\":" + (parry ? "true" : "false") + "}");
+
+        public Task SendGift(string npcId, string itemId, string itemName, string archetype) =>
+            SendEvt("gift:give",
+                "{\"npcId\":\"" + Escape(npcId)
+                + "\",\"itemId\":\"" + Escape(itemId)
+                + "\",\"itemName\":\"" + Escape(itemName)
+                + "\",\"archetype\":\"" + Escape(archetype)
+                + "\",\"worldId\":\"" + Escape(worldId) + "\"}");
+
+        public Task SendIntervene(string schemeId, string action) =>
+            SendEvt("scheme:intervene",
+                "{\"schemeId\":\"" + Escape(schemeId) + "\",\"action\":\"" + Escape(action) + "\"}");
+
+        public Task SendInheritance(string heirId, string deceasedId) =>
+            SendEvt("inheritance:request",
+                "{\"heirId\":\"" + Escape(heirId) + "\",\"deceasedId\":\"" + Escape(deceasedId) + "\"}");
+
+        public Task SendDungeonOpen(string encounterId) =>
+            SendEvt("dungeon:open",
+                "{\"encounterId\":\"" + Escape(encounterId)
+                + "\",\"worldId\":\"" + Escape(worldId) + "\"}");
 
         async Task SendEvt(string evt, string dataJson)
         {
@@ -417,6 +493,15 @@ namespace Concordia
             return true;
         }
 
+        void ApplyParty(string json)
+        {
+            var n = JsonInt(json, "count", 0);
+            if (n <= 0) n = JsonArrayCount(json, "members");
+            if (n <= 0) n = 1;
+            PartyCount = n;
+            PartyLine = n <= 1 ? "PARTY  ·  you" : "PARTY  ·  " + n;
+        }
+
         static bool JsonFlagFalse(string json, string key)
         {
             if (string.IsNullOrEmpty(json)) return true;
@@ -436,6 +521,29 @@ namespace Concordia
             var start = i + needle.Length;
             var end = json.IndexOf('"', start);
             return end <= start ? "" : json.Substring(start, end - start);
+        }
+
+        static int JsonInt(string json, string key, int fallback)
+        {
+            var v = JsonFloat(json, key, fallback);
+            return Mathf.RoundToInt(v);
+        }
+
+        static float JsonFloat(string json, string key, float fallback)
+        {
+            if (string.IsNullOrEmpty(json)) return fallback;
+            var needle = "\"" + key + "\":";
+            var i = json.IndexOf(needle, StringComparison.Ordinal);
+            if (i < 0) return fallback;
+            var rest = json.Substring(i + needle.Length).TrimStart();
+            int n = 0;
+            if (rest.Length > 0 && (rest[0] == '-' || rest[0] == '+')) n = 1;
+            while (n < rest.Length && ((rest[n] >= '0' && rest[n] <= '9') || rest[n] == '.')) n++;
+            if (n == 0 || (n == 1 && (rest[0] == '-' || rest[0] == '+'))) return fallback;
+            if (float.TryParse(rest.Substring(0, n), System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture, out var v))
+                return v;
+            return fallback;
         }
 
         static string JsonNestedString(string json, string key)

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
@@ -366,7 +366,12 @@ namespace Concordia
             }
             if (evt == "world:npc-gather")
             {
-                RunMain(() => WorldClock.NoteAct("a gathering"));
+                var res = JsonString(text, "resourceName");
+                if (string.IsNullOrEmpty(res)) res = JsonString(text, "resourceId");
+                var amt = JsonInt(text, "amount", 0);
+                var line = string.IsNullOrEmpty(res) ? "someone harvested" : "harvest · " + res;
+                if (amt > 0) line += " ×" + amt;
+                RunMain(() => WorldClock.PushFeed("economy", line));
                 return;
             }
             if (evt == "lens:result")
@@ -385,11 +390,13 @@ namespace Concordia
                 if (string.IsNullOrEmpty(heir)) heir = JsonString(text, "heir_name");
                 var from = JsonString(text, "deceasedName");
                 if (string.IsNullOrEmpty(from)) from = JsonString(text, "deceased_name");
+                var last = JsonString(text, "lastWords");
                 var line = string.IsNullOrEmpty(heir) ? "an heir rose" : heir + " inherited";
                 if (!string.IsNullOrEmpty(from)) line += " from " + from;
+                if (!string.IsNullOrEmpty(last)) line += " — \"" + last + "\"";
                 RunMain(() =>
                 {
-                    WorldClock.NoteAct(line);
+                    WorldClock.PushFeed("lineage", line);
                     ConcordiaHUD.Announce("Heir rose", line);
                 });
                 return;
@@ -502,6 +509,118 @@ namespace Concordia
                 RunMain(() => ApplyRun(text));
                 return;
             }
+            if (evt == "faction:war-declared")
+            {
+                var summary = JsonString(text, "summary");
+                var move = JsonString(text, "move");
+                var a = JsonString(text, "factionId");
+                var b = JsonString(text, "targetFactionId");
+                var line = summary;
+                if (string.IsNullOrEmpty(line))
+                    line = string.IsNullOrEmpty(a) ? "war declared" : a + " declared war" + (string.IsNullOrEmpty(b) ? "" : " on " + b);
+                if (!string.IsNullOrEmpty(move) && move == "RAID" && string.IsNullOrEmpty(summary))
+                    line = string.IsNullOrEmpty(a) ? "a raid" : a + " raids" + (string.IsNullOrEmpty(b) ? "" : " " + b);
+                Consequence("faction", "War", line, true, 0.12f);
+                return;
+            }
+            if (evt == "faction:alliance-formed")
+            {
+                var summary = JsonString(text, "summary");
+                var a = JsonString(text, "factionId");
+                var b = JsonString(text, "targetFactionId");
+                var line = summary;
+                if (string.IsNullOrEmpty(line))
+                    line = string.IsNullOrEmpty(a) ? "an alliance formed" : a + " allied" + (string.IsNullOrEmpty(b) ? "" : " with " + b);
+                Consequence("faction", "Alliance", line, true, -0.06f);
+                return;
+            }
+            if (evt == "faction:truce-sought")
+            {
+                var summary = JsonString(text, "summary");
+                var a = JsonString(text, "factionId");
+                var b = JsonString(text, "targetFactionId");
+                var line = summary;
+                if (string.IsNullOrEmpty(line))
+                    line = string.IsNullOrEmpty(a) ? "a truce sought" : a + " sought truce" + (string.IsNullOrEmpty(b) ? "" : " with " + b);
+                Consequence("faction", "Truce", line, true, -0.06f);
+                return;
+            }
+            if (evt == "faction:strategy-move")
+            {
+                var move = JsonString(text, "move");
+                var a = JsonString(text, "factionId");
+                var b = JsonString(text, "target");
+                if (string.IsNullOrEmpty(move)) return;
+                var line = string.IsNullOrEmpty(a) ? move : a + " · " + move;
+                if (!string.IsNullOrEmpty(b)) line += " → " + b;
+                Consequence("faction", "Faction", line, false, 0f);
+                return;
+            }
+            if (evt == "world:gathering-detected")
+            {
+                var loc = "";
+                var n = 0;
+                ForEachArrayObject(text, "gatherings", g =>
+                {
+                    if (n == 0) loc = JsonString(g, "location");
+                    var c = JsonInt(g, "playerCount", 0);
+                    if (c > n) n = c;
+                });
+                if (n <= 0) n = JsonArrayCount(text, "gatherings");
+                if (n <= 0) return;
+                var line = n + (n == 1 ? " soul gathered" : " souls gathered");
+                if (!string.IsNullOrEmpty(loc)) line += " · " + loc;
+                Consequence("social", "Gathering", line, true, 0f);
+                return;
+            }
+            if (evt == "world:boss-spawn")
+            {
+                var boss = JsonString(text, "bossTemplate");
+                if (string.IsNullOrEmpty(boss)) boss = JsonString(text, "activeId");
+                var line = string.IsNullOrEmpty(boss) ? "a world boss opened" : boss + " walks";
+                Consequence("crisis", "World boss", line, true, 0.08f);
+                return;
+            }
+            if (evt == "world:season-transition")
+            {
+                var season = JsonString(text, "seasonName");
+                var narrative = JsonString(text, "narrative");
+                var year = JsonInt(text, "year", 0);
+                var line = string.IsNullOrEmpty(narrative) ? (string.IsNullOrEmpty(season) ? "the season turned" : season) : narrative;
+                if (year > 0 && string.IsNullOrEmpty(narrative)) line += " · year " + year;
+                Consequence("season", "Season", line, true, 0f);
+                return;
+            }
+            if (evt == "festival:started")
+            {
+                var name = JsonString(text, "name");
+                if (string.IsNullOrEmpty(name)) name = JsonString(text, "festivalId");
+                var line = string.IsNullOrEmpty(name) ? "a festival opened" : name;
+                Consequence("season", "Festival", line, true, 0f);
+                return;
+            }
+            if (evt == "npc:economy-batch")
+            {
+                var crafts = JsonInt(text, "crafts", 0);
+                var trades = JsonInt(text, "trades", 0);
+                var notable = JsonArrayCount(text, "notable");
+                if (crafts <= 0 && trades <= 0 && notable <= 0) return;
+                var line = "work · ";
+                if (crafts > 0) line += crafts + " crafted";
+                if (trades > 0) line += (crafts > 0 ? ", " : "") + trades + " traded";
+                if (notable > 0 && crafts <= 0 && trades <= 0) line += notable + " notable";
+                Consequence("economy", "Market", line, false, 0f);
+                return;
+            }
+            if (evt == "npc:stress-break")
+            {
+                var trait = JsonString(text, "copingTrait");
+                var who = JsonString(text, "npcId");
+                var line = string.IsNullOrEmpty(trait) ? "someone broke" : "broke · " + trait;
+                if (!string.IsNullOrEmpty(who)) line += " · " + who;
+                Consequence("npc", "Broke", line, true, 0f);
+                return;
+            }
             if (evt == "combat:dodge:ack")
                 return;
             if (evt == "auth:error" || (evt == "error" && text.Contains("auth_required")))
@@ -584,6 +703,43 @@ namespace Concordia
             var w = JsonNestedString(json, "type");
             if (string.IsNullOrEmpty(w)) w = JsonString(json, "type");
             WorldClock.BindKernelWeather(w);
+            var gossipN = JsonArrayCount(json, "gossip");
+            if (gossipN > 0)
+            {
+                var shown = 0;
+                ForEachArrayObject(json, "gossip", row =>
+                {
+                    if (shown >= 3) return;
+                    var summary = JsonString(row, "summary");
+                    if (string.IsNullOrEmpty(summary)) return;
+                    WorldClock.PushFeed("gossip", summary);
+                    shown++;
+                });
+            }
+            var tombN = JsonArrayCount(json, "tombs");
+            if (tombN > 0)
+            {
+                var said = false;
+                ForEachArrayObject(json, "tombs", row =>
+                {
+                    if (said) return;
+                    var last = JsonString(row, "lastWords");
+                    if (string.IsNullOrEmpty(last)) return;
+                    WorldClock.PushFeed("lineage", "\"" + last + "\"");
+                    said = true;
+                });
+            }
+        }
+
+        void Consequence(string channel, string title, string line, bool announce, float heatDelta)
+        {
+            RunMain(() =>
+            {
+                WorldClock.PushFeed(channel, line);
+                if (announce) ConcordiaHUD.Announce(title, line);
+                if (heatDelta != 0f)
+                    WorldClock.FactionHeat = Mathf.Clamp01(WorldClock.FactionHeat + heatDelta);
+            });
         }
 
         void ApplyCombatFeel(string json, bool impact)

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
@@ -44,6 +44,7 @@ namespace Concordia
         public static string HoldLockReason { get; private set; } = "";
         public static string RunLine { get; private set; } = "";
         public static ConcordClient Live { get; private set; }
+        public string DungeonInstanceId { get; private set; } = "";
         string _userId = "";
         readonly System.Collections.Concurrent.ConcurrentQueue<System.Action> _main =
             new System.Collections.Concurrent.ConcurrentQueue<System.Action>();
@@ -526,9 +527,33 @@ namespace Concordia
                 DungeonLine = name + (string.IsNullOrEmpty(phase) ? "" : " · " + phase);
                 if (!string.IsNullOrEmpty(mechanic)) DungeonLine += " · " + mechanic;
                 ConcordiaHUD.Announce(name, string.IsNullOrEmpty(phase) ? "the hold opened" : phase);
+                var instanceId = JsonString(text, "instanceId");
+                if (!string.IsNullOrEmpty(instanceId)) DungeonInstanceId = instanceId;
                 var hp = JsonFloat(text, "hp", -1f);
                 var maxHp = JsonFloat(text, "maxHp", 1f);
                 RunMain(() => WorldBoss.BindState(name, hp, maxHp, phase, mechanic));
+                return;
+            }
+            if (evt == "dungeon:hit:ack")
+            {
+                if (JsonFlagFalse(text, "ok"))
+                {
+                    var reason = JsonString(text, "reason");
+                    if (!string.IsNullOrEmpty(reason))
+                        RunMain(() => ConcordiaHUD.Announce("Hold", reason));
+                    return;
+                }
+                var hpHit = JsonFloat(text, "bossHp", JsonFloat(text, "hp", -1f));
+                var maxHit = JsonFloat(text, "bossMaxHp", JsonFloat(text, "maxHp", 1f));
+                var phaseHit = JsonString(text, "phaseName");
+                if (string.IsNullOrEmpty(phaseHit)) phaseHit = JsonString(text, "phase");
+                var mechanicHit = JsonString(text, "mechanic");
+                var nm = JsonString(text, "encounterId");
+                RunMain(() =>
+                {
+                    WorldBoss.BindState(nm, hpHit, maxHit, phaseHit, mechanicHit);
+                    if (JsonFlagTrue(text, "cleared")) WorldBoss.Live?.Fall();
+                });
                 return;
             }
             if (evt == "run:data")
@@ -703,6 +728,16 @@ namespace Concordia
                 if (n > 0) line += " · " + n + (n == 1 ? " mourner" : " mourners");
                 Consequence("lineage", "Funeral", line, true, 0f);
                 RunMain(() => PresentFuneral(text, deceased, last));
+                return;
+            }
+            if (evt == "npc:wedding")
+            {
+                var n = JsonArrayCount(text, "attendees");
+                var partner = JsonString(text, "partnerId");
+                var line = string.IsNullOrEmpty(partner) ? "a wedding" : "married · " + partner;
+                if (n > 0) line += " · " + n + (n == 1 ? " guest" : " guests");
+                Consequence("social", "Wedding", line, true, 0f);
+                RunMain(() => PresentWedding(text));
                 return;
             }
             if (evt == "combat:chronicle")
@@ -930,18 +965,54 @@ namespace Concordia
         {
             var tomb = KernelTomb.Place(deceasedId, lastWords,
                 JsonFloat(json, "tombX", 0f), JsonFloat(json, "tombZ", 0f));
+            int of = Mathf.Max(1, JsonArrayCount(json, "attendees"));
+            int slot = 0;
+            int matched = 0;
             ForEachArrayObject(json, "attendees", row =>
             {
                 var id = JsonString(row, "id");
                 var guest = WorldPresence.FindGuest(id);
                 var life = guest ? guest.GetComponent<NpcLife>() : null;
+                var i = slot;
+                slot++;
                 if (!life) return;
+                matched++;
                 if (tomb)
-                {
-                    life.HeadFor(tomb.transform.position, 14f);
-                    life.Notice(tomb.transform, 8f);
-                }
+                    life.Attend(tomb.transform.position, tomb.transform, i, of, 28f);
             });
+            if (matched > 0 && tomb) GatheringTell.PlaceAt(tomb.transform.position);
+        }
+
+        static void PresentWedding(string json)
+        {
+            var dest = WeddingGround();
+            int of = Mathf.Max(1, JsonArrayCount(json, "attendees"));
+            int slot = 0;
+            int matched = 0;
+            Transform face = null;
+            var plaza = GameObject.Find("PlazaPad");
+            if (plaza) face = plaza.transform;
+            ForEachArrayObject(json, "attendees", row =>
+            {
+                var id = JsonString(row, "id");
+                var guest = WorldPresence.FindGuest(id);
+                var life = guest ? guest.GetComponent<NpcLife>() : null;
+                var i = slot;
+                slot++;
+                if (!life) return;
+                matched++;
+                life.Attend(dest, face, i, of, 32f);
+            });
+            if (matched > 0) GatheringTell.PlaceAt(dest);
+        }
+
+        static Vector3 WeddingGround()
+        {
+            var tavern = BuildingPlace.Nearest(Vector3.zero, "tavern");
+            if (tavern) return tavern.door;
+            var plaza = GameObject.Find("PlazaPad");
+            if (plaza) return plaza.transform.position;
+            return Vector3.zero;
         }
 
         static void PresentMigration(string npcId, string fromWorld, string toWorld)
@@ -1183,6 +1254,18 @@ namespace Concordia
                 "{\"encounterId\":\"" + Escape(encounterId)
                 + "\",\"worldId\":\"" + Escape(worldId) + "\"}");
 
+        public Task SendDungeonHit(float damage)
+        {
+            var active = WorldBoss.Live ? (WorldBoss.Live.activeId ?? "") : "";
+            var encounter = WorldBoss.Live ? (WorldBoss.Live.encounterId ?? "") : "";
+            return SendEvt("dungeon:hit",
+                "{\"instanceId\":\"" + Escape(DungeonInstanceId)
+                + "\",\"damage\":" + damage
+                + ",\"worldId\":\"" + Escape(worldId)
+                + "\",\"activeId\":\"" + Escape(active)
+                + "\",\"encounterId\":\"" + Escape(encounter) + "\"}");
+        }
+
         public Task RequestRunStart(string kind)
         {
             if (string.IsNullOrEmpty(kind)) kind = "horde";
@@ -1251,6 +1334,16 @@ namespace Concordia
             if (i < 0) return false;
             var rest = json.Substring(i + needle.Length).TrimStart();
             return rest.StartsWith("false", StringComparison.Ordinal);
+        }
+
+        static bool JsonFlagTrue(string json, string key)
+        {
+            if (string.IsNullOrEmpty(json)) return false;
+            var needle = "\"" + key + "\":";
+            var i = json.IndexOf(needle, StringComparison.Ordinal);
+            if (i < 0) return false;
+            var rest = json.Substring(i + needle.Length).TrimStart();
+            return rest.StartsWith("true", StringComparison.Ordinal);
         }
 
         static string JsonString(string json, string key)

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
@@ -41,6 +41,9 @@ namespace Concordia
         public static int PartyCount { get; private set; } = 1;
         public static string DungeonLine { get; private set; } = "";
         public static ConcordClient Live { get; private set; }
+        string _userId = "";
+        readonly System.Collections.Concurrent.ConcurrentQueue<System.Action> _main =
+            new System.Collections.Concurrent.ConcurrentQueue<System.Action>();
 
         public string WorldId => worldId;
 
@@ -52,6 +55,21 @@ namespace Concordia
                 gameObject.name = "ConcordClient";
             Live = this;
             ApplyPageConfig();
+        }
+
+        void Update()
+        {
+            System.Action a;
+            while (_main.TryDequeue(out a))
+            {
+                try { a(); }
+                catch (Exception e) { Debug.LogWarning("Concord frame: " + e.Message); }
+            }
+        }
+
+        void RunMain(System.Action a)
+        {
+            if (a != null) _main.Enqueue(a);
         }
 
         void OnDestroy()
@@ -215,6 +233,7 @@ namespace Concordia
                 await SendEvt("kingdom:request", "{\"worldId\":\"" + Escape(worldId) + "\"}");
                 await SendEvt("room:join", "{\"room\":\"world:" + Escape(worldId) + "\"}");
                 await SendEvt("party:request", "{\"worldId\":\"" + Escape(worldId) + "\"}");
+                await SendEvt("world:snapshot", "{\"worldId\":\"" + Escape(worldId) + "\"}");
                 LastReason = "awaiting_kingdom";
                 StatusJson = "{\"ok\":false,\"reason\":\"awaiting_kingdom\"}";
 #if !(UNITY_WEBGL && !UNITY_EDITOR)
@@ -241,11 +260,111 @@ namespace Concordia
 
         void HandleFrame(string evt, string text)
         {
+            if (evt == "hello")
+            {
+                var uid = JsonString(text, "userId");
+                if (!string.IsNullOrEmpty(uid)) _userId = uid;
+                return;
+            }
             if (evt == "kingdom:data")
             {
                 ApplyKingdom(text);
                 return;
             }
+            if (evt == "scene:data")
+            {
+                RunMain(() => ApplyScene(text));
+                return;
+            }
+            if (evt == "world:snapshot")
+            {
+                RunMain(() => ApplyWorldSnapshot(text));
+                return;
+            }
+            if (evt == "world:clock")
+            {
+                var phase = JsonFloat(text, "phase", WorldClock.Hour / 24f);
+                var segment = JsonString(text, "segment");
+                RunMain(() => WorldClock.BindKernelClock(phase, segment));
+                return;
+            }
+            if (evt == "world:weather" || evt == "weather:update")
+            {
+                var w = JsonString(text, "type");
+                if (string.IsNullOrEmpty(w)) w = JsonString(text, "weather");
+                RunMain(() =>
+                {
+                    WorldClock.BindKernelWeather(w);
+                    if (!string.IsNullOrEmpty(w)) WorldClock.NoteAct("weather · " + w);
+                });
+                return;
+            }
+            if (evt == "combat:hit" || evt == "combat:impact")
+            {
+                RunMain(() => ApplyCombatFeel(text, evt == "combat:impact"));
+                return;
+            }
+            if (evt == "combat:kill")
+            {
+                var who = JsonString(text, "targetId");
+                if (string.IsNullOrEmpty(who)) who = JsonString(text, "targetName");
+                RunMain(() =>
+                {
+                    WorldClock.NoteAct(string.IsNullOrEmpty(who) ? "a death" : who + " fell");
+                    ConcordiaHUD.Announce("Fell", string.IsNullOrEmpty(who) ? "someone died" : who);
+                });
+                return;
+            }
+            if (evt == "combat:telegraph")
+            {
+                var kind = JsonString(text, "kind");
+                if (string.IsNullOrEmpty(kind)) kind = JsonString(text, "style");
+                RunMain(() => { if (!string.IsNullOrEmpty(kind)) Hostile.TelegraphKind = kind; });
+                return;
+            }
+            if (evt == "world:crisis" || evt == "world:plague-declared")
+            {
+                var kind = JsonString(text, "type");
+                if (string.IsNullOrEmpty(kind)) kind = evt == "world:plague-declared" ? "plague" : "crisis";
+                RunMain(() =>
+                {
+                    WorldClock.NoteAct("crisis · " + kind);
+                    ConcordiaHUD.Announce("Crisis", kind);
+                });
+                return;
+            }
+            if (evt == "world:crisis-resolved")
+            {
+                RunMain(() =>
+                {
+                    WorldClock.NoteAct("the crisis broke");
+                    ConcordiaHUD.Announce("Resolved", "the crisis broke");
+                });
+                return;
+            }
+            if (evt == "quest:completed" || evt == "npc:quest-completed")
+            {
+                var q = JsonString(text, "questId");
+                RunMain(() => WorldClock.NoteAct(string.IsNullOrEmpty(q) ? "a quest closed" : "quest closed · " + q));
+                return;
+            }
+            if (evt == "npc:quest-accepted")
+            {
+                RunMain(() => WorldClock.NoteAct("someone took a quest"));
+                return;
+            }
+            if (evt == "npc:level-up")
+            {
+                RunMain(() => WorldClock.NoteAct("someone grew"));
+                return;
+            }
+            if (evt == "world:npc-gather")
+            {
+                RunMain(() => WorldClock.NoteAct("a gathering"));
+                return;
+            }
+            if (evt == "lens:result")
+                return;
             if (evt == "dialogue:data")
             {
                 ApplyDialogue(text);
@@ -404,6 +523,70 @@ namespace Concordia
                 + (n == 0 ? " · The Court is the city" : " · " + n + " settlements");
         }
 
+        void ApplyWorldSnapshot(string json)
+        {
+            if (JsonFlagFalse(json, "ok")) return;
+            WorldClock.BindKernelClock(JsonFloat(json, "phase", WorldClock.Hour / 24f), JsonNestedString(json, "segment"));
+            var w = JsonNestedString(json, "type");
+            if (string.IsNullOrEmpty(w)) w = JsonString(json, "type");
+            WorldClock.BindKernelWeather(w);
+        }
+
+        void ApplyCombatFeel(string json, bool impact)
+        {
+            var target = JsonString(json, "targetId");
+            var atk = JsonString(json, "attackerId");
+            var dmg = JsonFloat(json, "damage", JsonFloat(json, "amount", 8f));
+            var player = ConcordiaPlayer.Live;
+            if (player && !string.IsNullOrEmpty(_userId) && target == _userId)
+                player.TakeHit(Mathf.Max(1f, dmg), string.IsNullOrEmpty(atk) ? "a blow" : atk);
+            else
+            {
+                var feel = player ? player.GetComponent<CombatFeel>() : null;
+                feel?.Strike(impact, true);
+            }
+            if (impact)
+                WorldClock.NoteAct("steel");
+        }
+
+        /// <summary>
+        /// Consume scene:data for live kernel buildings. Hub look stays local
+        /// (FreePacks / WorldBuilder). Empty nodes stay empty — never fabricated.
+        /// The hub portal list in enrichScene is Three.js-scale scaffold and
+        /// must not stomp the authored Ring of Doors.
+        /// </summary>
+        void ApplyScene(string json)
+        {
+            if (JsonFlagFalse(json, "ok"))
+            {
+                var reason = JsonString(json, "reason");
+                if (!string.IsNullOrEmpty(reason) && string.IsNullOrEmpty(HudLine))
+                    LastReason = reason;
+                return;
+            }
+            WorldBuilder.ClearKernelLive();
+            var n = JsonArrayCount(json, "nodes");
+            if (n <= 0) return;
+            ForEachArrayObject(json, "nodes", node =>
+            {
+                var id = JsonString(node, "id");
+                var type = JsonString(node, "type");
+                var pos = JsonVec3(node, "translation");
+                var yaw = JsonFloat(node, "rotationY", 0f);
+                var scale = JsonVec3(node, "scale");
+                var maxDim = Mathf.Max(scale.x, Mathf.Max(scale.y, scale.z));
+                WorldBuilder.PlaceKernelBuilding(id, type, pos, yaw, maxDim);
+            });
+        }
+
+        public Task LensRun(string domain, string name, string inputJson = "{}")
+        {
+            var body = "{\"domain\":\"" + Escape(domain)
+                + "\",\"name\":\"" + Escape(name)
+                + "\",\"input\":" + (string.IsNullOrEmpty(inputJson) ? "{}" : inputJson) + "}";
+            return SendEvt("lens:run", body);
+        }
+
         public Task RequestKingdom(string nextWorldId)
         {
             if (!string.IsNullOrEmpty(nextWorldId)) worldId = nextWorldId;
@@ -417,6 +600,7 @@ namespace Concordia
             await SendEvt("kingdom:request", "{\"worldId\":\"" + Escape(worldId) + "\"}");
             await SendEvt("room:join", "{\"room\":\"world:" + Escape(worldId) + "\"}");
             await SendEvt("party:request", "{\"worldId\":\"" + Escape(worldId) + "\"}");
+            await SendEvt("world:snapshot", "{\"worldId\":\"" + Escape(worldId) + "\"}");
         }
 
         public Task SendMove(float x, float y, float z, string cityId) =>
@@ -576,6 +760,54 @@ namespace Concordia
                 else if (c == '{' && depth == 1) n++;
             }
             return n;
+        }
+
+        static void ForEachArrayObject(string json, string key, System.Action<string> each)
+        {
+            if (string.IsNullOrEmpty(json) || each == null) return;
+            var needle = "\"" + key + "\":";
+            var i = json.IndexOf(needle, StringComparison.Ordinal);
+            if (i < 0) return;
+            var start = json.IndexOf('[', i + needle.Length);
+            if (start < 0) return;
+            int depth = 0, objStart = -1;
+            bool inStr = false;
+            for (int p = start; p < json.Length; p++)
+            {
+                char c = json[p];
+                if (c == '"' && (p == 0 || json[p - 1] != '\\')) inStr = !inStr;
+                if (inStr) continue;
+                if (c == '[') depth++;
+                else if (c == ']')
+                {
+                    depth--;
+                    if (depth == 0) break;
+                }
+                else if (c == '{' && depth == 1) objStart = p;
+                else if (c == '}' && depth == 1 && objStart >= 0)
+                {
+                    each(json.Substring(objStart, p - objStart + 1));
+                    objStart = -1;
+                }
+            }
+        }
+
+        static Vector3 JsonVec3(string json, string key)
+        {
+            if (string.IsNullOrEmpty(json)) return Vector3.zero;
+            var needle = "\"" + key + "\":";
+            var i = json.IndexOf(needle, StringComparison.Ordinal);
+            if (i < 0) return Vector3.zero;
+            var start = json.IndexOf('[', i + needle.Length);
+            if (start < 0) return Vector3.zero;
+            var end = json.IndexOf(']', start);
+            if (end <= start) return Vector3.zero;
+            var inner = json.Substring(start + 1, end - start - 1).Split(',');
+            float x = 0, y = 0, z = 0;
+            if (inner.Length > 0) float.TryParse(inner[0].Trim(), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out x);
+            if (inner.Length > 1) float.TryParse(inner[1].Trim(), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out y);
+            if (inner.Length > 2) float.TryParse(inner[2].Trim(), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out z);
+            return new Vector3(x, y, z);
         }
 
         static string Escape(string s) => (s ?? "").Replace("\\", "\\\\").Replace("\"", "\\\"");

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
@@ -740,6 +740,18 @@ namespace Concordia
                 RunMain(() => PresentWedding(text));
                 return;
             }
+            if (evt == "creature:born")
+            {
+                var child = JsonString(text, "childId");
+                if (string.IsNullOrEmpty(child)) child = JsonString(text, "id");
+                var gen = JsonInt(text, "generation", 0);
+                var species = JsonString(text, "speciesId");
+                var line = string.IsNullOrEmpty(species) ? "a birth" : species;
+                if (gen > 0) line += " · gen " + gen;
+                Consequence("ecology", "Born", line, true, 0f);
+                RunMain(() => PresentCreatureBorn(text));
+                return;
+            }
             if (evt == "combat:chronicle")
             {
                 var id = JsonString(text, "chronicleId");
@@ -959,6 +971,8 @@ namespace Concordia
                     JsonString(row, "title"),
                     JsonString(row, "summary"));
             });
+            PresentKernelCreatures(json);
+            PresentEcology(json);
         }
 
         static void PresentFuneral(string json, string deceasedId, string lastWords)
@@ -1004,6 +1018,86 @@ namespace Concordia
                 life.Attend(dest, face, i, of, 32f);
             });
             if (matched > 0) GatheringTell.PlaceAt(dest);
+        }
+
+        static CreatureCard CardFromJson(string json)
+        {
+            var id = JsonString(json, "childId");
+            if (string.IsNullOrEmpty(id)) id = JsonString(json, "id");
+            var x = JsonFloat(json, "x", float.NaN);
+            var z = JsonFloat(json, "z", float.NaN);
+            return new CreatureCard
+            {
+                id = id,
+                speciesId = JsonString(json, "speciesId"),
+                topology = JsonString(json, "topology"),
+                parentA = JsonString(json, "parentA"),
+                parentB = JsonString(json, "parentB"),
+                dominant = JsonString(json, "dominant"),
+                variant = JsonString(json, "variant"),
+                affinity = JsonString(json, "affinity"),
+                gaitKind = JsonString(json, "gaitKind"),
+                lifestyle = JsonString(json, "lifestyle"),
+                massKg = JsonFloat(json, "massKg", -1f),
+                heightM = JsonFloat(json, "heightM", -1f),
+                walkMps = JsonFloat(json, "walkMps", -1f),
+                stability = JsonFloat(json, "stability", -1f),
+                generation = JsonInt(json, "generation", 0),
+                predator = JsonFlagTrue(json, "predator"),
+                fly = JsonFlagTrue(json, "fly"),
+                x = x,
+                z = z,
+                hasXz = !float.IsNaN(x) && !float.IsNaN(z),
+            };
+        }
+
+        static void PresentCreatureBorn(string json)
+        {
+            var card = CardFromJson(json);
+            if (string.IsNullOrEmpty(card.id)) return;
+            var root = UnityEngine.Object.FindFirstObjectByType<WorldBuilder>();
+            var parent = root ? root.transform : null;
+            var world = Canon.Get(WorldClock.World);
+            var go = CreatureCompiler.PresentKernel(parent, card, world);
+            if (go) WorldClock.PushFeed("ecology", card.speciesId + " gen " + card.generation);
+        }
+
+        static void PresentKernelCreatures(string json)
+        {
+            var n = JsonArrayCount(json, "creatures");
+            if (n <= 0) return;
+            var root = UnityEngine.Object.FindFirstObjectByType<WorldBuilder>();
+            var parent = root ? root.transform : null;
+            var world = Canon.Get(WorldClock.World);
+            var shown = 0;
+            ForEachArrayObject(json, "creatures", row =>
+            {
+                if (shown >= 12) return;
+                var card = CardFromJson(row);
+                if (string.IsNullOrEmpty(card.id)) return;
+                if (CreatureCompiler.PresentKernel(parent, card, world)) shown++;
+            });
+        }
+
+        static void PresentEcology(string json)
+        {
+            var n = JsonArrayCount(json, "ecology");
+            if (n <= 0) return;
+            var shown = 0;
+            ForEachArrayObject(json, "ecology", row =>
+            {
+                if (shown >= 3) return;
+                var species = JsonString(row, "speciesId");
+                if (string.IsNullOrEmpty(species)) return;
+                var count = JsonInt(row, "count", 0);
+                var target = JsonInt(row, "target", 0);
+                var biome = JsonString(row, "biome");
+                var line = species + " ×" + count;
+                if (target > 0) line += "/" + target;
+                if (!string.IsNullOrEmpty(biome)) line += " · " + biome;
+                WorldClock.PushFeed("ecology", line);
+                shown++;
+            });
         }
 
         static Vector3 WeddingGround()

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
@@ -66,6 +66,7 @@ namespace Concordia
                 try { a(); }
                 catch (Exception e) { Debug.LogWarning("Concord frame: " + e.Message); }
             }
+            AdaptiveScore.Tick();
         }
 
         void RunMain(System.Action a)
@@ -336,6 +337,7 @@ namespace Concordia
                 {
                     WorldClock.NoteAct("crisis · " + kind);
                     ConcordiaHUD.Announce("Crisis", kind);
+                    AdaptiveScore.Apply("world:crisis");
                 });
                 return;
             }
@@ -345,6 +347,7 @@ namespace Concordia
                 {
                     WorldClock.NoteAct("the crisis broke");
                     ConcordiaHUD.Announce("Resolved", "the crisis broke");
+                    AdaptiveScore.Apply("world:crisis-resolved");
                 });
                 return;
             }
@@ -449,6 +452,7 @@ namespace Concordia
                 {
                     WorldClock.NoteAct("scheme closed — " + line);
                     ConcordiaHUD.Announce("Scheme", line);
+                    AdaptiveScore.Apply("npc:scheme-resolved", outcome);
                 });
                 return;
             }
@@ -521,6 +525,12 @@ namespace Concordia
                 if (!string.IsNullOrEmpty(move) && move == "RAID" && string.IsNullOrEmpty(summary))
                     line = string.IsNullOrEmpty(a) ? "a raid" : a + " raids" + (string.IsNullOrEmpty(b) ? "" : " " + b);
                 Consequence("faction", "War", line, true, 0.12f);
+                RunMain(() =>
+                {
+                    RealmFill.MarkWar(a);
+                    RealmFill.MarkWar(b);
+                    AdaptiveScore.Apply("faction:war-declared");
+                });
                 return;
             }
             if (evt == "faction:alliance-formed")
@@ -532,6 +542,7 @@ namespace Concordia
                 if (string.IsNullOrEmpty(line))
                     line = string.IsNullOrEmpty(a) ? "an alliance formed" : a + " allied" + (string.IsNullOrEmpty(b) ? "" : " with " + b);
                 Consequence("faction", "Alliance", line, true, -0.06f);
+                RunMain(() => AdaptiveScore.Apply("faction:alliance-formed"));
                 return;
             }
             if (evt == "faction:truce-sought")
@@ -571,6 +582,13 @@ namespace Concordia
                 var line = n + (n == 1 ? " soul gathered" : " souls gathered");
                 if (!string.IsNullOrEmpty(loc)) line += " · " + loc;
                 Consequence("social", "Gathering", line, true, 0f);
+                RunMain(() =>
+                {
+                    ForEachArrayObject(text, "gatherings", g =>
+                    {
+                        GatheringTell.Place(JsonFloat(g, "x", 0f), JsonFloat(g, "y", 0f), JsonFloat(g, "z", 0f));
+                    });
+                });
                 return;
             }
             if (evt == "world:boss-spawn")
@@ -619,6 +637,24 @@ namespace Concordia
                 var line = string.IsNullOrEmpty(trait) ? "someone broke" : "broke · " + trait;
                 if (!string.IsNullOrEmpty(who)) line += " · " + who;
                 Consequence("npc", "Broke", line, true, 0f);
+                RunMain(() =>
+                {
+                    var guest = WorldPresence.FindGuest(who);
+                    var life = guest ? guest.GetComponent<NpcLife>() : null;
+                    if (life) life.Cope(trait);
+                });
+                return;
+            }
+            if (evt == "npc:migrated")
+            {
+                var npcId = JsonString(text, "npcId");
+                var from = JsonString(text, "fromWorld");
+                var to = JsonString(text, "toWorld");
+                var line = string.IsNullOrEmpty(npcId) ? "someone crossed" : npcId;
+                if (!string.IsNullOrEmpty(from) && !string.IsNullOrEmpty(to))
+                    line += " · " + from + " → " + to;
+                Consequence("npc", "Migration", line, false, 0f);
+                RunMain(() => PresentMigration(npcId, from, to));
                 return;
             }
             if (evt == "combat:dodge:ack")
@@ -709,11 +745,24 @@ namespace Concordia
                 var shown = 0;
                 ForEachArrayObject(json, "gossip", row =>
                 {
-                    if (shown >= 3) return;
                     var summary = JsonString(row, "summary");
                     if (string.IsNullOrEmpty(summary)) return;
-                    WorldClock.PushFeed("gossip", summary);
-                    shown++;
+                    if (shown < 3)
+                    {
+                        WorldClock.PushFeed("gossip", summary);
+                        shown++;
+                    }
+                    var a = WorldPresence.FindGuest(JsonString(row, "npcA"));
+                    var b = WorldPresence.FindGuest(JsonString(row, "npcB"));
+                    GossipEar.Attach(a, summary);
+                    GossipEar.Attach(b, summary);
+                    if (a && b)
+                    {
+                        var la = a.GetComponent<NpcLife>();
+                        var lb = b.GetComponent<NpcLife>();
+                        if (la) la.Notice(b.transform, 3f);
+                        if (lb) lb.Notice(a.transform, 3f);
+                    }
                 });
             }
             var tombN = JsonArrayCount(json, "tombs");
@@ -722,12 +771,34 @@ namespace Concordia
                 var said = false;
                 ForEachArrayObject(json, "tombs", row =>
                 {
-                    if (said) return;
                     var last = JsonString(row, "lastWords");
+                    var npcId = JsonString(row, "npcId");
+                    KernelTomb.Place(npcId, last, JsonFloat(row, "x", 0f), JsonFloat(row, "z", 0f));
+                    if (said) return;
                     if (string.IsNullOrEmpty(last)) return;
                     WorldClock.PushFeed("lineage", "\"" + last + "\"");
                     said = true;
                 });
+            }
+        }
+
+        static void PresentMigration(string npcId, string fromWorld, string toWorld)
+        {
+            var guest = WorldPresence.FindGuest(npcId);
+            var life = guest ? guest.GetComponent<NpcLife>() : null;
+            if (!life) return;
+            var here = WorldBook.Folder(WorldClock.World);
+            if (toWorld == here)
+            {
+                life.HeadFor(Canon.Spawn);
+                return;
+            }
+            var gate = WorldPresence.GateToward(toWorld);
+            if (gate) life.HeadFor(gate.transform.position);
+            else if (fromWorld == here)
+            {
+                gate = WorldPresence.GateToward(fromWorld);
+                if (gate) life.HeadFor(gate.transform.position);
             }
         }
 
@@ -1142,5 +1213,115 @@ namespace Concordia
         [DllImport("__Internal")] static extern void ConcordWsClose();
         [DllImport("__Internal")] static extern string ConcordReadConfig(string key);
 #endif
+    }
+
+    /// <summary>
+    /// Port of concord-frontend/lib/concordia/adaptive-score.ts scoreDirectivesFor.
+    /// Same numbers. Drives the existing DressAudio sources — not a second SM.
+    /// </summary>
+    public static class AdaptiveScore
+    {
+        public struct Dir
+        {
+            public string action, mode;
+            public float intensity, holdMs;
+        }
+
+        static float _combat;
+        static float _modeUntil;
+        static string _mode = "neutral";
+        static readonly Dictionary<int, float> _vol0 = new Dictionary<int, float>();
+
+        public static Dir[] For(string eventName, string outcome = "")
+        {
+            switch (eventName)
+            {
+                case "faction:war-declared":
+                    return new[] { Intensity(0.85f), Mode("minor", 12000f) };
+                case "world:crisis":
+                    return new[] { Intensity(0.7f), Mode("minor", 15000f) };
+                case "refusal:compound-threshold":
+                    return new[] { Mode("minor", 20000f) };
+                case "world:crisis-resolved":
+                case "faction:alliance-formed":
+                    return new[] { Intensity(0f), Mode("major", 8000f) };
+                case "kingdom:founded":
+                    return new[] { Mode("major", 6000f) };
+                case "kingdom:fallen":
+                    return new[] { Mode("minor", 10000f) };
+                case "npc:scheme-resolved":
+                    {
+                        var o = outcome ?? "";
+                        var foiled = o == "exposed" || o == "abandoned" || o == "failed";
+                        return new[] { Mode(foiled ? "major" : "minor", 3500f) };
+                    }
+                default:
+                    return Array.Empty<Dir>();
+            }
+        }
+
+        static Dir Intensity(float v) => new Dir { action = "setMusicCombatIntensity", intensity = v };
+        static Dir Mode(string m, float hold) => new Dir { action = "setMusicMode", mode = m, holdMs = hold };
+
+        public static void Apply(string eventName, string outcome = "")
+        {
+            var ds = For(eventName, outcome);
+            foreach (var d in ds)
+            {
+                if (d.action == "setMusicCombatIntensity") _combat = d.intensity;
+                if (d.action == "setMusicMode")
+                {
+                    _mode = d.mode;
+                    _modeUntil = Time.unscaledTime + d.holdMs / 1000f;
+                }
+            }
+            Mix();
+        }
+
+        public static void Tick()
+        {
+            if (_mode == "neutral" && _combat <= 0.01f) return;
+            if (_mode != "neutral" && Time.unscaledTime > _modeUntil)
+                _mode = "neutral";
+            if (_mode == "neutral")
+                _combat = Mathf.MoveTowards(_combat, 0f, Time.unscaledDeltaTime * 0.35f);
+            Mix();
+        }
+
+        static void Mix()
+        {
+            var srcs = Object.FindObjectsByType<AudioSource>(FindObjectsInactive.Exclude);
+            foreach (var s in srcs)
+            {
+                if (!s) continue;
+                var n = s.gameObject.name ?? "";
+                bool eth = n.IndexOf("Ethereal", StringComparison.OrdinalIgnoreCase) >= 0;
+                bool sus = n.IndexOf("Suspenseful", StringComparison.OrdinalIgnoreCase) >= 0;
+                bool act = n.IndexOf("Action", StringComparison.OrdinalIgnoreCase) >= 0;
+                if (!eth && !sus && !act) continue;
+                int id = s.GetInstanceID();
+                if (!_vol0.ContainsKey(id)) _vol0[id] = s.volume;
+                float v0 = _vol0[id];
+                float vol = v0;
+                float pitch = 1f;
+                if (_mode == "minor")
+                {
+                    pitch = 0.94f;
+                    if (eth) vol = v0 * 0.45f;
+                    if (sus) vol = Mathf.Max(v0, 0.55f);
+                    if (act) vol = Mathf.Lerp(v0, 0.7f, _combat);
+                }
+                else if (_mode == "major")
+                {
+                    pitch = 1.04f;
+                    if (eth) vol = Mathf.Max(v0, 0.5f);
+                    if (sus) vol = v0 * 0.4f;
+                }
+                if (_combat > 0.01f && (sus || act))
+                    vol = Mathf.Lerp(vol, Mathf.Max(vol, _combat), 0.8f);
+                s.volume = Mathf.Clamp01(vol);
+                s.pitch = pitch;
+            }
+        }
     }
 }

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
@@ -234,6 +234,7 @@ namespace Concordia
                 await SendEvt("room:join", "{\"room\":\"world:" + Escape(worldId) + "\"}");
                 await SendEvt("party:request", "{\"worldId\":\"" + Escape(worldId) + "\"}");
                 await SendEvt("world:snapshot", "{\"worldId\":\"" + Escape(worldId) + "\"}");
+                await LensRun("skills", "mastery");
                 LastReason = "awaiting_kingdom";
                 StatusJson = "{\"ok\":false,\"reason\":\"awaiting_kingdom\"}";
 #if !(UNITY_WEBGL && !UNITY_EDITOR)
@@ -256,6 +257,7 @@ namespace Concordia
             PartyLine = "PARTY  ·  you";
             PartyCount = 1;
             DungeonLine = "";
+            SkillLattice.Reset();
         }
 
         void HandleFrame(string evt, string text)
@@ -364,7 +366,10 @@ namespace Concordia
                 return;
             }
             if (evt == "lens:result")
+            {
+                RunMain(() => ApplyLensResult(text));
                 return;
+            }
             if (evt == "dialogue:data")
             {
                 ApplyDialogue(text);
@@ -537,15 +542,20 @@ namespace Concordia
             var target = JsonString(json, "targetId");
             var atk = JsonString(json, "attackerId");
             var dmg = JsonFloat(json, "damage", JsonFloat(json, "amount", 8f));
+            var skillKey = JsonString(json, "skillKey");
+            if (string.IsNullOrEmpty(skillKey)) skillKey = JsonString(json, "skillId");
             var player = ConcordiaPlayer.Live;
+            var kick = SkillLattice.KickMul(skillKey);
             if (player && !string.IsNullOrEmpty(_userId) && target == _userId)
                 player.TakeHit(Mathf.Max(1f, dmg), string.IsNullOrEmpty(atk) ? "a blow" : atk);
             else
             {
                 var feel = player ? player.GetComponent<CombatFeel>() : null;
-                feel?.Strike(impact, true);
+                feel?.Strike(impact, true, kick);
             }
-            if (impact)
+            if (!string.IsNullOrEmpty(skillKey))
+                WorldClock.NoteAct(skillKey + (impact ? " · impact" : " · steel"));
+            else if (impact)
                 WorldClock.NoteAct("steel");
         }
 
@@ -579,6 +589,39 @@ namespace Concordia
             });
         }
 
+        void ApplyLensResult(string json)
+        {
+            if (JsonFlagFalse(json, "ok")) return;
+            var lensName = JsonString(json, "lensName");
+            var catalogCount = JsonInt(json, "catalogCount", 0);
+            if (lensName != "mastery" && catalogCount <= 0) return;
+            SkillLattice.Reset();
+            ForEachArrayObject(json, "groups", groupJson =>
+            {
+                var group = JsonString(groupJson, "group");
+                ForEachArrayObject(groupJson, "skills", skillJson =>
+                {
+                    SkillLattice.Add(new SkillLattice.Row
+                    {
+                        skillType = JsonString(skillJson, "skillType"),
+                        group = string.IsNullOrEmpty(JsonString(skillJson, "group")) ? group : JsonString(skillJson, "group"),
+                        tier = JsonString(skillJson, "tier"),
+                        element = JsonNestedString(skillJson, "element"),
+                        preset = JsonString(skillJson, "preset"),
+                        level = JsonInt(skillJson, "level", 0),
+                        cameraKickPx = JsonInt(skillJson, "cameraKickPx", 0),
+                        potency = JsonFloat(skillJson, "potency", 1f),
+                        glow = JsonFloat(skillJson, "glow", 0.4f),
+                        finisher = skillJson.IndexOf("\"finisherFlourish\":true", System.StringComparison.Ordinal) >= 0
+                            || skillJson.IndexOf("\"finisherUnlocked\":true", System.StringComparison.Ordinal) >= 0,
+                    });
+                });
+            });
+            SkillLattice.Bind(catalogCount, JsonInt(json, "trainedCount", 0));
+            if (SkillLattice.FromKernel)
+                WorldClock.NoteAct(SkillLattice.CatalogCount + " skills · kernel");
+        }
+
         public Task LensRun(string domain, string name, string inputJson = "{}")
         {
             var body = "{\"domain\":\"" + Escape(domain)
@@ -601,13 +644,23 @@ namespace Concordia
             await SendEvt("room:join", "{\"room\":\"world:" + Escape(worldId) + "\"}");
             await SendEvt("party:request", "{\"worldId\":\"" + Escape(worldId) + "\"}");
             await SendEvt("world:snapshot", "{\"worldId\":\"" + Escape(worldId) + "\"}");
+            await LensRun("skills", "mastery");
         }
 
         public Task SendMove(float x, float y, float z, string cityId) =>
             SendEvt("player:move", "{\"cityId\":\"" + Escape(cityId) + "\",\"x\":" + x + ",\"y\":" + y + ",\"z\":" + z + ",\"direction\":0}");
 
-        public Task SendAttack(string targetId, float baseDamage = 20, float range = 5, string weapon = "sword") =>
-            SendEvt("combat:attack", "{\"targetId\":\"" + Escape(targetId) + "\",\"baseDamage\":" + baseDamage + ",\"range\":" + range + ",\"weapon\":\"" + Escape(weapon) + "\"}");
+        public Task SendAttack(string targetId, float baseDamage = 20, float range = 5, string weapon = "sword", string skillId = null)
+        {
+            if (string.IsNullOrEmpty(skillId)) skillId = SkillLattice.ActiveSkill;
+            if (string.IsNullOrEmpty(skillId)) skillId = "swords";
+            return SendEvt("combat:attack",
+                "{\"targetId\":\"" + Escape(targetId)
+                + "\",\"baseDamage\":" + baseDamage
+                + ",\"range\":" + range
+                + ",\"weapon\":\"" + Escape(weapon)
+                + "\",\"skillId\":\"" + Escape(skillId) + "\"}");
+        }
 
         public Task SendDodge(bool parry = false) =>
             SendEvt("combat:dodge", "{\"wasParry\":" + (parry ? "true" : "false") + "}");

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
@@ -243,6 +243,41 @@ namespace Concordia
                 ApplyDialogue(text);
                 return;
             }
+            if (evt == "npc:heir-rose")
+            {
+                var heir = JsonString(text, "heirName");
+                if (string.IsNullOrEmpty(heir)) heir = JsonString(text, "heir_name");
+                var from = JsonString(text, "deceasedName");
+                if (string.IsNullOrEmpty(from)) from = JsonString(text, "deceased_name");
+                var line = string.IsNullOrEmpty(heir) ? "an heir rose" : heir + " inherited";
+                if (!string.IsNullOrEmpty(from)) line += " from " + from;
+                WorldClock.NoteAct(line);
+                ConcordiaHUD.Announce("Heir rose", line);
+                return;
+            }
+            if (evt == "secret:weaponised")
+            {
+                var kind = JsonString(text, "kind");
+                if (string.IsNullOrEmpty(kind)) kind = "leverage";
+                WorldClock.NoteAct("a secret turned — " + kind);
+                return;
+            }
+            if (evt == "npc:scheme-resolved" || evt == "npc:conversation-bid")
+            {
+                var plotter = JsonString(text, "plotterName");
+                if (string.IsNullOrEmpty(plotter)) plotter = JsonString(text, "plotter");
+                var target = JsonString(text, "targetName");
+                if (string.IsNullOrEmpty(target)) target = JsonString(text, "target");
+                var kind = JsonString(text, "kind");
+                if (string.IsNullOrEmpty(kind)) kind = "scheme";
+                var line = kind;
+                if (!string.IsNullOrEmpty(plotter) && !string.IsNullOrEmpty(target))
+                    line = plotter + " ↔ " + target + ": " + kind;
+                else if (!string.IsNullOrEmpty(plotter))
+                    line = plotter + " · " + kind;
+                WorldClock.NoteAct("scheme nearby — " + line);
+                return;
+            }
             if (evt == "auth:error" || (evt == "error" && text.Contains("auth_required")))
                 MarkDisconnected();
         }

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
@@ -40,6 +40,8 @@ namespace Concordia
         public static string PartyLine { get; private set; } = "PARTY  ·  you";
         public static int PartyCount { get; private set; } = 1;
         public static string DungeonLine { get; private set; } = "";
+        public static bool HoldLocked { get; private set; }
+        public static string HoldLockReason { get; private set; } = "";
         public static string RunLine { get; private set; } = "";
         public static ConcordClient Live { get; private set; }
         string _userId = "";
@@ -259,6 +261,8 @@ namespace Concordia
             PartyLine = "PARTY  ·  you";
             PartyCount = 1;
             DungeonLine = "";
+            HoldLocked = false;
+            HoldLockReason = "";
             RunLine = "";
             SkillLattice.Reset();
         }
@@ -500,12 +504,31 @@ namespace Concordia
             }
             if (evt == "dungeon:data")
             {
+                if (JsonFlagFalse(text, "ok"))
+                {
+                    var reason = JsonString(text, "reason");
+                    if (string.IsNullOrEmpty(reason)) reason = "hold refused";
+                    HoldLocked = reason == "locked_out";
+                    HoldLockReason = reason;
+                    DungeonLine = reason;
+                    ConcordiaHUD.Announce(reason == "locked_out" ? "Lockout" : "Hold refused", reason);
+                    if (reason == "locked_out")
+                        RunMain(() => DungeonGate.EjectIfInside());
+                    return;
+                }
+                HoldLocked = false;
+                HoldLockReason = "";
                 var name = JsonNestedString(text, "name");
                 if (string.IsNullOrEmpty(name)) name = JsonString(text, "name");
                 var phase = JsonString(text, "phase");
+                var mechanic = JsonString(text, "mechanic");
                 if (string.IsNullOrEmpty(name)) name = "the hold";
                 DungeonLine = name + (string.IsNullOrEmpty(phase) ? "" : " · " + phase);
+                if (!string.IsNullOrEmpty(mechanic)) DungeonLine += " · " + mechanic;
                 ConcordiaHUD.Announce(name, string.IsNullOrEmpty(phase) ? "the hold opened" : phase);
+                var hp = JsonFloat(text, "hp", -1f);
+                var maxHp = JsonFloat(text, "maxHp", 1f);
+                RunMain(() => WorldBoss.BindState(name, hp, maxHp, phase, mechanic));
                 return;
             }
             if (evt == "run:data")
@@ -597,6 +620,7 @@ namespace Concordia
                 if (string.IsNullOrEmpty(boss)) boss = JsonString(text, "activeId");
                 var line = string.IsNullOrEmpty(boss) ? "a world boss opened" : boss + " walks";
                 Consequence("crisis", "World boss", line, true, 0.08f);
+                RunMain(() => WorldBoss.Present(boss, JsonString(text, "activeId")));
                 return;
             }
             if (evt == "world:season-transition")
@@ -628,6 +652,19 @@ namespace Concordia
                 if (trades > 0) line += (crafts > 0 ? ", " : "") + trades + " traded";
                 if (notable > 0 && crafts <= 0 && trades <= 0) line += notable + " notable";
                 Consequence("economy", "Market", line, false, 0f);
+                if (crafts > 0)
+                {
+                    var label = "";
+                    ForEachArrayObject(text, "notable", row =>
+                    {
+                        if (!string.IsNullOrEmpty(label)) return;
+                        if (JsonString(row, "kind") != "craft") return;
+                        label = JsonString(row, "outcome");
+                        if (string.IsNullOrEmpty(label)) label = JsonString(row, "actorId");
+                    });
+                    var stamp = label;
+                    RunMain(() => CraftedTell.PlaceAtStation(stamp));
+                }
                 return;
             }
             if (evt == "npc:stress-break")
@@ -655,6 +692,89 @@ namespace Concordia
                     line += " · " + from + " → " + to;
                 Consequence("npc", "Migration", line, false, 0f);
                 RunMain(() => PresentMigration(npcId, from, to));
+                return;
+            }
+            if (evt == "npc:funeral")
+            {
+                var deceased = JsonString(text, "deceasedId");
+                var last = JsonString(text, "lastWords");
+                var n = JsonArrayCount(text, "attendees");
+                var line = string.IsNullOrEmpty(last) ? "a funeral" : last;
+                if (n > 0) line += " · " + n + (n == 1 ? " mourner" : " mourners");
+                Consequence("lineage", "Funeral", line, true, 0f);
+                RunMain(() => PresentFuneral(text, deceased, last));
+                return;
+            }
+            if (evt == "combat:chronicle")
+            {
+                var id = JsonString(text, "chronicleId");
+                if (string.IsNullOrEmpty(id)) return;
+                var title = JsonString(text, "title");
+                var summary = JsonString(text, "summary");
+                var line = string.IsNullOrEmpty(title) ? summary : title;
+                if (string.IsNullOrEmpty(line)) line = "a bout was recorded";
+                Consequence("combat", "Chronicle", line, false, 0f);
+                RunMain(() => ChroniclePlaque.Place(id, title, summary));
+                return;
+            }
+            if (evt == "boss:state")
+            {
+                var name = JsonString(text, "name");
+                if (string.IsNullOrEmpty(name)) name = JsonString(text, "npcName");
+                var phase = JsonString(text, "phase");
+                var mechanic = JsonString(text, "mechanic");
+                var hp = JsonFloat(text, "currentHp", JsonFloat(text, "hp", -1f));
+                var maxHp = JsonFloat(text, "maxHp", 1f);
+                RunMain(() => WorldBoss.BindState(name, hp, maxHp, phase, mechanic));
+                return;
+            }
+            if (evt == "boss:phase-enter")
+            {
+                var name = JsonString(text, "npcName");
+                var phase = JsonString(text, "phase");
+                var line = string.IsNullOrEmpty(name) ? "phase" : name;
+                if (!string.IsNullOrEmpty(phase)) line += " · " + phase;
+                Consequence("crisis", "Phase", line, true, 0.04f);
+                return;
+            }
+            if (evt == "kingdom:decree-enacted")
+            {
+                var kind = JsonString(text, "decreeKind");
+                var line = string.IsNullOrEmpty(kind) ? "a decree enacted" : kind;
+                Consequence("kingdom", "Decree", line, true, 0f);
+                return;
+            }
+            if (evt == "kingdom:fallen")
+            {
+                var outcome = JsonString(text, "outcome");
+                Consequence("kingdom", "Fallen", string.IsNullOrEmpty(outcome) ? "a kingdom fell" : outcome, true, 0.08f);
+                return;
+            }
+            if (evt == "kingdom:contested")
+            {
+                var kind = JsonString(text, "contestKind");
+                Consequence("kingdom", "Contested", string.IsNullOrEmpty(kind) ? "a throne contested" : kind, true, 0.04f);
+                return;
+            }
+            if (evt == "dream:composed")
+            {
+                var n = JsonInt(text, "fragmentCount", 0);
+                Consequence("dream", "Dream", n > 0 ? n + " fragments composed" : "a dream composed", false, 0f);
+                return;
+            }
+            if (evt == "prediction:realised")
+            {
+                var outcome = JsonString(text, "outcome");
+                Consequence("foresight", "Prediction", string.IsNullOrEmpty(outcome) ? "a prediction realised" : outcome, false, 0f);
+                return;
+            }
+            if (evt == "world:refusal-field")
+            {
+                var kind = JsonString(text, "kind");
+                var strength = JsonFloat(text, "strength", 0f);
+                var line = string.IsNullOrEmpty(kind) ? "the field thickened" : kind;
+                if (strength > 0f) line += " · " + strength.ToString("0.#");
+                Consequence("refusal", "Field", line, true, 0f);
                 return;
             }
             if (evt == "combat:dodge:ack")
@@ -780,6 +900,48 @@ namespace Concordia
                     said = true;
                 });
             }
+            ForEachArrayObject(json, "bosses", row =>
+            {
+                WorldBoss.Present(JsonString(row, "bossTemplate"), JsonString(row, "activeId"));
+            });
+            ForEachArrayObject(json, "gear", row =>
+            {
+                var name = JsonString(row, "name");
+                var id = JsonString(row, "id");
+                if (string.IsNullOrEmpty(id) && string.IsNullOrEmpty(name)) return;
+                var labels = new System.Collections.Generic.List<string>();
+                ForEachArrayObject(row, "affixes", a =>
+                {
+                    var lab = JsonString(a, "label");
+                    if (!string.IsNullOrEmpty(lab)) labels.Add(lab);
+                });
+                KitBag.BindKernel(id, name, string.Join(" ", labels));
+            });
+            ForEachArrayObject(json, "chronicles", row =>
+            {
+                ChroniclePlaque.Place(
+                    JsonString(row, "id"),
+                    JsonString(row, "title"),
+                    JsonString(row, "summary"));
+            });
+        }
+
+        static void PresentFuneral(string json, string deceasedId, string lastWords)
+        {
+            var tomb = KernelTomb.Place(deceasedId, lastWords,
+                JsonFloat(json, "tombX", 0f), JsonFloat(json, "tombZ", 0f));
+            ForEachArrayObject(json, "attendees", row =>
+            {
+                var id = JsonString(row, "id");
+                var guest = WorldPresence.FindGuest(id);
+                var life = guest ? guest.GetComponent<NpcLife>() : null;
+                if (!life) return;
+                if (tomb)
+                {
+                    life.HeadFor(tomb.transform.position, 14f);
+                    life.Notice(tomb.transform, 8f);
+                }
+            });
         }
 
         static void PresentMigration(string npcId, string fromWorld, string toWorld)

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
@@ -1230,7 +1230,7 @@ namespace Concordia
         static float _combat;
         static float _modeUntil;
         static string _mode = "neutral";
-        static readonly Dictionary<int, float> _vol0 = new Dictionary<int, float>();
+        static readonly Dictionary<string, float> _vol0 = new Dictionary<string, float>();
 
         public static Dir[] For(string eventName, string outcome = "")
         {
@@ -1290,7 +1290,7 @@ namespace Concordia
 
         static void Mix()
         {
-            var srcs = Object.FindObjectsByType<AudioSource>(FindObjectsInactive.Exclude);
+            var srcs = UnityEngine.Object.FindObjectsByType<AudioSource>(FindObjectsInactive.Exclude);
             foreach (var s in srcs)
             {
                 if (!s) continue;
@@ -1299,9 +1299,8 @@ namespace Concordia
                 bool sus = n.IndexOf("Suspenseful", StringComparison.OrdinalIgnoreCase) >= 0;
                 bool act = n.IndexOf("Action", StringComparison.OrdinalIgnoreCase) >= 0;
                 if (!eth && !sus && !act) continue;
-                int id = s.GetInstanceID();
-                if (!_vol0.ContainsKey(id)) _vol0[id] = s.volume;
-                float v0 = _vol0[id];
+                if (!_vol0.ContainsKey(n)) _vol0[n] = s.volume;
+                float v0 = _vol0[n];
                 float vol = v0;
                 float pitch = 1f;
                 if (_mode == "minor")

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
@@ -40,6 +40,7 @@ namespace Concordia
         public static string PartyLine { get; private set; } = "PARTY  ·  you";
         public static int PartyCount { get; private set; } = 1;
         public static string DungeonLine { get; private set; } = "";
+        public static string RunLine { get; private set; } = "";
         public static ConcordClient Live { get; private set; }
         string _userId = "";
         readonly System.Collections.Concurrent.ConcurrentQueue<System.Action> _main =
@@ -257,6 +258,7 @@ namespace Concordia
             PartyLine = "PARTY  ·  you";
             PartyCount = 1;
             DungeonLine = "";
+            RunLine = "";
             SkillLattice.Reset();
         }
 
@@ -453,6 +455,11 @@ namespace Concordia
                 ConcordiaHUD.Announce(name, string.IsNullOrEmpty(phase) ? "the hold opened" : phase);
                 return;
             }
+            if (evt == "run:data")
+            {
+                RunMain(() => ApplyRun(text));
+                return;
+            }
             if (evt == "combat:dodge:ack")
                 return;
             if (evt == "auth:error" || (evt == "error" && text.Contains("auth_required")))
@@ -551,7 +558,7 @@ namespace Concordia
             else
             {
                 var feel = player ? player.GetComponent<CombatFeel>() : null;
-                feel?.Strike(impact, true, kick);
+                feel?.Strike(impact, true, kick, skillKey);
             }
             if (!string.IsNullOrEmpty(skillKey))
                 WorldClock.NoteAct(skillKey + (impact ? " · impact" : " · steel"));
@@ -622,6 +629,32 @@ namespace Concordia
                 WorldClock.NoteAct(SkillLattice.CatalogCount + " skills · kernel");
         }
 
+        void ApplyRun(string json)
+        {
+            if (JsonFlagFalse(json, "ok"))
+            {
+                var reason = JsonString(json, "reason");
+                if (string.IsNullOrEmpty(reason)) reason = JsonString(json, "error");
+                RunLine = "";
+                WorldClock.NoteAct(string.IsNullOrEmpty(reason) ? "run refused" : "run · " + reason);
+                ConcordiaHUD.Announce("Run refused", string.IsNullOrEmpty(reason) ? "no_db" : reason);
+                return;
+            }
+            var kind = JsonString(json, "kind");
+            if (string.IsNullOrEmpty(kind)) kind = "run";
+            var n = JsonArrayCount(json, "roster");
+            if (n <= 0) n = JsonInt(json, "count", 1);
+            var joined = json.IndexOf("\"joined\":true", System.StringComparison.Ordinal) >= 0;
+            var wave = JsonInt(json, "wave", 0);
+            var line = kind.ToUpperInvariant();
+            if (joined) line += "  ·  joined";
+            if (wave > 0) line += "  ·  wave " + wave;
+            line += n <= 1 ? "  ·  you" : "  ·  " + n + " in the run";
+            RunLine = line;
+            WorldClock.NoteAct(line);
+            ConcordiaHUD.Announce(kind, joined ? "joined the party run" : "run opened");
+        }
+
         public Task LensRun(string domain, string name, string inputJson = "{}")
         {
             var body = "{\"domain\":\"" + Escape(domain)
@@ -685,6 +718,13 @@ namespace Concordia
             SendEvt("dungeon:open",
                 "{\"encounterId\":\"" + Escape(encounterId)
                 + "\",\"worldId\":\"" + Escape(worldId) + "\"}");
+
+        public Task RequestRunStart(string kind)
+        {
+            if (string.IsNullOrEmpty(kind)) kind = "horde";
+            return SendEvt("run:start",
+                "{\"kind\":\"" + Escape(kind) + "\",\"worldId\":\"" + Escape(worldId) + "\"}");
+        }
 
         async Task SendEvt(string evt, string dataJson)
         {

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
@@ -321,9 +321,11 @@ namespace Concordia
             }
             if (evt == "combat:telegraph")
             {
-                var kind = JsonString(text, "kind");
-                if (string.IsNullOrEmpty(kind)) kind = JsonString(text, "style");
-                RunMain(() => { if (!string.IsNullOrEmpty(kind)) Hostile.TelegraphKind = kind; });
+                var kind = JsonString(text, "perilKind");
+                if (string.IsNullOrEmpty(kind)) kind = JsonString(text, "kind");
+                var counter = JsonString(text, "counter");
+                var ms = JsonFloat(text, "anticipationMs", 400f);
+                RunMain(() => Hostile.BindKernel(kind, counter, ms / 1000f));
                 return;
             }
             if (evt == "world:crisis" || evt == "world:plague-declared")
@@ -385,18 +387,43 @@ namespace Concordia
                 if (string.IsNullOrEmpty(from)) from = JsonString(text, "deceased_name");
                 var line = string.IsNullOrEmpty(heir) ? "an heir rose" : heir + " inherited";
                 if (!string.IsNullOrEmpty(from)) line += " from " + from;
-                WorldClock.NoteAct(line);
-                ConcordiaHUD.Announce("Heir rose", line);
+                RunMain(() =>
+                {
+                    WorldClock.NoteAct(line);
+                    ConcordiaHUD.Announce("Heir rose", line);
+                });
                 return;
             }
             if (evt == "secret:weaponised")
             {
                 var kind = JsonString(text, "kind");
                 if (string.IsNullOrEmpty(kind)) kind = "leverage";
-                WorldClock.NoteAct("a secret turned — " + kind);
+                var schemeId = JsonString(text, "schemeId");
+                var line = "a secret turned — " + kind;
+                RunMain(() =>
+                {
+                    WorldClock.NoteAct(line);
+                    ConcordiaHUD.Announce("Betrayal", line);
+                    if (!string.IsNullOrEmpty(schemeId)) Plots.Seed(line, schemeId);
+                });
                 return;
             }
-            if (evt == "npc:scheme-resolved" || evt == "npc:conversation-bid")
+            if (evt == "scheme:overheard")
+            {
+                var snippet = JsonString(text, "snippet");
+                var schemeId = JsonString(text, "schemeId");
+                var kind = JsonString(text, "schemeKind");
+                var line = snippet;
+                if (string.IsNullOrEmpty(line)) line = string.IsNullOrEmpty(kind) ? "a plot in the air" : kind;
+                RunMain(() =>
+                {
+                    Plots.Seed(line, schemeId);
+                    WorldClock.NoteAct("overheard — " + line);
+                    ConcordiaHUD.Announce("Overheard", line);
+                });
+                return;
+            }
+            if (evt == "npc:scheme-resolved")
             {
                 var plotter = JsonString(text, "plotterName");
                 if (string.IsNullOrEmpty(plotter)) plotter = JsonString(text, "plotter");
@@ -404,13 +431,23 @@ namespace Concordia
                 if (string.IsNullOrEmpty(target)) target = JsonString(text, "target");
                 var kind = JsonString(text, "kind");
                 if (string.IsNullOrEmpty(kind)) kind = "scheme";
+                var outcome = JsonString(text, "outcome");
                 var line = kind;
                 if (!string.IsNullOrEmpty(plotter) && !string.IsNullOrEmpty(target))
                     line = plotter + " ↔ " + target + ": " + kind;
                 else if (!string.IsNullOrEmpty(plotter))
                     line = plotter + " · " + kind;
-                WorldClock.NoteAct("scheme nearby — " + line);
-                Plots.Seed(line);
+                if (!string.IsNullOrEmpty(outcome)) line += " · " + outcome;
+                RunMain(() =>
+                {
+                    WorldClock.NoteAct("scheme closed — " + line);
+                    ConcordiaHUD.Announce("Scheme", line);
+                });
+                return;
+            }
+            if (evt == "npc:conversation-bid")
+            {
+                RunMain(() => WorldClock.NoteAct("voices nearby"));
                 return;
             }
             if (evt == "gift:result")
@@ -425,8 +462,19 @@ namespace Concordia
             }
             if (evt == "scheme:intervened")
             {
-                if (!JsonFlagFalse(text, "ok"))
+                RunMain(() =>
+                {
+                    if (JsonFlagFalse(text, "ok"))
+                    {
+                        var reason = JsonString(text, "reason");
+                        if (string.IsNullOrEmpty(reason)) reason = "the plot did not take";
+                        WorldClock.NoteAct(reason);
+                        ConcordiaHUD.Announce("Plot missed", reason);
+                        return;
+                    }
+                    Plots.ResolveKernel(JsonString(text, "action"));
                     WorldClock.NoteAct("the kernel named the plot");
+                });
                 return;
             }
             if (evt == "party:data")
@@ -436,13 +484,7 @@ namespace Concordia
             }
             if (evt == "inheritance:data")
             {
-                var heir = JsonString(text, "heirName");
-                if (string.IsNullOrEmpty(heir)) heir = JsonString(text, "heir_name");
-                if (!string.IsNullOrEmpty(heir))
-                {
-                    WorldClock.NoteAct(heir + " carries the thread");
-                    ConcordiaHUD.Announce("Heir rose", heir + " inherited");
-                }
+                RunMain(() => ApplyInheritance(text));
                 return;
             }
             if (evt == "dungeon:data")
@@ -551,19 +593,47 @@ namespace Concordia
             var dmg = JsonFloat(json, "damage", JsonFloat(json, "amount", 8f));
             var skillKey = JsonString(json, "skillKey");
             if (string.IsNullOrEmpty(skillKey)) skillKey = JsonString(json, "skillId");
+            var mom = JsonFloat(json, "impactMomentum", 0f);
+            if (mom <= 0f) mom = JsonFloat(json, "knockback", 0f);
+            var kb = mom > 0f ? Mathf.Clamp(mom * 0.12f, 0.05f, 2.4f) : -1f;
             var player = ConcordiaPlayer.Live;
             var kick = SkillLattice.KickMul(skillKey);
+            var feel = player ? player.GetComponent<CombatFeel>() : null;
             if (player && !string.IsNullOrEmpty(_userId) && target == _userId)
-                player.TakeHit(Mathf.Max(1f, dmg), string.IsNullOrEmpty(atk) ? "a blow" : atk);
+                player.TakeHit(Mathf.Max(1f, dmg), string.IsNullOrEmpty(atk) ? "a blow" : atk, kb);
             else
             {
-                var feel = player ? player.GetComponent<CombatFeel>() : null;
                 feel?.Strike(impact, true, kick, skillKey);
+                if (impact && feel && kb > 0f) feel.ApplyAck(true, kb, false, false);
             }
             if (!string.IsNullOrEmpty(skillKey))
                 WorldClock.NoteAct(skillKey + (impact ? " · impact" : " · steel"));
             else if (impact)
                 WorldClock.NoteAct("steel");
+        }
+
+        void ApplyInheritance(string json)
+        {
+            if (JsonFlagFalse(json, "ok"))
+            {
+                var reason = JsonString(json, "reason");
+                if (!string.IsNullOrEmpty(reason)) WorldClock.NoteAct(reason);
+                return;
+            }
+            var heir = JsonString(json, "heirName");
+            if (string.IsNullOrEmpty(heir)) heir = JsonString(json, "heir_name");
+            var n = JsonArrayCount(json, "links");
+            var kinds = new System.Collections.Generic.List<string>();
+            ForEachArrayObject(json, "links", link =>
+            {
+                var k = JsonString(link, "inherited_kind");
+                if (!string.IsNullOrEmpty(k) && !kinds.Contains(k)) kinds.Add(k);
+            });
+            var line = string.IsNullOrEmpty(heir) ? "the thread holds" : heir + " carries the thread";
+            if (kinds.Count > 0) line += " · " + string.Join(", ", kinds);
+            else if (n <= 0) line += " · nothing passed";
+            WorldClock.NoteAct(line);
+            ConcordiaHUD.Announce("Heir rose", line);
         }
 
         /// <summary>
@@ -695,8 +765,13 @@ namespace Concordia
                 + "\",\"skillId\":\"" + Escape(skillId) + "\"}");
         }
 
-        public Task SendDodge(bool parry = false) =>
-            SendEvt("combat:dodge", "{\"wasParry\":" + (parry ? "true" : "false") + "}");
+        public Task SendDodge(bool parry = false, string action = null)
+        {
+            if (string.IsNullOrEmpty(action)) action = parry ? "parry" : "dodge";
+            return SendEvt("combat:dodge",
+                "{\"wasParry\":" + (parry ? "true" : "false")
+                + ",\"action\":\"" + Escape(action) + "\"}");
+        }
 
         public Task SendGift(string npcId, string itemId, string itemName, string archetype) =>
             SendEvt("gift:give",

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaGame.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaGame.cs
@@ -305,7 +305,6 @@ namespace Concordia
                     var d = Vector3.Distance(pos, t.transform.position);
                     if (d < best) { best = d; tomb = t; gate = null; city = null; stone = null; npc = null; board = null; hold = null; loot = null; cook = null; }
                 }
-                }
             if (gate != null)
             {
                 Travel(gate.def.world);

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaGame.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaGame.cs
@@ -336,6 +336,10 @@ namespace Concordia
                     line += "\n" + extra;
                 if (!string.IsNullOrEmpty(WorldClock.LastEvent))
                     line += "\nThey heard: " + WorldClock.LastEvent;
+                var person = WorldBook.FindPerson(world, npc.personId ?? npc.def.id);
+                var lev = WorldBook.LeverageLine(person);
+                if (!string.IsNullOrEmpty(lev) && Bonds.Get(Bonds.Key(npc)) >= 0.22f)
+                    line += "\nLeverage: " + lev;
                 _player.OpenTalk(npc, line);
                 return "Talking with " + npc.def.name + ".";
             }

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaGame.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaGame.cs
@@ -27,6 +27,7 @@ namespace Concordia
         DungeonGate[] _holds;
         Gatherable[] _loot;
         CookStation[] _cooks;
+        KernelTomb[] _tombs;
         float _probeAt;
 
         async void Start()
@@ -131,6 +132,7 @@ namespace Concordia
             _holds = FindObjectsByType<DungeonGate>(FindObjectsInactive.Exclude);
             _loot = FindObjectsByType<Gatherable>(FindObjectsInactive.Exclude);
             _cooks = FindObjectsByType<CookStation>(FindObjectsInactive.Exclude);
+            _tombs = FindObjectsByType<KernelTomb>(FindObjectsInactive.Exclude);
             _probeAt = Time.unscaledTime;
         }
 
@@ -198,6 +200,13 @@ namespace Concordia
                     var d = Vector3.Distance(pos, k.transform.position);
                     if (d < best) { best = d; prompt = k.Prompt; }
                 }
+            if (_tombs != null)
+                foreach (var t in _tombs)
+                {
+                    if (!t) continue;
+                    var d = Vector3.Distance(pos, t.transform.position);
+                    if (d < best) { best = d; prompt = t.Prompt; }
+                }
             var use = UsePlace.Nearest(pos, 2.4f);
             if (use)
             {
@@ -231,62 +240,71 @@ namespace Concordia
             DungeonGate hold = null;
             Gatherable loot = null;
             CookStation cook = null;
+            KernelTomb tomb = null;
             float best = 3.2f;
             if (_gates != null)
                 foreach (var g in _gates)
                 {
                     if (!g) continue;
                     var d = Vector3.Distance(pos, g.transform.position);
-                    if (d < best) { best = d; gate = g; city = null; stone = null; npc = null; board = null; hold = null; loot = null; cook = null; }
+                    if (d < best) { best = d; gate = g; city = null; stone = null; npc = null; board = null; hold = null; loot = null; cook = null; tomb = null; }
                 }
             if (_cities != null)
                 foreach (var c in _cities)
                 {
                     if (!c) continue;
                     var d = Vector3.Distance(pos, c.transform.position);
-                    if (d < best) { best = d; city = c; gate = null; stone = null; npc = null; board = null; hold = null; loot = null; cook = null; }
+                    if (d < best) { best = d; city = c; gate = null; stone = null; npc = null; board = null; hold = null; loot = null; cook = null; tomb = null; }
                 }
             if (_holds != null)
                 foreach (var h in _holds)
                 {
                     if (!h) continue;
                     var d = Vector3.Distance(pos, h.transform.position);
-                    if (d < best) { best = d; hold = h; gate = null; city = null; stone = null; npc = null; board = null; loot = null; cook = null; }
+                    if (d < best) { best = d; hold = h; gate = null; city = null; stone = null; npc = null; board = null; loot = null; cook = null; tomb = null; }
                 }
             if (_boards != null)
                 foreach (var b in _boards)
                 {
                     if (!b) continue;
                     var d = Vector3.Distance(pos, b.transform.position);
-                    if (d < best) { best = d; board = b; gate = null; city = null; stone = null; npc = null; hold = null; loot = null; cook = null; }
+                    if (d < best) { best = d; board = b; gate = null; city = null; stone = null; npc = null; hold = null; loot = null; cook = null; tomb = null; }
                 }
             if (_loot != null)
                 foreach (var l in _loot)
                 {
                     if (!l || l.taken) continue;
                     var d = Vector3.Distance(pos, l.transform.position);
-                    if (d < best) { best = d; loot = l; gate = null; city = null; stone = null; npc = null; board = null; hold = null; cook = null; }
+                    if (d < best) { best = d; loot = l; gate = null; city = null; stone = null; npc = null; board = null; hold = null; cook = null; tomb = null; }
                 }
             if (_cooks != null)
                 foreach (var k in _cooks)
                 {
                     if (!k) continue;
                     var d = Vector3.Distance(pos, k.transform.position);
-                    if (d < best) { best = d; cook = k; gate = null; city = null; stone = null; npc = null; board = null; hold = null; loot = null; }
+                    if (d < best) { best = d; cook = k; gate = null; city = null; stone = null; npc = null; board = null; hold = null; loot = null; tomb = null; }
                 }
             if (_stones != null)
                 foreach (var s in _stones)
                 {
                     if (!s) continue;
                     var d = Vector3.Distance(pos, s.transform.position);
-                    if (d < best) { best = d; stone = s; gate = null; city = null; npc = null; board = null; hold = null; loot = null; cook = null; }
+                    if (d < best) { best = d; stone = s; gate = null; city = null; npc = null; board = null; hold = null; loot = null; cook = null; tomb = null; }
                 }
             if (_npcs != null)
                 foreach (var n in _npcs)
                 {
                     if (!n) continue;
                     var d = Vector3.Distance(pos, n.transform.position);
-                    if (d < best) { best = d; npc = n; gate = null; city = null; stone = null; board = null; hold = null; loot = null; cook = null; }
+                    if (d < best) { best = d; npc = n; gate = null; city = null; stone = null; board = null; hold = null; loot = null; cook = null; tomb = null; }
+                }
+            if (_tombs != null)
+                foreach (var t in _tombs)
+                {
+                    if (!t) continue;
+                    var d = Vector3.Distance(pos, t.transform.position);
+                    if (d < best) { best = d; tomb = t; gate = null; city = null; stone = null; npc = null; board = null; hold = null; loot = null; cook = null; }
+                }
                 }
             if (gate != null)
             {
@@ -307,6 +325,12 @@ namespace Concordia
             {
                 QuestLog.NoteLocation(stone.title);
                 return stone.title + "\n" + stone.text;
+            }
+            if (tomb != null)
+            {
+                var said = string.IsNullOrEmpty(tomb.lastWords) ? "a grave with no words" : tomb.lastWords;
+                WorldClock.LastEvent = said;
+                return said;
             }
             var use = UsePlace.Nearest(pos, 2.4f);
             var door = BuildingPlace.NearestDoor(pos, 3.4f);

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaGame.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaGame.cs
@@ -393,8 +393,11 @@ namespace Concordia
             QuestLog.NoteLocation("dungeon", "hold");
             if (hold.inHold)
             {
-                ConcordiaHUD.Announce("A hold", "Kenney tiles. No authored name.");
-                return "You enter the hold. Live steel if the world allows it.";
+                var client = ConcordClient.Live;
+                if (client != null) client.SendDungeonOpen(hold.encounterId);
+                var title = string.IsNullOrEmpty(hold.holdName) ? "The Hollow Warden" : hold.holdName;
+                ConcordiaHUD.Announce(title, string.IsNullOrEmpty(ConcordClient.DungeonLine) ? "the hold opened" : ConcordClient.DungeonLine);
+                return "You enter " + title + ".";
             }
             return "You leave the hold.";
         }

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaGame.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaGame.cs
@@ -418,6 +418,15 @@ namespace Concordia
             {
                 var client = ConcordClient.Live;
                 if (client != null) client.SendDungeonOpen(hold.encounterId);
+                if (ConcordClient.HoldLocked)
+                {
+                    hold.inHold = false;
+                    _player.cc.enabled = false;
+                    _player.transform.position = hold.mouth;
+                    _player.cc.enabled = true;
+                    Grounding.Snap(_player.cc);
+                    return "the hold is sealed — " + ConcordClient.HoldLockReason;
+                }
                 var title = string.IsNullOrEmpty(hold.holdName) ? "The Hollow Warden" : hold.holdName;
                 ConcordiaHUD.Announce(title, string.IsNullOrEmpty(ConcordClient.DungeonLine) ? "the hold opened" : ConcordClient.DungeonLine);
                 return "You enter " + title + ".";

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaHUD.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaHUD.cs
@@ -531,7 +531,10 @@ namespace Concordia
             DrawBar(cx - 140, y + 20, 280, 8, hpT, new Color(0.82f, 0.16f, 0.14f));
             if (!string.IsNullOrEmpty(peril))
             {
-                var hint = peril == "thrust" ? "Thrust — parry" : peril == "sweep" ? "Sweep — dodge" : "Grab — dodge";
+                var hint = peril == "thrust" ? "Thrust — X"
+                    : peril == "sweep" ? "Sweep — Space"
+                    : peril == "grab" ? "Grab — X"
+                    : peril;
                 GUI.Label(new Rect(cx - 150, y + 30, 300, 18), hint, _center);
             }
         }

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaHUD.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaHUD.cs
@@ -273,6 +273,7 @@ namespace Concordia
                 if (weaponsOnly && it.kind != "weapon") continue;
                 if (!weaponsOnly && it.kind == "weapon") continue;
                 var label = (it.id == KitBag.Equipped ? "▸ " : "  ") + it.name;
+                if (!string.IsNullOrEmpty(it.affixLine)) label += "  ·  " + it.affixLine;
                 if (weaponsOnly)
                 {
                     if (GUI.Button(new Rect(x, yy, w - 8, 32), label, _btn))
@@ -300,6 +301,8 @@ namespace Concordia
             DrawRing(cx, cy, 62, player.hp / 100f, new Color(0.78f, 0.18f, 0.16f));
             DrawRing(cx, cy, 48, player.stamina / 100f, new Color(0.86f, 0.64f, 0.22f));
             DrawRing(cx, cy, 34, player.poise / 16f, new Color(0.42f, 0.72f, 0.82f));
+            if (WorldBoss.Live && WorldBoss.Live.HpPct >= 0f)
+                DrawRing(cx, cy + 86f, 44, WorldBoss.Live.HpPct, new Color(0.78f, 0.22f, 0.16f));
         }
 
         void DrawRing(float cx, float cy, float size, float t, Color c)
@@ -341,6 +344,8 @@ namespace Concordia
                 Dot(new Vector3(c.x, 0f, c.z), new Color(0.85f, 0.7f, 0.35f), 5f);
             foreach (var g in FindObjectsByType<DungeonGate>(FindObjectsInactive.Exclude))
                 if (g) Dot(g.transform.position, new Color(0.55f, 0.35f, 0.2f), 5f);
+            if (WorldBoss.Live)
+                Dot(WorldBoss.Live.transform.position, new Color(0.9f, 0.18f, 0.12f), 7f);
             foreach (var n in FindObjectsByType<GuestNpc>(FindObjectsInactive.Exclude))
                 if (n) Dot(n.transform.position, new Color(0.75f, 0.82f, 0.55f), 3f);
             foreach (var host in FindObjectsByType<Hostile>(FindObjectsInactive.Exclude))

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaHUD.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaHUD.cs
@@ -83,6 +83,7 @@ namespace Concordia
             Arrival(w, h);
             if (player.talkOpen) TalkPanel(w, h);
             if (player.menuOpen) KitMenu(w, h);
+            PlotBar(w, h);
             Hints(w, h);
         }
 
@@ -96,7 +97,7 @@ namespace Concordia
                     : player.menuOpen
                         ? "I  close kit  ·  click a weapon  ·  1/2/3  art  ·  Esc  close"
                         : "I  kit   ·   1/2/3  " + style.light + "/" + style.heavy + "/" + style.special
-                          + "   ·   LMB  swing   ·   E  use   ·   Q  cycle   ·   Tab  cursor",
+                          + "   ·   LMB  swing   ·   X  dodge   ·   E  use   ·   Q  cycle   ·   Tab  cursor",
                 _small);
             GUI.color = Color.white;
         }
@@ -122,11 +123,8 @@ namespace Concordia
             var lineage = WorldMemory.LineageLine(player.world);
             if (!string.IsNullOrEmpty(lineage))
                 GUI.Label(new Rect(32, 102, 280, 14), lineage, _small);
-            else if (!string.IsNullOrEmpty(WorldClock.NearbyAct) && WorldClock.NearbyAct.ToLowerInvariant().Contains("scheme"))
-                GUI.Label(new Rect(32, 102, 280, 14),
-                    ConcordClient.Live != null && ConcordClient.Live.Connected
-                        ? "scheme nearby — barge-in is kernel-side"
-                        : "scheme nearby — barge-in needs /unity-ws", _small);
+            else if (Plots.Nearby != null)
+                GUI.Label(new Rect(32, 102, 280, 14), "scheme nearby — Expose / Abet / Ignore", _small);
         }
 
         static string TwoBStatus()
@@ -419,8 +417,26 @@ namespace Concordia
             GUI.color = new Color(0f, 0f, 0f, 0.4f);
             GUI.DrawTexture(new Rect(22, 142, 300, 28), _white);
             GUI.color = Color.white;
-            GUI.Label(new Rect(32, 144, 160, 16), "PARTY  ·  solo", _small);
+            GUI.Label(new Rect(32, 144, 280, 16), ConcordClient.PartyLine, _small);
             DrawBar(170, 150, 140, 8, player.hp / 100f, new Color(0.78f, 0.18f, 0.16f));
+        }
+
+        void PlotBar(float w, float h)
+        {
+            var plot = Plots.Nearby;
+            if (plot == null || player.talkOpen || player.menuOpen) return;
+            float pw = 520f, ph = 72f;
+            float x = (w - pw) * 0.5f, y = h - 118f;
+            GUI.color = new Color(0.05f, 0.03f, 0.02f, 0.88f);
+            GUI.DrawTexture(new Rect(x, y, pw, ph), _white);
+            GUI.color = Color.white;
+            GUI.Label(new Rect(x + 12, y + 6, pw - 24, 32), plot.text, _small);
+            if (GUI.Button(new Rect(x + 12, y + 40, 150, 24), "Expose", _btn))
+                Plots.Intervene("expose");
+            if (GUI.Button(new Rect(x + 176, y + 40, 150, 24), "Abet", _btn))
+                Plots.Intervene("abet");
+            if (GUI.Button(new Rect(x + 340, y + 40, 166, 24), "Ignore", _btn))
+                Plots.Intervene("ignore");
         }
 
         void TargetBar(float w)

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaHUD.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaHUD.cs
@@ -83,6 +83,7 @@ namespace Concordia
             Arrival(w, h);
             if (player.talkOpen) TalkPanel(w, h);
             if (player.menuOpen) KitMenu(w, h);
+            if (player.skillOpen) SkillSheet(w, h);
             PlotBar(w, h);
             Hints(w, h);
         }
@@ -93,10 +94,12 @@ namespace Concordia
             GUI.Label(new Rect(18, h - 22, w - 36, 20),
                 player.talkOpen
                     ? "Type  ·  Enter  send  ·  Esc  leave  ·  2B " + TwoBStatus()
-                    : player.menuOpen
-                        ? "I  close  ·  click a weapon  ·  1/2/3  skill  ·  [ ]  group  ·  Esc  close"
-                        : "I  kit   ·   1/2/3  " + SkillLattice.ActiveSkill
-                          + "   ·   LMB  swing   ·   X  dodge   ·   E  use   ·   Q  cycle   ·   Tab  cursor",
+                    : player.skillOpen
+                        ? "K  close  ·  click a skill  ·  [ ]  group  ·  Esc  close"
+                        : player.menuOpen
+                            ? "I  close  ·  click a weapon  ·  1/2/3  combat slot  ·  K  lattice  ·  Esc  close"
+                            : "I  kit   ·   K  " + SkillLattice.CatalogCount + " skills   ·   1/2/3  " + SkillLattice.ActiveSkill
+                              + "   ·   H  horde   ·   J  extract   ·   LMB  swing   ·   X  dodge   ·   E  use",
                 _small);
             GUI.color = Color.white;
         }
@@ -196,12 +199,61 @@ namespace Concordia
             GUI.color = new Color(0.04f, 0.03f, 0.02f, 0.9f);
             GUI.DrawTexture(new Rect(x, y, pw, ph), _white);
             GUI.color = Color.white;
-            GUI.Label(new Rect(x + 18, y + 12, pw - 36, 24), "KIT  ·  inventory  ·  weapons  ·  skills", _title);
-            float col = (pw - 48f) / 3f;
+            GUI.Label(new Rect(x + 18, y + 12, pw - 36, 24), "KIT  ·  inventory  ·  weapons", _title);
+            float col = (pw - 48f) / 2f;
             DrawInvCol(x + 16, y + 44, col, "Carry", false);
-            DrawInvCol(x + 24 + col, y + 44, col, "Weapons", true);
-            DrawSkillCol(x + 32 + col * 2f, y + 44, col);
+            DrawInvCol(x + 32 + col, y + 44, col, "Weapons", true);
+            GUI.Label(new Rect(x + 18, y + ph - 48, pw - 36, 18),
+                SkillLattice.FromKernel
+                    ? "K  opens the " + SkillLattice.CatalogCount + "-skill lattice  ·  " + SkillLattice.HudLine()
+                    : "K  opens the lattice. skills.mastery unbound until Concord answers.", _small);
             GUI.Label(new Rect(x + 18, y + ph - 28, pw - 36, 18), QuestLog.HudBlock(), _small);
+        }
+
+        void SkillSheet(float w, float h)
+        {
+            float pw = Mathf.Min(1080f, w - 48f), ph = Mathf.Min(620f, h - 80f);
+            float x = (w - pw) * 0.5f, y = (h - ph) * 0.5f;
+            GUI.color = new Color(0.03f, 0.02f, 0.015f, 0.92f);
+            GUI.DrawTexture(new Rect(x, y, pw, ph), _white);
+            GUI.color = Color.white;
+            var head = SkillLattice.FromKernel
+                ? SkillLattice.CatalogCount + " SKILLS  ·  " + SkillLattice.TrainedCount + " trained  ·  kernel"
+                : "SKILLS  ·  skills.mastery unbound";
+            GUI.Label(new Rect(x + 18, y + 12, pw - 36, 24), head, _title);
+            GUI.Label(new Rect(x + 18, y + 38, pw - 36, 18), SkillLattice.HudLine(), _small);
+            if (!SkillLattice.FromKernel)
+            {
+                GUI.Label(new Rect(x + 18, y + 70, pw - 36, 80),
+                    "The catalog lives on Concord. This overlay stays empty until skills.mastery answers. Kit arts are not this lattice.",
+                    _small);
+                return;
+            }
+            int cols = Mathf.Max(1, SkillLattice.Groups.Count);
+            float colW = (pw - 36f) / cols;
+            for (int g = 0; g < cols; g++)
+            {
+                var group = SkillLattice.Groups[g];
+                float cx = x + 18 + colW * g;
+                var title = group == SkillLattice.Group ? "▸ " + group.ToUpperInvariant() : group.ToUpperInvariant();
+                if (GUI.Button(new Rect(cx, y + 62, colW - 10, 24), title, _btn))
+                    SkillLattice.Group = group;
+                float yy = y + 92f;
+                for (int i = 0; i < SkillLattice.All.Count; i++)
+                {
+                    var row = SkillLattice.All[i];
+                    if (row.group != group) continue;
+                    var mark = row.skillType == SkillLattice.ActiveSkill ? "▸ " : "  ";
+                    var label = mark + row.skillType + "  L" + row.level;
+                    if (GUI.Button(new Rect(cx, yy, colW - 10, 22), label, _btn))
+                    {
+                        SkillLattice.Group = group;
+                        SkillLattice.ActiveSkill = row.skillType;
+                    }
+                    yy += 24f;
+                    if (yy > y + ph - 36f) break;
+                }
+            }
         }
 
         void DrawInvCol(float x, float y, float w, string title, bool weaponsOnly)
@@ -234,36 +286,10 @@ namespace Concordia
 
         void DrawSkillCol(float x, float y, float w)
         {
-            GUI.Label(new Rect(x, y, w, 20),
+            GUI.Label(new Rect(x, y, w, 40),
                 SkillLattice.FromKernel
-                    ? SkillLattice.Group.ToUpperInvariant() + "  ·  " + SkillLattice.CatalogCount
-                    : "Skills", _center);
-            if (!SkillLattice.FromKernel)
-            {
-                GUI.Label(new Rect(x, y + 26, w - 8, 72),
-                    "skills.mastery unbound. Kit arts stay local until Concord answers.", _small);
-                return;
-            }
-            float yy = y + 26f;
-            if (GUI.Button(new Rect(x, yy, (w - 16) * 0.5f, 22), "<", _btn))
-                SkillLattice.CycleGroup(-1);
-            if (GUI.Button(new Rect(x + (w - 16) * 0.5f + 8, yy, (w - 16) * 0.5f, 22), ">", _btn))
-                SkillLattice.CycleGroup(1);
-            yy += 28f;
-            int shown = 0;
-            for (int i = 0; i < SkillLattice.All.Count; i++)
-            {
-                var row = SkillLattice.All[i];
-                if (row.group != SkillLattice.Group) continue;
-                var mark = row.skillType == SkillLattice.ActiveSkill ? "▸ " : "  ";
-                var label = mark + row.skillType + "  L" + row.level;
-                if (GUI.Button(new Rect(x, yy, w - 8, 26), label, _btn))
-                    SkillLattice.ActiveSkill = row.skillType;
-                yy += 28f;
-                shown++;
-                if (shown >= 8) break;
-            }
-            GUI.Label(new Rect(x, y + 280, w - 8, 36), SkillLattice.HudLine(), _small);
+                    ? "K  " + SkillLattice.CatalogCount + " skills"
+                    : "K  lattice unbound", _small);
         }
 
         void Rings(float w)
@@ -430,17 +456,21 @@ namespace Concordia
 
         void PartyStrip()
         {
+            var run = ConcordClient.RunLine;
+            float extra = string.IsNullOrEmpty(run) ? 0f : 18f;
             GUI.color = new Color(0f, 0f, 0f, 0.4f);
-            GUI.DrawTexture(new Rect(22, 142, 300, 28), _white);
+            GUI.DrawTexture(new Rect(22, 142, 300, 28 + extra), _white);
             GUI.color = Color.white;
             GUI.Label(new Rect(32, 144, 280, 16), ConcordClient.PartyLine, _small);
             DrawBar(170, 150, 140, 8, player.hp / 100f, new Color(0.78f, 0.18f, 0.16f));
+            if (!string.IsNullOrEmpty(run))
+                GUI.Label(new Rect(32, 162, 280, 16), run, _small);
         }
 
         void PlotBar(float w, float h)
         {
             var plot = Plots.Nearby;
-            if (plot == null || player.talkOpen || player.menuOpen) return;
+            if (plot == null || player.talkOpen || player.menuOpen || player.skillOpen) return;
             float pw = 520f, ph = 72f;
             float x = (w - pw) * 0.5f, y = h - 118f;
             GUI.color = new Color(0.05f, 0.03f, 0.02f, 0.88f);

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaHUD.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaHUD.cs
@@ -81,6 +81,7 @@ namespace Concordia
             Prompt(w, h);
             Toast(w);
             Arrival(w, h);
+            ConsequenceFeed(w, h);
             if (player.talkOpen) TalkPanel(w, h);
             if (player.menuOpen) KitMenu(w, h);
             if (player.skillOpen) SkillSheet(w, h);
@@ -451,6 +452,27 @@ namespace Concordia
             GUI.Label(new Rect(40, h * 0.40f, w - 80, 54), _announceTitle, _card);
             GUI.color = new Color(0.92f, 0.82f, 0.62f, a);
             GUI.Label(new Rect(80, h * 0.50f, w - 160, 40), _announceLine, _cardSub);
+            GUI.color = Color.white;
+        }
+
+        void ConsequenceFeed(float w, float h)
+        {
+            int n = WorldClock.FeedCount;
+            if (n <= 0 || player.talkOpen || player.menuOpen || player.skillOpen) return;
+            float fw = 320f;
+            float fh = 18f + n * 16f;
+            float x = w - fw - 18f;
+            float y = 28f;
+            GUI.color = new Color(0f, 0f, 0f, 0.42f);
+            GUI.DrawTexture(new Rect(x, y, fw, fh), _white);
+            GUI.color = new Color(0.86f, 0.78f, 0.62f, 0.92f);
+            for (int i = 0; i < n; i++)
+            {
+                var beat = WorldClock.FeedAt(i);
+                if (string.IsNullOrEmpty(beat.line)) continue;
+                var prefix = string.IsNullOrEmpty(beat.channel) ? "" : beat.channel + "  ·  ";
+                GUI.Label(new Rect(x + 10, y + 6 + i * 16f, fw - 20, 16), prefix + beat.line, _small);
+            }
             GUI.color = Color.white;
         }
 

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaHUD.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaHUD.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -73,6 +74,8 @@ namespace Concordia
             float w = Screen.width, h = Screen.height;
             Compass(w);
             Vitals();
+            PartyStrip();
+            TargetBar(w);
             Rings(w);
             if (!player.Busy) Minimap(h);
             Prompt(w, h);
@@ -104,7 +107,7 @@ namespace Concordia
             var live = Canon.SteelLive(player.world, player.transform.position);
             GUI.color = new Color(0f, 0f, 0f, 0.45f);
             var city = CityAtlas.Nearest(player.world, player.transform.position, 18f);
-            GUI.DrawTexture(new Rect(22, 28, 300, 92), _white);
+            GUI.DrawTexture(new Rect(22, 28, 300, 108), _white);
             GUI.color = Color.white;
             GUI.Label(new Rect(32, 32, 280, 22), world.title.ToUpperInvariant(), _title);
             GUI.Label(new Rect(32, 54, 280, 16),
@@ -116,6 +119,14 @@ namespace Concordia
             GUI.Label(new Rect(32, 86, 280, 16),
                 !string.IsNullOrEmpty(WorldClock.NearbyAct) ? WorldClock.NearbyAct
                 : HubObjectives.Line(), _small);
+            var lineage = WorldMemory.LineageLine(player.world);
+            if (!string.IsNullOrEmpty(lineage))
+                GUI.Label(new Rect(32, 102, 280, 14), lineage, _small);
+            else if (!string.IsNullOrEmpty(WorldClock.NearbyAct) && WorldClock.NearbyAct.ToLowerInvariant().Contains("scheme"))
+                GUI.Label(new Rect(32, 102, 280, 14),
+                    ConcordClient.Live != null && ConcordClient.Live.Connected
+                        ? "scheme nearby — barge-in is kernel-side"
+                        : "scheme nearby — barge-in needs /unity-ws", _small);
         }
 
         static string TwoBStatus()
@@ -128,12 +139,12 @@ namespace Concordia
 
         void TalkPanel(float w, float h)
         {
-            float pw = 640f, ph = 248f;
+            float pw = 640f, ph = 308f;
             float x = (w - pw) * 0.5f, y = h - ph - 36f;
             GUI.color = new Color(0.04f, 0.03f, 0.02f, 0.88f);
             GUI.DrawTexture(new Rect(x, y, pw, ph), _white);
             GUI.color = Color.white;
-            var who = player.talkNpc != null ? player.talkNpc.def.name : "Someone";
+            var who = player.talkNpc != null && player.talkNpc.def != null ? player.talkNpc.def.name : "Someone";
             GUI.Label(new Rect(x + 16, y + 10, pw - 32, 22), who + "  ·  2B " + TwoBStatus(), _title);
             var log = player.talkLog.Count == 0 ? "" : string.Join("\n", player.talkLog);
             GUI.Label(new Rect(x + 16, y + 36, pw - 32, 140), log, _log);
@@ -146,7 +157,39 @@ namespace Concordia
             }
             if (GUI.Button(new Rect(x + pw - 116, y + 186, 100, 28), "Send", _btn))
                 player.SubmitTalk();
-            GUI.Label(new Rect(x + 16, y + 220, pw - 32, 18), "Enter send  ·  Esc leave", _small);
+            var aff = Bonds.Get(Bonds.Key(player.talkNpc));
+            DrawBar(x + 16, y + 220, 220, 8, aff, new Color(0.92f, 0.42f, 0.55f));
+            GUI.Label(new Rect(x + 244, y + 214, 160, 18), "affinity " + Mathf.RoundToInt(aff * 100f) + "%", _small);
+            if (KitBag.HasLoot())
+            {
+                if (GUI.Button(new Rect(x + pw - 116, y + 216, 100, 24), "Give", _btn))
+                    player.AppendTalk(Bonds.Give(player.talkNpc));
+            }
+            else
+                GUI.Label(new Rect(x + pw - 200, y + 214, 184, 18), "no gift in kit", _small);
+            var lev = LeverageHint();
+            if (!string.IsNullOrEmpty(lev))
+                GUI.Label(new Rect(x + 16, y + 238, pw - 32, 32), lev, _small);
+            var talkLineage = WorldMemory.LineageLine(player.world);
+            if (!string.IsNullOrEmpty(talkLineage))
+                GUI.Label(new Rect(x + 16, y + 270, pw - 32, 18), talkLineage, _small);
+        }
+
+        string LeverageHint()
+        {
+            if (player.talkNpc == null) return "";
+            var key = Bonds.Key(player.talkNpc);
+            var p = WorldBook.FindPerson(player.world, key);
+            if (p == null && player.talkNpc.def != null)
+            {
+                p = WorldBook.FindPerson(player.world, player.talkNpc.def.id);
+                if (p == null) p = WorldBook.FindPerson(player.world, player.talkNpc.def.name);
+            }
+            var lev = WorldBook.LeverageLine(p);
+            if (string.IsNullOrEmpty(lev)) return "";
+            var aff = Bonds.Get(key);
+            if (aff < 0.22f) return "They carry leverage. Talk or give until they open it.";
+            return "Leverage: " + lev;
         }
 
         void KitMenu(float w, float h)
@@ -261,6 +304,11 @@ namespace Concordia
                 if (n) Dot(n.transform.position, new Color(0.75f, 0.82f, 0.55f), 3f);
             foreach (var host in FindObjectsByType<Hostile>(FindObjectsInactive.Exclude))
                 if (host) Dot(host.transform.position, new Color(0.82f, 0.18f, 0.14f), 4f);
+            foreach (var b in FindObjectsByType<QuestBeacon>(FindObjectsInactive.Exclude))
+            {
+                if (!b || !BeaconMatchesQuest(b)) continue;
+                Dot(b.transform.position, new Color(1f, 0.82f, 0.22f), 6f);
+            }
             if (player.world == WorldId.Hub)
                 foreach (var g in Canon.Gates)
                     Dot(new Vector3(Mathf.Cos(g.angle), 0f, Mathf.Sin(g.angle)) * Canon.RingRadius, g.color, 4f);
@@ -364,6 +412,85 @@ namespace Concordia
             GUI.color = new Color(0.92f, 0.82f, 0.62f, a);
             GUI.Label(new Rect(80, h * 0.50f, w - 160, 40), _announceLine, _cardSub);
             GUI.color = Color.white;
+        }
+
+        void PartyStrip()
+        {
+            GUI.color = new Color(0f, 0f, 0f, 0.4f);
+            GUI.DrawTexture(new Rect(22, 142, 300, 28), _white);
+            GUI.color = Color.white;
+            GUI.Label(new Rect(32, 144, 160, 16), "PARTY  ·  solo", _small);
+            DrawBar(170, 150, 140, 8, player.hp / 100f, new Color(0.78f, 0.18f, 0.16f));
+        }
+
+        void TargetBar(float w)
+        {
+            TrainingDummy dummy = null;
+            Hostile host = null;
+            float best = 22f;
+            var origin = player.transform.position;
+            var fwd = player.cam ? player.cam.PlanarForward : player.transform.forward;
+            foreach (var h in FindObjectsByType<Hostile>(FindObjectsInactive.Exclude))
+            {
+                if (!h) continue;
+                var to = h.transform.position - origin;
+                to.y = 0f;
+                var dist = to.magnitude;
+                if (dist > best || dist < 0.4f) continue;
+                if (Vector3.Dot(fwd.normalized, to.normalized) < 0.25f) continue;
+                best = dist;
+                host = h;
+                dummy = h.GetComponent<TrainingDummy>() ?? h.GetComponentInParent<TrainingDummy>();
+            }
+            if (host == null)
+            {
+                foreach (var d in FindObjectsByType<TrainingDummy>(FindObjectsInactive.Exclude))
+                {
+                    if (!d || d.hp <= 0f) continue;
+                    var to = d.transform.position - origin;
+                    to.y = 0f;
+                    var dist = to.magnitude;
+                    if (dist > 8f || dist < 0.4f) continue;
+                    if (Vector3.Dot(fwd.normalized, to.normalized) < 0.35f) continue;
+                    dummy = d;
+                    break;
+                }
+            }
+            var peril = Hostile.TelegraphKind;
+            if (dummy == null && string.IsNullOrEmpty(peril)) return;
+            float cx = w * 0.5f;
+            float y = 64f;
+            GUI.color = new Color(0f, 0f, 0f, 0.5f);
+            GUI.DrawTexture(new Rect(cx - 160, y, 320, string.IsNullOrEmpty(peril) ? 36 : 52), _white);
+            GUI.color = Color.white;
+            var label = dummy ? dummy.name : (host ? host.name : "foe");
+            float hpT = dummy ? Mathf.Clamp01(dummy.hp / 80f) : 1f;
+            GUI.Label(new Rect(cx - 150, y + 2, 300, 16), label.ToUpperInvariant(), _center);
+            DrawBar(cx - 140, y + 20, 280, 8, hpT, new Color(0.82f, 0.16f, 0.14f));
+            if (!string.IsNullOrEmpty(peril))
+            {
+                var hint = peril == "thrust" ? "Thrust — parry" : peril == "sweep" ? "Sweep — dodge" : "Grab — dodge";
+                GUI.Label(new Rect(cx - 150, y + 30, 300, 18), hint, _center);
+            }
+        }
+
+        static bool BeaconMatchesQuest(QuestBeacon b)
+        {
+            if (b.tokens == null || QuestLog.Active.Count == 0) return false;
+            foreach (var a in QuestLog.Active)
+            {
+                var objs = a.quest?.objectives;
+                if (objs == null) continue;
+                foreach (var o in objs)
+                {
+                    if (o == null || string.IsNullOrEmpty(o.target)) continue;
+                    foreach (var tok in b.tokens)
+                        if (QuestLog.Hit(new HashSet<string> { QuestLog.Norm(tok) }, o.target)
+                            || QuestLog.Norm(tok) == QuestLog.Norm(o.target))
+                            return true;
+                }
+            }
+            return false;
         }
 
         static void DrawBar(float x, float y, float w, float h, float t, Color c)

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaHUD.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaHUD.cs
@@ -90,13 +90,12 @@ namespace Concordia
         void Hints(float w, float h)
         {
             GUI.color = new Color(0.92f, 0.84f, 0.66f, 0.88f);
-            var style = Canon.Get(player.world).style;
             GUI.Label(new Rect(18, h - 22, w - 36, 20),
                 player.talkOpen
                     ? "Type  ·  Enter  send  ·  Esc  leave  ·  2B " + TwoBStatus()
                     : player.menuOpen
-                        ? "I  close kit  ·  click a weapon  ·  1/2/3  art  ·  Esc  close"
-                        : "I  kit   ·   1/2/3  " + style.light + "/" + style.heavy + "/" + style.special
+                        ? "I  close  ·  click a weapon  ·  1/2/3  skill  ·  [ ]  group  ·  Esc  close"
+                        : "I  kit   ·   1/2/3  " + SkillLattice.ActiveSkill
                           + "   ·   LMB  swing   ·   X  dodge   ·   E  use   ·   Q  cycle   ·   Tab  cursor",
                 _small);
             GUI.color = Color.white;
@@ -114,7 +113,7 @@ namespace Concordia
             GUI.Label(new Rect(32, 54, 280, 16),
                 (live ? "LIVE STEEL" : "FLOWER-LAW") + (city == null ? "" : "  ·  " + city.name)
                 + (string.IsNullOrEmpty(player.kitWeapon) ? "" : "  ·  " + player.kitWeapon)
-                + "  ·  " + KitBag.ArtName(player.world), _small);
+                + "  ·  " + SkillLattice.HudLine(), _small);
             GUI.Label(new Rect(32, 70, 280, 16), WorldClock.HudClock()
                 + (string.IsNullOrEmpty(ConcordClient.HudLine) ? "" : "  ·  " + ConcordClient.HudLine), _small);
             GUI.Label(new Rect(32, 86, 280, 16),
@@ -197,11 +196,11 @@ namespace Concordia
             GUI.color = new Color(0.04f, 0.03f, 0.02f, 0.9f);
             GUI.DrawTexture(new Rect(x, y, pw, ph), _white);
             GUI.color = Color.white;
-            GUI.Label(new Rect(x + 18, y + 12, pw - 36, 24), "KIT  ·  inventory  ·  weapons  ·  arts", _title);
+            GUI.Label(new Rect(x + 18, y + 12, pw - 36, 24), "KIT  ·  inventory  ·  weapons  ·  skills", _title);
             float col = (pw - 48f) / 3f;
             DrawInvCol(x + 16, y + 44, col, "Carry", false);
             DrawInvCol(x + 24 + col, y + 44, col, "Weapons", true);
-            DrawArtCol(x + 32 + col * 2f, y + 44, col);
+            DrawSkillCol(x + 32 + col * 2f, y + 44, col);
             GUI.Label(new Rect(x + 18, y + ph - 28, pw - 36, 18), QuestLog.HudBlock(), _small);
         }
 
@@ -233,21 +232,38 @@ namespace Concordia
             }
         }
 
-        void DrawArtCol(float x, float y, float w)
+        void DrawSkillCol(float x, float y, float w)
         {
-            var s = Canon.Get(player.world).style;
-            GUI.Label(new Rect(x, y, w, 20), "Arts", _center);
-            ArtBtn(x, y + 26, w, 0, "1  ·  " + s.light);
-            ArtBtn(x, y + 70, w, 1, "2  ·  " + s.heavy);
-            ArtBtn(x, y + 114, w, 2, "3  ·  " + s.special);
-            GUI.Label(new Rect(x, y + 168, w, 48), "LMB fires the selected art. F and G still cut heavy and special.", _small);
-        }
-
-        void ArtBtn(float x, float y, float w, int art, string label)
-        {
-            var mark = KitBag.Art == art ? "▸ " + label : label;
-            if (GUI.Button(new Rect(x, y, w - 8, 36), mark, _btn))
-                KitBag.Art = art;
+            GUI.Label(new Rect(x, y, w, 20),
+                SkillLattice.FromKernel
+                    ? SkillLattice.Group.ToUpperInvariant() + "  ·  " + SkillLattice.CatalogCount
+                    : "Skills", _center);
+            if (!SkillLattice.FromKernel)
+            {
+                GUI.Label(new Rect(x, y + 26, w - 8, 72),
+                    "skills.mastery unbound. Kit arts stay local until Concord answers.", _small);
+                return;
+            }
+            float yy = y + 26f;
+            if (GUI.Button(new Rect(x, yy, (w - 16) * 0.5f, 22), "<", _btn))
+                SkillLattice.CycleGroup(-1);
+            if (GUI.Button(new Rect(x + (w - 16) * 0.5f + 8, yy, (w - 16) * 0.5f, 22), ">", _btn))
+                SkillLattice.CycleGroup(1);
+            yy += 28f;
+            int shown = 0;
+            for (int i = 0; i < SkillLattice.All.Count; i++)
+            {
+                var row = SkillLattice.All[i];
+                if (row.group != SkillLattice.Group) continue;
+                var mark = row.skillType == SkillLattice.ActiveSkill ? "▸ " : "  ";
+                var label = mark + row.skillType + "  L" + row.level;
+                if (GUI.Button(new Rect(x, yy, w - 8, 26), label, _btn))
+                    SkillLattice.ActiveSkill = row.skillType;
+                yy += 28f;
+                shown++;
+                if (shown >= 8) break;
+            }
+            GUI.Label(new Rect(x, y + 280, w - 8, 36), SkillLattice.HudLine(), _small);
         }
 
         void Rings(float w)

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaPlayer.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaPlayer.cs
@@ -194,6 +194,7 @@ namespace Concordia
             if (!string.IsNullOrEmpty(first)) talkLog.Add(first);
             focusTalk = true;
             UnlockCursor();
+            Bonds.TalkBump(Bonds.Key(npc));
         }
 
         public void CloseTalk()
@@ -448,6 +449,8 @@ namespace Concordia
             poise = Mathf.Max(0f, poise - dmg * 0.25f);
             _vel -= transform.forward * 1.8f;
             person?.Hurt();
+            var feel = GetComponent<CombatFeel>();
+            feel?.ApplyAck(true, Mathf.Min(dmg * 0.08f, 2.4f), false, false);
             Toast(from + " hits.");
             if (hp > 0f) return;
             hp = 100f;

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaPlayer.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaPlayer.cs
@@ -18,7 +18,7 @@ namespace Concordia
         public float hp = 100, stamina = 100, poise = 12;
         public float hostility;
         Vector3 _vel;
-        float _yaw, _slashUntil, _dodgeUntil, _attackKind, _coyote;
+        float _yaw, _slashUntil, _dodgeUntil, _iframeUntil, _attackKind, _coyote;
         bool _wasGrounded = true;
         public string prompt;
         public string toast;
@@ -88,7 +88,10 @@ namespace Concordia
             {
                 _vel += wish.normalized * 12.4f;
                 _dodgeUntil = Time.time + 0.38f;
+                _iframeUntil = Time.time + 0.35f;
                 stamina -= 18;
+                var client = ConcordClient.Live;
+                if (client != null) client.SendDodge();
             }
             if (person && wish.sqrMagnitude > 0.04f) person.Sit(false);
 
@@ -439,6 +442,11 @@ namespace Concordia
 
         public void TakeHit(float dmg, string from)
         {
+            if (Time.time < _iframeUntil)
+            {
+                Toast("the cut passes through");
+                return;
+            }
             if (!Canon.SteelLive(world, transform.position))
             {
                 FlowerBurst();

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaPlayer.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaPlayer.cs
@@ -252,9 +252,11 @@ namespace Concordia
             if (talkOpen && KeyDown(KeyCode.Return)) SubmitTalk();
             if (KeyDown(KeyCode.I) && !talkOpen) ToggleMenu();
             if (Busy) return;
-            if (KeyDown(KeyCode.Alpha1)) { KitBag.Art = 0; Toast(KitBag.ArtName(world)); }
-            if (KeyDown(KeyCode.Alpha2)) { KitBag.Art = 1; Toast(KitBag.ArtName(world)); }
-            if (KeyDown(KeyCode.Alpha3)) { KitBag.Art = 2; Toast(KitBag.ArtName(world)); }
+            if (KeyDown(KeyCode.Alpha1)) { SkillLattice.SelectSlot(0); Toast(SkillLattice.HudLine()); }
+            if (KeyDown(KeyCode.Alpha2)) { SkillLattice.SelectSlot(1); Toast(SkillLattice.HudLine()); }
+            if (KeyDown(KeyCode.Alpha3)) { SkillLattice.SelectSlot(2); Toast(SkillLattice.HudLine()); }
+            if (menuOpen && KeyDown(KeyCode.LeftBracket)) SkillLattice.CycleGroup(-1);
+            if (menuOpen && KeyDown(KeyCode.RightBracket)) SkillLattice.CycleGroup(1);
         }
 
         void TryAttack(bool heavy)
@@ -282,7 +284,7 @@ namespace Concordia
             var connected = HitScan(heavy, 1f);
             SkillLedger.Record(art, connected);
             var feel = GetComponent<CombatFeel>();
-            feel?.Strike(heavy, connected);
+            feel?.Strike(heavy, connected, SkillLattice.KickMul(SkillLattice.ActiveSkill));
         }
 
         void TrySpecial()

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaPlayer.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaPlayer.cs
@@ -40,6 +40,7 @@ namespace Concordia
         GameObject _heldKit;
         TrainingDummy _pendingKernelTarget;
         float _moveSentAt;
+        WorldId _fightWorld = (WorldId)(-1);
 
         void OnEnable() => Live = this;
         void OnDisable() { if (Live == this) Live = null; }
@@ -61,6 +62,13 @@ namespace Concordia
             }
             var dt = Time.deltaTime;
             var style = Canon.Get(world).style;
+            if (_fightWorld != world)
+            {
+                _fightWorld = world;
+                var fs = Canon.PickFight(null, null, world);
+                avatar?.BindStyle(fs);
+                person?.BindStyle(fs);
+            }
             HandleMenuKeys();
             LookInput();
             var axes = Busy ? Vector2.zero : MoveAxes();
@@ -409,6 +417,14 @@ namespace Concordia
             }
             if (!dummy) return false;
             var client = ConcordClient.Live;
+            var boss = dummy.GetComponent<WorldBoss>() ?? dummy.GetComponentInParent<WorldBoss>();
+            if (boss != null && client && client.Connected && !string.IsNullOrEmpty(client.DungeonInstanceId))
+            {
+                _pendingKernelTarget = dummy;
+                Toast(dummy.name + " — Concord resolving");
+                _ = client.SendDungeonHit(dmg);
+                return true;
+            }
             if (client && client.Connected)
             {
                 // Kernel resolves HP. Presentation already played the swing.
@@ -489,7 +505,8 @@ namespace Concordia
             _vel -= transform.forward * 1.8f;
             person?.Hurt();
             avatar?.Hit();
-            if (poise < 4f) avatar?.Stagger();
+            if (knockback > 1.8f || poise < 2.5f) avatar?.Knockdown();
+            else if (poise < 4f || knockback > 1.1f) avatar?.Stagger();
             var feel = GetComponent<CombatFeel>();
             feel?.ApplyAck(true, knockback >= 0f ? knockback : Mathf.Min(dmg * 0.08f, 2.4f), false, false);
             Toast(from + " hits.");

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaPlayer.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaPlayer.cs
@@ -84,6 +84,12 @@ namespace Concordia
                 _vel.y = 8.2f;
                 _coyote = 0f;
                 grounded = false;
+                if (Hostile.TelegraphKind == "sweep")
+                {
+                    _iframeUntil = Time.time + 0.28f;
+                    var hop = ConcordClient.Live;
+                    if (hop != null) hop.SendDodge(false, "jump");
+                }
             }
             if (!Busy && KeyDown(KeyCode.X) && Time.time > _dodgeUntil)
             {
@@ -460,12 +466,16 @@ namespace Concordia
             return null;
         }
 
-        public void TakeHit(float dmg, string from)
+        public void TakeHit(float dmg, string from, float knockback = -1f)
         {
             if (Time.time < _iframeUntil)
             {
-                Toast("the cut passes through");
-                return;
+                var defense = (!cc.isGrounded && _vel.y > 1f) ? "jump" : "dodge";
+                if (Hostile.CounterMatches(Hostile.TelegraphKind, defense))
+                {
+                    Toast("the cut passes through");
+                    return;
+                }
             }
             if (!Canon.SteelLive(world, transform.position))
             {
@@ -478,7 +488,7 @@ namespace Concordia
             _vel -= transform.forward * 1.8f;
             person?.Hurt();
             var feel = GetComponent<CombatFeel>();
-            feel?.ApplyAck(true, Mathf.Min(dmg * 0.08f, 2.4f), false, false);
+            feel?.ApplyAck(true, knockback >= 0f ? knockback : Mathf.Min(dmg * 0.08f, 2.4f), false, false);
             Toast(from + " hits.");
             if (hp > 0f) return;
             hp = 100f;

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaPlayer.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaPlayer.cs
@@ -24,6 +24,7 @@ namespace Concordia
         public string toast;
         public string kitWeapon;
         public bool menuOpen;
+        public bool skillOpen;
         public bool talkOpen;
         public bool focusTalk;
         public string talkDraft = "";
@@ -34,7 +35,7 @@ namespace Concordia
         public System.Action<string> onToast;
         public System.Func<Vector3, string> onInteract;
         public static ConcordiaPlayer Live { get; private set; }
-        public bool Busy => talkOpen || menuOpen;
+        public bool Busy => talkOpen || menuOpen || skillOpen;
         float _dmgMul = 1f;
         GameObject _heldKit;
         TrainingDummy _pendingKernelTarget;
@@ -191,6 +192,7 @@ namespace Concordia
         {
             talkOpen = true;
             menuOpen = false;
+            skillOpen = false;
             talkNpc = npc;
             talkDraft = "";
             talkLog.Clear();
@@ -229,6 +231,7 @@ namespace Concordia
             if (menuOpen)
             {
                 talkOpen = false;
+                skillOpen = false;
                 UnlockCursor();
             }
             else LockCursor();
@@ -247,16 +250,31 @@ namespace Concordia
             Cursor.visible = false;
         }
 
+        public void ToggleSkillSheet()
+        {
+            skillOpen = !skillOpen;
+            if (skillOpen)
+            {
+                menuOpen = false;
+                talkOpen = false;
+                UnlockCursor();
+            }
+            else LockCursor();
+        }
+
         void HandleMenuKeys()
         {
             if (talkOpen && KeyDown(KeyCode.Return)) SubmitTalk();
             if (KeyDown(KeyCode.I) && !talkOpen) ToggleMenu();
-            if (Busy) return;
+            if (KeyDown(KeyCode.K) && !talkOpen) ToggleSkillSheet();
+            if (talkOpen) return;
             if (KeyDown(KeyCode.Alpha1)) { SkillLattice.SelectSlot(0); Toast(SkillLattice.HudLine()); }
             if (KeyDown(KeyCode.Alpha2)) { SkillLattice.SelectSlot(1); Toast(SkillLattice.HudLine()); }
             if (KeyDown(KeyCode.Alpha3)) { SkillLattice.SelectSlot(2); Toast(SkillLattice.HudLine()); }
-            if (menuOpen && KeyDown(KeyCode.LeftBracket)) SkillLattice.CycleGroup(-1);
-            if (menuOpen && KeyDown(KeyCode.RightBracket)) SkillLattice.CycleGroup(1);
+            if ((menuOpen || skillOpen) && KeyDown(KeyCode.LeftBracket)) SkillLattice.CycleGroup(-1);
+            if ((menuOpen || skillOpen) && KeyDown(KeyCode.RightBracket)) SkillLattice.CycleGroup(1);
+            if (!Busy && KeyDown(KeyCode.H)) ConcordClient.Live?.RequestRunStart("horde");
+            if (!Busy && KeyDown(KeyCode.J)) ConcordClient.Live?.RequestRunStart("extraction");
         }
 
         void TryAttack(bool heavy)
@@ -284,7 +302,7 @@ namespace Concordia
             var connected = HitScan(heavy, 1f);
             SkillLedger.Record(art, connected);
             var feel = GetComponent<CombatFeel>();
-            feel?.Strike(heavy, connected, SkillLattice.KickMul(SkillLattice.ActiveSkill));
+            feel?.Strike(heavy, connected, SkillLattice.KickMul(SkillLattice.ActiveSkill), SkillLattice.ActiveSkill);
         }
 
         void TrySpecial()
@@ -521,6 +539,19 @@ namespace Concordia
 
         void Interact()
         {
+            SkillPylon nearest = null;
+            float best = 3.4f;
+            foreach (var p in FindObjectsByType<SkillPylon>(FindObjectsInactive.Exclude))
+            {
+                if (!p) continue;
+                var d = Vector3.Distance(transform.position, p.transform.position);
+                if (d < best) { best = d; nearest = p; }
+            }
+            if (nearest != null)
+            {
+                Toast(nearest.Take());
+                return;
+            }
             var msg = onInteract?.Invoke(transform.position);
             if (!string.IsNullOrEmpty(msg)) Toast(msg);
         }
@@ -564,6 +595,12 @@ namespace Concordia
             if (talkOpen && KeyDown(KeyCode.Escape))
             {
                 CloseTalk();
+                return;
+            }
+            if (skillOpen && KeyDown(KeyCode.Escape))
+            {
+                skillOpen = false;
+                LockCursor();
                 return;
             }
             if (menuOpen && KeyDown(KeyCode.Escape))
@@ -612,10 +649,15 @@ namespace Concordia
             KeyCode.Q => Key.Q,
             KeyCode.E => Key.E,
             KeyCode.I => Key.I,
+            KeyCode.K => Key.K,
+            KeyCode.H => Key.H,
+            KeyCode.J => Key.J,
             KeyCode.Return => Key.Enter,
             KeyCode.Alpha1 => Key.Digit1,
             KeyCode.Alpha2 => Key.Digit2,
             KeyCode.Alpha3 => Key.Digit3,
+            KeyCode.LeftBracket => Key.LeftBracket,
+            KeyCode.RightBracket => Key.RightBracket,
             KeyCode.Escape => Key.Escape,
             KeyCode.Tab => Key.Tab,
             _ => null

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaPlayer.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaPlayer.cs
@@ -317,6 +317,7 @@ namespace Concordia
             if (stamina < 22f) { Toast("Winded."); return; }
             stamina -= 22f;
             person?.Slash();
+            avatar?.Slash();
             _slashUntil = Time.time + 0.7f;
             var live = Canon.SteelLive(world, transform.position);
             if (!live)
@@ -487,6 +488,8 @@ namespace Concordia
             poise = Mathf.Max(0f, poise - dmg * 0.25f);
             _vel -= transform.forward * 1.8f;
             person?.Hurt();
+            avatar?.Hit();
+            if (poise < 4f) avatar?.Stagger();
             var feel = GetComponent<CombatFeel>();
             feel?.ApplyAck(true, knockback >= 0f ? knockback : Mathf.Min(dmg * 0.08f, 2.4f), false, false);
             Toast(from + " hits.");

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/CreatureCompiler.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/CreatureCompiler.cs
@@ -1,0 +1,395 @@
+using UnityEngine;
+
+namespace Concordia
+{
+    /// <summary>
+    /// Detached genome card (not a MonoBehaviour). Kernel fields only.
+    /// Generation 0 = founding stock, not a fabricated lineage.
+    /// </summary>
+    public class CreatureCard
+    {
+        public string id, speciesId, topology, parentA, parentB;
+        public string dominant, variant, affinity, gaitKind, lifestyle;
+        public float massKg = -1f, heightM = -1f, walkMps = -1f, stability = -1f, x, z;
+        public int generation;
+        public bool predator, fly, hasXz;
+    }
+
+    /// <summary>
+    /// Persistent genome on a compiled creature.
+    /// </summary>
+    public class CreatureGenome : MonoBehaviour
+    {
+        public string id;
+        public string speciesId;
+        public string topology;
+        public float massKg = -1f;
+        public float heightM = -1f;
+        public int generation;
+        public string parentA;
+        public string parentB;
+        public string dominant;
+        public string variant;
+        public string affinity;
+        public string gaitKind;
+        public float walkMps = -1f;
+        public string lifestyle;
+        public bool predator;
+        public bool fly;
+        public float stability = -1f;
+
+        public string Label
+        {
+            get
+            {
+                var name = string.IsNullOrEmpty(speciesId) ? "creature" : speciesId;
+                if (generation > 0) name += " · gen " + generation;
+                if (!string.IsNullOrEmpty(variant)) name += " · " + variant;
+                else if (!string.IsNullOrEmpty(dominant)) name += " · " + dominant;
+                return name;
+            }
+        }
+
+        public void Bind(CreatureCard card)
+        {
+            if (card == null) return;
+            id = card.id;
+            speciesId = card.speciesId;
+            topology = card.topology;
+            massKg = card.massKg;
+            heightM = card.heightM;
+            generation = card.generation;
+            parentA = card.parentA;
+            parentB = card.parentB;
+            dominant = card.dominant;
+            variant = card.variant;
+            affinity = card.affinity;
+            gaitKind = card.gaitKind;
+            walkMps = card.walkMps;
+            lifestyle = card.lifestyle;
+            predator = card.predator;
+            fly = card.fly || Winged(topology);
+            if (string.IsNullOrEmpty(gaitKind) && Winged(topology)) gaitKind = "winged";
+            stability = card.stability;
+        }
+
+        /// <summary>
+        /// Sparse kernel cards omit fly/gait. Do not wipe a winged body back to ground.
+        /// </summary>
+        public void FillGaps(CreatureCard card)
+        {
+            if (card == null) return;
+            if (string.IsNullOrEmpty(topology) && !string.IsNullOrEmpty(card.topology))
+                topology = card.topology;
+            if (string.IsNullOrEmpty(speciesId) && !string.IsNullOrEmpty(card.speciesId))
+                speciesId = card.speciesId;
+            if (string.IsNullOrEmpty(gaitKind))
+                gaitKind = string.IsNullOrEmpty(card.gaitKind) ? (Winged(topology) ? "winged" : gaitKind) : card.gaitKind;
+            if (Winged(topology) || Winged(card.topology) || card.fly) fly = true;
+            if (card.predator) predator = true;
+            if (walkMps < 0.1f && card.walkMps > 0.1f) walkMps = card.walkMps;
+        }
+
+        public static bool Winged(string topology) =>
+            !string.IsNullOrEmpty(topology) && topology.StartsWith("winged", System.StringComparison.OrdinalIgnoreCase);
+
+        public static CreatureGenome Find(string creatureId)
+        {
+            if (string.IsNullOrEmpty(creatureId)) return null;
+            foreach (var g in Object.FindObjectsByType<CreatureGenome>(FindObjectsInactive.Exclude))
+            {
+                if (!g) continue;
+                if (g.id == creatureId) return g;
+            }
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// genome → phenotype → Unity body. Topology / mass / height / generation
+    /// come from the kernel. Extra limbs come from topology, not a second
+    /// bestiary. Missing FreePacks stems fall back to primitives.
+    /// </summary>
+    public static class CreatureCompiler
+    {
+        public static GameObject Compile(Transform parent, CreatureCard card, Vector3 pos, WorldDef world)
+        {
+            if (card == null || string.IsNullOrEmpty(card.id)) return null;
+            var key = "Evo_" + card.id;
+            Normalize(card);
+            var existing = GameObject.Find(key);
+            if (existing)
+            {
+                var g = existing.GetComponent<CreatureGenome>();
+                if (g)
+                {
+                    if (card.generation > g.generation || string.IsNullOrEmpty(g.id))
+                        g.Bind(card);
+                    else
+                        g.FillGaps(card);
+                }
+                var life = existing.GetComponent<FaunaLife>();
+                if (life && g) life.BindGenome(g);
+                return existing;
+            }
+
+            var height = card.heightM > 0.05f ? card.heightM : HeightFor(card.topology, card.speciesId);
+            var topology = card.topology;
+
+            GameObject go = null;
+            var stem = StemFor(topology, card.speciesId);
+            if (!string.IsNullOrEmpty(stem))
+                go = FreePacks.Spawn(stem, parent, pos, Random.Range(0, 360f), ScaleHint(topology, height));
+            if (go == null)
+            {
+                go = new GameObject(key);
+                go.transform.SetParent(parent, false);
+                go.transform.position = pos + Vector3.up * (card.fly ? 2.2f : height * 0.35f);
+            }
+            go.name = key;
+
+            var genome = go.GetComponent<CreatureGenome>() ?? go.AddComponent<CreatureGenome>();
+            genome.Bind(card);
+
+            DressMorphology(go.transform, topology, height, Coat(card, world));
+            FreePacks.EnsureCollider(go, Mathf.Max(1.1f, height * 0.7f));
+            if (!go.GetComponent<CharacterController>())
+                Grounding.EnsureController(go, Mathf.Max(1.2f, height * 0.85f));
+
+            var dummy = go.GetComponent<TrainingDummy>() ?? go.AddComponent<TrainingDummy>();
+            dummy.living = true;
+            dummy.hp = card.massKg > 0f ? Mathf.Clamp(card.massKg * 0.9f, 24f, 180f) : 70f;
+            dummy.unburied = world != null && (world.id == WorldId.Ruins || world.id == WorldId.Crucible);
+
+            if (card.predator && !go.GetComponent<Hostile>()) go.AddComponent<Hostile>();
+            var fauna = go.GetComponent<FaunaLife>() ?? go.AddComponent<FaunaLife>();
+            fauna.BindGenome(genome);
+
+            PersonLabel.Attach(go.transform, genome.Label, card.lifestyle);
+            var spin = go.GetComponent<EvoDrift>();
+            if (spin) spin.enabled = false;
+            return go;
+        }
+
+        public static GameObject FromCritter(Transform parent, WorldBook.Critter c, Vector3 pos, WorldDef world)
+        {
+            if (c == null) return null;
+            var id = string.IsNullOrEmpty(c.id) ? c.name : c.id;
+            if (string.IsNullOrEmpty(id)) return null;
+            var topology = TopologyFor(c.topology_hint, id);
+            return Compile(parent, new CreatureCard
+            {
+                id = id,
+                speciesId = id,
+                topology = topology,
+                generation = 0,
+                fly = CreatureGenome.Winged(topology),
+                predator = ((c.topology_hint ?? "") + " " + id).ToLowerInvariant().IndexOf("wolf") >= 0
+                    || ((c.topology_hint ?? "") + " " + id).ToLowerInvariant().IndexOf("drake") >= 0
+                    || ((c.topology_hint ?? "") + " " + id).ToLowerInvariant().IndexOf("griffin") >= 0
+                    || ((c.topology_hint ?? "") + " " + id).ToLowerInvariant().IndexOf("basilisk") >= 0,
+                lifestyle = "omnivore",
+            }, pos, world);
+        }
+
+        public static GameObject FromKind(Transform parent, string kind, Vector3 pos, WorldDef world)
+        {
+            if (string.IsNullOrEmpty(kind)) return null;
+            return Compile(parent, new CreatureCard
+            {
+                id = kind,
+                speciesId = kind,
+                topology = TopologyFor(kind),
+                generation = 0,
+                fly = IsFlyKind(kind),
+                predator = IsPredatorKind(kind),
+                lifestyle = IsPredatorKind(kind) ? "carnivore" : "omnivore",
+            }, pos, world);
+        }
+
+        /// <summary>
+        /// Kernel snapshot / creature:born. Bodies only at a real presenter xz
+        /// or beside a matching parent already in the scene. Far coords stay unplaced.
+        /// </summary>
+        public static GameObject PresentKernel(Transform parent, CreatureCard card, WorldDef world)
+        {
+            if (card == null || string.IsNullOrEmpty(card.id)) return null;
+            Vector3 p;
+            var hostA = CreatureGenome.Find(card.parentA);
+            var hostB = CreatureGenome.Find(card.parentB);
+            if (card.hasXz && WorldPresence.InPresenter(card.x, card.z))
+                p = new Vector3(card.x, 0f, card.z);
+            else if (hostA)
+                p = hostA.transform.position + hostA.transform.right * 1.4f;
+            else if (hostB)
+                p = hostB.transform.position + hostB.transform.right * -1.4f;
+            else
+                return null;
+            return Compile(parent, card, p, world);
+        }
+
+        static void DressMorphology(Transform root, string topology, float height, Material coat)
+        {
+            var t = topology ?? "quadruped";
+            if (t.StartsWith("winged") || t == "winged_quadruped" || t == "winged_biped")
+            {
+                Wing(root, -1, height, coat);
+                Wing(root, 1, height, coat);
+            }
+            if (t == "quadruped" || t == "winged_quadruped")
+                Tail(root, height, coat);
+            if (t == "serpentine" || t == "eel")
+                Coil(root, height, coat);
+            if (t == "polyped")
+            {
+                for (int i = 0; i < 6; i++)
+                    Leg(root, i, 6, height, coat);
+            }
+            if (t == "amorphous")
+            {
+                var blob = HubLook.Prim(root, PrimitiveType.Sphere, new Vector3(0f, height * 0.2f, 0f),
+                    Vector3.one * (height * 0.55f), coat, "morph_core", false);
+                blob.transform.localScale = new Vector3(height * 0.7f, height * 0.45f, height * 0.7f);
+            }
+        }
+
+        static void Wing(Transform root, int side, float height, Material coat)
+        {
+            var go = HubLook.Prim(root, PrimitiveType.Cube,
+                new Vector3(side * height * 0.45f, height * 0.35f, 0f),
+                new Vector3(height * 0.85f, height * 0.06f, height * 0.32f),
+                coat, side < 0 ? "morph_wing_l" : "morph_wing_r", false);
+            go.transform.localRotation = Quaternion.Euler(0f, 0f, side * -18f);
+        }
+
+        static void Tail(Transform root, float height, Material coat)
+        {
+            HubLook.Prim(root, PrimitiveType.Capsule,
+                new Vector3(0f, height * 0.12f, -height * 0.55f),
+                new Vector3(height * 0.12f, height * 0.28f, height * 0.12f),
+                coat, "morph_tail", false);
+        }
+
+        static void Coil(Transform root, float height, Material coat)
+        {
+            for (int i = 0; i < 5; i++)
+            {
+                HubLook.Prim(root, PrimitiveType.Sphere,
+                    new Vector3(0f, height * 0.12f, -i * height * 0.28f),
+                    Vector3.one * (height * 0.22f),
+                    coat, "morph_seg_" + i, false);
+            }
+        }
+
+        static void Leg(Transform root, int i, int of, float height, Material coat)
+        {
+            float a = (i / (float)of) * Mathf.PI * 2f;
+            HubLook.Prim(root, PrimitiveType.Capsule,
+                new Vector3(Mathf.Cos(a) * height * 0.35f, -height * 0.15f, Mathf.Sin(a) * height * 0.35f),
+                new Vector3(height * 0.08f, height * 0.28f, height * 0.08f),
+                coat, "morph_leg_" + i, false);
+        }
+
+        static Material Coat(CreatureCard card, WorldDef world)
+        {
+            var c = ColorFor(card.variant, card.dominant, card.affinity, world);
+            return HubLook.Lit(c, string.IsNullOrEmpty(card.variant) ? 0.08f : 0.22f, 0.28f);
+        }
+
+        static Color ColorFor(string variant, string dominant, string affinity, WorldDef world)
+        {
+            var key = (variant ?? dominant ?? affinity ?? "").ToLowerInvariant();
+            return key switch
+            {
+                "fire" or "heat" or "ember" => new Color(0.86f, 0.28f, 0.08f),
+                "ice" or "frost" or "cold" => new Color(0.62f, 0.82f, 0.95f),
+                "steam" => new Color(0.78f, 0.82f, 0.86f),
+                "brine" or "water" => new Color(0.22f, 0.48f, 0.62f),
+                "glitch" or "data" or "neural" => new Color(0.45f, 0.95f, 0.72f),
+                "magic" or "curse" => new Color(0.55f, 0.32f, 0.82f),
+                "nature" => new Color(0.32f, 0.62f, 0.28f),
+                "shadow" or "trauma" => new Color(0.18f, 0.16f, 0.22f),
+                _ => world != null ? Color.Lerp(world.ground, world.sun, 0.35f) : new Color(0.45f, 0.4f, 0.32f),
+            };
+        }
+
+        static void Normalize(CreatureCard card)
+        {
+            if (card == null) return;
+            var topology = TopologyFor(card.topology, card.speciesId);
+            card.topology = topology;
+            card.fly = card.fly || CreatureGenome.Winged(topology);
+            if (string.IsNullOrEmpty(card.gaitKind)) card.gaitKind = GaitFor(topology);
+            if (string.IsNullOrEmpty(card.lifestyle))
+                card.lifestyle = card.predator ? "carnivore" : "omnivore";
+            card.predator = card.predator || card.lifestyle == "carnivore";
+        }
+
+        public static string TopologyFor(string hint, string species = null)
+        {
+            var h = (hint ?? "").Trim().ToLowerInvariant();
+            if (h == "winged_quadruped" || h == "winged_biped" || h == "serpentine" || h == "humanoid"
+                || h == "quadruped" || h == "amorphous" || h == "polyped" || h == "eel")
+                return h;
+            var s = (h + " " + (species ?? "")).ToLowerInvariant();
+            if (s.Contains("wing") || s.Contains("hawk") || s.Contains("harpy") || s.Contains("griffin") || s.Contains("drake") || s.Contains("dragon") || s.Contains("wyvern") || s.Contains("falcon") || s.Contains("owl") || s.Contains("pigeon") || s.Contains("finch"))
+                return s.Contains("quad") || s.Contains("griffin") || s.Contains("drake") || s.Contains("dragon") ? "winged_quadruped" : "winged_biped";
+            if (s.Contains("serpent") || s.Contains("snake") || s.Contains("viper") || s.Contains("basilisk") || s.Contains("wyrm"))
+                return "serpentine";
+            if (s.Contains("drone") || s.Contains("mech") || s.Contains("construct") || s.Contains("sentinel"))
+                return "humanoid";
+            if (s.Contains("wraith") || s.Contains("drift") || s.Contains("sprite") || s.Contains("ghost") || s.Contains("amorphous") || s.Contains("shade") || s.Contains("shadow"))
+                return "amorphous";
+            if (s.Contains("spider") || s.Contains("scorpion") || s.Contains("crab") || s.Contains("polyp"))
+                return "polyped";
+            if (s.Contains("human")) return "humanoid";
+            if (s.Contains("quad")) return "quadruped";
+            return "quadruped";
+        }
+
+        static string GaitFor(string topology)
+        {
+            if (string.IsNullOrEmpty(topology)) return "quadruped";
+            if (topology.StartsWith("winged")) return "winged";
+            if (topology == "humanoid") return "biped";
+            return topology;
+        }
+
+        static float HeightFor(string topology, string species)
+        {
+            var s = ((topology ?? "") + " " + (species ?? "")).ToLowerInvariant();
+            if (s.Contains("bear") || s.Contains("griffin") || s.Contains("wyrm")) return 2.2f;
+            if (s.Contains("hawk") || s.Contains("rabbit") || s.Contains("finch") || s.Contains("rat")) return 0.55f;
+            if (s.Contains("drone") || s.Contains("sentinel")) return 0.7f;
+            return 1.15f;
+        }
+
+        static string StemFor(string topology, string species)
+        {
+            var s = ((species ?? "") + " " + (topology ?? "")).ToLowerInvariant();
+            if (s.Contains("drone") || s.Contains("sentinel")) return "enemy-ufo-a";
+            if (s.Contains("wraith") || s.Contains("ghost")) return "character-ghost";
+            if (s.Contains("construct")) return "astronautA";
+            if (s.Contains("drift") || topology == "amorphous") return "alien";
+            if (topology == "serpentine" || s.Contains("basilisk")) return "quadruped_01";
+            if (topology == "winged_biped" || s.Contains("harpy") || s.Contains("parrot")) return "Parrot";
+            if (topology == "winged_quadruped" || s.Contains("griffin") || s.Contains("horse")) return "Horse";
+            if (s.Contains("sealie") || s.Contains("flamingo")) return "Flamingo";
+            if (topology == "humanoid") return "character-ghost";
+            return "Fox";
+        }
+
+        static float ScaleHint(string topology, float height)
+        {
+            var h = height > 0.05f ? height : 1.15f;
+            if (topology != null && topology.StartsWith("winged")) return Mathf.Clamp(h * 1.4f, 1.1f, 2.8f);
+            return Mathf.Clamp(h, 0.7f, 2.4f);
+        }
+
+        static bool IsFlyKind(string kind) =>
+            kind is "griffin" or "harpy" or "drone" or "sentinel" or "drift" or "wraith";
+
+        static bool IsPredatorKind(string kind) =>
+            kind is "wolf" or "hound" or "griffin" or "basilisk" or "wraith" or "drone" or "sentinel";
+    }
+}

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/CreatureCompiler.cs.meta
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/CreatureCompiler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7c4e91a2b8d64f0e9a1c3d5e7f902b14

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/EvoSpawner.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/EvoSpawner.cs
@@ -13,118 +13,15 @@ namespace Concordia
             if (c == null) return null;
             if (WorldMemory.IsDead(world.id, c.id) || WorldMemory.IsDead(world.id, c.name))
                 return null;
-            var hint = (c.topology_hint ?? "").ToLowerInvariant();
-            string kind =
-                hint.Contains("quad") ? "wolf" :
-                hint.Contains("wing") ? "harpy" :
-                hint.Contains("serpent") ? "basilisk" :
-                hint.Contains("drone") || hint.Contains("mech") ? "drone" :
-                hint.Contains("human") ? "wraith" :
-                "hound";
-            var go = Spawn(parent, kind, pos, world);
-            if (go)
-            {
-                go.name = string.IsNullOrEmpty(c.name) ? c.id : c.name;
-                var dummy = go.GetComponent<TrainingDummy>();
-                if (dummy) dummy.unburied = world.id == WorldId.Ruins || world.id == WorldId.Crucible;
-                var life = go.GetComponent<FaunaLife>();
-                if (life)
-                {
-                    life.critterId = string.IsNullOrEmpty(c.id) ? c.name : c.id;
-                    life.predator = IsPredator(kind);
-                }
-            }
-            return go;
+            return CreatureCompiler.FromCritter(parent, c, pos, world);
         }
 
         public static GameObject Spawn(Transform parent, string kind, Vector3 pos, WorldDef world)
         {
             if (WorldMemory.IsDead(world.id, kind) && WorldClock.Ecology < 0.45f)
                 return null;
-            var stem = StemFor(kind);
-            GameObject go = null;
-            if (!string.IsNullOrEmpty(stem))
-                go = FreePacks.Spawn(stem, parent, pos, Random.Range(0, 360f), ScaleHint(kind));
-            if (go == null)
-            {
-                go = GameObject.CreatePrimitive(KindPrim(kind));
-                go.name = "Evo_" + kind;
-                go.transform.SetParent(parent, false);
-                var fly = IsFly(kind);
-                go.transform.position = pos + Vector3.up * (fly ? 2.4f : 0.6f);
-                go.transform.localScale = ScaleFor(kind);
-                var r = go.GetComponent<Renderer>();
-                r.material = new Material(r.sharedMaterial) { color = ColorFor(kind, world) };
-            }
-            go.name = "Evo_" + kind;
-            FreePacks.EnsureCollider(go, 1.2f);
-            if (!go.GetComponent<CharacterController>())
-                Grounding.EnsureController(go, 1.4f);
-            var dummy = go.GetComponent<TrainingDummy>() ?? go.AddComponent<TrainingDummy>();
-            dummy.unburied = world.id == WorldId.Ruins || world.id == WorldId.Crucible;
-            dummy.hp = 70;
-            dummy.living = true;
-            if (!go.GetComponent<Hostile>()) go.AddComponent<Hostile>();
-            var life = go.GetComponent<FaunaLife>() ?? go.AddComponent<FaunaLife>();
-            life.fly = IsFly(kind);
-            life.predator = IsPredator(kind);
-            life.critterId = kind;
-            var spin = go.GetComponent<EvoDrift>();
-            if (spin) spin.enabled = false;
-            return go;
+            return CreatureCompiler.FromKind(parent, kind, pos, world);
         }
-
-        static bool IsFly(string kind) =>
-            kind is "griffin" or "harpy" or "drone" or "sentinel" or "drift" or "wraith";
-
-        static bool IsPredator(string kind) =>
-            kind is "wolf" or "hound" or "griffin" or "basilisk" or "wraith" or "drone" or "sentinel";
-
-        static string StemFor(string k) => k switch
-        {
-            "wolf" or "hound" => "Fox",
-            "sealie" => "Flamingo",
-            "griffin" => "Horse",
-            "harpy" => "Parrot",
-            "wraith" => "character-ghost",
-            "drone" or "sentinel" => "enemy-ufo-a",
-            "construct" => "astronautA",
-            "basilisk" => "quadruped_01",
-            "drift" => "alien",
-            _ => "Fox"
-        };
-
-        static float ScaleHint(string k) => k switch
-        {
-            "griffin" => 2.6f,
-            "drone" or "sentinel" => 1.5f,
-            "wraith" => 1.85f,
-            "wolf" or "hound" => 1.15f,
-            "sealie" => 1.4f,
-            "harpy" => 1.1f,
-            _ => 1.25f
-        };
-
-        static PrimitiveType KindPrim(string k) =>
-            k is "drone" or "construct" or "golem" ? PrimitiveType.Cube :
-            k is "serpent" or "wyrm" or "basilisk" ? PrimitiveType.Capsule :
-            PrimitiveType.Sphere;
-
-        static Vector3 ScaleFor(string k) => k switch
-        {
-            "griffin" or "dragon" or "wyrm" => new Vector3(1.6f, 0.7f, 1.8f),
-            "wolf" or "hound" or "sealie" => new Vector3(0.9f, 0.55f, 1.3f),
-            "drone" => new Vector3(0.5f, 0.2f, 0.7f),
-            _ => Vector3.one * 0.8f
-        };
-
-        static Color ColorFor(string k, WorldDef w) => k switch
-        {
-            "wraith" => new Color(0.7f, 0.85f, 0.9f, 0.7f),
-            "drone" => w.sun,
-            "sealie" => new Color(0.4f, 0.7f, 0.85f),
-            _ => Color.Lerp(w.ground, w.sun, 0.4f)
-        };
     }
 
     /// <summary>Legacy sine orbit. Disabled on the live spawn path — FaunaLife owns motion.</summary>
@@ -151,6 +48,7 @@ namespace Concordia
         public bool hunting;
         public string critterId;
         public string act = "wander";
+        float _walkMps = -1f;
         Vector3 _home;
         Vector3 _dest;
         CharacterController _cc;
@@ -168,7 +66,21 @@ namespace Concordia
             _cc = GetComponent<CharacterController>();
             _body = GetComponent<TrainingDummy>();
             _rend = GetComponentsInChildren<Renderer>(true);
+            var genome = GetComponent<CreatureGenome>();
+            if (genome) BindGenome(genome);
             Pick();
+        }
+
+        /// <summary>
+        /// Kernel genome drives fly / predator / gait. Missing fields stay as spawned.
+        /// </summary>
+        public void BindGenome(CreatureGenome g)
+        {
+            if (!g) return;
+            if (!string.IsNullOrEmpty(g.id)) critterId = g.id;
+            fly = g.fly;
+            predator = g.predator;
+            if (g.walkMps > 0.1f) _walkMps = g.walkMps;
         }
 
         void Update()
@@ -244,7 +156,8 @@ namespace Concordia
                 return;
             }
             act = "wander";
-            Step(_dest, fly ? 2.6f : 1.8f);
+            var walk = _walkMps > 0.1f ? _walkMps : (fly ? 2.6f : 1.8f);
+            Step(_dest, walk);
             if (lod == SimLod.Real && dist < 18f) WorldClock.NoteAct(Label() + " " + act + "s");
         }
 
@@ -261,7 +174,8 @@ namespace Concordia
             }
             if (!prey) return false;
             act = "hunt";
-            Step(prey.transform.position, fly ? 3.8f : 3.1f);
+            var chase = _walkMps > 0.1f ? _walkMps * 1.45f : (fly ? 3.8f : 3.1f);
+            Step(prey.transform.position, chase);
             if (lod == SimLod.Real) WorldClock.NoteAct(Label() + " hunts");
             return true;
         }
@@ -322,6 +236,8 @@ namespace Concordia
 
         string Label()
         {
+            var g = GetComponent<CreatureGenome>();
+            if (g && !string.IsNullOrEmpty(g.Label)) return g.Label;
             if (!string.IsNullOrEmpty(critterId)) return critterId;
             return name.Replace("Evo_", "");
         }

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/FreePacks.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/FreePacks.cs
@@ -715,13 +715,13 @@ namespace Concordia
         public static string Tree(WorldId id)
         {
             var c = Culture(id);
-            if (c == "grid") return FirstStem(new[] { "LowPoly - FirTree A", "tree_1" }, "tree-baobab");
-            if (c == "ash") return FirstStem(new[] { "half_tree", "tree" }, "tree-dead");
-            return FirstStem(new[] { "OakBigTree01_pr", "tree_1", "tree", "LowPoly - FirTree A" }, "tree_oak");
+            if (c == "grid") return FirstStem(new[] { "UNS_Spruce_01", "LowPoly - FirTree A", "tree_1" }, "tree-baobab");
+            if (c == "ash") return FirstStem(new[] { "half_tree", "UNS_Spruce_01", "tree" }, "tree-dead");
+            return FirstStem(new[] { "OakBigTree01_pr", "UNS_Spruce_01", "tree_1", "tree", "LowPoly - FirTree A" }, "tree_oak");
         }
 
         public static string Grass(WorldId id) =>
-            FirstStem(new[] { "grass01", "LowPoly - Grass A", "Grass_01" }, "grass");
+            FirstStem(new[] { "UNS_Grass", "grass01", "LowPoly - Grass A", "Grass_01" }, "grass");
 
         public static string Prop(WorldId id)
         {
@@ -732,16 +732,18 @@ namespace Concordia
         }
 
         public static string Column(WorldId id) =>
-            FirstStem(new[] { "stone_column" }, "column");
+            FirstStem(new[] { "wood_column.001", "Column_01_Top", "stone_column" }, "column");
 
         public static string Cart() => FirstStem(new[] { "wagon" }, "cart");
         public static string Crate() => FirstStem(new[] { "crate", "barrel" }, "crate");
         public static string Table() => FirstStem(new[] { "table" }, "table");
         public static string Chair() => FirstStem(new[] { "chair" }, "chair");
         public static string Chest() => FirstStem(new[] { "chest" }, "chest");
+        public static string Well() => FirstStem(new[] { "well" }, "well");
+        public static string Torch() => FirstStem(new[] { "torch" }, "torch");
         public static string Dummy() => FirstStem(new[] { "HumanDummy_M White", "Human_BasicMotionsDummy_M" }, "character-skeleton");
         public static string Bird() => FirstStem(new[] { "lb_sparrow", "lb_robin", "lb_cardinal" }, "");
-        public static string Rock() => FirstStem(new[] { "Rock1A", "LowPoly - Rock A", "LowPoly - Rock B" }, "rock_smallA");
+        public static string Rock() => FirstStem(new[] { "Rock1B", "Rock2", "Rock1A", "UNS_Standard_Rock_01", "LowPoly - Rock A", "LowPoly - Rock B" }, "rock_smallA");
 
         /// <summary>
         /// Owned MYFG stems when they exist. Spear / staff / wand / dagger / mace

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/FreePacks.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/FreePacks.cs
@@ -904,7 +904,7 @@ namespace Concordia
         /// Hero city (index 0) keeps four playable rooms. Cities 1–3 get fake windows.
         /// The rest stay facade-only so Tunya's 17 towns do not hitch.
         /// </summary>
-        public static int PlayableRooms(int cityIndex) => cityIndex == 0 ? 4 : 0;
+        public static int PlayableRooms(int cityIndex) => cityIndex == 0 ? 4 : cityIndex <= 2 ? 2 : 0;
         public static bool WantsFakeWindows(int cityIndex) => cityIndex >= 1 && cityIndex <= 3;
 
         public static string Audit()
@@ -932,7 +932,8 @@ namespace Concordia
             sb.AppendLine("Tree(Tunya)=" + Tree(WorldId.Tunya));
             sb.AppendLine("Weapon(sword)=" + Weapon("sword") + " Weapon(greatsword)=" + Weapon("greatsword") + " Weapon(spear)=" + Weapon("spear"));
             sb.AppendLine("Dummy=" + Dummy());
-            sb.AppendLine("PlayableRooms hero=" + PlayableRooms(0) + " other=" + PlayableRooms(1));
+            sb.AppendLine("PlayableRooms hero=" + PlayableRooms(0) + " city1=" + PlayableRooms(1) + " city3=" + PlayableRooms(3));
+            sb.AppendLine("unique authored .glb per world: none in tree — Culture+Kit is the honest unique presentation");
             sb.AppendLine("FakeWindows cities 1-3=" + WantsFakeWindows(2) + " city4=" + WantsFakeWindows(4));
             sb.AppendLine("WORLD NEED vs HAVE");
             foreach (var id in new[]

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/FreePacks.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/FreePacks.cs
@@ -717,7 +717,7 @@ namespace Concordia
             var c = Culture(id);
             if (c == "grid") return FirstStem(new[] { "LowPoly - FirTree A", "tree_1" }, "tree-baobab");
             if (c == "ash") return FirstStem(new[] { "half_tree", "tree" }, "tree-dead");
-            return FirstStem(new[] { "tree_1", "tree", "LowPoly - FirTree A" }, "tree_oak");
+            return FirstStem(new[] { "OakBigTree01_pr", "tree_1", "tree", "LowPoly - FirTree A" }, "tree_oak");
         }
 
         public static string Grass(WorldId id) =>
@@ -741,7 +741,7 @@ namespace Concordia
         public static string Chest() => FirstStem(new[] { "chest" }, "chest");
         public static string Dummy() => FirstStem(new[] { "HumanDummy_M White", "Human_BasicMotionsDummy_M" }, "character-skeleton");
         public static string Bird() => FirstStem(new[] { "lb_sparrow", "lb_robin", "lb_cardinal" }, "");
-        public static string Rock() => FirstStem(new[] { "LowPoly - Rock A", "LowPoly - Rock B" }, "rock_smallA");
+        public static string Rock() => FirstStem(new[] { "Rock1A", "LowPoly - Rock A", "LowPoly - Rock B" }, "rock_smallA");
 
         /// <summary>
         /// Owned MYFG stems when they exist. Spear / staff / wand / dagger / mace
@@ -847,10 +847,22 @@ namespace Concordia
         {
             var c = Culture(id);
             if (c == "court") return "unpaved Court — no house ring";
-            if (c == "grove" && id == WorldId.Frontier) return "no palm pack — Kenney palm fallback; embassy is road only";
-            if (c == "grove") return "no wheat/hedge pack — Kenney crops/hedge fallback";
+            if (c == "grove" && id == WorldId.Frontier)
+            {
+                var palm = FirstStem(new[] { "Palm" }, "palm-straight");
+                return palm != "palm-straight" ? "SUIMONO palms" : "no palm pack — Kenney palm fallback; embassy is road only";
+            }
+            if (c == "grove")
+            {
+                var wheat = FirstStem(new[] { "Crops", "Wheat" }, "crops_wheatStageB");
+                return wheat != "crops_wheatStageB" ? "store crops" : "no wheat/hedge pack — Kenney crops/hedge fallback";
+            }
             if (c == "ash") return "no crypt/gravestone pack — Kenney fallback";
-            if (c == "street") return "no dumpster pack — Kenney dumpster fallback";
+            if (c == "street")
+            {
+                var dump = FirstStem(new[] { "Dumpster" }, "dumpster");
+                return dump != "dumpster" ? "industrial dumpsters" : "no dumpster pack — Kenney dumpster fallback";
+            }
             if (c == "grid") return "no sci-fi lab / Kyle — modular rooms then Kenney skyline";
             return "no crystal pack — Kenney crystal fallback";
         }
@@ -962,9 +974,9 @@ namespace Concordia
             new PackHint { id = "4387", role = "water (SUIMONO) — imported, not the live water path", needles = new[] { "SUIMONO" } },
             new PackHint { id = "14360", role = "weapon meshes", needles = new[] { "MYFG-Weapon" } },
             new PackHint { id = "267961", role = "controller reference — do not replace Concordia", needles = new[] { "Starter Assets" } },
-            new PackHint { id = "279431", role = "big oak (re-download if truncated)", needles = new[] { "Big Oak", "Objective Environment" } },
+            new PackHint { id = "279431", role = "big oak (re-download if truncated)", needles = new[] { "ALP_Assets", "Big Oak" } },
             new PackHint { id = "269772", role = "demo city (re-download if truncated; do not vendor)", needles = new[] { "Demo City", "Versatile Studio" } },
-            new PackHint { id = "155776", role = "sound fx (re-download if truncated)", needles = new[] { "Sound Effects" } }
+            new PackHint { id = "155776", role = "sound fx (re-download if truncated)", needles = new[] { "Free Pack", "Sound Effects" } }
         };
 
         public static bool FolderPresent(string[] needles)

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/FreePacks.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/FreePacks.cs
@@ -824,7 +824,12 @@ namespace Concordia
                 }
                 : kind == "fireflies"
                     ? new[] { "Assets/VFX/VFX_Fireflies.prefab" }
-                    : new[] { "Assets/VFX/VFX_Snow.prefab" };
+                    : new[]
+                    {
+                        "Assets/VFX/VFX_Snow.prefab",
+                        "Assets/UnityTechnologies/ParticlePack/EffectExamples/Smoke & Steam Effects/Prefabs/DustStorm.prefab",
+                        "Assets/UnityTechnologies/ParticlePack/EffectExamples/Smoke & Steam Effects/Prefabs/SmokeEffect.prefab"
+                    };
             foreach (var p in paths)
                 if (FreePacks.Load<GameObject>(p) != null) return p;
             return paths[paths.Length - 1];
@@ -834,7 +839,7 @@ namespace Concordia
         {
             var stem = kind == "rain" ? FirstStem(new[] { "RainPrefab", "vfx_Rain_01", "RainEffect" }, "")
                 : kind == "fireflies" ? FirstStem(new[] { "FireFlies" }, "")
-                : FirstStem(new[] { "SnowEffect" }, "");
+                : FirstStem(new[] { "SnowEffect", "DustStorm", "SmokeEffect" }, "");
             if (!string.IsNullOrEmpty(stem) && FreePacks.HasStem(stem))
             {
                 FreePacks.Spawn(stem, root, pos, 0, 0);

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/Hostile.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/Hostile.cs
@@ -26,10 +26,38 @@ namespace Concordia
         Transform _tell;
         Renderer _tellRend;
         public static string TelegraphKind;
+        public static string TelegraphCounter;
         public static Transform TelegraphFrom;
         public static float TelegraphUntil;
+        public static float KernelUntil;
 
         static readonly string[] Perils = { "thrust", "sweep", "grab" };
+
+        public static string CounterFor(string kind)
+        {
+            if (kind == "thrust") return "dodge";
+            if (kind == "sweep") return "jump";
+            if (kind == "grab") return "break";
+            return "dodge";
+        }
+
+        public static bool CounterMatches(string peril, string defense)
+        {
+            if (string.IsNullOrEmpty(defense)) return false;
+            if (defense == "parry") return true;
+            if (string.IsNullOrEmpty(peril)) return defense == "dodge";
+            if (peril == "grab" && defense == "dodge") return true;
+            return CounterFor(peril) == defense;
+        }
+
+        public static void BindKernel(string kind, string counter, float seconds)
+        {
+            if (string.IsNullOrEmpty(kind)) return;
+            TelegraphKind = kind;
+            TelegraphCounter = string.IsNullOrEmpty(counter) ? CounterFor(kind) : counter;
+            KernelUntil = Time.time + Mathf.Max(0.2f, seconds);
+            TelegraphUntil = KernelUntil;
+        }
 
         void Start()
         {
@@ -72,7 +100,11 @@ namespace Concordia
             {
                 if (TelegraphFrom == transform)
                 {
-                    TelegraphKind = null;
+                    if (Time.time >= KernelUntil)
+                    {
+                        TelegraphKind = null;
+                        TelegraphCounter = null;
+                    }
                     TelegraphFrom = null;
                     _windup = 0f;
                 }
@@ -105,7 +137,11 @@ namespace Concordia
             if (_windup <= 0f)
             {
                 _windup = 0.48f;
-                TelegraphKind = Perils[Mathf.Abs(name.GetHashCode()) % Perils.Length];
+                if (Time.time >= KernelUntil)
+                {
+                    TelegraphKind = Perils[Mathf.Abs(name.GetHashCode()) % Perils.Length];
+                    TelegraphCounter = CounterFor(TelegraphKind);
+                }
                 TelegraphFrom = transform;
                 TelegraphUntil = Time.time + _windup;
                 ShowTell(true);
@@ -116,7 +152,11 @@ namespace Concordia
             _cd = 0.85f + (1.4f - _style);
             if (TelegraphFrom == transform)
             {
-                TelegraphKind = null;
+                if (Time.time >= KernelUntil)
+                {
+                    TelegraphKind = null;
+                    TelegraphCounter = null;
+                }
                 TelegraphFrom = null;
             }
             ShowTell(false);

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/Hostile.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/Hostile.cs
@@ -22,6 +22,14 @@ namespace Concordia
         Vector3 _vel;
         float _strafe;
         float _style;
+        float _windup;
+        Transform _tell;
+        Renderer _tellRend;
+        public static string TelegraphKind;
+        public static Transform TelegraphFrom;
+        public static float TelegraphUntil;
+
+        static readonly string[] Perils = { "thrust", "sweep", "grab" };
 
         void Start()
         {
@@ -62,6 +70,13 @@ namespace Concordia
 
             if (_seen <= 0f && dist > aggro)
             {
+                if (TelegraphFrom == transform)
+                {
+                    TelegraphKind = null;
+                    TelegraphFrom = null;
+                    _windup = 0f;
+                }
+                ShowTell(false);
                 if (_fauna) _fauna.hunting = false;
                 var home = _home - transform.position;
                 home.y = 0f;
@@ -87,7 +102,24 @@ namespace Concordia
             Step((side * Mathf.Sin(_strafe * 2.2f) * 0.55f).normalized);
             Face(aim);
             if (_cd > 0f) return;
+            if (_windup <= 0f)
+            {
+                _windup = 0.48f;
+                TelegraphKind = Perils[Mathf.Abs(name.GetHashCode()) % Perils.Length];
+                TelegraphFrom = transform;
+                TelegraphUntil = Time.time + _windup;
+                ShowTell(true);
+                return;
+            }
+            _windup -= Time.deltaTime;
+            if (_windup > 0f) return;
             _cd = 0.85f + (1.4f - _style);
+            if (TelegraphFrom == transform)
+            {
+                TelegraphKind = null;
+                TelegraphFrom = null;
+            }
+            ShowTell(false);
             player.TakeHit(damage, name);
         }
 
@@ -124,6 +156,40 @@ namespace Concordia
             if (dir.sqrMagnitude < 0.01f) return;
             var look = Quaternion.LookRotation(new Vector3(dir.x, 0f, dir.z));
             transform.rotation = Quaternion.Slerp(transform.rotation, look, Time.deltaTime * 8f);
+        }
+
+        void ShowTell(bool on)
+        {
+            if (!on)
+            {
+                if (_tell) _tell.gameObject.SetActive(false);
+                return;
+            }
+            if (!_tell)
+            {
+                var go = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+                go.name = "Telegraph";
+                var col = go.GetComponent<Collider>();
+                if (col) UnityEngine.Object.Destroy(col);
+                _tell = go.transform;
+                _tell.SetParent(transform, false);
+                _tell.localPosition = new Vector3(0f, 2.25f, 0.2f);
+                _tell.localScale = Vector3.one * 0.22f;
+                _tellRend = go.GetComponent<Renderer>();
+            }
+            _tell.gameObject.SetActive(true);
+            if (!_tellRend) return;
+            var kind = TelegraphKind ?? "thrust";
+            var c = kind == "sweep" ? new Color(1f, 0.55f, 0.12f, 1f)
+                : kind == "grab" ? new Color(0.85f, 0.2f, 0.95f, 1f)
+                : new Color(1f, 0.18f, 0.12f, 1f);
+            var mat = _tellRend.material;
+            mat.color = c;
+            if (mat.HasProperty("_EmissionColor"))
+            {
+                mat.EnableKeyword("_EMISSION");
+                mat.SetColor("_EmissionColor", c * 4f);
+            }
         }
     }
 }

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/Hostile.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/Hostile.cs
@@ -59,6 +59,23 @@ namespace Concordia
             TelegraphUntil = KernelUntil;
         }
 
+        public void TelegraphNow()
+        {
+            _windup = 0.48f;
+            if (Time.time >= KernelUntil)
+            {
+                TelegraphKind = Perils[Mathf.Abs(name.GetHashCode()) % Perils.Length];
+                TelegraphCounter = CounterFor(TelegraphKind);
+            }
+            TelegraphFrom = transform;
+            TelegraphUntil = Time.time + _windup;
+            ShowTell(true);
+            var av = GetComponentInChildren<MixamoAvatar>();
+            av?.Anticipate();
+            var person = GetComponentInChildren<ModularPerson>();
+            person?.Anticipate();
+        }
+
         void Start()
         {
             _body = GetComponent<TrainingDummy>() ?? GetComponentInParent<TrainingDummy>();
@@ -136,15 +153,7 @@ namespace Concordia
             if (_cd > 0f) return;
             if (_windup <= 0f)
             {
-                _windup = 0.48f;
-                if (Time.time >= KernelUntil)
-                {
-                    TelegraphKind = Perils[Mathf.Abs(name.GetHashCode()) % Perils.Length];
-                    TelegraphCounter = CounterFor(TelegraphKind);
-                }
-                TelegraphFrom = transform;
-                TelegraphUntil = Time.time + _windup;
-                ShowTell(true);
+                TelegraphNow();
                 return;
             }
             _windup -= Time.deltaTime;

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/HubLook.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/HubLook.cs
@@ -204,7 +204,10 @@ namespace Concordia
 
         public static void Lantern(Transform parent, Vector3 pos)
         {
-            FreePacks.Spawn("lantern", parent, pos, 0, 1.35f);
+            const string forge =
+                "Assets/3DForge/Fantasy_Interiors/Villages_&_Towns/Prefabs/Props/Lighting/Standing/fi_vil_light_candle_holder04_lit.prefab";
+            var held = FreePacks.Prefab(forge, parent, pos, 0);
+            if (!held) FreePacks.Spawn("lantern", parent, pos, 0, 1.35f);
             var bulb = GameObject.CreatePrimitive(PrimitiveType.Sphere);
             bulb.name = "LanternGlow";
             bulb.transform.SetParent(parent, false);

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/HubLook.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/HubLook.cs
@@ -212,6 +212,15 @@ namespace Concordia
             bulb.transform.localScale = Vector3.one * 0.18f;
             Object.Destroy(bulb.GetComponent<Collider>());
             bulb.GetComponent<Renderer>().sharedMaterial = Emit(new Color(1f, 0.72f, 0.38f), 3.5f);
+            var lightGo = new GameObject("LanternLight");
+            lightGo.transform.SetParent(parent, false);
+            lightGo.transform.position = pos + Vector3.up * 1.7f;
+            var pl = lightGo.AddComponent<Light>();
+            pl.type = LightType.Point;
+            pl.color = new Color(1f, 0.72f, 0.38f);
+            pl.intensity = 2.6f;
+            pl.range = 10f;
+            pl.shadows = LightShadows.Soft;
         }
 
         public static Material GroundMat(WorldId world, Color tint)

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/HubObjectives.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/HubObjectives.cs
@@ -23,6 +23,7 @@ namespace Concordia
             Seen.Clear();
             QuestLog.Reset();
             SkillLedger.Reset();
+            SkillLattice.Reset();
             KitBag.Reset();
             Bonds.Reset();
             Plots.Reset();
@@ -372,6 +373,111 @@ namespace Concordia
         }
 
         static int Count(Dictionary<string, int> d, string k) => d.TryGetValue(k, out var n) ? n : 0;
+    }
+
+    /// <summary>
+    /// T3.1 kernel skill overlay. Bound from skills.mastery over /unity-ws.
+    /// Untrained catalog rows stay level 0. Empty until Concord answers —
+    /// kit arts are not this lattice.
+    /// </summary>
+    public static class SkillLattice
+    {
+        public class Row
+        {
+            public string skillType, group, tier, element, preset;
+            public int level, cameraKickPx;
+            public float potency, glow;
+            public bool finisher;
+        }
+
+        public static readonly List<Row> All = new List<Row>();
+        public static readonly List<string> Groups = new List<string>();
+        public static bool FromKernel;
+        public static string Group = "combat";
+        public static string ActiveSkill = "swords";
+        public static int CatalogCount;
+        public static int TrainedCount;
+
+        public static void Reset()
+        {
+            All.Clear();
+            Groups.Clear();
+            FromKernel = false;
+            Group = "combat";
+            ActiveSkill = "swords";
+            CatalogCount = 0;
+            TrainedCount = 0;
+        }
+
+        public static void Bind(int catalogCount, int trainedCount)
+        {
+            CatalogCount = catalogCount;
+            TrainedCount = trainedCount;
+            FromKernel = catalogCount > 0;
+            if (string.IsNullOrEmpty(Group)) Group = "combat";
+            if (Find(ActiveSkill) == null) ActiveSkill = CombatSlot(0);
+        }
+
+        public static void Add(Row row)
+        {
+            if (row == null || string.IsNullOrEmpty(row.skillType)) return;
+            All.Add(row);
+            if (!string.IsNullOrEmpty(row.group) && !Groups.Contains(row.group))
+                Groups.Add(row.group);
+        }
+
+        public static Row Find(string skillType)
+        {
+            if (string.IsNullOrEmpty(skillType)) return null;
+            for (int i = 0; i < All.Count; i++)
+                if (All[i].skillType == skillType) return All[i];
+            return null;
+        }
+
+        public static string CombatSlot(int art)
+        {
+            int n = 0;
+            for (int i = 0; i < All.Count; i++)
+            {
+                if (All[i].group != "combat") continue;
+                if (n == art) return All[i].skillType;
+                n++;
+            }
+            if (art == 1) return "fists";
+            if (art == 2) return "archery";
+            return "swords";
+        }
+
+        public static void SelectSlot(int art)
+        {
+            KitBag.Art = art;
+            ActiveSkill = CombatSlot(art);
+        }
+
+        public static void CycleGroup(int delta)
+        {
+            if (Groups.Count == 0) return;
+            int i = Groups.IndexOf(Group);
+            if (i < 0) i = 0;
+            i = (i + delta + Groups.Count * 8) % Groups.Count;
+            Group = Groups[i];
+        }
+
+        public static string HudLine()
+        {
+            if (!FromKernel) return "skills.mastery unbound";
+            var row = Find(ActiveSkill);
+            if (row == null) return CatalogCount + " skills · kernel";
+            return row.skillType + "  L" + row.level + "  " + row.tier
+                + (row.finisher ? "  finisher" : "");
+        }
+
+        public static float KickMul(string skillType)
+        {
+            var row = Find(skillType);
+            if (row == null) return 1f;
+            return Mathf.Clamp(0.7f + row.glow * 0.8f + row.cameraKickPx * 0.08f, 0.5f, 2.4f);
+        }
     }
 
     /// <summary>

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/HubObjectives.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/HubObjectives.cs
@@ -416,6 +416,35 @@ namespace Concordia
             FromKernel = catalogCount > 0;
             if (string.IsNullOrEmpty(Group)) Group = "combat";
             if (Find(ActiveSkill) == null) ActiveSkill = CombatSlot(0);
+            WorldBuilder.PresentSkillPylons();
+        }
+
+        public static string FirstInGroup(string group)
+        {
+            if (string.IsNullOrEmpty(group)) return ActiveSkill;
+            for (int i = 0; i < All.Count; i++)
+                if (All[i].group == group) return All[i].skillType;
+            return group == "combat" ? "swords" : "";
+        }
+
+        public static string VfxPath(string skillType)
+        {
+            var row = Find(skillType);
+            var e = row != null ? (row.element ?? "") : "";
+            if (string.IsNullOrEmpty(e)) e = skillType ?? "";
+            e = e.ToLowerInvariant();
+            const string root = "Assets/GabrielAguiarProductions/FreeQuickEffectsVol1/Prefabs/";
+            if (e.Contains("fire") || e.Contains("ember") || e.Contains("flame"))
+                return root + "vfx_Flamethrower_01.prefab";
+            if (e.Contains("lightning") || e.Contains("electric") || e.Contains("shock"))
+                return root + "vfx_Lightning_01.prefab";
+            if (e.Contains("ice") || e.Contains("water") || e.Contains("frost"))
+                return root + "vfx_Shockwave_01.prefab";
+            if (e.Contains("poison") || e.Contains("bio") || e.Contains("miasma"))
+                return root + "vfx_Smoke_01.prefab";
+            if (e.Contains("energy") || e.Contains("heal") || e.Contains("plasma"))
+                return root + "vfx_Heal_02.prefab";
+            return root + "vfx_Impact_01.prefab";
         }
 
         public static void Add(Row row)
@@ -477,6 +506,23 @@ namespace Concordia
             var row = Find(skillType);
             if (row == null) return 1f;
             return Mathf.Clamp(0.7f + row.glow * 0.8f + row.cameraKickPx * 0.08f, 0.5f, 2.4f);
+        }
+    }
+
+    /// <summary>
+    /// In-world skill group marker around the training dummy. E selects the
+    /// group's first catalog skill. The full 67 live on the K overlay.
+    /// </summary>
+    public class SkillPylon : MonoBehaviour
+    {
+        public string group;
+        public string skillType;
+
+        public string Take()
+        {
+            if (!string.IsNullOrEmpty(group)) SkillLattice.Group = group;
+            if (!string.IsNullOrEmpty(skillType)) SkillLattice.ActiveSkill = skillType;
+            return SkillLattice.HudLine();
         }
     }
 

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/HubObjectives.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/HubObjectives.cs
@@ -534,7 +534,7 @@ namespace Concordia
     {
         public class Item
         {
-            public string id, name, kind, stem;
+            public string id, name, kind, stem, affixLine;
         }
 
         public static readonly List<Item> Items = new List<Item>();
@@ -560,6 +560,26 @@ namespace Concordia
         {
             if (string.IsNullOrEmpty(id) || Has(id)) return;
             Items.Add(new Item { id = id, name = name ?? Pretty(id), kind = "loot", stem = id });
+        }
+
+        /// <summary>
+        /// Kernel loadout row from world:snapshot.gear. Affix labels only —
+        /// never invented stats.
+        /// </summary>
+        public static void BindKernel(string id, string name, string affixLine)
+        {
+            if (string.IsNullOrEmpty(id) && string.IsNullOrEmpty(name)) return;
+            var key = string.IsNullOrEmpty(id) ? name : id;
+            Item found = null;
+            foreach (var it in Items)
+                if (it.id == key || it.name == name) { found = it; break; }
+            if (found == null)
+            {
+                found = new Item { id = key, name = string.IsNullOrEmpty(name) ? Pretty(key) : name, kind = "loot", stem = key };
+                Items.Add(found);
+            }
+            found.affixLine = affixLine ?? "";
+            if (!string.IsNullOrEmpty(name)) found.name = name;
         }
 
         public static Item TakeLoot()

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/HubObjectives.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/HubObjectives.cs
@@ -24,6 +24,7 @@ namespace Concordia
             QuestLog.Reset();
             SkillLedger.Reset();
             KitBag.Reset();
+            Bonds.Reset();
         }
 
         public static void NoteLamp() => Lamp = true;
@@ -408,6 +409,25 @@ namespace Concordia
             Items.Add(new Item { id = id, name = name ?? Pretty(id), kind = "loot", stem = id });
         }
 
+        public static Item TakeLoot()
+        {
+            for (int i = 0; i < Items.Count; i++)
+            {
+                if (Items[i].kind == "weapon") continue;
+                var it = Items[i];
+                Items.RemoveAt(i);
+                return it;
+            }
+            return null;
+        }
+
+        public static bool HasLoot()
+        {
+            foreach (var it in Items)
+                if (it.kind != "weapon") return true;
+            return false;
+        }
+
         public static bool Has(string id)
         {
             foreach (var it in Items)
@@ -462,6 +482,54 @@ namespace Concordia
             foreach (var f in WorldBook.Factions(world))
                 if (f != null && f.id == factionId) return f;
             return null;
+        }
+    }
+
+    /// <summary>
+    /// T1 affinity + T2 gifts. Local until /unity-ws carries romance.give_gift.
+    /// </summary>
+    public static class Bonds
+    {
+        static readonly Dictionary<string, float> Aff = new Dictionary<string, float>();
+
+        public static void Reset() => Aff.Clear();
+
+        public static string Key(GuestNpc npc)
+        {
+            if (npc == null) return "";
+            if (!string.IsNullOrEmpty(npc.personId)) return npc.personId;
+            if (npc.def != null && !string.IsNullOrEmpty(npc.def.id)) return npc.def.id;
+            return npc.def != null ? npc.def.name : npc.name;
+        }
+
+        public static float Get(string id)
+        {
+            if (string.IsNullOrEmpty(id)) return 0f;
+            return Aff.TryGetValue(id, out var v) ? v : 0.08f;
+        }
+
+        public static float TalkBump(string id)
+        {
+            if (string.IsNullOrEmpty(id)) return 0f;
+            var next = Mathf.Clamp01(Get(id) + 0.02f);
+            Aff[id] = next;
+            return next;
+        }
+
+        public static string Give(GuestNpc npc)
+        {
+            var id = Key(npc);
+            if (string.IsNullOrEmpty(id)) return "No one to give to.";
+            var item = KitBag.TakeLoot();
+            if (item == null) return "Empty hands. Take something from the ring first.";
+            float bump = 0.12f;
+            var n = (item.name ?? item.id ?? "").ToLowerInvariant();
+            if (n.Contains("meal") || n.Contains("flower") || n.Contains("lamp")) bump = 0.22f;
+            var next = Mathf.Clamp01(Get(id) + bump);
+            Aff[id] = next;
+            WorldClock.NoteAct("a gift changed the air");
+            var who = npc.def != null ? npc.def.name : "them";
+            return "You give " + who + " " + item.name + ". Affinity " + Mathf.RoundToInt(next * 100f) + "%.";
         }
     }
 }

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/HubObjectives.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/HubObjectives.cs
@@ -813,15 +813,16 @@ namespace Concordia
     }
 
     /// <summary>
-    /// Local scheme board. Same verbs as interveneInScheme (expose/abet/ignore).
-    /// Kernel row wins when it exists; missing row is not a fake success — the
-    /// local plot still resolves because the kitchen IS the scheme here.
+    /// Scheme board. Kernel schemeId from scheme:overheard / secret:weaponised
+    /// barges in via scheme:intervene. Kitchen-only plots stay local and never
+    /// claim a kernel success.
     /// </summary>
     public static class Plots
     {
         public class Rec
         {
             public string id, text, phase;
+            public bool kernel;
         }
 
         static Rec _live;
@@ -829,30 +830,45 @@ namespace Concordia
 
         public static void Reset() => _live = null;
 
-        public static void Seed(string text)
+        public static void Seed(string text, string schemeId = null)
         {
+            var kernel = !string.IsNullOrEmpty(schemeId) && !schemeId.StartsWith("local_");
             _live = new Rec
             {
-                id = "local_" + WorldClock.Day + "_" + Mathf.FloorToInt(WorldClock.Hour),
+                id = kernel ? schemeId : "local_" + WorldClock.Day + "_" + Mathf.FloorToInt(WorldClock.Hour),
                 text = text ?? "A faction scheme ripened.",
-                phase = "brewing"
+                phase = "brewing",
+                kernel = kernel
             };
+        }
+
+        public static void ResolveKernel(string action)
+        {
+            if (_live == null) return;
+            if (action != "expose" && action != "abet") action = "ignore";
+            _live.phase = action == "expose" ? "exposed" : action == "abet" ? "abetted" : "ignored";
         }
 
         public static string Intervene(string action)
         {
             if (_live == null) return "No plot in the air.";
             if (action != "expose" && action != "abet") action = "ignore";
-            _live.phase = action == "expose" ? "exposed" : action == "abet" ? "abetted" : "ignored";
             var line = action == "expose"
                 ? "You name the plot. The air goes still."
                 : action == "abet"
                     ? "You put your weight behind it."
                     : "You let it pass.";
+            if (_live.kernel)
+            {
+                var client = ConcordClient.Live;
+                if (client != null) client.SendIntervene(_live.id, action);
+                WorldClock.NoteAct("waiting on the kernel");
+                ConcordiaHUD.Announce(action, "waiting on the kernel");
+                return line + (string.IsNullOrEmpty(_live.text) ? "" : " · " + _live.text);
+            }
+            _live.phase = action == "expose" ? "exposed" : action == "abet" ? "abetted" : "ignored";
             WorldClock.NoteAct(line);
             ConcordiaHUD.Announce(action, line);
-            var client = ConcordClient.Live;
-            if (client != null) client.SendIntervene(_live.id, action);
             return line + (string.IsNullOrEmpty(_live.text) ? "" : " · " + _live.text);
         }
     }

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/HubObjectives.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/HubObjectives.cs
@@ -25,6 +25,7 @@ namespace Concordia
             SkillLedger.Reset();
             KitBag.Reset();
             Bonds.Reset();
+            Plots.Reset();
         }
 
         public static void NoteLamp() => Lamp = true;
@@ -486,13 +487,105 @@ namespace Concordia
     }
 
     /// <summary>
-    /// T1 affinity + T2 gifts. Local until /unity-ws carries romance.give_gift.
+    /// Same reaction table as server/lib/gifting.js. Kitchen and kernel
+    /// share the math so a gift is never a fabricated success.
+    /// </summary>
+    public static class GiftFeel
+    {
+        public static string Category(string itemName)
+        {
+            var n = itemName ?? "";
+            if (Contains(n, "sword", "blade", "dagger", "axe", "mace", "hammer", "spear", "lance", "bow", "whetstone", "arrow")) return "weapon";
+            if (Contains(n, "armour", "armor", "shield", "helm", "plate", "mail", "gauntlet", "greave", "boot")) return "armor";
+            if (Contains(n, "book", "scroll", "tome", "codex", "ink", "quill", "map", "treatise", "ledger")) return "book";
+            if (Contains(n, "herb", "root", "leaf", "flower", "poultice", "salve", "potion", "elixir", "tonic", "remedy")) return "herb";
+            if (Contains(n, "gem", "jewel", "crystal", "diamond", "ruby", "sapphire", "emerald", "pearl", "coin", "spark", "gold", "silver")) return "gem";
+            if (Contains(n, "relic", "rune", "glyph", "sigil", "talisman", "amulet", "charm", "idol", "fragment")) return "relic";
+            if (Contains(n, "bread", "stew", "roast", "soup", "ale", "tea", "pastry", "meat", "fish", "cheese", "wine", "fruit", "meal")) return "food";
+            if (Contains(n, "pelt", "hide", "fur", "leather", "bone", "fang", "claw", "feather")) return "pelt";
+            if (Contains(n, "tool", "gear", "cog", "wrench", "pick", "kit", "device", "component", "lamp")) return "tool";
+            return "misc";
+        }
+
+        public static string Reaction(string archetype, string itemName)
+        {
+            var cat = Category(itemName);
+            var arch = string.IsNullOrEmpty(archetype) ? "default" : archetype;
+            Prefs(arch, out var loved, out var liked, out var disliked);
+            if (Has(loved, cat)) return "loved";
+            if (Has(disliked, cat)) return "disliked";
+            if (Has(liked, cat)) return "liked";
+            return "neutral";
+        }
+
+        public static float Delta(string reaction)
+        {
+            if (reaction == "loved") return 0.15f;
+            if (reaction == "liked") return 0.10f;
+            if (reaction == "disliked") return -0.05f;
+            return 0.03f;
+        }
+
+        static bool Contains(string n, params string[] keys)
+        {
+            var low = (n ?? "").ToLowerInvariant();
+            for (int i = 0; i < keys.Length; i++)
+                if (low.IndexOf(keys[i], StringComparison.Ordinal) >= 0) return true;
+            return false;
+        }
+
+        static bool Has(string[] list, string cat)
+        {
+            if (list == null) return false;
+            for (int i = 0; i < list.Length; i++)
+                if (list[i] == cat) return true;
+            return false;
+        }
+
+        static void Prefs(string arch, out string[] loved, out string[] liked, out string[] disliked)
+        {
+            switch (arch)
+            {
+                case "scholar": loved = new[] { "book", "relic" }; liked = new[] { "gem", "tool" }; disliked = new[] { "pelt" }; break;
+                case "mystic": loved = new[] { "relic", "gem" }; liked = new[] { "book", "herb" }; disliked = new[] { "weapon" }; break;
+                case "healer": loved = new[] { "herb", "book" }; liked = new[] { "food", "relic" }; disliked = new[] { "weapon" }; break;
+                case "warrior":
+                case "warlord":
+                case "guard": loved = new[] { "weapon", "armor" }; liked = new[] { "pelt", "food" }; disliked = new[] { "book" }; break;
+                case "hunter": loved = new[] { "pelt", "weapon" }; liked = new[] { "food", "herb" }; disliked = new[] { "gem" }; break;
+                case "trader":
+                case "noble": loved = new[] { "gem", "relic" }; liked = new[] { "book", "food" }; disliked = new[] { "pelt" }; break;
+                default: loved = new[] { "gem", "food" }; liked = new[] { "relic", "book" }; disliked = Array.Empty<string>(); break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// T1 affinity + F1.2 gifts. Same deltas as gifting.js. Heart beats match
+    /// content/heart-events/default.json. Companion walk starts at 0.55.
     /// </summary>
     public static class Bonds
     {
         static readonly Dictionary<string, float> Aff = new Dictionary<string, float>();
+        static readonly Dictionary<string, HashSet<string>> Hearts = new Dictionary<string, HashSet<string>>();
+        static readonly HeartBeat[] Beats =
+        {
+            new HeartBeat { id = "small_kindnesses", t = 0.15f, title = "The Second Look" },
+            new HeartBeat { id = "first_spark", t = 0.30f, title = "A Shared Quiet" },
+            new HeartBeat { id = "learning_the_shape", t = 0.45f, title = "How You Take Your Mornings" },
+            new HeartBeat { id = "deepening", t = 0.60f, title = "The Thing Not Said" },
+            new HeartBeat { id = "the_harder_conversation", t = 0.75f, title = "What the Silence Cost" },
+            new HeartBeat { id = "devotion", t = 0.85f, title = "Before the Asking" },
+            new HeartBeat { id = "the_long_field", t = 0.95f, title = "The Long Field" },
+        };
 
-        public static void Reset() => Aff.Clear();
+        struct HeartBeat { public string id, title; public float t; }
+
+        public static void Reset()
+        {
+            Aff.Clear();
+            Hearts.Clear();
+        }
 
         public static string Key(GuestNpc npc)
         {
@@ -508,11 +601,19 @@ namespace Concordia
             return Aff.TryGetValue(id, out var v) ? v : 0.08f;
         }
 
+        public static void Set(string id, float v)
+        {
+            if (string.IsNullOrEmpty(id)) return;
+            Aff[id] = Mathf.Clamp01(v);
+        }
+
         public static float TalkBump(string id)
         {
             if (string.IsNullOrEmpty(id)) return 0f;
-            var next = Mathf.Clamp01(Get(id) + 0.02f);
+            var prev = Get(id);
+            var next = Mathf.Clamp01(prev + 0.02f);
             Aff[id] = next;
+            MaybeHeart(id, prev, next, id);
             return next;
         }
 
@@ -522,14 +623,85 @@ namespace Concordia
             if (string.IsNullOrEmpty(id)) return "No one to give to.";
             var item = KitBag.TakeLoot();
             if (item == null) return "Empty hands. Take something from the ring first.";
-            float bump = 0.12f;
-            var n = (item.name ?? item.id ?? "").ToLowerInvariant();
-            if (n.Contains("meal") || n.Contains("flower") || n.Contains("lamp")) bump = 0.22f;
-            var next = Mathf.Clamp01(Get(id) + bump);
+            var person = WorldBook.FindPerson(WorldClock.World, id);
+            var arch = person != null ? person.archetype : "";
+            var reaction = GiftFeel.Reaction(arch, item.name ?? item.id);
+            var bump = GiftFeel.Delta(reaction);
+            var prev = Get(id);
+            var next = Mathf.Clamp01(prev + bump);
             Aff[id] = next;
+            MaybeHeart(id, prev, next, npc.def != null ? npc.def.name : id);
+            if (next >= 0.55f)
+            {
+                var life = npc.GetComponent<NpcLife>();
+                if (life) life.job = NpcLife.Job.Companion;
+            }
             WorldClock.NoteAct("a gift changed the air");
             var who = npc.def != null ? npc.def.name : "them";
-            return "You give " + who + " " + item.name + ". Affinity " + Mathf.RoundToInt(next * 100f) + "%.";
+            var client = ConcordClient.Live;
+            if (client != null)
+                client.SendGift(id, item.id, item.name, arch);
+            return "You give " + who + " " + item.name + " (" + reaction + "). Affinity " + Mathf.RoundToInt(next * 100f) + "%.";
+        }
+
+        static void MaybeHeart(string id, float prev, float next, string who)
+        {
+            if (!Hearts.TryGetValue(id, out var seen))
+            {
+                seen = new HashSet<string>();
+                Hearts[id] = seen;
+            }
+            for (int i = 0; i < Beats.Length; i++)
+            {
+                var b = Beats[i];
+                if (prev < b.t && next >= b.t && seen.Add(b.id))
+                    ConcordiaHUD.Announce(b.title, who + " · " + Mathf.RoundToInt(b.t * 100f) + "%");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Local scheme board. Same verbs as interveneInScheme (expose/abet/ignore).
+    /// Kernel row wins when it exists; missing row is not a fake success — the
+    /// local plot still resolves because the kitchen IS the scheme here.
+    /// </summary>
+    public static class Plots
+    {
+        public class Rec
+        {
+            public string id, text, phase;
+        }
+
+        static Rec _live;
+        public static Rec Nearby => _live != null && _live.phase == "brewing" ? _live : null;
+
+        public static void Reset() => _live = null;
+
+        public static void Seed(string text)
+        {
+            _live = new Rec
+            {
+                id = "local_" + WorldClock.Day + "_" + Mathf.FloorToInt(WorldClock.Hour),
+                text = text ?? "A faction scheme ripened.",
+                phase = "brewing"
+            };
+        }
+
+        public static string Intervene(string action)
+        {
+            if (_live == null) return "No plot in the air.";
+            if (action != "expose" && action != "abet") action = "ignore";
+            _live.phase = action == "expose" ? "exposed" : action == "abet" ? "abetted" : "ignored";
+            var line = action == "expose"
+                ? "You name the plot. The air goes still."
+                : action == "abet"
+                    ? "You put your weight behind it."
+                    : "You let it pass.";
+            WorldClock.NoteAct(line);
+            ConcordiaHUD.Announce(action, line);
+            var client = ConcordClient.Live;
+            if (client != null) client.SendIntervene(_live.id, action);
+            return line + (string.IsNullOrEmpty(_live.text) ? "" : " · " + _live.text);
         }
     }
 }

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/MixamoAvatar.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/MixamoAvatar.cs
@@ -14,7 +14,8 @@ namespace Concordia
         public Transform rightHand;
         public GameObject sword;
         public Animator animator;
-        float _slashT, _hitT, _staggerT, _speed, _vert;
+        public FightStyle style = FightStyle.MuayThai;
+        float _slashT, _slashDur, _hitT, _staggerT, _knockT, _anticipateT, _speed, _vert;
         bool _grounded = true, _bound;
         int _plantFrames;
         Transform _body, _hips, _spine, _lArm, _lFore, _rArm, _rFore, _lUp, _lLeg, _rUp, _rLeg;
@@ -50,6 +51,7 @@ namespace Concordia
             av.sword.transform.localPosition = new Vector3(0.02f, 0.04f, 0.08f);
             av.sword.transform.localRotation = Quaternion.Euler(70, 0, 12);
             CharacterGear.Attach(body, "shield-round", false, 0.55f);
+            av.BindStyle(FightStyle.MuayThai);
             return av;
         }
 
@@ -104,6 +106,12 @@ namespace Concordia
             if (t) rest = t.localRotation;
         }
 
+        public void BindStyle(FightStyle s)
+        {
+            style = s;
+            if (sword) sword.SetActive(s == FightStyle.Sword);
+        }
+
         public void SetGait(float speed, bool grounded, float vert = 0f)
         {
             _speed = speed;
@@ -117,9 +125,43 @@ namespace Concordia
             }
         }
 
-        public void Slash() => _slashT = 0.48f;
+        public void Anticipate() => _anticipateT = Windup();
+        public void Slash()
+        {
+            _slashDur = StrikeDur();
+            _slashT = _slashDur;
+            _anticipateT = 0f;
+        }
         public void Hit() => _hitT = 0.32f;
         public void Stagger() => _staggerT = 0.55f;
+        public void Knockdown() => _knockT = 0.72f;
+
+        float StanceWidth() => style switch
+        {
+            FightStyle.Karate => 1.20f,
+            FightStyle.MuayThai => 1.05f,
+            FightStyle.WingChun => 0.85f,
+            FightStyle.Capoeira => 1.40f,
+            _ => 1.15f
+        };
+
+        float Windup() => style switch
+        {
+            FightStyle.WingChun => 0.18f,
+            FightStyle.Karate => 0.28f,
+            FightStyle.Capoeira => 0.36f,
+            FightStyle.Sword => 0.42f,
+            _ => 0.32f
+        };
+
+        float StrikeDur() => style switch
+        {
+            FightStyle.WingChun => 0.28f,
+            FightStyle.Karate => 0.36f,
+            FightStyle.MuayThai => 0.42f,
+            FightStyle.Capoeira => 0.52f,
+            _ => 0.48f
+        };
 
         void LateUpdate()
         {
@@ -127,20 +169,130 @@ namespace Concordia
             if (!_grounded && _bound) ApplyJump();
             else if (_bound && (animator == null || animator.runtimeAnimatorController == null))
                 ApplyProceduralGait();
+            ApplyStance();
+            ApplyAnticipate();
             ApplySlash();
             ApplyHit();
             ApplyStagger();
+            ApplyKnockdown();
+        }
+
+        void ApplyStance()
+        {
+            if (!_bound || !_grounded) return;
+            if (_slashT > 0f || _anticipateT > 0f || _knockT > 0f) return;
+            float spread = (StanceWidth() - 1f) * 16f;
+            if (_lUp) _lUp.localRotation *= Quaternion.Euler(0f, 0f, spread);
+            if (_rUp) _rUp.localRotation *= Quaternion.Euler(0f, 0f, -spread);
+            switch (style)
+            {
+                case FightStyle.Karate:
+                    if (_lArm) _lArm.localRotation *= Quaternion.Euler(18f, 0f, 38f);
+                    if (_rArm) _rArm.localRotation *= Quaternion.Euler(-22f, 12f, -8f);
+                    break;
+                case FightStyle.MuayThai:
+                    if (_lArm) _lArm.localRotation *= Quaternion.Euler(-38f, 0f, 32f);
+                    if (_rArm) _rArm.localRotation *= Quaternion.Euler(-38f, 0f, -32f);
+                    if (_spine) _spine.localRotation *= Quaternion.Euler(6f, 0f, 0f);
+                    break;
+                case FightStyle.WingChun:
+                    if (_lArm) _lArm.localRotation *= Quaternion.Euler(-28f, 8f, 18f);
+                    if (_rArm) _rArm.localRotation *= Quaternion.Euler(-28f, -8f, -18f);
+                    if (_lFore) _lFore.localRotation *= Quaternion.Euler(-22f, 0f, 0f);
+                    if (_rFore) _rFore.localRotation *= Quaternion.Euler(-22f, 0f, 0f);
+                    break;
+                case FightStyle.Capoeira:
+                    if (_hips) _hips.localRotation *= Quaternion.Euler(10f, Mathf.Sin(Time.time * 2.4f) * 14f, 0f);
+                    if (_lArm) _lArm.localRotation *= Quaternion.Euler(12f, 0f, 28f);
+                    if (_rArm) _rArm.localRotation *= Quaternion.Euler(-16f, 0f, -22f);
+                    break;
+                default:
+                    if (_rArm) _rArm.localRotation *= Quaternion.Euler(-24f, 18f, 0f);
+                    if (_lArm) _lArm.localRotation *= Quaternion.Euler(8f, 0f, 22f);
+                    break;
+            }
+        }
+
+        void ApplyAnticipate()
+        {
+            if (_anticipateT <= 0f) return;
+            _anticipateT -= Time.deltaTime;
+            var t = Mathf.Clamp01(_anticipateT / Mathf.Max(0.08f, Windup()));
+            switch (style)
+            {
+                case FightStyle.Karate:
+                    if (_rArm) _rArm.localRotation *= Quaternion.Euler(-55f * t, 12f * t, 0f);
+                    if (_spine) _spine.localRotation *= Quaternion.Euler(-8f * t, 10f * t, 0f);
+                    break;
+                case FightStyle.MuayThai:
+                    if (_rUp) _rUp.localRotation *= Quaternion.Euler(-28f * t, 0f, 0f);
+                    if (_rArm) _rArm.localRotation *= Quaternion.Euler(-40f * t, 0f, -18f * t);
+                    break;
+                case FightStyle.WingChun:
+                    if (_rArm) _rArm.localRotation *= Quaternion.Euler(-18f * t, 0f, 0f);
+                    if (_lArm) _lArm.localRotation *= Quaternion.Euler(-12f * t, 0f, 0f);
+                    break;
+                case FightStyle.Capoeira:
+                    if (_hips) _hips.localRotation *= Quaternion.Euler(18f * t, -22f * t, 0f);
+                    if (_rUp) _rUp.localRotation *= Quaternion.Euler(-40f * t, 0f, 8f * t);
+                    break;
+                default:
+                    if (_rArm) _rArm.localRotation *= Quaternion.Euler(-70f * t, 20f * t, 0f);
+                    if (_spine) _spine.localRotation *= Quaternion.Euler(-6f * t, 8f * t, 0f);
+                    break;
+            }
         }
 
         void ApplySlash()
         {
             if (_slashT <= 0 || _rArm == null) return;
             _slashT -= Time.deltaTime;
-            var t = 1f - Mathf.Clamp01(_slashT / 0.48f);
-            float wind = t < 0.25f ? t / 0.25f : t < 0.45f ? 1f : 1f - (t - 0.45f) / 0.55f;
-            var swing = t < 0.4f ? Mathf.Lerp(-70, 100, t / 0.4f) : Mathf.Lerp(100, 0, (t - 0.4f) / 0.6f);
-            _rArm.localRotation *= Quaternion.Euler(swing * wind, 20f * wind, 0);
-            if (_rFore) _rFore.localRotation *= Quaternion.Euler(-18f * wind, 0, 0);
+            var dur = Mathf.Max(0.12f, _slashDur);
+            var t = 1f - Mathf.Clamp01(_slashT / dur);
+            float wind = t < 0.22f ? t / 0.22f : t < 0.48f ? 1f : 1f - (t - 0.48f) / 0.52f;
+            switch (style)
+            {
+                case FightStyle.Karate:
+                    {
+                        var punch = t < 0.35f ? Mathf.Lerp(-40f, 95f, t / 0.35f) : Mathf.Lerp(95f, 0f, (t - 0.35f) / 0.65f);
+                        _rArm.localRotation *= Quaternion.Euler(punch * wind, 8f * wind, 0f);
+                        if (_rFore) _rFore.localRotation *= Quaternion.Euler(-8f * wind, 0f, 0f);
+                        if (_spine) _spine.localRotation *= Quaternion.Euler(-6f * wind, 10f * wind, 0f);
+                        break;
+                    }
+                case FightStyle.MuayThai:
+                    {
+                        if (_rUp) _rUp.localRotation *= Quaternion.Euler(-70f * wind, 0f, 8f * wind);
+                        if (_rLeg) _rLeg.localRotation *= Quaternion.Euler(40f * wind, 0f, 0f);
+                        _rArm.localRotation *= Quaternion.Euler(-50f * wind, 0f, -28f * wind);
+                        if (_spine) _spine.localRotation *= Quaternion.Euler(8f * wind, 0f, 0f);
+                        break;
+                    }
+                case FightStyle.WingChun:
+                    {
+                        var chain = Mathf.Sin(t * Mathf.PI * 3f) * 28f * wind;
+                        _rArm.localRotation *= Quaternion.Euler(-30f * wind + chain, 0f, 0f);
+                        if (_lArm) _lArm.localRotation *= Quaternion.Euler(-24f * wind - chain * 0.6f, 0f, 12f * wind);
+                        if (_rFore) _rFore.localRotation *= Quaternion.Euler(-30f * wind, 0f, 0f);
+                        break;
+                    }
+                case FightStyle.Capoeira:
+                    {
+                        if (_hips) _hips.localRotation *= Quaternion.Euler(12f * wind, -40f * wind, 0f);
+                        if (_rUp) _rUp.localRotation *= Quaternion.Euler(-95f * wind, 0f, 10f * wind);
+                        if (_rLeg) _rLeg.localRotation *= Quaternion.Euler(55f * wind, 0f, 0f);
+                        _rArm.localRotation *= Quaternion.Euler(20f * wind, 0f, -40f * wind);
+                        if (_lArm) _lArm.localRotation *= Quaternion.Euler(-30f * wind, 0f, 35f * wind);
+                        break;
+                    }
+                default:
+                    {
+                        var swing = t < 0.4f ? Mathf.Lerp(-70f, 100f, t / 0.4f) : Mathf.Lerp(100f, 0f, (t - 0.4f) / 0.6f);
+                        _rArm.localRotation *= Quaternion.Euler(swing * wind, 20f * wind, 0f);
+                        if (_rFore) _rFore.localRotation *= Quaternion.Euler(-18f * wind, 0f, 0f);
+                        break;
+                    }
+            }
         }
 
         void ApplyHit()
@@ -159,6 +311,17 @@ namespace Concordia
             var t = Mathf.Clamp01(_staggerT / 0.55f);
             if (_hips) _hips.localRotation *= Quaternion.Euler(22f * t, 0, -8f * t);
             if (_spine) _spine.localRotation *= Quaternion.Euler(14f * t, -16f * t, 0);
+        }
+
+        void ApplyKnockdown()
+        {
+            if (_knockT <= 0) return;
+            _knockT -= Time.deltaTime;
+            var t = Mathf.Clamp01(_knockT / 0.72f);
+            if (_hips) _hips.localRotation *= Quaternion.Euler(48f * t, 0f, -14f * t);
+            if (_spine) _spine.localRotation *= Quaternion.Euler(28f * t, -22f * t, 0f);
+            if (_lUp) _lUp.localRotation *= Quaternion.Euler(30f * t, 0f, 12f * t);
+            if (_rUp) _rUp.localRotation *= Quaternion.Euler(22f * t, 0f, -12f * t);
         }
 
         float _phase;

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/MixamoAvatar.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/MixamoAvatar.cs
@@ -14,7 +14,7 @@ namespace Concordia
         public Transform rightHand;
         public GameObject sword;
         public Animator animator;
-        float _slashT, _speed, _vert;
+        float _slashT, _hitT, _staggerT, _speed, _vert;
         bool _grounded = true, _bound;
         int _plantFrames;
         Transform _body, _hips, _spine, _lArm, _lFore, _rArm, _rFore, _lUp, _lLeg, _rUp, _rLeg;
@@ -118,6 +118,8 @@ namespace Concordia
         }
 
         public void Slash() => _slashT = 0.48f;
+        public void Hit() => _hitT = 0.32f;
+        public void Stagger() => _staggerT = 0.55f;
 
         void LateUpdate()
         {
@@ -125,6 +127,13 @@ namespace Concordia
             if (!_grounded && _bound) ApplyJump();
             else if (_bound && (animator == null || animator.runtimeAnimatorController == null))
                 ApplyProceduralGait();
+            ApplySlash();
+            ApplyHit();
+            ApplyStagger();
+        }
+
+        void ApplySlash()
+        {
             if (_slashT <= 0 || _rArm == null) return;
             _slashT -= Time.deltaTime;
             var t = 1f - Mathf.Clamp01(_slashT / 0.48f);
@@ -132,6 +141,24 @@ namespace Concordia
             var swing = t < 0.4f ? Mathf.Lerp(-70, 100, t / 0.4f) : Mathf.Lerp(100, 0, (t - 0.4f) / 0.6f);
             _rArm.localRotation *= Quaternion.Euler(swing * wind, 20f * wind, 0);
             if (_rFore) _rFore.localRotation *= Quaternion.Euler(-18f * wind, 0, 0);
+        }
+
+        void ApplyHit()
+        {
+            if (_hitT <= 0) return;
+            _hitT -= Time.deltaTime;
+            var t = Mathf.Clamp01(_hitT / 0.32f);
+            if (_spine) _spine.localRotation *= Quaternion.Euler(-18f * t, 12f * t, 0);
+            if (_lArm) _lArm.localRotation *= Quaternion.Euler(20f * t, 0, 28f * t);
+        }
+
+        void ApplyStagger()
+        {
+            if (_staggerT <= 0) return;
+            _staggerT -= Time.deltaTime;
+            var t = Mathf.Clamp01(_staggerT / 0.55f);
+            if (_hips) _hips.localRotation *= Quaternion.Euler(22f * t, 0, -8f * t);
+            if (_spine) _spine.localRotation *= Quaternion.Euler(14f * t, -16f * t, 0);
         }
 
         float _phase;

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ModularPerson.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ModularPerson.cs
@@ -87,6 +87,7 @@ namespace Concordia // FORCE_REFRESH_0022
                 var w = go.AddComponent<NpcWander>();
                 w.roam = roam;
             }
+            PersonLabel.Attach(go.transform, look != null ? look.displayName : go.name, null);
             return go;
         }
 

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ModularPerson.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ModularPerson.cs
@@ -26,8 +26,9 @@ namespace Concordia // FORCE_REFRESH_0022
         Quaternion _hipsRest, _spineRest, _lArmRest, _lForeRest, _rArmRest, _rForeRest;
         Quaternion _lUpRest, _lLegRest, _rUpRest, _rLegRest, _headRest;
         Vector3 _hipPos0;
-        float _speed, _vert, _slashT, _phase, _sit, _sitShown, _shown, _hitT, _landT;
+        float _speed, _vert, _slashT, _phase, _sit, _sitShown, _shown, _hitT, _landT, _anticipateT;
         bool _grounded = true;
+        FightStyle _style = FightStyle.MuayThai;
         bool _built;
         bool _authored;
         bool _biped;
@@ -107,12 +108,19 @@ namespace Concordia // FORCE_REFRESH_0022
 
         public void Slash()
         {
-            _slashT = 0.48f;
+            _slashT = _style == FightStyle.WingChun ? 0.28f : _style == FightStyle.Karate ? 0.36f : 0.48f;
+            _anticipateT = 0f;
             if (_anim && _anim.runtimeAnimatorController)
             {
                 if (HasParam(_anim, "Attack")) _anim.SetTrigger("Attack");
                 else if (HasParam(_anim, "Slash")) _anim.SetTrigger("Slash");
             }
+        }
+        public void Anticipate() => _anticipateT = 0.32f;
+        public void BindStyle(FightStyle s)
+        {
+            _style = s;
+            if (sword) sword.SetActive(s == FightStyle.Sword);
         }
         public void Sit(bool on) => _sit = on ? 1f : 0f;
         public void Hurt() => _hitT = 0.32f;
@@ -726,17 +734,56 @@ namespace Concordia // FORCE_REFRESH_0022
             if (_slashT > 0f && _uArmR)
             {
                 _slashT -= Time.deltaTime;
-                var t = 1f - Mathf.Clamp01(_slashT / 0.48f);
+                var dur = _style == FightStyle.WingChun ? 0.28f : _style == FightStyle.Karate ? 0.36f : 0.48f;
+                var t = 1f - Mathf.Clamp01(_slashT / dur);
                 float wind = t < 0.08f ? t / 0.08f : t < 0.5f ? 1f : 1f - (t - 0.5f) / 0.5f;
-                var swing = t < 0.32f ? Mathf.Lerp(-20f, 125f, t / 0.32f) : Mathf.Lerp(125f, 0f, (t - 0.32f) / 0.68f);
-                float arc = swing * wind;
-                if (_biped)
+                if (_style == FightStyle.Capoeira && _uLegR)
                 {
-                    _uArmR.localRotation = BipedArm(_uArmR, _rArmRest, 18f + arc * 0.95f, false);
-                    if (_fArmR) _fArmR.localRotation = _rForeRest * ForeDelta(36f + 28f * wind, false);
+                    _uLegR.localRotation *= Quaternion.Euler(-90f * wind, 0f, 8f * wind);
+                    if (_hip) _hip.localRotation *= Quaternion.Euler(10f * wind, -28f * wind, 0f);
+                }
+                else if (_style == FightStyle.MuayThai && _uLegR)
+                {
+                    _uLegR.localRotation *= Quaternion.Euler(-62f * wind, 0f, 6f * wind);
+                    var arc = Mathf.Lerp(-20f, 70f, t) * wind;
+                    if (_biped) _uArmR.localRotation = BipedArm(_uArmR, _rArmRest, 18f + arc * 0.6f, false);
+                    else _uArmR.localRotation *= Quaternion.Euler(-40f * wind, 0f, -24f * wind);
+                }
+                else if (_style == FightStyle.WingChun)
+                {
+                    var chain = Mathf.Sin(t * Mathf.PI * 3f) * 22f * wind;
+                    if (_biped)
+                    {
+                        _uArmR.localRotation = BipedArm(_uArmR, _rArmRest, 28f + chain, false);
+                        if (_uArmL) _uArmL.localRotation = BipedArm(_uArmL, _lArmRest, 22f - chain * 0.5f, true);
+                    }
+                    else
+                    {
+                        _uArmR.localRotation *= Quaternion.Euler(-28f * wind + chain, 0f, 0f);
+                        if (_uArmL) _uArmL.localRotation *= Quaternion.Euler(-22f * wind - chain * 0.5f, 0f, 10f * wind);
+                    }
                 }
                 else
-                    _uArmR.localRotation *= Quaternion.Euler(arc, 18f * wind, 0f);
+                {
+                    var swing = t < 0.32f ? Mathf.Lerp(-20f, 125f, t / 0.32f) : Mathf.Lerp(125f, 0f, (t - 0.32f) / 0.68f);
+                    float arc = swing * wind;
+                    if (_biped)
+                    {
+                        _uArmR.localRotation = BipedArm(_uArmR, _rArmRest, 18f + arc * 0.95f, false);
+                        if (_fArmR) _fArmR.localRotation = _rForeRest * ForeDelta(36f + 28f * wind, false);
+                    }
+                    else
+                        _uArmR.localRotation *= Quaternion.Euler(arc, 18f * wind, 0f);
+                }
+            }
+            else if (_anticipateT > 0f && _uArmR)
+            {
+                _anticipateT -= Time.deltaTime;
+                var t = Mathf.Clamp01(_anticipateT / 0.32f);
+                if (_style == FightStyle.Capoeira && _uLegR)
+                    _uLegR.localRotation *= Quaternion.Euler(-28f * t, 0f, 0f);
+                else
+                    _uArmR.localRotation *= Quaternion.Euler(-40f * t, 12f * t, 0f);
             }
 
             // Idle plant only. While moving the gait owns the feet — planting

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ModularPerson.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ModularPerson.cs
@@ -265,6 +265,38 @@ namespace Concordia // FORCE_REFRESH_0022
         static GameObject LoadPersonPrefab(bool hero)
         {
             GameObject go = null;
+
+            // World-appropriate body (2026-09-11, root-caused this session): CastingWorld
+            // is set per-world by WorldBuilder but was never read here, so every world —
+            // Fantasy, Tunya, Ruins, all of them — got the same Rocketbox photoreal adult,
+            // whose baked texture is business-casual civilian wear by design (it's a
+            // Microsoft crowd-sim asset, not a game character). That's the actual "polo
+            // shirt hero" bug: not a missing tint (Rocketbox bakes skin+clothes into one
+            // continuous photo texture with no separate cloth UV region, so a multiplied
+            // tint would discolor visible skin too — a real dead end, not just untried),
+            // but a missing per-world body choice on an already-existing hook. Hub is the
+            // one world with solid textual grounding as modern/neutral (concordia-hub =
+            // "neutral baseline" in the retired ART_STYLE_GUIDE) — Rocketbox reads
+            // correctly there and keeps its current behavior. Everywhere else, prefer the
+            // already-painted, already-in-project KayKit Knight (no new assets needed).
+            // FreePacks.Mesh resolves in both Editor (AssetDatabase index) and Player/
+            // WebGL (HubKit/StreamingAssets), so this fixes the real shipped web client,
+            // not just the Editor. Whether every non-Hub world is genuinely "knight-coded"
+            // (Cyber/Crime plausibly want modern too) is a first-pass call, not verified
+            // lore — tune per-world as real per-world body assets are added.
+            if (CastingWorld != WorldId.Hub)
+            {
+                go = FreePacks.Mesh("Knight");
+                if (go)
+                {
+#if UNITY_EDITOR
+                    _lastPrefabPath = AssetDatabase.GetAssetPath(go);
+#endif
+                    return go;
+                }
+                // Knight unresolved (asset missing) — honest fallback to Rocketbox below
+                // rather than returning no body at all.
+            }
 #if UNITY_EDITOR
             // Mixamo Vanguard has no folder albedo. Rocketbox is the painted adult.
             var adult = new[]
@@ -1216,7 +1248,18 @@ namespace Concordia // FORCE_REFRESH_0022
 
         static GameObject MakeSword()
         {
-            var mesh = FreePacks.Mesh("longsword") ?? FreePacks.Mesh("weapon-sword");
+            // "Oversized sword" root-caused live in Unity (2026-09-12): not a scale
+            // bug — FitMax's uniform-scale-to-1.05m target math is correct — but the
+            // Kenney weapon-sword.glb mesh it fell back to is chibi-proportioned
+            // (width is 52% of its length), so scaling its length up to a realistic
+            // sword also drags its already-fat width/thickness up with it, reading
+            // as a giant slab. "longsword" (tried first below) has never actually
+            // resolved to anything — confirmed live via FreePacks.Mesh returning
+            // null — so every hero silently fell through to the Kenney mesh. The
+            // MYFG Weapon Pack Lite (already in the project) has real,
+            // human-sword-proportioned meshes; Sword16 measured live at a 0.14
+            // width/length ratio vs Kenney's 0.52 — prefer it.
+            var mesh = FreePacks.Mesh("longsword") ?? FreePacks.Mesh("Sword16") ?? FreePacks.Mesh("weapon-sword");
             if (mesh)
             {
                 var held = Object.Instantiate(mesh);

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/NpcLife.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/NpcLife.cs
@@ -37,6 +37,9 @@ namespace Concordia
         bool _withdrawn;
         Vector3 _headFor;
         float _headForT;
+        Vector3 _attend;
+        Transform _attendFace;
+        float _attendT;
 
         void Start()
         {
@@ -93,6 +96,21 @@ namespace Concordia
         {
             _headFor = dest;
             _headForT = seconds;
+            _attendT = 0f;
+        }
+
+        /// <summary>
+        /// Kernel funeral/wedding: walk to a ring slot around a real site
+        /// and stay. Slot/of come from gatherAttendees — never invented mourners.
+        /// </summary>
+        public void Attend(Vector3 site, Transform face, int slot, int of, float seconds = 28f)
+        {
+            of = Mathf.Max(1, of);
+            float a = (slot / (float)of) * Mathf.PI * 2f + 0.35f;
+            _attend = site + new Vector3(Mathf.Cos(a) * 2.15f, 0f, Mathf.Sin(a) * 2.15f);
+            _attendFace = face;
+            _attendT = seconds;
+            _headForT = 0f;
         }
 
         public void BindWorkplace(Vector3 pos) => workplace = pos;
@@ -128,6 +146,25 @@ namespace Concordia
                 }
                 else
                     Hold();
+                return;
+            }
+
+            if (_attendT > 0f)
+            {
+                _attendT -= Time.deltaTime;
+                Show(true);
+                if (!Arrived(_attend))
+                {
+                    act = "gather";
+                    Walk(_attend, 2.6f);
+                    return;
+                }
+                act = "watch";
+                Hold();
+                _person?.Sit(true);
+                _person?.SetGait(0f, true);
+                if (_attendFace) Notice(_attendFace, 0.4f);
+                FaceRegard();
                 return;
             }
 

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/NpcLife.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/NpcLife.cs
@@ -10,7 +10,7 @@ namespace Concordia
     /// </summary>
     public class NpcLife : MonoBehaviour
     {
-        public enum Job { Wander, Stall, Sit, Sweep, Watch }
+        public enum Job { Wander, Stall, Sit, Sweep, Watch, Companion }
         public Job job = Job.Wander;
         public bool pinned;
         public string act = "idle";
@@ -70,6 +70,28 @@ namespace Concordia
                 Hold();
                 _person?.SetGait(0f, true);
                 act = "watch";
+                return;
+            }
+
+            if (job == Job.Companion)
+            {
+                Show(true);
+                var p = ConcordiaPlayer.Live;
+                if (p)
+                {
+                    act = "follow";
+                    var follow = p.transform.position - p.transform.forward * 1.6f;
+                    follow.y = transform.position.y;
+                    if (Vector3.Distance(transform.position, follow) > 2.2f)
+                        Walk(follow, 4.2f);
+                    else
+                    {
+                        Hold();
+                        _person?.SetGait(0f, true);
+                    }
+                }
+                else
+                    Hold();
                 return;
             }
 

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/NpcLife.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/NpcLife.cs
@@ -32,6 +32,11 @@ namespace Concordia
         Renderer[] _rend;
         bool _hidden;
         GameObject _carry;
+        string _coping;
+        float _walkMul = 1f;
+        bool _withdrawn;
+        Vector3 _headFor;
+        float _headForT;
 
         void Start()
         {
@@ -57,6 +62,37 @@ namespace Concordia
         {
             _regard = whom;
             _pause = Mathf.Max(_pause, seconds);
+        }
+
+        /// <summary>
+        /// Kernel coping_trait from npc:stress-break. Uses jobs and Notice
+        /// that already exist — no second AI.
+        /// </summary>
+        public void Cope(string trait)
+        {
+            _coping = trait ?? "";
+            if (_coping == "drink") job = Job.Sit;
+            else if (_coping == "withdraw") _withdrawn = true;
+            else if (_coping == "reckless") _walkMul = 1.55f;
+            else if (_coping == "paranoid") NoticePlayer(12f);
+            else if (_coping == "cruel")
+            {
+                GuestNpc nearest = null;
+                float best = 9f;
+                foreach (var n in FindObjectsByType<GuestNpc>(FindObjectsInactive.Exclude))
+                {
+                    if (!n || n.gameObject == gameObject) continue;
+                    var d = Vector3.Distance(transform.position, n.transform.position);
+                    if (d < best) { best = d; nearest = n; }
+                }
+                if (nearest) Notice(nearest.transform, 8f);
+            }
+        }
+
+        public void HeadFor(Vector3 dest, float seconds = 10f)
+        {
+            _headFor = dest;
+            _headForT = seconds;
         }
 
         public void BindWorkplace(Vector3 pos) => workplace = pos;
@@ -92,6 +128,15 @@ namespace Concordia
                 }
                 else
                     Hold();
+                return;
+            }
+
+            if (_headForT > 0f)
+            {
+                _headForT -= Time.deltaTime;
+                act = "deliver";
+                Show(true);
+                Walk(_headFor, 2.8f);
                 return;
             }
 
@@ -226,6 +271,7 @@ namespace Concordia
 
         bool TrySocial(SimLod lod)
         {
+            if (_withdrawn) return false;
             if (lod != SimLod.Real) return false;
             if (IsWalkingJob) return false;
             if (Time.time < _socialAt) return false;
@@ -310,6 +356,7 @@ namespace Concordia
 
         void Walk(Vector3 dest, float speed)
         {
+            speed *= _walkMul;
             var to = dest - transform.position;
             to.y = 0f;
             if (to.magnitude < 0.7f) { Hold(); _person?.SetGait(0f, true); return; }
@@ -363,7 +410,8 @@ namespace Concordia
         Vector3 EveningDest()
         {
             if (job == Job.Watch) return post;
-            if (job == Job.Sit)
+            if (_withdrawn) return home;
+            if (job == Job.Sit || _coping == "drink")
             {
                 var tavern = BuildingPlace.Nearest(home, "tavern");
                 if (tavern) return tavern.door;

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/RealmFill.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/RealmFill.cs
@@ -783,7 +783,8 @@ namespace Concordia // keep-spawn-assign
             gateGo.transform.SetParent(hold, false);
             gateGo.transform.position = mouth;
             var gate = gateGo.AddComponent<DungeonGate>();
-            gate.holdName = "the hold";
+            gate.encounterId = w.id == WorldId.Ruins ? "hollow_warden" : "tide_colossus";
+            gate.holdName = w.id == WorldId.Ruins ? "The Hollow Warden" : "Tide Colossus";
             gate.inside = inside;
             gate.mouth = mouth + new Vector3(0f, 0.12f, -3.2f);
             var box = gateGo.AddComponent<BoxCollider>();
@@ -794,8 +795,8 @@ namespace Concordia // keep-spawn-assign
             var plaque = HubLook.Prim(hold, PrimitiveType.Cube, new Vector3(0f, 1.05f, -2.6f),
                 new Vector3(1.05f, 1.5f, 0.12f), HubLook.Lit(w.ground, 0.08f, 0.22f), "HoldPlaque");
             var stone = plaque.AddComponent<LoreStone>();
-            stone.title = "A hold";
-            stone.text = "Kenney tiles. Mouth, hall, vault — geometry roles. No authored dungeon name in this world's canon — the geometry is dressing. Live steel applies.";
+            stone.title = gate.holdName;
+            stone.text = gate.holdName + " — mouth, hall, vault. Live steel applies. The encounter is the authored dungeon, not dressing.";
 
             var beacon = hold.gameObject.AddComponent<QuestBeacon>();
             beacon.tokens = new[] { "dungeon", "hold", "training_hollow", WorldBook.Folder(w.id) + "_hold" };

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/RealmFill.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/RealmFill.cs
@@ -142,6 +142,28 @@ namespace Concordia // keep-spawn-assign
             }
         }
 
+        /// <summary>
+        /// Kernel war lands on the authored banner already placed for that
+        /// faction id. No match is an honest no-op — never invent a faction.
+        /// </summary>
+        public static void MarkWar(string factionId)
+        {
+            if (string.IsNullOrEmpty(factionId)) return;
+            BrightenNamed("FactionBanner_" + factionId);
+            BrightenNamed("FactionPole_" + factionId);
+            BrightenNamed("Faction_" + factionId);
+        }
+
+        static void BrightenNamed(string n)
+        {
+            var go = GameObject.Find(n);
+            if (!go) return;
+            var r = go.GetComponent<Renderer>();
+            if (!r) return;
+            var c = r.sharedMaterial ? r.sharedMaterial.color : Color.white;
+            r.material = HubLook.Emit(c, 2.6f);
+        }
+
         static void Lore(Transform root, WorldDef w)
         {
             var lore = WorldBook.Lore(w.id);

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/RealmFill.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/RealmFill.cs
@@ -37,12 +37,14 @@ namespace Concordia // keep-spawn-assign
                     Scatter(root, "coffin", 8, 6f, 16f, 1.6f);
                     Scatter(root, "altar-stone", 4, 8f, 14f, 1.8f);
                     Scatter(root, "crypt-small", 6, 14f, 24f, 4.2f);
+                    Scatter(root, DressVocab.House(WorldId.Ruins), 5, 18f, 28f, 5.5f);
                     Horizon(root, "cliff_large_stone", 52f, 10, 9f);
                     break;
                 case WorldId.Tunya:
                     for (int i = 0; i < 36; i++)
                         FreePacks.Spawn("crops_cornStageD", root, new Vector3(-14 + (i % 12) * 1.3f, 0, 7 + (i / 12) * 2.1f), 0, 1.4f);
                     Ring(root, "tent_detailedOpen", 14f, 7, 3.2f, 30f);
+                    Ring(root, DressVocab.House(WorldId.Tunya), 18f, 6, 5.2f, 12f);
                     Ring(root, "tree_oak", 20f, 12, 7f, 15f);
                     Ring(root, "tree_pineTallA", 28f, 10, 9f, 20f);
                     Scatter(root, "bridge_wood", 3, 10f, 16f, 2.4f);
@@ -50,6 +52,7 @@ namespace Concordia // keep-spawn-assign
                     Horizon(root, "cliff_large_rock", 54f, 8, 10f);
                     break;
                 case WorldId.Fantasy:
+                    Ring(root, DressVocab.House(WorldId.Fantasy), 14f, 8, 6.4f, 8f);
                     Ring(root, "hedge-large", 16f, 12, 2.8f, 0f);
                     FreePacks.Spawn("fountain-round", root, new Vector3(0, 0, 9), 0, 3.2f);
                     Ring(root, "banner-red", 11f, 8, 2.4f, 0f);
@@ -59,22 +62,27 @@ namespace Concordia // keep-spawn-assign
                     Horizon(root, "tower-hexagon-base", 48f, 6, 12f);
                     break;
                 case WorldId.Crime:
-                    Ring(root, "building-d", 20f, 6, 11f, 0f);
-                    Ring(root, "building-type-h", 14f, 8, 7f, 40f);
-                    Scatter(root, "dumpster", 10, 5f, 16f, 1.8f);
-                    Scatter(root, "detail-awning", 8, 10f, 18f, 2.2f);
+                    Ring(root, "building-type-h", 10f, 10, 5.4f, 18f);
+                    Ring(root, "building-d", 16f, 8, 7.2f, 0f);
+                    Scatter(root, "dumpster", 12, 4f, 14f, 1.8f);
+                    Scatter(root, "detail-awning", 10, 8f, 16f, 2.2f);
                     Scatter(root, "barrel", 10, 4f, 14f, 0.9f);
-                    Horizon(root, "building-skyscraper-e", 50f, 7, 22f);
+                    Ring(root, DressVocab.Wall(WorldId.Crime), 7f, 8, 3.2f, 40f);
                     break;
                 case WorldId.Cyber:
-                    Ring(root, "building-skyscraper-c", 22f, 6, 20f, 0f);
-                    Ring(root, "building-skyscraper-a", 16f, 6, 16f, 45f);
+                    Ring(root, "building-skyscraper-c", 14f, 8, 26f, 0f);
+                    Ring(root, "building-skyscraper-a", 20f, 7, 22f, 45f);
+                    Ring(root, "building-skyscraper-d", 28f, 6, 18f, 20f);
                     FreePacks.Spawn("corridor_cross", root, new Vector3(0, 0, 8), 0, 6f);
-                    Scatter(root, "detail-overhang-wide", 8, 8f, 18f, 3.4f);
-                    Horizon(root, "building-skyscraper-d", 48f, 8, 24f);
+                    Scatter(root, "detail-overhang-wide", 10, 8f, 18f, 3.4f);
+                    Horizon(root, "building-skyscraper-d", 48f, 8, 28f);
+                    HubLook.Point(root, "NeonA", new Vector3(8f, 10f, 12f), new Color(0.12f, 1f, 0.92f), 3.4f, 22f);
+                    HubLook.Point(root, "NeonB", new Vector3(-11f, 12f, 6f), new Color(1f, 0.12f, 0.72f), 3.2f, 20f);
+                    HubLook.Point(root, "NeonC", new Vector3(4f, 8f, -14f), new Color(0.45f, 0.2f, 1f), 2.8f, 18f);
                     break;
                 case WorldId.Frontier:
-                    Ring(root, "tent_detailedOpen", 14f, 8, 3f, 25f);
+                    Ring(root, DressVocab.House(WorldId.Frontier), 16f, 7, 4.8f, 18f);
+                    Ring(root, "tent_detailedOpen", 12f, 8, 3f, 25f);
                     Scatter(root, "palm-detailed-bend", 10, 12f, 22f, 5f);
                     Scatter(root, "campfire_stones", 8, 4f, 14f, 1.4f);
                     Scatter(root, "cart", 6, 8f, 16f, 2f);
@@ -252,6 +260,8 @@ namespace Concordia // keep-spawn-assign
                 };
                 guest.personId = person.id;
                 guest.questHooks = person.quest_hooks;
+                var personGo = go.GetComponent<ModularPerson>();
+                personGo?.BindStyle(Canon.PickFight(person.faction_id, person.archetype, w.id));
                 var weap = PersonKit.WeaponStem(facI >= 0 ? facs[facI] : null, n);
                 if (!string.IsNullOrEmpty(weap)) CharacterGear.Attach(go, weap, true, 0.95f);
                 if (facI >= 0 && facs[facI].visual != null && !string.IsNullOrEmpty(facs[facI].visual.primary_color)
@@ -510,7 +520,7 @@ namespace Concordia // keep-spawn-assign
             hold.rotation = Quaternion.Euler(0f, yaw, 0f);
 
             PlazaPad(hold, w);
-            CrossStreets(hold, yaw);
+            CrossStreets(hold, w, yaw);
             Sidewalks(hold);
 
             var kit = DressVocab.Kit(w.id);
@@ -601,8 +611,19 @@ namespace Concordia // keep-spawn-assign
             HubLook.Prim(hold, PrimitiveType.Cube, new Vector3(0f, 0.03f, 0f), new Vector3(22f, 0.08f, 22f), mat, "PlazaPad", false);
         }
 
-        static void CrossStreets(Transform hold, float yaw)
+        static void CrossStreets(Transform hold, WorldDef w, float yaw)
         {
+            if (w.id == WorldId.Crime || w.id == WorldId.Sere)
+            {
+                FreePacks.Spawn("road-straight", hold, hold.TransformPoint(new Vector3(0f, 0f, 0f)), yaw, 3.2f, false, false);
+                FreePacks.Spawn(DressVocab.Wall(w.id), hold, hold.TransformPoint(new Vector3(-3.8f, 0f, -6.2f)), yaw, 3.4f);
+                FreePacks.Spawn(DressVocab.Wall(w.id), hold, hold.TransformPoint(new Vector3(3.8f, 0f, -6.2f)), yaw, 3.4f);
+                FreePacks.Spawn(DressVocab.Wall(w.id), hold, hold.TransformPoint(new Vector3(-3.8f, 0f, 6.2f)), yaw, 3.4f);
+                FreePacks.Spawn(DressVocab.Wall(w.id), hold, hold.TransformPoint(new Vector3(3.8f, 0f, 6.2f)), yaw, 3.4f);
+                return;
+            }
+            if (w.id == WorldId.Frontier || w.id == WorldId.Tunya)
+                return;
             float[] along = { -10.5f, 0f, 10.5f };
             for (int i = 0; i < along.Length; i++)
             {

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/StoreDress.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/StoreDress.cs
@@ -3,22 +3,15 @@ using UnityEngine;
 namespace Concordia
 {
     /// <summary>
-    /// Places Get Started / Unity Asset Store prefabs that actually live in this project:
-    /// Prefabs (PlayerRobot, Stairs, Wall_Light, Collectible_Star, Moving_Platform),
-    /// TimmyRobot, SourceFiles models. No Synty/POLYGON pack is imported here.
+    /// Places owned-pack dressing (Mega Fantasy, 3DForge, forest/rocks).
+    /// Unity Get Started robots/stars/stairs stay out of the world.
     /// </summary>
     public static class StoreDress
     {
-        const string LightsL = "Assets/Prefabs/Wall_Light_Left.prefab";
-        const string LightsR = "Assets/Prefabs/Wall_Light_Right.prefab";
-        const string Stairs = "Assets/Prefabs/Stairs.prefab";
-        const string Star = "Assets/Prefabs/Collectible_Star.prefab";
-        const string Robot = "Assets/Prefabs/PlayerRobot.prefab";
-        const string Platform = "Assets/Prefabs/Moving_Platform.prefab";
-        const string Timmy = "Assets/SourceFiles/TimmyRobot/Models/TimmyRobot.fbx";
-        const string StairMesh = "Assets/SourceFiles/Models/Stairs_650_400_300_Mesh.fbx";
-        const string Hollow = "Assets/SourceFiles/Models/CubeHollow.fbx";
-        const string Box = "Assets/SourceFiles/Models/Box_350x250x300_Mesh.fbx";
+        const string WallLit =
+            "Assets/3DForge/Fantasy_Interiors/Villages_&_Towns/Prefabs/Props/Lighting/WallMounted/fi_vil_light_candle_wall02_lit_b.prefab";
+        const string StandLit =
+            "Assets/3DForge/Fantasy_Interiors/Villages_&_Towns/Prefabs/Props/Lighting/Standing/fi_vil_light_candle_holder04_lit.prefab";
 
         public static void Hub(Transform root)
         {
@@ -27,35 +20,38 @@ namespace Concordia
                 var dir = new Vector3(Mathf.Cos(g.angle), 0f, Mathf.Sin(g.angle));
                 var side = Vector3.Cross(Vector3.up, dir).normalized;
                 var baseP = dir * Canon.RingRadius;
-                Place(LightsL, root, baseP + side * 4.4f + Vector3.up * 4.6f + dir * -0.8f, -g.angle * Mathf.Rad2Deg, 0.9f);
-                Place(LightsR, root, baseP - side * 4.4f + Vector3.up * 4.6f + dir * -0.8f, -g.angle * Mathf.Rad2Deg, 0.9f);
+                Place(WallLit, root, baseP + side * 4.4f + Vector3.up * 2.4f + dir * -0.6f, -g.angle * Mathf.Rad2Deg, 1.5f);
+                Place(WallLit, root, baseP - side * 4.4f + Vector3.up * 2.4f + dir * -0.6f, -g.angle * Mathf.Rad2Deg, 1.5f);
             }
-            Place(Star, root, new Vector3(0f, 7.4f, 0f), 0f, 0.55f);
+            Place(StandLit, root, new Vector3(0f, 0f, 0f), 0f, 1.7f);
+            FreePacks.Spawn(DressVocab.Well(), root, new Vector3(-8.4f, 0f, 6.2f), 20f, 1.6f, required: false);
+            FreePacks.Spawn(DressVocab.Cart(), root, new Vector3(9.2f, 0f, -5.4f), -35f, 2.1f, required: false);
+            FreePacks.Spawn(DressVocab.Tree(WorldId.Hub), root, new Vector3(-14f, 0f, 11f), 12f, 9f, required: false);
+            FreePacks.Spawn(DressVocab.Tree(WorldId.Hub), root, new Vector3(13.4f, 0f, 12.2f), -28f, 8.2f, required: false);
+            FreePacks.Spawn(DressVocab.Rock(), root, new Vector3(-11.2f, 0f, -8.6f), 40f, 1.3f, required: false);
         }
 
         public static void Realm(Transform root, WorldDef w)
         {
-            Place(Stairs, root, new Vector3(0f, 0f, -10.4f), 180f, 0);
-            Place(StairMesh, root, new Vector3(3.2f, 0f, -10.4f), 180f, 2.4f);
-            Place(Hollow, root, new Vector3(-4.5f, 0f, 6f), 25f, 2.2f);
-            Place(Box, root, new Vector3(5.2f, 0f, 5.4f), -20f, 1.6f);
-
-            if (w.id == WorldId.Cyber || w.id == WorldId.Crucible)
+            FreePacks.Spawn(DressVocab.House(w.id), root, new Vector3(-6.2f, 0f, 5.4f), 25f, 5.2f, required: false);
+            FreePacks.Spawn(DressVocab.Tower(w.id), root, new Vector3(7.4f, 0f, 6.2f), -20f, 6.5f, required: false);
+            FreePacks.Spawn(DressVocab.Tree(w.id), root, new Vector3(-3.2f, 0f, -4.4f), 40f, 8f, required: false);
+            FreePacks.Spawn(DressVocab.Tree(w.id), root, new Vector3(5.6f, 0f, -6.1f), -15f, 7.2f, required: false);
+            FreePacks.Spawn(DressVocab.Prop(w.id), root, new Vector3(2.4f, 0f, 4.8f), 15f, 0.9f, required: false);
+            FreePacks.Spawn(DressVocab.Rock(), root, new Vector3(4.2f, 0f, -3.2f), 10f, 1.1f, required: false);
+            HubLook.Lantern(root, new Vector3(0.8f, 0f, 2.2f));
+            if (w.id == WorldId.Frontier)
+                FreePacks.Spawn(DressVocab.Cart(), root, new Vector3(0f, 0f, 10f), 12f, 2.2f, required: false);
+            if (w.id == WorldId.Crime)
             {
-                var bot = Place(Robot, root, new Vector3(-6f, 0f, 4f), 140f, 1.75f);
-                if (bot) bot.name = "StoreRobot";
-                var tim = Place(Timmy, root, new Vector3(6.4f, 0f, 3.2f), -40f, 1.7f);
-                if (tim) tim.name = "Timmy";
+                FreePacks.Spawn(DressVocab.Crate(), root, new Vector3(-4.2f, 0f, 3.1f), 8f, 0.9f, required: false);
+                FreePacks.Spawn(DressVocab.Crate(), root, new Vector3(-3.4f, 0f, 3.8f), -20f, 0.8f, required: false);
             }
-            if (w.id == WorldId.Crucible || w.id == WorldId.Frontier)
-                Place(Platform, root, new Vector3(0f, 0.2f, 10f), 0f, 0);
-            if (w.id == WorldId.Fantasy || w.id == WorldId.Superhero)
-                Place(Star, root, new Vector3(0f, 4.2f, 8f), 0f, 0.7f);
         }
 
         public static void QuestMark(Transform root, Vector3 boardTop)
         {
-            Place(Star, root, boardTop + Vector3.up * 0.85f, 0f, 0.45f);
+            Place(StandLit, root, boardTop, 0f, 1.1f);
         }
 
         public static GameObject Place(string path, Transform parent, Vector3 pos, float yawDeg, float height)

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/TrainingDummy.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/TrainingDummy.cs
@@ -52,6 +52,12 @@ namespace Concordia
             ApplyDamage(dmg, world);
         }
 
+        public void SyncHp(float next)
+        {
+            if (next < hp) _flash = 0.16f;
+            hp = next;
+        }
+
         /// <summary>HP from combat:attack:ack. Same presentation as the offline sandbox Hit.</summary>
         public void ApplyServerHit(float dmg, WorldId world)
         {
@@ -65,6 +71,12 @@ namespace Concordia
             _flash = 0.16f;
             transform.position += -transform.forward * 0.42f + Vector3.up * 0.06f;
             if (hp > 0) return;
+            var boss = GetComponent<WorldBoss>();
+            if (boss)
+            {
+                boss.Fall();
+                return;
+            }
             QuestLog.NoteDefeat(name);
             if (world == WorldId.Ruins || world == WorldId.Crucible)
             {

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldBook.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldBook.cs
@@ -433,6 +433,8 @@ namespace Concordia
         static float _actAge;
         static float _threatAt;
         static float _eventCd = 16f;
+        static string _visualWeather;
+        static float _baseFog = -1f;
 
         public static void Enter(WorldId id)
         {
@@ -448,6 +450,7 @@ namespace Concordia
             LastEvent = slice.lastEvent;
             Weather = Canon.Get(id).weather;
             ApplySky();
+            ApplyWeatherVisuals(force: true);
             NoteAct(Canon.Get(id).title + " kept its hours.");
             KingdomBook.Dump();
         }
@@ -498,6 +501,8 @@ namespace Concordia
                 var cycle = new[] { kit, "wind", "clear", kit };
                 Weather = cycle[UnityEngine.Random.Range(0, cycle.Length)];
                 LastEvent = Canon.Get(World).title + ": weather shifted. Schedules will.";
+                ApplyWeatherVisuals(force: false);
+                ApplySky();
             }
             _actAge += dt;
             if (_actAge > 8f) NearbyAct = "";
@@ -698,11 +703,64 @@ namespace Concordia
             }
             if (sun)
             {
+                float wx = WeatherDim();
                 if (World == WorldId.Hub)
-                    sun.intensity = 0.92f + 0.38f * day;
+                    sun.intensity = (0.92f + 0.38f * day) * wx;
                 else
-                    sun.intensity = 0.35f + 0.9f * day;
+                    sun.intensity = (0.35f + 0.9f * day) * wx;
             }
+        }
+
+        /// <summary>
+        /// DressSky owns the per-world fog floor. Capture it after that write so
+        /// weather can thicken rain/ash/smog without compounding across shifts.
+        /// </summary>
+        public static void NoteFogBase()
+        {
+            _baseFog = RenderSettings.fogDensity;
+            _visualWeather = null;
+        }
+
+        static float WeatherDim()
+        {
+            if (Weather == "rain" || Weather == "ash" || Weather == "smog") return 0.62f;
+            if (Weather == "wind") return 0.88f;
+            return 1f;
+        }
+
+        /// <summary>
+        /// Bind precip + fog to the live Weather string. Build-time PlaceWeather
+        /// used Canon.WorldDef.weather once and then ignored the kernel cycle, so
+        /// Crime rained forever and a "weather shifted" HUD line changed nothing
+        /// on screen. Identity VFX (Hub/Tunya/Fantasy fireflies) stay in DressSky
+        /// / Accents — they are not weather.
+        /// </summary>
+        static void ApplyWeatherVisuals(bool force)
+        {
+            if (!force && Weather == _visualWeather) return;
+            _visualWeather = Weather;
+            var world = GameObject.Find("World");
+            if (!world) return;
+            var holder = world.transform.Find("WeatherFx");
+            if (holder) UnityEngine.Object.DestroyImmediate(holder.gameObject);
+            var go = new GameObject("WeatherFx");
+            go.transform.SetParent(world.transform, false);
+            var kind = WeatherKind(Weather);
+            if (kind != null)
+                DressVocab.PlaceWeather(kind, go.transform, new Vector3(0f, 8f, 0f));
+            if (_baseFog < 0f) _baseFog = RenderSettings.fogDensity;
+            float mul = (Weather == "rain" || Weather == "ash") ? 1.45f
+                : Weather == "smog" ? 1.7f
+                : 1f;
+            RenderSettings.fogDensity = _baseFog * mul;
+        }
+
+        static string WeatherKind(string weather)
+        {
+            if (weather == "rain") return "rain";
+            // Ruins kit weather is "ash"; the in-project snow VFX is the ash-fall.
+            if (weather == "ash") return "snow";
+            return null;
         }
 
         static float Now() => (float)(DateTime.UtcNow - new DateTime(2026, 1, 1)).TotalSeconds;

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldBook.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldBook.cs
@@ -21,11 +21,18 @@ namespace Concordia
             public string id, title, type, era, description, significance;
         }
         [Serializable] public class PeopleDoc { public Person[] items; }
+        [Serializable] public class Narrative
+        {
+            // Secret is never deserialized here — T2.1 surfaces weaponise_at only.
+            public string weaponise_at, fear, current_goal;
+        }
         [Serializable] public class Person
         {
             public string id, name, title, archetype, backstory, background, faction_id, dialogue_style;
             public bool quest_giver;
             public string[] quest_hooks;
+            public Narrative narrative_context;
+            public string cross_world_hook;
         }
         [Serializable] public class CritterDoc { public Critter[] items; }
         [Serializable] public class Critter
@@ -156,6 +163,36 @@ namespace Concordia
             foreach (var q in Quests(id))
                 if (q != null && q.id == questId) return q;
             return null;
+        }
+
+        public static Person FindPerson(WorldId id, string key)
+        {
+            if (string.IsNullOrEmpty(key)) return null;
+            Person loose = null;
+            foreach (var p in People(id))
+            {
+                if (p == null) continue;
+                if (string.Equals(p.id, key, StringComparison.OrdinalIgnoreCase)) return p;
+                if (string.Equals(p.name, key, StringComparison.OrdinalIgnoreCase)) return p;
+                if (loose == null && !string.IsNullOrEmpty(p.id)
+                    && p.id.IndexOf(key, StringComparison.OrdinalIgnoreCase) >= 0)
+                    loose = p;
+                if (loose == null && !string.IsNullOrEmpty(p.name)
+                    && p.name.IndexOf(key, StringComparison.OrdinalIgnoreCase) >= 0)
+                    loose = p;
+            }
+            return loose;
+        }
+
+        /// <summary>T2.1 — authored leverage, never the secret.</summary>
+        public static string LeverageLine(Person p)
+        {
+            var raw = p?.narrative_context?.weaponise_at;
+            if (string.IsNullOrEmpty(raw)) return "";
+            var cut = raw.IndexOf(". ", StringComparison.Ordinal);
+            var s = cut > 20 && cut < 180 ? raw.Substring(0, cut + 1) : raw;
+            if (s.Length > 180) s = s.Substring(0, 177) + "…";
+            return s;
         }
 
         public static Quest[] OfferedBy(WorldId id, string npcId)
@@ -545,6 +582,9 @@ namespace Concordia
             Ecology = Mathf.Max(0.15f, Ecology - 0.03f);
             FactionHeat = Mathf.Min(1f, FactionHeat + 0.04f);
             LastEvent = Canon.Get(World).title + ": a pack thinned.";
+            var who = string.IsNullOrEmpty(id) ? "someone" : id;
+            NoteAct(who + " fell. Heirs would carry this — kernel npc_legacy needs /unity-ws.");
+            ConcordiaHUD.Announce("A thread passes", who + " is dead. Inheritance is kernel-side.");
         }
 
         /// <summary>Port of events.ts tickEvents / rollEvent — authored strings only.</summary>
@@ -966,6 +1006,30 @@ namespace Concordia
 
         public static string DeadCsv(WorldId id) => Load(id).deadCsv ?? "";
         public static int Births(WorldId id) => Load(id).births;
+
+        /// <summary>T2.2 — local lineage until npc_legacy arrives on /unity-ws.</summary>
+        public static string LineageLine(WorldId id)
+        {
+            var dead = DeadCsv(id);
+            var births = Births(id);
+            if (string.IsNullOrEmpty(dead) && births <= 0) return "";
+            var n = 0;
+            string first = "";
+            if (!string.IsNullOrEmpty(dead))
+            {
+                foreach (var p in dead.Split(','))
+                {
+                    var t = (p ?? "").Trim();
+                    if (t.Length == 0) continue;
+                    if (n == 0) first = t;
+                    n++;
+                }
+            }
+            var line = n > 0 ? n + " dead" : "none dead";
+            if (births > 0) line += " · " + births + " births";
+            if (!string.IsNullOrEmpty(first)) line += " · " + first + " still weighs";
+            return "lineage · " + line;
+        }
 
         static LivingSaveRec ReadFile()
         {

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldBook.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldBook.cs
@@ -605,6 +605,36 @@ namespace Concordia
             _actAge = 0f;
         }
 
+        public struct FeedBeat
+        {
+            public string channel;
+            public string line;
+        }
+
+        static readonly FeedBeat[] _feed = new FeedBeat[8];
+        static int _feedN;
+
+        /// <summary>
+        /// Kernel consequence strip — Emergent Event Feed role. Empty line is a no-op.
+        /// </summary>
+        public static void PushFeed(string channel, string line)
+        {
+            NoteAct(line);
+            if (string.IsNullOrEmpty(line)) return;
+            _feed[_feedN % _feed.Length] = new FeedBeat { channel = channel ?? "", line = line };
+            _feedN++;
+        }
+
+        public static int FeedCount => _feedN < _feed.Length ? _feedN : _feed.Length;
+
+        public static FeedBeat FeedAt(int newestIndex)
+        {
+            if (newestIndex < 0 || newestIndex >= FeedCount) return default;
+            int idx = _feedN - 1 - newestIndex;
+            if (idx < 0) return default;
+            return _feed[idx % _feed.Length];
+        }
+
         public static void NoteKill(string id)
         {
             WorldMemory.MarkDead(World, id);

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldBook.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldBook.cs
@@ -583,8 +583,40 @@ namespace Concordia
             FactionHeat = Mathf.Min(1f, FactionHeat + 0.04f);
             LastEvent = Canon.Get(World).title + ": a pack thinned.";
             var who = string.IsNullOrEmpty(id) ? "someone" : id;
-            NoteAct(who + " fell. Heirs would carry this — kernel npc_legacy needs /unity-ws.");
-            ConcordiaHUD.Announce("A thread passes", who + " is dead. Inheritance is kernel-side.");
+            string heirName = "";
+            string heirId = "";
+            var deadPerson = WorldBook.FindPerson(World, id);
+            var fac = deadPerson != null ? deadPerson.faction_id : "";
+            var guests = UnityEngine.Object.FindObjectsByType<GuestNpc>(FindObjectsInactive.Exclude);
+            GuestNpc heir = null;
+            for (int i = 0; i < guests.Length; i++)
+            {
+                var g = guests[i];
+                if (!g) continue;
+                var key = Bonds.Key(g);
+                if (string.IsNullOrEmpty(key) || string.Equals(key, id, StringComparison.OrdinalIgnoreCase)) continue;
+                if (WorldMemory.IsDead(World, key)) continue;
+                var gp = WorldBook.FindPerson(World, key);
+                if (!string.IsNullOrEmpty(fac) && gp != null && gp.faction_id == fac)
+                {
+                    heir = g;
+                    break;
+                }
+                if (heir == null) heir = g;
+            }
+            if (heir != null)
+            {
+                heirName = heir.def != null ? heir.def.name : heir.name;
+                heirId = Bonds.Key(heir);
+                WorldMemory.NoteHeir(World, who, heirName);
+            }
+            var line = string.IsNullOrEmpty(heirName)
+                ? who + " fell. No heir stood."
+                : who + " fell. " + heirName + " carries the thread.";
+            NoteAct(line);
+            ConcordiaHUD.Announce("A thread passes", line);
+            var client = ConcordClient.Live;
+            if (client != null) client.SendInheritance(heirId, id);
         }
 
         /// <summary>Port of events.ts tickEvents / rollEvent — authored strings only.</summary>
@@ -606,6 +638,13 @@ namespace Concordia
             public string text;
             public float ecology, heat, prices;
             public int births;
+        }
+
+        static EvRec SeedScheme(string beat)
+        {
+            var text = "A faction scheme ripened. " + beat;
+            Plots.Seed(text);
+            return new EvRec { text = text, heat = 0.16f, prices = 0.04f };
         }
 
         static EvRec RollEvent()
@@ -632,11 +671,7 @@ namespace Concordia
                     text = w.title + ": stores tightened. " + w.refusal,
                     ecology = -0.08f, heat = 0.1f, prices = 0.14f
                 },
-                "scheme" => new EvRec
-                {
-                    text = "A faction scheme ripened. " + beat,
-                    heat = 0.16f, prices = 0.04f
-                },
+                "scheme" => SeedScheme(beat),
                 "emergence" => new EvRec
                 {
                     text = w.title + ": " + creature + " took the hour.",
@@ -744,11 +779,12 @@ namespace Concordia
             if (sun)
             {
                 float wx = WeatherDim();
-                if (World == WorldId.Hub)
-                    sun.intensity = (0.92f + 0.38f * day) * wx;
-                else
-                    sun.intensity = (0.35f + 0.9f * day) * wx;
+                sun.intensity = (0.06f + 1.12f * day) * wx;
+                sun.color = Color.Lerp(new Color(0.28f, 0.36f, 0.62f), new Color(1f, 0.94f, 0.82f), day);
             }
+            var box = RenderSettings.skybox;
+            if (box && box.HasProperty("_Exposure"))
+                box.SetFloat("_Exposure", 0.22f + 0.98f * day);
         }
 
         /// <summary>
@@ -1007,7 +1043,15 @@ namespace Concordia
         public static string DeadCsv(WorldId id) => Load(id).deadCsv ?? "";
         public static int Births(WorldId id) => Load(id).births;
 
-        /// <summary>T2.2 — local lineage until npc_legacy arrives on /unity-ws.</summary>
+        /// <summary>T2.2 — last heir named when someone fell.</summary>
+        static string _heirLine;
+
+        public static void NoteHeir(WorldId id, string dead, string heir)
+        {
+            if (string.IsNullOrEmpty(heir)) return;
+            _heirLine = heir + " carries " + (string.IsNullOrEmpty(dead) ? "the dead" : dead);
+        }
+
         public static string LineageLine(WorldId id)
         {
             var dead = DeadCsv(id);
@@ -1028,6 +1072,7 @@ namespace Concordia
             var line = n > 0 ? n + " dead" : "none dead";
             if (births > 0) line += " · " + births + " births";
             if (!string.IsNullOrEmpty(first)) line += " · " + first + " still weighs";
+            if (!string.IsNullOrEmpty(_heirLine)) line += " · " + _heirLine;
             return "lineage · " + line;
         }
 

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldBook.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldBook.cs
@@ -472,6 +472,8 @@ namespace Concordia
         static float _eventCd = 16f;
         static string _visualWeather;
         static float _baseFog = -1f;
+        static bool _kernelLive;
+        static float _kernelAt;
 
         public static void Enter(WorldId id)
         {
@@ -490,6 +492,31 @@ namespace Concordia
             ApplyWeatherVisuals(force: true);
             NoteAct(Canon.Get(id).title + " kept its hours.");
             KingdomBook.Dump();
+        }
+
+        /// <summary>
+        /// Server day-phase [0,1). Hour follows the kernel while frames keep arriving.
+        /// </summary>
+        public static void BindKernelClock(float phase, string segment)
+        {
+            Hour = Mathf.Repeat(phase * 24f, 24f);
+            _kernelLive = true;
+            _kernelAt = Time.unscaledTime;
+            if (!string.IsNullOrEmpty(segment)) LastEvent = Canon.Get(World).title + " · " + segment;
+            ApplySky();
+        }
+
+        /// <summary>
+        /// Server weather type. Stops the local random cycle from overwriting it.
+        /// </summary>
+        public static void BindKernelWeather(string type)
+        {
+            if (string.IsNullOrEmpty(type)) return;
+            Weather = type;
+            _kernelLive = true;
+            _kernelAt = Time.unscaledTime;
+            ApplyWeatherVisuals(force: false);
+            ApplySky();
         }
 
         public static void Leave()
@@ -521,7 +548,9 @@ namespace Concordia
 
         public static void Tick(float dt)
         {
-            Hour = (Hour + dt * 0.08f) % 24f;
+            var kernelFresh = _kernelLive && Time.unscaledTime - _kernelAt < 90f;
+            if (!kernelFresh)
+                Hour = (Hour + dt * 0.08f) % 24f;
             if (Hour < 0.05f * dt + 0.02f)
             {
                 Day += 1;
@@ -531,7 +560,7 @@ namespace Concordia
             _weatherT -= dt;
             Ecology = Mathf.Clamp(Ecology + dt * 0.004f, 0.15f, 1f);
             FactionHeat = Mathf.Max(0f, FactionHeat - dt * 0.02f);
-            if (_weatherT <= 0f)
+            if (!kernelFresh && _weatherT <= 0f)
             {
                 _weatherT = 28f + UnityEngine.Random.value * 22f;
                 var kit = Canon.Get(World).weather;
@@ -799,7 +828,8 @@ namespace Concordia
 
         static float WeatherDim()
         {
-            if (Weather == "rain" || Weather == "ash" || Weather == "smog") return 0.62f;
+            if (Weather == "rain" || Weather == "ash" || Weather == "smog" || Weather == "storm") return 0.62f;
+            if (Weather == "fog" || Weather == "overcast") return 0.78f;
             if (Weather == "wind") return 0.88f;
             return 1f;
         }
@@ -825,17 +855,18 @@ namespace Concordia
             if (kind != null)
                 DressVocab.PlaceWeather(kind, go.transform, new Vector3(0f, 8f, 0f));
             if (_baseFog < 0f) _baseFog = RenderSettings.fogDensity;
-            float mul = (Weather == "rain" || Weather == "ash") ? 1.45f
-                : Weather == "smog" ? 1.7f
+            float mul = (Weather == "rain" || Weather == "ash" || Weather == "storm") ? 1.45f
+                : (Weather == "smog" || Weather == "fog") ? 1.7f
+                : Weather == "overcast" ? 1.2f
                 : 1f;
             RenderSettings.fogDensity = _baseFog * mul;
         }
 
         static string WeatherKind(string weather)
         {
-            if (weather == "rain") return "rain";
+            if (weather == "rain" || weather == "storm") return "rain";
             // Ruins kit weather is "ash"; the in-project snow VFX is the ash-fall.
-            if (weather == "ash") return "snow";
+            if (weather == "ash" || weather == "snow") return "snow";
             return null;
         }
 

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldBuilder.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldBuilder.cs
@@ -7,29 +7,6 @@ namespace Concordia
         public Transform root;
         public ConcordiaPlayer player;
 
-        static readonly string[] ForestTrees =
-        {
-            "tree_oak", "tree_default", "tree_pineTallA", "tree_detailed",
-            "tree_tall", "tree_fat", "tree_simple", "tree_pineDefaultA",
-            "tree-large", "tree-small", "detail-tree-large"
-        };
-        static readonly string[] Flowers =
-        {
-            "flower_redA", "flower_yellowA", "flower_purpleA",
-            "flower_redB", "flower_yellowB", "flower_purpleC"
-        };
-        static readonly string[] Houses =
-        {
-            "building-type-a", "building-type-b", "building-type-c", "building-type-d",
-            "building-type-e", "building-type-h", "building-type-k", "building-type-n",
-            "building-small-a", "building-small-b", "building-small-c", "building-small-d"
-        };
-        static readonly string[] Shops =
-        {
-            "building-a", "building-c", "building-e", "building-g",
-            "building-skyscraper-a", "building-skyscraper-c"
-        };
-
         public void Build(WorldId world)
         {
             PurgeWorldRoots();
@@ -69,7 +46,7 @@ namespace Concordia
         {
             if (w.id == WorldId.Hub)
             {
-                HubLook.MakeSun(root, new Color(1f, 0.94f, 0.82f), 1.18f, new Vector3(42f, -38f, 0f));
+                HubLook.MakeSun(root, new Color(1f, 0.94f, 0.82f), 1.55f, new Vector3(42f, -38f, 0f));
                 return;
             }
             var g = GameObject.CreatePrimitive(PrimitiveType.Plane);
@@ -247,8 +224,10 @@ namespace Concordia
                 float a = i / 4f * Mathf.PI * 2f + 0.55f;
                 var p = new Vector3(Mathf.Cos(a) * 19.4f, 0f, Mathf.Sin(a) * 19.4f);
                 if (Canon.InArena(p)) continue;
-                HubLook.Prim(root, PrimitiveType.Cube, p + Vector3.up * 0.28f, new Vector3(1.4f, 0.22f, 0.45f),
-                    HubLook.Lit(new Color(0.35f, 0.2f, 0.1f), 0.1f, 0.25f), "Bench" + i);
+                var bench = FreePacks.Spawn(DressVocab.Table(), root, p, -a * Mathf.Rad2Deg, 0.55f, required: false);
+                if (!bench)
+                    HubLook.Prim(root, PrimitiveType.Cube, p + Vector3.up * 0.28f, new Vector3(1.4f, 0.22f, 0.45f),
+                        HubLook.Lit(new Color(0.35f, 0.2f, 0.1f), 0.1f, 0.25f), "Bench" + i);
                 var look = Appearance.Random(3300 + i * 13);
                 var go = ModularPerson.SpawnNpc(root, p + new Vector3(0f, 0f, 0.1f), -a * Mathf.Rad2Deg, look, false);
                 go.AddComponent<NpcLife>().job = NpcLife.Job.Sit;
@@ -276,6 +255,8 @@ namespace Concordia
             var col = DressVocab.Column(WorldId.Hub);
             var sword = DressVocab.Weapon("sword");
             var tower = DressVocab.Tower(WorldId.Hub);
+            var tree = DressVocab.Tree(WorldId.Hub);
+            var rock = DressVocab.Rock();
             for (int i = 0; i < 12; i++)
             {
                 var a = (i / 12f) * Mathf.PI * 2;
@@ -283,15 +264,66 @@ namespace Concordia
                     -a * Mathf.Rad2Deg + 90, 3.2f);
                 if (i % 3 == 0)
                     FreePacks.Spawn(col, root, c + new Vector3(Mathf.Cos(a) * 7.2f, 0, Mathf.Sin(a) * 7.2f), 0, 2.6f);
+                if (i % 2 == 0)
+                    HubLook.Lantern(root, c + new Vector3(Mathf.Cos(a) * 9.2f, 0, Mathf.Sin(a) * 9.2f));
             }
-            FreePacks.Spawn(DressVocab.FirstStem(new[] { "Statue" }, "statue"), root, c + new Vector3(6, 0, 6), 40, 2.2f);
-            FreePacks.Spawn("weapon-rack", root, c + new Vector3(-5, 0, 5), 90, 1.8f);
-            FreePacks.Spawn(sword, root, c + new Vector3(-5.4f, 0, 5), 90, 1.2f);
-            FreePacks.Spawn("banner", root, c + new Vector3(0, 0, -7.4f), 0, 2.4f);
-            FreePacks.Spawn("trophy", root, c + new Vector3(4.5f, 0, -3), 0, 1.1f);
-            FreePacks.Prefab("Assets/Prefabs/Stairs.prefab", root, c + new Vector3(0, 0, -10), 0);
-            FreePacks.Spawn(tower, root, c + new Vector3(10, 0, 0), 0, 4.5f);
-            FreePacks.Spawn(tower, root, c + new Vector3(-10, 0, 0), 0, 4.5f);
+            FreePacks.Spawn(DressVocab.FirstStem(new[] { "Statue" }, "statue"), root, c + new Vector3(6, 0, 6), 40, 2.2f, required: false);
+            FreePacks.Spawn(sword, root, c + new Vector3(-5.4f, 0, 5), 90, 1.2f, required: false);
+            FreePacks.Spawn(DressVocab.Prop(WorldId.Hub), root, c + new Vector3(-5.1f, 0, 5.6f), 20, 0.9f, required: false);
+            FreePacks.Spawn(DressVocab.Well(), root, c + new Vector3(5.2f, 0, -4.4f), 0, 1.5f, required: false);
+            FreePacks.Spawn(tower, root, c + new Vector3(10, 0, 0), 0, 4.5f, required: false);
+            FreePacks.Spawn(tower, root, c + new Vector3(-10, 0, 0), 0, 4.5f, required: false);
+            FreePacks.Spawn(tree, root, c + new Vector3(12.4f, 0, 8.2f), 18, 8.5f, required: false);
+            FreePacks.Spawn(tree, root, c + new Vector3(-11.8f, 0, 9.1f), -30, 7.8f, required: false);
+            FreePacks.Spawn(rock, root, c + new Vector3(8.6f, 0, -7.2f), 12, 1.2f, required: false);
+            FreePacks.Spawn(rock, root, c + new Vector3(-7.4f, 0, -8.1f), -22, 1.0f, required: false);
+            PresentSkillPylons();
+        }
+
+        /// <summary>
+        /// Combat pylons around the training dummy — one per catalog group,
+        /// labeled from skills.mastery when Concord has answered. Walk up and
+        /// press E, or open K for the full 67. Empty until the lattice binds.
+        /// </summary>
+        public static void PresentSkillPylons()
+        {
+            var world = GameObject.Find("World");
+            if (!world) return;
+            var old = world.transform.Find("SkillRing");
+            if (old) Object.DestroyImmediate(old.gameObject);
+            var hold = new GameObject("SkillRing").transform;
+            hold.SetParent(world.transform, false);
+            var c = Canon.Arena;
+            var groups = SkillLattice.Groups.Count > 0
+                ? SkillLattice.Groups
+                : new System.Collections.Generic.List<string> { "combat", "athletic", "craft", "arts", "social", "scholar", "side" };
+            var col = DressVocab.Column(WorldId.Hub);
+            for (int i = 0; i < groups.Count; i++)
+            {
+                var a = (i / (float)groups.Count) * Mathf.PI * 2f + 0.18f;
+                var pos = c + new Vector3(Mathf.Cos(a) * 5.6f, 0f, Mathf.Sin(a) * 5.6f);
+                var go = FreePacks.Spawn(col, hold, pos, -a * Mathf.Rad2Deg, 2.4f, required: false);
+                if (!go)
+                {
+                    go = HubLook.Prim(hold, PrimitiveType.Cylinder, pos + Vector3.up * 1.1f,
+                        new Vector3(0.38f, 2.2f, 0.38f), HubLook.Lit(new Color(0.42f, 0.32f, 0.22f), 0.15f, 0.3f),
+                        "Pylon_" + groups[i]);
+                }
+                var pylon = go.GetComponent<SkillPylon>() ?? go.AddComponent<SkillPylon>();
+                pylon.group = groups[i];
+                pylon.skillType = SkillLattice.FirstInGroup(groups[i]);
+                var label = new GameObject("Name").AddComponent<TextMesh>();
+                label.transform.SetParent(go.transform, false);
+                label.transform.localPosition = new Vector3(0f, 2.6f, 0f);
+                label.text = groups[i].ToUpperInvariant();
+                label.fontSize = 42;
+                label.characterSize = 0.06f;
+                label.anchor = TextAnchor.MiddleCenter;
+                label.alignment = TextAlignment.Center;
+                label.color = new Color(1f, 0.93f, 0.78f);
+                HubLook.DressTextMesh(label);
+                FreePacks.EnsureCollider(go, 2.2f);
+            }
         }
 
         void DressEmbassy(GateDef gate, Vector3 p, float yaw)
@@ -369,7 +401,7 @@ namespace Concordia
         {
             FreePacks.Spawn("campfire_stones", root, p + new Vector3(3, 0, 2), 0, 1.6f);
             FreePacks.Spawn("campfire_logs", root, p + new Vector3(3, 0, 2), 0, 1.2f);
-            FreePacks.Spawn("weapon-rack", root, p + new Vector3(-2, 0, 2), 90, 1.8f);
+            FreePacks.Spawn(DressVocab.Prop(WorldId.Hub), root, p + new Vector3(-2, 0, 2), 90, 1.1f, required: false);
             FreePacks.Spawn(DressVocab.Weapon("sword"), root, p + new Vector3(2, 0, -1), 0, 1.1f);
         }
 
@@ -417,9 +449,9 @@ namespace Concordia
                 var pos = new Vector3(Mathf.Cos(a) * rad, 0, Mathf.Sin(a) * rad);
                 var yaw = Mathf.Atan2(-Mathf.Cos(a), -Mathf.Sin(a)) * Mathf.Rad2Deg;
                 if (i % 5 == 0)
-                    FreePacks.Spawn(Shops[i % Shops.Length], root, pos, yaw, 9f, required: false, byHeight: true);
+                    FreePacks.Spawn(DressVocab.Tower(WorldId.Hub), root, pos, yaw, 9f, required: false, byHeight: true);
                 else
-                    FreePacks.Spawn(Houses[i % Houses.Length], root, pos, yaw, 6.5f, required: false, byHeight: true);
+                    FreePacks.Spawn(DressVocab.House(WorldId.Hub), root, pos, yaw, 6.5f, required: false, byHeight: true);
             }
             EvoCatalog.Spawn(EvoCatalog.SmallA, root, new Vector3(52, 0, 18), Quaternion.Euler(0, 70, 0), 1f);
             EvoCatalog.Spawn(EvoCatalog.Garage, root, new Vector3(48, 0, -12), Quaternion.Euler(0, 90, 0), 1f);
@@ -432,8 +464,8 @@ namespace Concordia
                 var a = (i / 40f) * Mathf.PI * 2 + 0.51f;
                 if (Mathf.Sin(a) > 0.62f) continue;
                 var rad = 28 + (i % 4) * 3.4f;
-                FreePacks.Spawn(ForestTrees[i % ForestTrees.Length], root,
-                    new Vector3(Mathf.Cos(a) * rad, 0, Mathf.Sin(a) * rad), i * 17f, 4.5f);
+                FreePacks.Spawn(DressVocab.Tree(WorldId.Hub), root,
+                    new Vector3(Mathf.Cos(a) * rad, 0, Mathf.Sin(a) * rad), i * 17f, 7.5f, required: false);
                 if (i % 3 == 0)
                     FreePacks.Spawn("plant_bush", root,
                         new Vector3(Mathf.Cos(a + 0.08f) * (rad - 2), 0, Mathf.Sin(a + 0.08f) * (rad - 2)), 0, 1.2f);
@@ -799,7 +831,7 @@ namespace Concordia
                 holder = goHolder.transform;
             }
             if (maxDim < 1.6f) maxDim = 3.2f;
-            var stem = Houses[Mathf.Abs((id ?? type ?? "b").GetHashCode()) % Houses.Length];
+            var stem = DressVocab.House(WorldId.Hub);
             var go = FreePacks.Spawn(stem, holder, pos, yawRad * Mathf.Rad2Deg, maxDim);
             if (go) go.name = string.IsNullOrEmpty(id) ? "KernelBuilding" : "KernelBuilding_" + id;
         }

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldBuilder.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldBuilder.cs
@@ -139,12 +139,11 @@ namespace Concordia
                 _ => new Color(0.08f, 0.28f, 0.28f)
             };
             DynamicGI.UpdateEnvironment();
+            WorldClock.NoteFogBase();
+            // Hub fireflies are identity ambience, not weather. Rain/ash/snow
+            // follow WorldClock.Weather from Enter/Tick (see ApplyWeatherVisuals).
             if (w.id == WorldId.Hub)
                 DressVocab.PlaceWeather("fireflies", root, new Vector3(0, 2.2f, 0));
-            if (w.id == WorldId.Crime || w.weather == "rain")
-                DressVocab.PlaceWeather("rain", root, new Vector3(0, 8, 0));
-            if (w.id == WorldId.Ruins || w.id == WorldId.Crucible)
-                DressVocab.PlaceWeather("snow", root, new Vector3(0, 8, 0));
         }
 
         void DressAudio(WorldDef w)

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldBuilder.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldBuilder.cs
@@ -774,5 +774,34 @@ namespace Concordia
             var r = go.GetComponent<Renderer>();
             if (!r || r.sharedMaterial == null) Tint(go, c);
         }
+
+        /// <summary>
+        /// Live kernel buildings from scene:data. Local Kenney dressing stays;
+        /// this overlay is which buildings exist right now, not how the hub looks.
+        /// </summary>
+        public static void ClearKernelLive()
+        {
+            var world = GameObject.Find("World");
+            if (!world) return;
+            var old = world.transform.Find("KernelLive");
+            if (old) Object.DestroyImmediate(old.gameObject);
+        }
+
+        public static void PlaceKernelBuilding(string id, string type, Vector3 pos, float yawRad, float maxDim)
+        {
+            var world = GameObject.Find("World");
+            if (!world) return;
+            var holder = world.transform.Find("KernelLive");
+            if (!holder)
+            {
+                var goHolder = new GameObject("KernelLive");
+                goHolder.transform.SetParent(world.transform, false);
+                holder = goHolder.transform;
+            }
+            if (maxDim < 1.6f) maxDim = 3.2f;
+            var stem = Houses[Mathf.Abs((id ?? type ?? "b").GetHashCode()) % Houses.Length];
+            var go = FreePacks.Spawn(stem, holder, pos, yawRad * Mathf.Rad2Deg, maxDim);
+            if (go) go.name = string.IsNullOrEmpty(id) ? "KernelBuilding" : "KernelBuilding_" + id;
+        }
     }
 }

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldGate.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldGate.cs
@@ -95,6 +95,13 @@ namespace Concordia
         public string personId;
         public string[] questHooks;
         public string Prompt => "E  ·  " + def.name + ", " + def.title;
+
+        void Start()
+        {
+            var name = def != null ? def.name : "someone";
+            var role = def != null ? def.title : null;
+            PersonLabel.Attach(transform, name, role);
+        }
     }
 
     /// <summary>Authored quest on a board. E accepts or reports progress.</summary>
@@ -207,6 +214,85 @@ namespace Concordia
             float flap = Mathf.Sin(Time.time * 11f + _phase) * 28f;
             if (_wingL) _wingL.localRotation = Quaternion.Euler(0f, 0f, flap);
             if (_wingR) _wingR.localRotation = Quaternion.Euler(0f, 0f, -flap);
+        }
+    }
+
+    /// <summary>T1 nameplate. World-space name over a living person.</summary>
+    public class PersonLabel : MonoBehaviour
+    {
+        public string title;
+        public string role;
+        TextMesh _mesh;
+        const float MaxDist = 22f;
+
+        public static PersonLabel Attach(Transform host, string title, string role = null)
+        {
+            if (!host) return null;
+            var existing = host.GetComponentInChildren<PersonLabel>();
+            if (existing)
+            {
+                existing.title = title;
+                existing.role = role;
+                existing.Apply();
+                return existing;
+            }
+            var go = new GameObject("Nameplate");
+            go.transform.SetParent(host, false);
+            go.transform.localPosition = new Vector3(0f, 2.15f, 0f);
+            var lab = go.AddComponent<PersonLabel>();
+            lab.title = title;
+            lab.role = role;
+            lab.Build();
+            return lab;
+        }
+
+        void Build()
+        {
+            _mesh = gameObject.AddComponent<TextMesh>();
+            _mesh.anchor = TextAnchor.LowerCenter;
+            _mesh.alignment = TextAlignment.Center;
+            _mesh.characterSize = 0.045f;
+            _mesh.fontSize = 42;
+            _mesh.color = new Color(1f, 0.94f, 0.82f, 0.95f);
+            var font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            if (font)
+            {
+                _mesh.font = font;
+                var matRend = _mesh.GetComponent<Renderer>();
+                if (matRend && font.material) matRend.sharedMaterial = font.material;
+            }
+            var rend = _mesh.GetComponent<Renderer>();
+            if (rend)
+            {
+                rend.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+                rend.receiveShadows = false;
+            }
+            Apply();
+        }
+
+        void Apply()
+        {
+            if (!_mesh) _mesh = GetComponent<TextMesh>();
+            if (!_mesh) return;
+            var line = string.IsNullOrEmpty(title) ? "someone" : title;
+            if (!string.IsNullOrEmpty(role)) line += "\n" + role;
+            _mesh.text = line;
+        }
+
+        void LateUpdate()
+        {
+            var cam = Camera.main;
+            var rend = _mesh ? _mesh.GetComponent<Renderer>() : GetComponent<Renderer>();
+            if (!cam)
+            {
+                if (rend) rend.enabled = false;
+                return;
+            }
+            var d = Vector3.Distance(cam.transform.position, transform.position);
+            var show = d < MaxDist;
+            if (rend) rend.enabled = show;
+            if (!show) return;
+            transform.rotation = Quaternion.LookRotation(transform.position - cam.transform.position);
         }
     }
 }

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldGate.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldGate.cs
@@ -437,11 +437,15 @@ namespace Concordia
         public static void Place(float x, float y, float z)
         {
             if (!WorldPresence.InPresenter(x, z)) return;
+            PlaceAt(new Vector3(x, y > 0.01f && y < 4.5f ? y : 0.08f, z));
+        }
+
+        public static void PlaceAt(Vector3 p)
+        {
             var root = Object.FindFirstObjectByType<WorldBuilder>();
             var parent = root ? root.transform : null;
-            float py = y > 0.01f && y < 4.5f ? y : 0.08f;
             var go = HubLook.Prim(parent, PrimitiveType.Cylinder,
-                new Vector3(x, py + 0.04f, z),
+                new Vector3(p.x, p.y + 0.04f, p.z),
                 new Vector3(2.4f, 0.04f, 2.4f),
                 HubLook.Emit(new Color(0.95f, 0.82f, 0.45f), 1.6f),
                 "GatheringTell", false);
@@ -458,16 +462,24 @@ namespace Concordia
     /// <summary>
     /// World boss body only at an existing DungeonGate mouth. No invented xz.
     /// Template slug may differ from hollow_warden — the hold is the site.
+    /// Hostile + TrainingDummy are the body: HP / phase from kernel BindState,
+    /// attacks from Hostile, death → Fall → chronicle plaque at the mouth.
     /// </summary>
     public class WorldBoss : MonoBehaviour
     {
         public static WorldBoss Live;
         public string template;
         public string activeId;
+        public string encounterId;
         public float hp = -1f, maxHp = 1f;
         public string phase;
         public string mechanic;
+        public bool fallen;
         public float HpPct => maxHp > 0f && hp >= 0f ? Mathf.Clamp01(hp / maxHp) : -1f;
+        TrainingDummy _dummy;
+        Hostile _hostile;
+        Vector3 _scale0;
+        Renderer _rend;
 
         public static WorldBoss Present(string template, string activeId)
         {
@@ -486,6 +498,7 @@ namespace Concordia
                 {
                     Live = boss;
                     if (!string.IsNullOrEmpty(template)) boss.template = template;
+                    if (!string.IsNullOrEmpty(hold.encounterId)) boss.encounterId = hold.encounterId;
                 }
                 return boss;
             }
@@ -499,6 +512,21 @@ namespace Concordia
             var presented = go.AddComponent<WorldBoss>();
             presented.template = template ?? "";
             presented.activeId = activeId ?? "";
+            presented.encounterId = hold.encounterId ?? "";
+            presented._rend = go.GetComponent<Renderer>();
+            presented._scale0 = go.transform.localScale;
+            var cc = go.GetComponent<CharacterController>() ?? go.AddComponent<CharacterController>();
+            cc.height = 3.2f;
+            cc.radius = 0.7f;
+            cc.center = Vector3.up * 0.2f;
+            presented._dummy = go.GetComponent<TrainingDummy>() ?? go.AddComponent<TrainingDummy>();
+            presented._dummy.living = true;
+            presented._dummy.hp = 80f;
+            presented._hostile = go.GetComponent<Hostile>() ?? go.AddComponent<Hostile>();
+            presented._hostile.damage = 16f;
+            presented._hostile.range = 2.6f;
+            presented._hostile.aggro = 22f;
+            presented._hostile.speed = 2.2f;
             Live = presented;
             var label = string.IsNullOrEmpty(template) ? hold.holdName : template;
             PersonLabel.Attach(go.transform, label, "boss");
@@ -513,11 +541,47 @@ namespace Concordia
             if (!string.IsNullOrEmpty(name)) boss.template = name;
             boss.hp = hp;
             boss.maxHp = maxHp > 0f ? maxHp : 1f;
+            var prev = boss.phase;
             boss.phase = phase ?? "";
             boss.mechanic = mechanic ?? "";
             var title = string.IsNullOrEmpty(boss.template) ? "world boss" : boss.template;
             if (!string.IsNullOrEmpty(phase)) title += " · " + phase;
             PersonLabel.Attach(boss.transform, title, mechanic);
+            boss.PaintPhase(prev != boss.phase);
+            if (boss._dummy)
+            {
+                if (hp >= 0f) boss._dummy.SyncHp(hp);
+            }
+            if (hp >= 0f && hp <= 0.01f) boss.Fall();
+        }
+
+        void PaintPhase(bool entered)
+        {
+            var pct = HpPct < 0f ? 1f : HpPct;
+            if (_scale0.sqrMagnitude < 0.01f) _scale0 = transform.localScale;
+            transform.localScale = _scale0 * (1f + (1f - pct) * 0.18f);
+            if (!_rend) _rend = GetComponent<Renderer>();
+            if (_rend)
+            {
+                var c = phase == "desperate" || phase == "undertow"
+                    ? new Color(0.95f, 0.18f, 0.08f)
+                    : phase == "sundered" || phase == "surge"
+                        ? new Color(0.85f, 0.38f, 0.1f)
+                        : new Color(0.52f, 0.12f, 0.1f);
+                _rend.material = HubLook.Lit(c, entered ? 0.35f : 0.12f, 0.32f);
+            }
+            if (entered && _hostile) _hostile.TelegraphNow();
+        }
+
+        public void Fall()
+        {
+            if (fallen) return;
+            fallen = true;
+            hp = 0f;
+            if (_dummy) _dummy.hp = 0f;
+            if (_hostile) _hostile.enabled = false;
+            transform.rotation = Quaternion.Euler(78f, transform.eulerAngles.y, 12f);
+            PersonLabel.Attach(transform, string.IsNullOrEmpty(template) ? "fallen" : template, "fallen");
         }
 
         void OnDestroy()
@@ -544,6 +608,8 @@ namespace Concordia
             var root = FindFirstObjectByType<WorldBuilder>();
             var parent = root ? root.transform : null;
             var p = Canon.Arena + Vector3.right * 3.4f + Vector3.up * 0.9f;
+            if (WorldBoss.Live && WorldBoss.Live.fallen)
+                p = WorldBoss.Live.transform.position + Vector3.right * 2.2f + Vector3.up * 0.9f;
             var go = HubLook.Prim(parent, PrimitiveType.Cube, p,
                 new Vector3(0.9f, 1.4f, 0.14f),
                 HubLook.Lit(new Color(0.42f, 0.36f, 0.22f), 0.12f, 0.28f),

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldGate.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldGate.cs
@@ -124,7 +124,8 @@ namespace Concordia
     /// <summary>Kenney hold mouth. Geometry is dressing; the plaque stays honest.</summary>
     public class DungeonGate : MonoBehaviour
     {
-        public string holdName = "the hold";
+        public string encounterId = "hollow_warden";
+        public string holdName = "The Hollow Warden";
         public Vector3 inside;
         public Vector3 mouth;
         public bool inHold;

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldGate.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldGate.cs
@@ -296,4 +296,143 @@ namespace Concordia
             transform.rotation = Quaternion.LookRotation(transform.position - cam.transform.position);
         }
     }
+
+    public static class WorldPresence
+    {
+        public static GuestNpc FindGuest(string id)
+        {
+            if (string.IsNullOrEmpty(id)) return null;
+            foreach (var n in Object.FindObjectsByType<GuestNpc>(FindObjectsInactive.Exclude))
+            {
+                if (!n) continue;
+                if (n.personId == id) return n;
+                if (n.def != null && n.def.id == id) return n;
+            }
+            return null;
+        }
+
+        public static WorldGate GateToward(string kernelWorld)
+        {
+            if (string.IsNullOrEmpty(kernelWorld)) return null;
+            foreach (var g in Object.FindObjectsByType<WorldGate>(FindObjectsInactive.Exclude))
+            {
+                if (!g || g.def == null) continue;
+                if (WorldBook.Folder(g.def.world) == kernelWorld) return g;
+            }
+            return null;
+        }
+
+        public static bool InPresenter(float x, float z)
+        {
+            var mag = new Vector2(x, z).magnitude;
+            return mag > 0.4f && mag <= Canon.RingRadius + 16f;
+        }
+    }
+
+    /// <summary>
+    /// Kernel tomb from world:snapshot.tombs. Coords outside the presenter
+    /// stay unplaced. Matching GuestNpc feet win over a far kernel xz.
+    /// </summary>
+    public class KernelTomb : MonoBehaviour
+    {
+        public string npcId;
+        public string lastWords;
+        public string Prompt => string.IsNullOrEmpty(lastWords)
+            ? "E  ·  a grave"
+            : "E  ·  last words";
+
+        public static KernelTomb Place(string npcId, string lastWords, float x, float z)
+        {
+            if (string.IsNullOrEmpty(npcId)) return null;
+            var existing = GameObject.Find("KernelTomb_" + npcId);
+            if (existing) return existing.GetComponent<KernelTomb>();
+            var guest = WorldPresence.FindGuest(npcId);
+            Vector3 p;
+            if (guest)
+                p = guest.transform.position + guest.transform.right * 0.9f;
+            else if (WorldPresence.InPresenter(x, z))
+                p = new Vector3(x, 0.08f, z);
+            else
+                return null;
+            var root = Object.FindFirstObjectByType<WorldBuilder>();
+            var parent = root ? root.transform : null;
+            var stone = HubLook.Prim(parent, PrimitiveType.Cube, p + Vector3.up * 0.55f,
+                new Vector3(0.55f, 1.1f, 0.22f),
+                HubLook.Lit(new Color(0.38f, 0.34f, 0.3f), 0.04f, 0.18f),
+                "KernelTomb_" + npcId);
+            var tomb = stone.AddComponent<KernelTomb>();
+            tomb.npcId = npcId;
+            tomb.lastWords = lastWords ?? "";
+            foreach (var n in Object.FindObjectsByType<GuestNpc>(FindObjectsInactive.Exclude))
+            {
+                if (!n || n == guest) continue;
+                if (Vector3.Distance(n.transform.position, stone.transform.position) > 12f) continue;
+                var life = n.GetComponent<NpcLife>();
+                if (life) life.Notice(stone.transform, 5f);
+            }
+            return tomb;
+        }
+    }
+
+    /// <summary>
+    /// Real gossip summary on a matching GuestNpc. One-shot when the player
+    /// walks within 7m. Does not spawn a fake speaker.
+    /// </summary>
+    public class GossipEar : MonoBehaviour
+    {
+        public string summary;
+        bool _heard;
+        const float Reach = 7f;
+
+        public static void Attach(GuestNpc npc, string line)
+        {
+            if (!npc || string.IsNullOrEmpty(line)) return;
+            var ear = npc.GetComponent<GossipEar>();
+            if (!ear) ear = npc.gameObject.AddComponent<GossipEar>();
+            ear.summary = line;
+            ear._heard = false;
+        }
+
+        void Update()
+        {
+            if (_heard || string.IsNullOrEmpty(summary)) return;
+            var p = ConcordiaPlayer.Live;
+            if (!p) return;
+            if (Vector3.Distance(p.transform.position, transform.position) > Reach) return;
+            _heard = true;
+            WorldClock.LastEvent = summary;
+            WorldClock.PushFeed("gossip", summary);
+            var life = GetComponent<NpcLife>();
+            if (life) life.NoticePlayer(4f);
+        }
+    }
+
+    /// <summary>
+    /// Player co-location centroid from world:gathering-detected. Marker only;
+    /// never a fabricated crowd.
+    /// </summary>
+    public class GatheringTell : MonoBehaviour
+    {
+        float _life = 18f;
+
+        public static void Place(float x, float y, float z)
+        {
+            if (!WorldPresence.InPresenter(x, z)) return;
+            var root = Object.FindFirstObjectByType<WorldBuilder>();
+            var parent = root ? root.transform : null;
+            float py = y > 0.01f && y < 4.5f ? y : 0.08f;
+            var go = HubLook.Prim(parent, PrimitiveType.Cylinder,
+                new Vector3(x, py + 0.04f, z),
+                new Vector3(2.4f, 0.04f, 2.4f),
+                HubLook.Emit(new Color(0.95f, 0.82f, 0.45f), 1.6f),
+                "GatheringTell", false);
+            go.AddComponent<GatheringTell>();
+        }
+
+        void Update()
+        {
+            _life -= Time.deltaTime;
+            if (_life <= 0f) Destroy(gameObject);
+        }
+    }
 }

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldGate.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldGate.cs
@@ -132,6 +132,25 @@ namespace Concordia
         public string Prompt => inHold
             ? "E  ·  Leave " + holdName
             : "E  ·  Enter " + holdName;
+
+        /// <summary>
+        /// F5.1 lockout: kernel said locked_out after dungeon:open.
+        /// Geometry is local; eject instead of staying in a sealed hold.
+        /// </summary>
+        public static void EjectIfInside()
+        {
+            var player = ConcordiaPlayer.Live;
+            if (!player || !player.cc) return;
+            foreach (var g in FindObjectsByType<DungeonGate>(FindObjectsInactive.Exclude))
+            {
+                if (!g || !g.inHold) continue;
+                g.inHold = false;
+                player.cc.enabled = false;
+                player.transform.position = g.mouth;
+                player.cc.enabled = true;
+                Grounding.Snap(player.cc);
+            }
+        }
     }
 
     /// <summary>E picks up. Only stamps what this object actually is.</summary>
@@ -427,6 +446,143 @@ namespace Concordia
                 HubLook.Emit(new Color(0.95f, 0.82f, 0.45f), 1.6f),
                 "GatheringTell", false);
             go.AddComponent<GatheringTell>();
+        }
+
+        void Update()
+        {
+            _life -= Time.deltaTime;
+            if (_life <= 0f) Destroy(gameObject);
+        }
+    }
+
+    /// <summary>
+    /// World boss body only at an existing DungeonGate mouth. No invented xz.
+    /// Template slug may differ from hollow_warden — the hold is the site.
+    /// </summary>
+    public class WorldBoss : MonoBehaviour
+    {
+        public static WorldBoss Live;
+        public string template;
+        public string activeId;
+        public float hp = -1f, maxHp = 1f;
+        public string phase;
+        public string mechanic;
+        public float HpPct => maxHp > 0f && hp >= 0f ? Mathf.Clamp01(hp / maxHp) : -1f;
+
+        public static WorldBoss Present(string template, string activeId)
+        {
+            DungeonGate hold = null;
+            foreach (var g in FindObjectsByType<DungeonGate>(FindObjectsInactive.Exclude))
+            {
+                if (g && g.gameObject.activeInHierarchy) { hold = g; break; }
+            }
+            if (!hold) return null;
+            var key = "WorldBoss_" + (string.IsNullOrEmpty(activeId) ? (template ?? "open") : activeId);
+            var existing = GameObject.Find(key);
+            if (existing)
+            {
+                var boss = existing.GetComponent<WorldBoss>();
+                if (boss)
+                {
+                    Live = boss;
+                    if (!string.IsNullOrEmpty(template)) boss.template = template;
+                }
+                return boss;
+            }
+            var root = FindFirstObjectByType<WorldBuilder>();
+            var parent = root ? root.transform : null;
+            var p = hold.mouth + Vector3.up * 1.6f + hold.transform.forward * 1.4f;
+            var go = HubLook.Prim(parent, PrimitiveType.Capsule, p,
+                new Vector3(1.6f, 2.4f, 1.6f),
+                HubLook.Lit(new Color(0.52f, 0.12f, 0.1f), 0.1f, 0.32f),
+                key);
+            var presented = go.AddComponent<WorldBoss>();
+            presented.template = template ?? "";
+            presented.activeId = activeId ?? "";
+            Live = presented;
+            var label = string.IsNullOrEmpty(template) ? hold.holdName : template;
+            PersonLabel.Attach(go.transform, label, "boss");
+            return presented;
+        }
+
+        public static void BindState(string name, float hp, float maxHp, string phase, string mechanic)
+        {
+            var boss = Live;
+            if (!boss) boss = Present(name, null);
+            if (!boss) return;
+            if (!string.IsNullOrEmpty(name)) boss.template = name;
+            boss.hp = hp;
+            boss.maxHp = maxHp > 0f ? maxHp : 1f;
+            boss.phase = phase ?? "";
+            boss.mechanic = mechanic ?? "";
+            var title = string.IsNullOrEmpty(boss.template) ? "world boss" : boss.template;
+            if (!string.IsNullOrEmpty(phase)) title += " · " + phase;
+            PersonLabel.Attach(boss.transform, title, mechanic);
+        }
+
+        void OnDestroy()
+        {
+            if (Live == this) Live = null;
+        }
+    }
+
+    /// <summary>
+    /// Match chronicle plaque at the Arena. Only when a real chronicleId exists.
+    /// </summary>
+    public class ChroniclePlaque : MonoBehaviour
+    {
+        public string chronicleId;
+        public string title;
+        public string summary;
+        public string Prompt => string.IsNullOrEmpty(title) ? "E  ·  chronicle" : "E  ·  " + title;
+
+        public static ChroniclePlaque Place(string chronicleId, string title, string summary)
+        {
+            if (string.IsNullOrEmpty(chronicleId)) return null;
+            var existing = GameObject.Find("ChroniclePlaque_" + chronicleId);
+            if (existing) return existing.GetComponent<ChroniclePlaque>();
+            var root = FindFirstObjectByType<WorldBuilder>();
+            var parent = root ? root.transform : null;
+            var p = Canon.Arena + Vector3.right * 3.4f + Vector3.up * 0.9f;
+            var go = HubLook.Prim(parent, PrimitiveType.Cube, p,
+                new Vector3(0.9f, 1.4f, 0.14f),
+                HubLook.Lit(new Color(0.42f, 0.36f, 0.22f), 0.12f, 0.28f),
+                "ChroniclePlaque_" + chronicleId);
+            var plaque = go.AddComponent<ChroniclePlaque>();
+            plaque.chronicleId = chronicleId;
+            plaque.title = title ?? "";
+            plaque.summary = summary ?? "";
+            var stone = go.AddComponent<LoreStone>();
+            stone.title = string.IsNullOrEmpty(title) ? "chronicle" : title;
+            stone.text = string.IsNullOrEmpty(summary) ? "a bout was recorded." : summary;
+            return plaque;
+        }
+    }
+
+    /// <summary>
+    /// Crafted work at an existing cook/market station. Never a fabricated map pin.
+    /// </summary>
+    public class CraftedTell : MonoBehaviour
+    {
+        float _life = 22f;
+
+        public static void PlaceAtStation(string label)
+        {
+            CookStation cook = null;
+            foreach (var c in FindObjectsByType<CookStation>(FindObjectsInactive.Exclude))
+            {
+                if (c) { cook = c; break; }
+            }
+            if (!cook) return;
+            var root = FindFirstObjectByType<WorldBuilder>();
+            var parent = root ? root.transform : null;
+            var p = cook.transform.position + Vector3.up * 0.08f;
+            var go = HubLook.Prim(parent, PrimitiveType.Cylinder, p,
+                new Vector3(1.1f, 0.05f, 1.1f),
+                HubLook.Emit(new Color(0.72f, 0.55f, 0.28f), 1.4f),
+                "CraftedTell", false);
+            go.AddComponent<CraftedTell>();
+            if (!string.IsNullOrEmpty(label)) WorldClock.PushFeed("economy", label);
         }
 
         void Update()

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldKit.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldKit.cs
@@ -186,10 +186,8 @@ namespace Concordia
 
         static void Accents(Transform root, WorldDef w)
         {
-            if (w.id == WorldId.Crime || w.weather == "rain")
-                DressVocab.PlaceWeather("rain", root, new Vector3(0, 8, 0));
-            if (w.id == WorldId.Ruins)
-                DressVocab.PlaceWeather("snow", root, new Vector3(0, 8, 0));
+            // Rain/ash follow WorldClock.Weather. Grove/wildfireflies stay here
+            // as identity ambience for Tunya and Fantasy.
             if (w.id == WorldId.Tunya || w.id == WorldId.Fantasy)
                 DressVocab.PlaceWeather("fireflies", root, new Vector3(0, 2.2f, 8));
         }

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldKit.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldKit.cs
@@ -69,7 +69,7 @@ namespace Concordia
                     FreePacks.Spawn(DressVocab.FirstStem(new[] { "banner-red" }, "banner-red"), root, new Vector3(3, 0, 5), 20, 3f);
                     break;
                 case WorldId.Crime:
-                    FreePacks.Spawn(house, root, new Vector3(0, 0, 12), 0, 14f);
+                    FreePacks.Spawn(house, root, new Vector3(0, 0, 12), 0, 6.2f);
                     FreePacks.Spawn(DressVocab.FirstStem(new[] { "Dumpster" }, "dumpster"), root, new Vector3(4, 0, 6), 20, 2f);
                     FreePacks.Spawn(DressVocab.FirstStem(new[] { "Dumpster" }, "dumpster"), root, new Vector3(-5, 0, 7), -10, 2f);
                     FreePacks.Spawn(prop, root, new Vector3(2, 0, 5), 0, 1f);
@@ -157,6 +157,11 @@ namespace Concordia
                         h = 8f + ring * 2f;
                     if (key.Contains("house")) h = 5.2f + ring * 1.4f;
                     if (key.Contains("tower")) h = 8.4f + ring * 1.6f;
+                    var culture = DressVocab.Culture(w.id);
+                    if (culture == "street") h = Mathf.Min(h, 5.8f);
+                    else if (culture == "grid") h = Mathf.Max(h, 16f + ring * 4f);
+                    else if (culture == "ash" && (key.Contains("tower") || key.Contains("destroyed")))
+                        h = Mathf.Max(h, 9f);
                     FreePacks.Spawn(stem, root, p, yaw, h);
                 }
             }
@@ -176,7 +181,10 @@ namespace Concordia
                 WorldId.Sere => DressVocab.House(w.id),
                 _ => DressVocab.FirstStem(new[] { "LowPoly - Rock A" }, "cliff_stone")
             };
-            float h = w.id == WorldId.Cyber || w.id == WorldId.Superhero ? 22f : 10f;
+            float h = w.id == WorldId.Cyber || w.id == WorldId.Superhero ? 22f
+                : w.id == WorldId.Crime || w.id == WorldId.Sere ? 5.5f
+                : w.id == WorldId.Ruins ? 8.5f
+                : 10f;
             for (int i = 0; i < 14; i++)
             {
                 float a = i / 14f * Mathf.PI * 2f + 0.08f;

--- a/content/world/concordia-hub/factions.json
+++ b/content/world/concordia-hub/factions.json
@@ -24,7 +24,7 @@
     "leader_npc_id": "captain_ren_solare",
     "stance": "consolidate",
     "values": ["order", "discretion", "neighborhood_trust"],
-    "rivalries": [],
+    "rivalries": ["bazaar_consortium"],
     "alliances": ["concordant_assembly"]
   },
   {
@@ -38,7 +38,7 @@
     "leader_npc_id": "merchant_velka_ironhand",
     "stance": "expand",
     "values": ["fair_dealing", "haggling_as_craft", "network"],
-    "rivalries": [],
+    "rivalries": ["concordant_watch"],
     "alliances": ["brassgate_foundry", "crosswind_couriers"]
   },
   {

--- a/content/world/concordia-hub/npcs.json
+++ b/content/world/concordia-hub/npcs.json
@@ -16,6 +16,13 @@
     "concord_link_resonance": "tunya:warlord_iyatte_sanguire",
     "cross_world_hook": "Asbir's hidden cavity is the proof-of-concept for Concordia's cross-world memory bridge. If a player surfaces the sealed letter — by stealth, persuasion, or being given it — the Sanguire-Vessine plotline shifts in tunya.",
     "dialogue_style": "long sentences with pauses; never interrupts; reframes questions before answering",
+    "relationships": [
+      {
+        "npc_id": "scribe_isa_velt",
+        "type": "wary_respect",
+        "notes": "Isa catches what Asbir misses. He has not told her about the sealed cavity."
+      }
+    ],
     "needs": [
       {
         "id": "archive_integrity",
@@ -808,6 +815,13 @@
     "concord_link_resonance": null,
     "cross_world_hook": null,
     "dialogue_style": "considered, formal in public, warm in private",
+    "relationships": [
+      {
+        "npc_id": "oracle_nesha_keep",
+        "type": "wary_truce",
+        "notes": "Nesha told Mira the dome will fail again. Mira has not told the Assembly."
+      }
+    ],
     "needs": [
       {
         "id": "assembly_business",
@@ -1001,6 +1015,13 @@
     "concord_link_resonance": null,
     "cross_world_hook": null,
     "dialogue_style": "quick, articulate, occasionally self-deprecating, sharp under stress",
+    "relationships": [
+      {
+        "npc_id": "lord_curator_asbir_thelane",
+        "type": "reluctant_apprentice",
+        "notes": "She is uncertain whether to admire or resent him. She has noticed the sealed cavity."
+      }
+    ],
     "needs": [
       {
         "id": "archive_work",

--- a/docs/ART_DIRECTION_UNITY_WEB.md
+++ b/docs/ART_DIRECTION_UNITY_WEB.md
@@ -81,8 +81,8 @@ session's standing verification discipline. Two categories of finding:
 
 ## Recommended next steps
 
-1. **Job 1 shipped** — `LoadPersonPrefab` now reads `CastingWorld` (Knight off-Hub, Rocketbox on Hub). Remaining: visually verify the Knight path in a non-Hub world (Hub Play-mode check already confirmed Rocketbox still renders there).
-2. **Oversized-sword shipped** — `MakeSword` prefers `Sword16` (MYFG Weapon Pack Lite) over the chibi Kenney `weapon-sword` fallback. Live-verified: `sharedMesh` = Sword16, scale ~0.97. Floating NPCs were a spawn-frame false alarm — do not "fix" `Grounding.cs`.
-3. **Weather-visuals binding** — `WorldClock.Weather` ticks and cycles, but `DressVocab.PlaceWeather` only runs at world-build from `Canon.WorldDef.weather`. Live weather shifts currently do not change what you see.
+1. **Weather-visuals binding SHIPPED** — `WorldClock.ApplyWeatherVisuals` now places rain/ash (snow VFX) and thickens fog from the live `Weather` string on Enter and on each kernel cycle. Build-time `PlaceWeather("rain"|"snow")` in DressSky/Accents was the leak: Crime rained forever and a "weather shifted" HUD line changed nothing on screen. Hub/Tunya/Fantasy fireflies stay as identity ambience, not weather. Remaining: visual confirm in Play mode (Hub is clear, so force `WorldClock.Weather = "rain"` or travel to Crime).
+2. **Job 1 shipped** — `LoadPersonPrefab` now reads `CastingWorld` (Knight off-Hub, Rocketbox on Hub). Remaining: visually verify the Knight path in a non-Hub world (Hub Play-mode check already confirmed Rocketbox still renders there).
+3. **Oversized-sword shipped** — `MakeSword` prefers `Sword16` (MYFG Weapon Pack Lite) over the chibi Kenney `weapon-sword` fallback. Live-verified: `sharedMesh` = Sword16, scale ~0.97. Floating NPCs were a spawn-frame false alarm — do not "fix" `Grounding.cs`.
 4. **Reconcile the 9-vs-10 world list** between `Canon.cs` (`Sere` is the 10th) and the retired Three.js theme file, so no future doc repeats the stale "9 worlds" figure.
 5. Before buying anything from the list, re-verify title/price/live-status directly on the Asset Store at purchase time (listings drift) — don't batch-buy off the pasted doc as-is.

--- a/docs/ART_DIRECTION_UNITY_WEB.md
+++ b/docs/ART_DIRECTION_UNITY_WEB.md
@@ -1,0 +1,88 @@
+# Concordia Art Direction — Unity Web (photoreal), 2026-09-11
+
+## Canonicity (owner decision, this date)
+
+- **Unity is now the canonical World Lens web client.** It ships to the browser via
+  `scripts/export-unity-web.mjs` (Unity 6, batchmode `Concordia.Editor.ConcordiaWebExport.Export`,
+  output to `concord-frontend/public/unity-client/`, same serving shape as the Godot
+  export) and talks to the server over `mountUnityGateway` (`server/lib/unity-bridge.js`,
+  mounted in `server.js`) — both pieces are real and already built, not new
+  infrastructure. `Assets/Plugins/WebGL/ConcordWs.jslib` and the Editor/WebGL split in
+  `ConcordClient.cs`/`FreePacks.cs`/`HubKit.cs` show the project was already written with
+  WebGL as a first-class target, not an afterthought.
+- **Three.js's World Lens implementation (`concord-frontend/lib/world-lens/`,
+  `components/world/`, `components/world-lens/`) is retired as canonical.** Its
+  `ART_STYLE_GUIDE.md` stylized-BotW/Palworld mandate governed *only* that renderer
+  (confirmed by grep — zero references outside those directories) and is retired with
+  it; see the retirement note at the top of that file.
+- **Godot (`world-lens-godot/`) becomes the presenter role** — its existing read-only
+  spectator viewer (PR #875) is the lighter-weight, non-interactive way to view
+  Concordia, alongside the full Unity client.
+- **Nothing about the game's systems changes.** Quests, combat resolution, NPC AI, the
+  economy, crafting — all of it lives server-side (`server/emergent/`, `server/domains/`,
+  `server/lib/npc-*.js`, etc.) and is client-agnostic by construction. Retiring Three.js
+  retires a *renderer*, not a system. This is the "systems are good, the web version with
+  three.js ruined so much" read the owner gave, and it checks out structurally: nothing
+  in the backend depends on which client is drawing the pixels.
+- **Target shape:** Concordia reachable at the World Lens inside concord-os.org, same as
+  every other lens, rendered by the Unity WebGL build, with Godot's spectator view as a
+  secondary/lightweight path.
+
+## The direction: photorealistic
+
+This reverses `ART_DIRECTION_AUDIT.md`'s deliberate "photorealism is explicitly rejected"
+call — that call was scoped to the Three.js/stylized-BotW/Palworld renderer, made for
+reasons (avoid AAA-comparison traps, keep a small team's production fast) that applied to
+*that* renderer. It does not bind Unity, and the owner has now made the opposite call for
+Unity explicitly. Two things worth carrying forward from the old audit rather than
+discarding outright:
+- The "avoid AAA-comparison trap" risk is real for photoreal specifically — a photoreal
+  target invites direct comparison to $200M productions in a way a stylized target
+  doesn't. Mitigate with **art direction, not raw fidelity**: a coherent lighting/color
+  language, a curated (not maximal) asset palette, and hero-asset polish concentrated
+  where the camera actually spends time (NPC faces/hands, weapons, hero outfits) rather
+  than spread thin.
+- Rocketbox (the existing photoreal crowd-sim character pack already in the project,
+  used by `ModularPerson.cs`'s authored-body path) is architecturally correct for a
+  photoreal **Hub** — that world has textual grounding as modern/neutral. Its
+  "polo shirt hero" problem is **not** a tinting bug. Live check (2026-09-12):
+  Rocketbox bakes skin AND clothing into one continuous texture with no separate
+  cloth UV region, so a multiplied `DyeCloth`/`ClothDye` tint would also discolor
+  visible skin — a real dead end. The actual mechanism was that
+  `ModularPerson.CastingWorld` was set per-world by `WorldBuilder` but never read
+  by `LoadPersonPrefab`, so every world got the same Rocketbox civilian. Job 1
+  shipped as a body-choice branch: Hub keeps Rocketbox; every other world prefers
+  the already-in-project KayKit Knight (`FreePacks.Mesh("Knight")`), with an
+  honest Rocketbox fallback if Knight is missing. Cyber/Crime may want a modern
+  body too — that's a later per-world tuning pass, not a reason to tint skin.
+
+## Acquisition-list audit
+
+The pasted acquisition list was checked claim-by-claim before acting on it, per this
+session's standing verification discipline. Two categories of finding:
+
+### Confirmed wrong (fix before using the list as a planning input)
+
+| Claim | Reality | Source |
+|---|---|---|
+| "9 worlds" | **10 worlds** — `Canon.cs`'s `WorldId` enum: Hub, Ruins, Tunya, Fantasy, Crime, Cyber, Frontier, Superhero, Crucible, **Sere**. `Sere` isn't even in the retired Three.js style guide's own 9-row saturation table — a real, separate discrepancy between the Three.js theme file and the Unity canon worth reconciling later, independent of this acquisition list. | `Canon.cs`, `ART_STYLE_GUIDE.md` |
+| "200+ Hub buildings" | The code's own comment (`FreePacks.cs:884`) targets **100 buildings** (70 exterior / 20 fake-window / 10 playable interior) **per city**, not per-Hub — and `DressVocab`'s own comment states the Hub specifically "never calls this (Court is unpaved)," i.e. the Hub has ~zero buildings through this system. The "200+" figure doesn't match either the per-city target or the Hub specifically. | `FreePacks.cs`, `DressVocab.cs` |
+
+### Spot-checked and confirmed real (4 of the ~20+ named packages/families checked so far)
+
+| Package | Verdict |
+|---|---|
+| "Human Basic Motions FREE" — Kevin Iglesias | **Real**, live on the Asset Store, 15,865+ favorites — matches the doc's description (idle/locomotion/social anims, masculine+feminine, Avatar Masks). |
+| "FREE Starter Pack — Sidekick Modular Characters by Synty" | **Real**, live on the Asset Store (`...-336970`) and on the Synty store directly — 50+ sci-fi/fantasy parts + 90+ modular human-base parts, matches the doc. |
+| KHS Korean-heritage architecture packs | **Real family exists** — multiple live "KHS - Gyeongbokgung Palace" packs (Geunjeongjeon Hall, Sajeongjeon Hall, Gyeonghoeru, Mangyeongjeon) from Korea Heritage Service. Couldn't independently confirm the specific "Daejojeon"/"Changdeokgung" titles the doc named — those may be mislabeled Gyeongbokgung-family packages rather than fabricated; re-verify the exact title before buying if that specific building matters. |
+| "Free Slavic Medieval Environment — Town Interior and Exterior" | **Real**, live on the Asset Store (EmacEArt), 220+ low-poly assets + a demo scene, matches the doc closely (title has drifted slightly across store listings — "Town Kit," "Village Free" — same publisher/family). |
+
+**Not yet spot-checked** (the remaining ~16+ named packages across the doc's ~20 categories — terrain/nature, weapons, VFX, UI/icon packs, additional character packs, etc.): treat those as **unverified, not confirmed** until checked the same way. Given the 4/4 hit rate so far and 2 clean numeric errors caught, the doc reads as a genuine research pass with real citations, not fabrication — but "mostly real" isn't "fully verified," and a specific title/price/availability should be re-confirmed at time of purchase regardless, since Asset Store listings do get renamed, delisted, or repriced.
+
+## Recommended next steps
+
+1. **Job 1 shipped** — `LoadPersonPrefab` now reads `CastingWorld` (Knight off-Hub, Rocketbox on Hub). Remaining: visually verify the Knight path in a non-Hub world (Hub Play-mode check already confirmed Rocketbox still renders there).
+2. **Oversized-sword shipped** — `MakeSword` prefers `Sword16` (MYFG Weapon Pack Lite) over the chibi Kenney `weapon-sword` fallback. Live-verified: `sharedMesh` = Sword16, scale ~0.97. Floating NPCs were a spawn-frame false alarm — do not "fix" `Grounding.cs`.
+3. **Weather-visuals binding** — `WorldClock.Weather` ticks and cycles, but `DressVocab.PlaceWeather` only runs at world-build from `Canon.WorldDef.weather`. Live weather shifts currently do not change what you see.
+4. **Reconcile the 9-vs-10 world list** between `Canon.cs` (`Sere` is the 10th) and the retired Three.js theme file, so no future doc repeats the stale "9 worlds" figure.
+5. Before buying anything from the list, re-verify title/price/live-status directly on the Asset Store at purchase time (listings drift) — don't batch-buy off the pasted doc as-is.

--- a/docs/ART_STYLE_GUIDE.md
+++ b/docs/ART_STYLE_GUIDE.md
@@ -1,5 +1,24 @@
 # Concordia Art Style Guide — coherence > fidelity
 
+**⚠️ RETIRED for the World Lens (2026-09-11, owner decision).** This guide governed the
+Three.js web client (`concord-frontend/lib/world-lens/concordia-theme.ts`) exclusively —
+grep confirms `ART_STYLE`/`toonGradient`/`WORLD_SATURATION` are referenced ONLY inside
+`world-lens/`, `components/world/`, `components/world-lens/`, and this doc's own tests;
+zero references anywhere in the Unity project. The owner has now retired the Three.js
+renderer as the canonical World Lens client — reason given: "the web version with
+three.js ruined so much but the systems and stuff are good" (the systems referenced are
+almost entirely server-side — `server/emergent/`, `server/domains/`, quest/combat/economy
+engines — and are untouched by this change, since they're client-agnostic by construction).
+**Unity (exported to WebGL via `scripts/export-unity-web.mjs`, already real and already
+wired to `mountUnityGateway` in `server.js`) is now the canonical World Lens web client,**
+targeting a photoreal direction — see `docs/ART_DIRECTION_UNITY_WEB.md`. Godot
+(`world-lens-godot/`, already shipping a read-only spectator viewer) becomes the
+lightweight **presenter** role alongside it. This file is kept for historical record and
+in case any future non-Concordia stylized surface wants the constants; it no longer
+describes the World Lens's target look.
+
+---
+
 **The thesis (locked).** Photoreal invites comparison to $200M productions; a stylized
 look *sets its own standard* — as long as everything shares one visual language. Hades
 chose pen-and-ink partly because it was *faster to produce*. We pick a style whose

--- a/docs/CONCORDIA_PLAN.md
+++ b/docs/CONCORDIA_PLAN.md
@@ -44,22 +44,33 @@ Branch `claude/lens-population-depth-DVcsF` — 7 commits, **161/161 tests green
   by a column check (was querying non-existent columns → threw in prod). `skill-tree-real-schema.test.js` 3/3.
 
 ### ⏳ REMAINING
-- **T1.4b / T2 / F1** Unity presenter was the open hole; the kernel tickets were already shipped.
-  Closed this pass: `/unity-ws` `gift:give`, `scheme:intervene`, `party:request`,
-  `inheritance:request`, `combat:dodge` i-frames, `dungeon:open`; Hub night sun dim + lantern
-  point lights; local gift/heart/plot/heir rules match the kernel math; no HUD copy that
-  parks a verb on “needs `/unity-ws`”.
-- **T3.1 / T3.1b** per-skill descriptors live in `concord-frontend/lib/concordia/skill-descriptors.ts`
-  (tested). Unity now binds `skills.mastery` over `/unity-ws` (`lens:run`) and paints the catalog
-  overlay (untrained = L0 novice). Kit arts are no longer presented as the 67-skill system.
-- **T3.2** hub `lore.json` + `content/codex/eight-refusals.json` + `seedCodex` are in tree.
-  Hub Watch↔Bazaar rivalries and Asbir/Isa + Mira/Nesha relationships now seed T1.1/T1.3.
-- **T3.3** per-world sky tints + night sun/exposure dim are live. Zone architecture is still
-  Kenney-pack dressing, not a unique silhouette per world.
-- **T3.4** restaurant tips 0.20/0.15 and mahjong yaku re-weight are shipped + tested.
-- **T0** this remaining block was stale (claimed T1.4b/T2 unshipped). Corrected here.
-- **F4.3 / F5.1** party session + dungeon open are on `/unity-ws`. Extraction/horde co-op
-  and a full raid lockout loop are the leftover kernel-scale tickets.
+- **T1.4b / T2 / F1 presenter** — kernel tickets were already shipped; Unity
+  now consumes them. Closed: `/unity-ws` gift/scheme/party/inheritance/dodge/
+  dungeon; `secret:weaponised` + `scheme:overheard` + `npc:conversation-bid`
+  fan through the gateway mirror (not socket.io-only); `npc:heir-rose` emits
+  from `onNpcDeath`; Plots barge-in uses the kernel `schemeId` and local
+  kitchen plots never send a fake id; typed telegraphs (`perilKind`/`counter`)
+  win over local tells; i-frames from the wrong counter do not negate a
+  peril; `combat:impact` momentum drives Unity knockback/shake.
+- **T3.1b** Mixamo combat clips / fluid PD-motor movesets are still open.
+  The 67-skill overlay + element VFX from descriptors are live. Do not claim
+  Mixamo done.
+- **T3.2** hub `lore.json` + `content/codex/eight-refusals.json` + `seedCodex`
+  are in tree. Hub Watch↔Bazaar rivalries and Asbir/Isa + Mira/Nesha
+  relationships seed T1.1/T1.3. Thin-world faction/NPC authoring remains a
+  content job — do not invent NPCs.
+- **T3.3** per-world sky tints + night dim + `DressVocab.Culture` silhouettes
+  are live (grid vertical, street lowrise, ash ruined towers). Unique GLB
+  hero mesh per world is not this floor.
+- **T3.4** restaurant tips 0.20/0.15 and mahjong yaku re-weight are shipped +
+  tested.
+- **T2.4** `node scripts/audit-emergent-wiring.mjs` → 0 ORPHAN (237 files,
+  130 WIRED / 107 ENTITY-INLINE). CI-pinned by
+  `server/tests/integration/emergent-wiring-audit.test.js`.
+- **T0** remaining-block drift corrected here.
+- **F2 / F3.1–F3.3 / F5.1 / F6** affixes, hyperarmor, executions, raid lockout,
+  heart-events — not this foundation pass. F4.3 extraction/horde party join
+  shipped; full raid lockout is still F5.1.
 
 ### 📥 Authored content delivered by the user (to wire under T3.2)
 Two finished artifacts, ready to slot into the seed pipeline:
@@ -950,9 +961,9 @@ audit). Sequenced by impact ÷ effort. Quick wins first.
 
 | Ticket | Build | Reuse / anchors | Verify |
 |---|---|---|---|
-| **F1.1 i-frame dodge wiring** ⭐ | The live `combat:dodge` socket handler acks but never grants invuln. Add: on dodge, call `grantIFrames(userId, 350)` (500ms on perfect dodge). | Handler `server/server.js:8548`; `grantIFrames(actorId,durationMs)` `combat-state.js:114`; `applyHitToState` already whiffs hits while `now < iframeUntil` (`combat-state.js:48`); perfect-dodge window via `attemptDodge` `combat-polish.js:325`. ~3-line change. | node test: grant i-frames → `applyHitToState` returns `iframed:true`, zero damage, within window. |
-| **F1.2 Gift system** ⭐ | New `server/domains/gifting.js` → `romance.give_gift`: consume item → affinity delta by NPC preference. Author `gift_preferences` into `npcs.json`. Surface in `NPCActionMenu` + courtship lens. | Inventory-consume pattern `craft-engine.js:114`; affinity write `romance-engine.js#courtInteraction:39` (base `COURT_AFFINITY_DELTA=0.05` :19 → gift uses 0.10–0.20 × pref); inventory schema `migrations/050`; prefs loaded by `content-seeder.js`. | test: give preferred item → affinity↑ + item consumed; disliked → affinity↓; missing item → rejected. |
-| **F1.3 Typed attack telegraphs** | Upgrade the generic light/heavy windup to *typed* perilous tells (thrust/sweep/grab → forced counter), the one real remaining E0 item. | `combat:telegraph` emit `server.js:8318` → `BodyLanguageOverlay.tsx`; add a `perilKind` to the payload + counter gate. | manual: telegraph shows typed icon; wrong counter fails, right counter negates. |
+| **F1.1 i-frame dodge wiring** ⭐ | ✅ The live `combat:dodge` socket handler grants i-frames (`grantIFrames`). Unity `/unity-ws` `handleDodge` does too. PvP `applyAttack` now consults `applyHitToState` so a dodge actually zeros the next hit. | Handler `server/server.js`; `grantIFrames` `combat-state.js`; `applyAttack` `city-presence.js`. | node test: grant i-frames → `applyHitToState` returns `iframed:true`. |
+| **F1.2 Gift system** ⭐ | ✅ `server/domains/gifting.js` + `/unity-ws` `gift:give`. | Inventory-consume + romance affinity. | test: preferred item → affinity↑; missing item → rejected. |
+| **F1.3 Typed attack telegraphs** | ✅ Kernel emits `perilKind`+`counter`. `noteIncomingPeril` gates i-frames: wrong counter fails, right counter (or parry) negates. Unity HUD shows thrust→X / sweep→Space / grab→X; kernel tell wins over local random. | `telegraph-peril.js`; `combat-state.js`; Unity `Hostile.BindKernel`. | node test: sweep+dodge still damages; sweep+jump iframed. |
 
 ## Sprint F2 — Build agency & itemization (ARPG/MMO day-1 dopamine)
 
@@ -969,8 +980,8 @@ audit). Sequenced by impact ÷ effort. Quick wins first.
 | **F3.1 Hyperarmor** | Heavy attacks ignore incoming stagger during active frames (poise-attacker side). | flag in `combat-impact.js`/`combat-polish.js#triggerStaggerFromImpact`; frame data `combat-frame-data.js`. |
 | **F3.2 Execution moves** | Backstab/positional crit (offAxis already computes harder poise break → add crit-damage execution); posture-break deathblow; stun→grab finisher (link `rocked` → `attemptGrapple`). | `combat-impact.js` offAxis; `attemptGrapple` `combat-polish.js:477`; rocked state. |
 | **F3.3 Anim-cancel + input buffering** | Cancel windows (≥50% recovery) + 4–6-frame input buffer. | frontend `CombatInputController.tsx`; frame data cancel windows in `combat-frame-data.js`. |
-| **F3.4 Per-skill VFX + mastery** | The data-driven `skill-descriptors.ts` overlay (already specced in the Combat-depth section / T3.1) so 67 skills differentiate; mastery from `player_skill_levels`. | T3.1 design (plan lines ~497); `element-vfx.ts`, `combo-vfx.ts`, `CombatVFXBridge.tsx`. |
-| **F3.5 T1.4b client feel** | Wire momentum → hitstop/knockback/reflex on the client (impact-resolver + ImpactMomentumBridge). | T1.4b design (plan ~464); server already emits momentum (T1.4a ✅). |
+| **F3.4 Per-skill VFX + mastery** | ✅ Unity skill lattice + GabrielAguiar VFX from kernel descriptors. Mixamo style clips remain T3.1b. | T3.1 design; `skill-descriptors.ts`. |
+| **F3.5 T1.4b client feel** | ✅ Unity `ApplyCombatFeel` reads `impactMomentum` / `feel.knockback` into `CombatFeel.ApplyAck`. Three.js ImpactMomentumBridge was already shipped. | T1.4b design; server already emits momentum (T1.4a ✅). |
 
 ## Sprint F4 — Run-mode depth (replayability)
 
@@ -978,7 +989,7 @@ audit). Sequenced by impact ÷ effort. Quick wins first.
 |---|---|---|
 | **F4.1 Shared in-run draft** | Generalize horde's deterministic pick-1-of-3 into `server/lib/run-draft.js` (+ `run_draft_picks`, `draft_options` tables); wire boon/relic drafts into roguelite + extraction; effects **applied**, not descriptive strings; add synergy combos. | `_rollUpgrades` `horde-mode.js:84` (drop-in generalize); run state `roguelite.js:27`/`extraction.js:35` (add `run_picks_json`). |
 | **F4.2 Difficulty + meta wired to runs** | Wire `difficulty.js` tiers (currently world-boss-only) + author a meta-currency→run-modifier catalog so unlocks change runs. | `difficulty.js`; `roguelite_meta_currency` + `purchaseUnlock` `roguelite.js:115`. |
-| **F4.3 Multiplayer in runs** (larger) | Co-op / PvPvE session for extraction + horde; the real source of Tarkov/DRG/DbD tension. Scope after F4.1/F4.2. | parties `parties.js`; horror asymmetry `horror.js` as the template. |
+| **F4.3 Multiplayer in runs** (larger) | ✅ Extraction + horde party join (`party_id` + `run_participants`). Full raid lockout is F5.1. | parties `parties.js`; `run-coop.js`. |
 
 ## Sprint F5 — Grouped instanced PvE
 

--- a/docs/CONCORDIA_PLAN.md
+++ b/docs/CONCORDIA_PLAN.md
@@ -46,11 +46,15 @@ Branch `claude/lens-population-depth-DVcsF` — 7 commits, **161/161 tests green
 ### ⏳ REMAINING
 - **Presentation audit (2026-09-12)** — the MMO sim is already deep; Unity
   was presenting a fraction of the consequences. Ranked gap table:
-  `docs/CONCORDIA_UNITY_PRESENTATION_AUDIT.md`. First wave (this pass):
-  faction war/alliance/truce, gatherings, bosses, seasons/festivals, gossip
-  + tombs on `world:snapshot`, stress-break, heir last-words, one
-  consequence strip. Do not invent engines. Mixamo / funeral 3D / adaptive
-  audio SM / migration emit remain open.
+  `docs/CONCORDIA_UNITY_PRESENTATION_AUDIT.md`. First wave: faction
+  war/alliance/truce, gatherings, bosses, seasons/festivals, gossip +
+  tombs on `world:snapshot`, stress-break, heir last-words, one
+  consequence strip. Second wave (this pass): those same payloads collide
+  in 3D — kernel tombs, overheard gossip on matching GuestNpcs, stress
+  `Cope` on existing jobs, gathering centroid markers, faction-banner
+  war light, inherited `scoreDirectivesFor` music, `npc:migrated` walk
+  to a named gate. Still open: Mixamo / funeral crowds / boss body /
+  unique GLB. Do not invent engines.
 - **T1.4b / T2 / F1 presenter** — kernel tickets were already shipped; Unity
   now consumes them. Closed: `/unity-ws` gift/scheme/party/inheritance/dodge/
   dungeon; `secret:weaponised` + `scheme:overheard` + `npc:conversation-bid`

--- a/docs/CONCORDIA_PLAN.md
+++ b/docs/CONCORDIA_PLAN.md
@@ -44,15 +44,21 @@ Branch `claude/lens-population-depth-DVcsF` — 7 commits, **161/161 tests green
   by a column check (was querying non-existent columns → threw in prod). `skill-tree-real-schema.test.js` 3/3.
 
 ### ⏳ REMAINING
-- **T1.4b** client impact feel + reflex from the shared momentum (impact-resolver.ts, ImpactMomentumBridge,
-  ReflexBridge wiring) — frontend, build/type-check verify only.
-- **T3.1 / T3.1b** per-skill descriptors + mastery (on the BUG A fix) + fighting-styles-shown + PD-motor
-  fluidity + new `combat.skill_mastery` route — frontend + thin backend.
-- **T2.1** consume `weaponise_at` · **T2.2** inheritance UI · **T2.3** scheme barge-in route · **T2.4**
-  emergent-module reconciliation audit script (backend-testable).
-- **T3.2** content authoring into engine-read fields — **partially supplied by the user (see below)**.
-- **T3.3** zone architecture (skybox/silhouette) · **T3.4** mahjong re-weight + restaurant tip adoption
-  (backend-testable) · **T0** doc corrections (land with the code that makes each claim true).
+- **T1.4b / T2 / F1** Unity presenter was the open hole; the kernel tickets were already shipped.
+  Closed this pass: `/unity-ws` `gift:give`, `scheme:intervene`, `party:request`,
+  `inheritance:request`, `combat:dodge` i-frames, `dungeon:open`; Hub night sun dim + lantern
+  point lights; local gift/heart/plot/heir rules match the kernel math; no HUD copy that
+  parks a verb on “needs `/unity-ws`”.
+- **T3.1 / T3.1b** per-skill descriptors live in `concord-frontend/lib/concordia/skill-descriptors.ts`
+  (tested). Unity still presents kit arts, not the 67-skill overlay.
+- **T3.2** hub `lore.json` + `content/codex/eight-refusals.json` + `seedCodex` are in tree.
+  Hub Watch↔Bazaar rivalries and Asbir/Isa + Mira/Nesha relationships now seed T1.1/T1.3.
+- **T3.3** per-world sky tints + night sun/exposure dim are live. Zone architecture is still
+  Kenney-pack dressing, not a unique silhouette per world.
+- **T3.4** restaurant tips 0.20/0.15 and mahjong yaku re-weight are shipped + tested.
+- **T0** this remaining block was stale (claimed T1.4b/T2 unshipped). Corrected here.
+- **F4.3 / F5.1** party session + dungeon open are on `/unity-ws`. Extraction/horde co-op
+  and a full raid lockout loop are the leftover kernel-scale tickets.
 
 ### 📥 Authored content delivered by the user (to wire under T3.2)
 Two finished artifacts, ready to slot into the seed pipeline:

--- a/docs/CONCORDIA_PLAN.md
+++ b/docs/CONCORDIA_PLAN.md
@@ -44,6 +44,13 @@ Branch `claude/lens-population-depth-DVcsF` — 7 commits, **161/161 tests green
   by a column check (was querying non-existent columns → threw in prod). `skill-tree-real-schema.test.js` 3/3.
 
 ### ⏳ REMAINING
+- **Presentation audit (2026-09-12)** — the MMO sim is already deep; Unity
+  was presenting a fraction of the consequences. Ranked gap table:
+  `docs/CONCORDIA_UNITY_PRESENTATION_AUDIT.md`. First wave (this pass):
+  faction war/alliance/truce, gatherings, bosses, seasons/festivals, gossip
+  + tombs on `world:snapshot`, stress-break, heir last-words, one
+  consequence strip. Do not invent engines. Mixamo / funeral 3D / adaptive
+  audio SM / migration emit remain open.
 - **T1.4b / T2 / F1 presenter** — kernel tickets were already shipped; Unity
   now consumes them. Closed: `/unity-ws` gift/scheme/party/inheritance/dodge/
   dungeon; `secret:weaponised` + `scheme:overheard` + `npc:conversation-bid`

--- a/docs/CONCORDIA_PLAN.md
+++ b/docs/CONCORDIA_PLAN.md
@@ -50,7 +50,8 @@ Branch `claude/lens-population-depth-DVcsF` — 7 commits, **161/161 tests green
   point lights; local gift/heart/plot/heir rules match the kernel math; no HUD copy that
   parks a verb on “needs `/unity-ws`”.
 - **T3.1 / T3.1b** per-skill descriptors live in `concord-frontend/lib/concordia/skill-descriptors.ts`
-  (tested). Unity still presents kit arts, not the 67-skill overlay.
+  (tested). Unity now binds `skills.mastery` over `/unity-ws` (`lens:run`) and paints the catalog
+  overlay (untrained = L0 novice). Kit arts are no longer presented as the 67-skill system.
 - **T3.2** hub `lore.json` + `content/codex/eight-refusals.json` + `seedCodex` are in tree.
   Hub Watch↔Bazaar rivalries and Asbir/Isa + Mira/Nesha relationships now seed T1.1/T1.3.
 - **T3.3** per-world sky tints + night sun/exposure dim are live. Zone architecture is still

--- a/docs/CONCORDIA_UNITY_PRESENTATION_AUDIT.md
+++ b/docs/CONCORDIA_UNITY_PRESENTATION_AUDIT.md
@@ -82,9 +82,31 @@ substrate yet).
    write. Faction coping bias was already live; Unity can now *see* the break.
 6. **`npc:heir-rose.lastWords`** — the words `onNpcDeath` already composed.
 
-**Not this pass:** Mixamo, funeral 3D crowds, boss HP bar, adaptive audio SM,
-migration emit, crafted-DTU world props, unique GLB per world, interiors,
-F2 affixes, F5.1 raid lockout.
+**3D collision pass (same payloads, in-world):**
+
+1. **Kernel tombs** from `world:snapshot.tombs` — stone + E last-words when
+   xz fits the presenter or a matching `GuestNpc` exists. Nearby NPCs
+   `Notice` the grave. Empty stays empty. Far kernel coords are skipped.
+2. **Gossip overheard** — snapshot now includes `npcA`/`npcB`. Matching
+   `GuestNpc`s get a `GossipEar`; walking within 7m one-shots the real
+   `summary`. No fake speakers.
+3. **Stress acting** — `npc:stress-break` finds a `GuestNpc` and
+   `NpcLife.Cope(trait)`: drink→tavern Sit, withdraw skips social,
+   reckless faster walk, paranoid NoticePlayer, cruel Notices a neighbor.
+4. **Gathering marker** — `world:gathering-detected` centroid x/y/z as a
+   temporary tell. Never a fabricated crowd.
+5. **Faction banners** — `faction:war-declared` brightens existing
+   `FactionBanner_{id}`. No match is a no-op.
+6. **Adaptive music** — Unity `AdaptiveScore.For` is a literal port of
+   `scoreDirectivesFor` (0.85/minor 12s war, 0.7/minor 15s crisis, major
+   8s on alliance/crisis-resolved, scheme outcome fork). Drives the
+   existing Ethereal/Suspenseful/Action sources.
+7. **Migration** — `arriveAtDestination` emits `npc:migrated` with its
+   existing fields. Matching GuestNpc `HeadFor` the named gate or spawn.
+
+**Not this pass:** Mixamo, funeral 3D crowds, boss HP bar / boss body,
+crafted-DTU world props, unique GLB per world, interiors, F2 affixes,
+F5.1 raid lockout.
 
 Honesty checks:
 
@@ -93,5 +115,7 @@ Honesty checks:
 - Funerals/weddings are `daily_life.gather` composition. There is no
   heartbeat that spawns mourners in the 3D world. Empty stays empty.
 - Gossip with zero `npc_nemesis_events` rows is `[]`, never invented rumor.
-- Adaptive music: copy `scoreDirectivesFor` when a Unity soundscape exists.
+- Adaptive music: Unity `AdaptiveScore.For` copies `scoreDirectivesFor`.
   Do not fork a second mapping.
+- World bosses still have **no spawn coordinates**. HUD only — do not drop
+  a fake body at the arena.

--- a/docs/CONCORDIA_UNITY_PRESENTATION_AUDIT.md
+++ b/docs/CONCORDIA_UNITY_PRESENTATION_AUDIT.md
@@ -1,0 +1,97 @@
+# Concordia Unity presentation audit
+
+**Date:** 2026-09-12. **Premise (owner):** the MMO simulation already exists.
+Unity currently presents only a fraction of the consequences. Do **not** invent
+new engines. Find every Concordia backend system that has a real
+event/state/output but no Unity manifestation, then present the ones already
+on the wire.
+
+Reproduction (re-run before trusting a count here):
+
+```bash
+# Unity HandleFrame event names
+rg -o 'evt == "[^"]+"' apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
+# io.emit-only sites that still need gateway mirrors
+rg -n 'io\?\.emit\?\.|io\.to\(`world:' server/emergent server/lib --glob '!**/tests/**'
+# Village gossip is REST, not a socket
+rg -n 'getVillageGossipFeed' server/lib/npc-relationships.js server/routes/worlds.js
+```
+
+Transport classes (how a kernel signal can reach `/unity-ws`):
+
+| Class | Meaning |
+|---|---|
+| `realtimeEmit` | Already fans into Unity (`_unityGatewayEmitter`). Handler is the only gap. |
+| `emitToWorld` | Already mirrors Unity. Handler is the only gap. |
+| `io.emit` / `io.to` | Socket.io-only until `mirrorToGateways`. Unity is deaf without the mirror. |
+| `REST` / `lens:run` | Unity has **no HTTP client**. Pull via `world:snapshot` or `lens:run`. |
+| `silent` | Real DB/state, no player-facing emit. Presenting it requires a thin emit of **existing** fields — not a new engine. |
+
+Triage: **PRESENT-NOW** (handler + maybe mirror, this pass) · **ALREADY-REAL** ·
+**NEEDS-EMIT** (state is real, no event yet) · **LENS-RUN** · **3D-LATER**
+(in-world acting, Mixamo, tombs as meshes) · **DEFER** (too chatty / no 3D
+substrate yet).
+
+---
+
+## The 15 candidates (code, not memory)
+
+| # | Claim | Kernel | Transport before this pass | Three.js | Unity before this pass | Triage |
+|---|---|---|---|---|---|---|
+| 1 | Faction civilization is alive (stance / momentum / next-move / pairwise relations / deterministic `pickMove`) | `lib/embodied/faction-strategy.js` `applyMove`; cycle at `emergent/faction-strategy-cycle.js`. Authored `rival_factions` / `allied_factions` seed rows (`seedFactionStrategyState`). | `faction:war-declared` / `alliance-formed` / `truce-sought` via `_concordRealtimeEmit` (**already Unity**). `faction:strategy-move` was `io.emit` only. | `EmergentEventFeed`, `StrategicWarBanner`, `AdaptiveScoreBridge`, spectate ticker | Authored factions exist in `WorldBook` as kit metadata. **No HandleFrame cases.** | PRESENT-NOW |
+| 2 | NPC death ≫ disappear (last words, inheritance, CK3 hooks, death-appraisal, tombs) | `lib/npc-legacy.js` `onNpcDeath` / `getTombsForWorld` / `inheritHooks` | `npc:heir-rose` already `realtimeEmit` (T2.2). Last words lived only in `npc_legacies`. | dialogue tomb line; npc-legacy domain | HUD heir announce + `inheritance:data`. **No last words, no tomb list.** | PRESENT-NOW (last words + tomb rows on snapshot). 3D tomb meshes later. |
+| 3 | Village gossip is a real feed | `getVillageGossipFeed` → `GET /api/worlds/:id/npc-relationships/gossip-feed` | REST only. Separate SL2 rumor engine (`lib/social/gossip.js`) is NPC→NPC spread, also not on `/unity-ws`. | `VillageGossipFeed.tsx` (WorldOsSurface dynamic import) | Nothing | PRESENT-NOW via `world:snapshot.gossip`. Empty stays `[]`. |
+| 4 | Adaptive music is event-driven | `AdaptiveScoreBridge.tsx` + `lib/concordia/adaptive-score.ts` `scoreDirectivesFor` | Same sockets as #1/#9. Mapping is pure (war→minor 0.85, alliance/crisis-resolved→major, scheme outcome forks). | SoundscapeEngine | No soundscape SM | DEFER the audio SM. **Inherit this mapping; do not invent a second one.** First wave: the same events hit the consequence strip. |
+| 5 | World bosses are a scheduled subsystem | `emergent/world-boss-cycle.js`, `lib/world-bosses.js`, content-seeder (cold-start empty table was the bug, now seeded) | `world:boss-spawn` was `io.emit` only. `boss:state` / `boss:phase-enter` still `io.to` in `routes/worlds.js` (combat HUD). | `NamedEncounterController`, `BossHealthBar`, EmergentEventFeed | Nothing | PRESENT-NOW for spawn. Phase/HP HUD is 3D-LATER (needs a live boss body). |
+| 6 | NPC stress feeds behavior | `lib/npc-stress.js` — grudges/war/heir death/rituals → `coping_trait` (paranoid/reckless/cruel/withdraw/drink) → `pickMove` bias + narrative traits + routine overrides. Break at stress ≥ 80. | **Silent.** `bumpStress` logged; no socket. | coping line in dialogue only | Local `NpcLife` jobs; no kernel stress | PRESENT-NOW: emit `npc:stress-break` on the existing `broke` write. 3D acting (drunk walk, withdrawn idle) is later. |
+| 7 | Social gatherings | Two different systems. (a) `lib/social-gatherings.js` composes wedding/funeral/festival attendees from live relations — **pull** via `daily_life.gather`. (b) `world:gathering-detected` is **player** co-location (`spontaneousGatherings`). (c) `world:npc-gather` is an NPC **harvesting a resource node**, not a funeral. | (a) REST/macro. (b) `emitToWorld` already Unity. (c) `io.to` only. | EventsGatherings; WorldOsSurface | `world:npc-gather` → log line `"a gathering"` (wrong event) | PRESENT-NOW: detected clusters + honest harvest line. Funerals: LENS-RUN / 3D-LATER (no push emit; do not fake crowds). |
+| 8 | Combat stack is deeper than a damage formula | biomech / motor / reflex / impact / momentum / strike FX / mastery / boss phases / flow / executions / faction-war | T1.4a/b + F1.3 + F3.5 already on `/unity-ws` | CombatHUD, juice bridges | Typed telegraphs, impact momentum, knockback. Mixamo clips **not** done. | ALREADY-REAL for feel wire. Next leap is **legibility** (3D-LATER Mixamo), not another formula. |
+| 9 | Gossip + emergent feed + music = one presentation layer | `EmergentEventFeed.tsx` (~20 channels: deaths, dreams, drift, faction wars, bosses, seasons, schemes…) | Mix of `realtimeEmit` and `io.emit` | WorldOsSurface loads feed + gossip + AdaptiveScoreBridge | Scattered `NoteAct` / `Announce` | PRESENT-NOW: one Unity consequence strip. |
+| 10 | NPC migration | `emergent/population-migration-cycle.js` (T2.4 wired the orphan) | **Silent.** Arrivals write DB; no player-facing emit. | none | none | NEEDS-EMIT (then present). Do not invent a migration engine. |
+| 11 | NPC economy | `emergent/npc-economy-cycle.js` → `npc:economy-batch` | `realtimeEmit` (already Unity) | EmergentEventFeed | `npc:level-up` → `"someone grew"` only | PRESENT-NOW when crafts/trades/notable are real and non-zero. |
+| 12 | Seasons / festivals | `lib/seasons.js` `world:season-transition`; `emergent/festival-trigger-cycle.js` `festival:started` | Both `io` only | EmergentEventFeed, FestivalBanner | Clock/weather bound; no season/festival beat | PRESENT-NOW |
+| 13 | Skill mastery | `skills.mastery` via `lens:run` | already | skill HUD | **K overlay + pylons** | ALREADY-REAL. Do not rebuild. |
+| 14 | Combat replay / chronicle | match chronicles / combat-flow recording | REST / domain | some HUD | none | 3D-LATER |
+| 15 | Crafted DTUs as world objects | DTU substrate | REST | marketplace lenses | none | 3D-LATER |
+
+**Also found (not on the original 15, same class):**
+
+| Signal | Kernel | Unity gap | Triage |
+|---|---|---|---|
+| `npc:activity-batch` | routine cycle, every ~75s | too chatty for a toast | DEFER (strip would drown) |
+| `kingdom:decree-enacted` / `fallen` / `contested` | kingdom-decrees | no HandleFrame | next wave |
+| `dream:composed` / `prediction:realised` | embodied cycles | no HandleFrame | next wave |
+| `world:refusal-field` | refusal-field | no HandleFrame | next wave |
+
+---
+
+## Closed this pass (no new engines)
+
+1. **Gateway mirrors** so io-only emits reach `/unity-ws`: `faction:strategy-move`,
+   `world:boss-spawn`, `festival:started`, `world:season-transition`,
+   `world:npc-gather`.
+2. **Unity consequence strip** (`WorldClock.PushFeed` + HUD) — the Emergent
+   Event Feed role, keyed off real payloads (`summary`, `seasonName`,
+   `bossTemplate`, gossip `summary`). Missing substrate stays unrendered.
+3. **HandleFrame** for faction war/alliance/truce/strategy-move, gathering
+   detected, honest NPC harvest, boss spawn, season, festival, economy-batch
+   (only when crafts/trades/notable exist), stress-break, heir last words.
+4. **`world:snapshot`** now includes `gossip` + `tombs` from the existing
+   readers. Empty arrays stay empty.
+5. **`npc:stress-break`** — thin emit of the existing `broke` + `copingTrait`
+   write. Faction coping bias was already live; Unity can now *see* the break.
+6. **`npc:heir-rose.lastWords`** — the words `onNpcDeath` already composed.
+
+**Not this pass:** Mixamo, funeral 3D crowds, boss HP bar, adaptive audio SM,
+migration emit, crafted-DTU world props, unique GLB per world, interiors,
+F2 affixes, F5.1 raid lockout.
+
+Honesty checks:
+
+- `world:npc-gather` is a **resource swing**, not a social scene. The Unity
+  line now names the resource. Do not relabel it as a funeral.
+- Funerals/weddings are `daily_life.gather` composition. There is no
+  heartbeat that spawns mourners in the 3D world. Empty stays empty.
+- Gossip with zero `npc_nemesis_events` rows is `[]`, never invented rumor.
+- Adaptive music: copy `scoreDirectivesFor` when a Unity soundscape exists.
+  Do not fork a second mapping.

--- a/docs/CONCORDIA_UNITY_WIRING_PLAN.md
+++ b/docs/CONCORDIA_UNITY_WIRING_PLAN.md
@@ -1,0 +1,154 @@
+# Concordia — Three.js → Unity wiring plan (2026-09-12)
+
+**Premise (owner):** retire the Three.js *art/rendering* layer only. Every system
+behind it that is solid and that Unity can present well gets kept and wired.
+Nothing in the logic tier is being thrown away.
+
+**Lane discipline while Cursor is mid-flight.** Cursor owns the Unity C# client
+(`unity-client/Assets/Concordia/Scripts/**`) and the art-direction docs.
+This plan's work is server-side transport (`server/server.js`,
+`server/lib/godot-gateway.js`, `server/lib/unity-bridge.js`) plus this file.
+The two lanes touch different trees; the only shared seam is the wire contract
+below, which is additive on both sides.
+
+---
+
+## What's actually on the wire (measured, not estimated)
+
+| Surface | Exists | Three.js consumed | Unity consumes today |
+|---|---:|---:|---:|
+| Realtime broadcast events | 117 | 33 | ~6 handlers |
+| Gateway RPC verbs | 13 | — | 13 (complete) |
+| REST `/api/` endpoints | 239 | 239 | 0 |
+
+Unity has no HTTP client at all — zero `/api/` strings in the C# codebase.
+Everything it does rides one authenticated WebSocket.
+
+**REST surface by top-level segment** (the shape that drives the phasing):
+
+| Segment | Count | Note |
+|---|---:|---|
+| `/api/lens/*` | 65 | universal macro entry — all covered by one verb (Phase 1) |
+| `/api/worlds/*` + `/api/world/*` | 101 | core world spine (Phase 2) |
+| long tail (parties 17, roguelite 10, crafting 10, combat-flow 8, companions 7, combat 7, auctions 7, coop 6, mahjong/horde/hidden-object/factory 5 each, …) | ~73 | per-mode triage (Phase 3) |
+
+---
+
+## Already done (this session)
+
+**Realtime fan-out now reaches Unity.** `realtimeEmit` mirrored into
+`_godotGatewayEmitter` only; the Unity mount created no emitter, so `/unity-ws`
+received zero broadcasts and Unity's correctly-written handlers for
+`secret:weaponised` / `npc:scheme-resolved` / `npc:conversation-bid` could never
+fire. Added `_unityGatewayEmitter` + mirrors at all four fan-out tiers.
+Pinned by `server/tests/invariants/gateway-realtime-mirror-parity.test.js`
+(per-tier parity, bidirectionally verified). 40/40 existing gateway tests pass.
+
+This unblocked the *transport*. Unity still needs client-side handlers for the
+events it now actually receives — that's Phase 2's client half, Cursor's lane.
+
+**Phase 1 shipped — `lens:run`.** One authenticated WebSocket verb covers the
+entire `/api/lens/*` macro surface. `godot-gateway.js` forwards to injected
+`deps.runMacro` with `{ actor, userId, reqMeta: { path:"/api/lens/run", method:"POST" } }`.
+Both `/godot-ws` and `/unity-ws` mounts inject `_runMacroFromGateway`, which
+rebuilds ctx through `makeCtx`, applies the HTTP H1 anon gate, and dispatches
+through the same LENS_ACTIONS-then-runMacro lookup `POST /api/lens/run` uses.
+The gateway does **not** reimplement Gate 2 or Gate 3 — those stay inside
+`runMacro`. Missing dep → honest `lens_run_unavailable`. A thrown `forbidden`
+stays `{ok:false}`. Pinned by `server/tests/unity-lens-run.test.js`.
+
+---
+
+## Phase 1 — the keystone: one `lens:run` gateway verb
+
+**Covers 65 of 239 endpoints (27%) in a single change.**
+
+`runMacro(domain, name, input, ctx)` (`server.js:13787`) is already the
+universal entry point behind `POST /api/lens/run`, and is already injected as a
+dependency into other subsystems. `mountGodotGateway` takes a `deps` object that
+already receives `exportScene` / `exportKingdom` the same way — adding
+`runMacro` alongside them is consistent with the existing pattern, not a new one.
+
+One new verb forwarding to `runMacro` with the authenticated client's ctx gives
+Unity the entire ~10,632-macro surface over the connection it already has, with
+the auth it already passes, and no CORS or second-auth path to solve in WebGL.
+
+Non-negotiables for this verb:
+- Runs through the **same three permission gates** as the HTTP path
+  (`authMiddleware` allowlist → `runMacro`'s `publicReadDomains` → Chicken2).
+  A gateway verb must not become a way around the gates the REST route enforces.
+- Honest failure envelope — a macro that can't run returns `{ok:false, reason}`,
+  never a fabricated success.
+- Rate-limited on the existing gateway limiter (20/s, burst 30), so a client
+  can't use it to hammer macros faster than HTTP allows.
+
+## Phase 2 — the world spine
+
+**101 endpoints + the ~30 realtime events that carry visible state.**
+
+This is what makes the world feel alive, and it's the tier Unity renders
+natively better than a web canvas ever did: presence and positions, building
+spawn/remove/state, combat feedback (hit/kill/stagger/impact/telegraph),
+weather and world clock, NPC bark/alert/gather/travel, quest accepted/completed,
+season transitions, crisis and world events.
+
+Split:
+- *Server side (this lane):* confirm each of those events actually reaches
+  `/unity-ws` now, and add gateway verbs for the world reads that don't fit the
+  macro passthrough.
+- *Client side (Cursor's lane):* `HandleFrame` cases + the presentation for
+  each. This is where "show it in a dope way" actually happens.
+
+## Phase 3 — long-tail triage (~73 endpoints)
+
+Judgment tier. Three buckets, and note that **none of them is "delete the
+backend"** — the backend stays either way:
+
+- **Native in 3D — wire and present.** Arena, coop raids, extraction, horde,
+  roguelite, farming, factory, mounts, companions, auctions, crafting, parties.
+  These were cramped in a web page and get *better* in Unity.
+- **In-world surface, not a page.** Hacking, code-puzzle, trivia, hidden-object,
+  mahjong, karaoke. Keep the (real, tested) engines; present them as in-world
+  terminals/tables the player walks up to, rather than porting a 2D page. Defer
+  until Phase 2 lands — they're self-contained and lose nothing by waiting.
+- **Stays web-only for now.** Anything that is genuinely a dashboard rather than
+  a world interaction. Reachable through the lens system on the site; no Unity
+  surface needed.
+
+## Phase 4 — resolve `scene:data`
+
+The server computes a full enriched scene descriptor (`exportScene` →
+`enrichScene`, with per-node asset URLs, portals, per-client hints) and sends it
+on `scene:request`. Unity requests it on connect and **has no handler** — it's
+dropped unread, because Unity builds its world locally from `FreePacks`/
+`WorldBuilder` against its own imported asset library.
+
+Two honest options; pick one and stop leaving it ambiguous:
+1. **Consume it** for the parts Unity can't know locally (which buildings exist
+   right now, portal placement, live world state) while keeping local assets for
+   *how* they look.
+2. **Delete the Unity branch of it** (`toUnityScene`, `getUnityAssetList`,
+   `unityBuildSettings` — the last has zero callers repo-wide) and let Three.js
+   keep it until Three.js goes.
+
+Option 1 is probably right, because "which buildings exist" is genuinely server
+truth. But silent scaffold is worse than either choice.
+
+---
+
+## What actually gets dropped
+
+Only the Three.js **render layer**: `concordia-theme.ts` constants, cel-shade,
+toon ramps, outline passes, the Three.js scene graph and its art rules
+(`docs/ART_STYLE_GUIDE.md`, already marked retired). Every system it was
+*displaying* — 43 `npc-*.js` modules / 12,040 lines, the quest engine, economy,
+factions, schemes, secrets, the authored `content/world/**` for all 10 worlds —
+is client-agnostic and stays exactly as is.
+
+## Sequencing note
+
+Phase 1 is independent of everything Cursor is doing and unblocks the widest
+surface per unit of work — it should go first. Phase 2's server half can run in
+parallel with Cursor's client work; its client half depends on Cursor's current
+pass landing. Phases 3 and 4 are deliberately after, so they're decided with a
+working spine in hand rather than in the abstract.

--- a/docs/CONCORDIA_UNITY_WIRING_PLAN.md
+++ b/docs/CONCORDIA_UNITY_WIRING_PLAN.md
@@ -57,6 +57,30 @@ The gateway does **not** reimplement Gate 2 or Gate 3 — those stay inside
 `runMacro`. Missing dep → honest `lens_run_unavailable`. A thrown `forbidden`
 stays `{ok:false}`. Pinned by `server/tests/unity-lens-run.test.js`.
 
+**Phase 2 server shipped.** Combat/quest events that already used `realtimeEmit`
+now reach `/unity-ws` via the Unity emitter. Clock/weather/npc-quest/crisis
+were `REALTIME.io.emit` only (socket.io) — they now also call
+`mirrorToGateways` (`globalThis._concordGatewayMirror`), a gateway-only hook
+so socket.io is not double-fired. `world:snapshot` returns the live
+`getWorldPhase` + `getWeather` engines. Pinned by
+`tests/unity-world-spine.test.js` + the mirror-parity invariant.
+
+**Phase 4 decision: consume `scene:data`.** Unity applies live `nodes`
+(real `world_buildings` rows) as a `KernelLive` overlay dressed with local
+packs. Empty nodes stay empty. The hub `portals` array in `enrichScene` is
+Three.js-scale scaffold and must not stomp the authored Ring of Doors —
+those gates stay Canon. `toUnityScene` / `getUnityAssetList` remain for the
+Three.js path until that renderer is actually retired; they are no longer
+the Unity client's world.
+
+**Phase 3 buckets (judgment, engines kept either way):**
+- Native 3D (wire): arena, coop/raids, extraction, horde, farming, factory,
+  mounts, auctions, crafting, parties — reach the kernel via `lens:run` plus
+  the play verbs already on the socket (party, dungeon, gift, dodge).
+- In-world terminals later: hacking, trivia, mahjong, karaoke, code-puzzle —
+  engines stay; no page port.
+- Stay web: genuine dashboards.
+
 ---
 
 ## Phase 1 — the keystone: one `lens:run` gateway verb

--- a/docs/CONCORDIA_UNITY_WIRING_PLAN.md
+++ b/docs/CONCORDIA_UNITY_WIRING_PLAN.md
@@ -77,6 +77,8 @@ the Unity client's world.
 - Native 3D (wire): arena, coop/raids, extraction, horde, farming, factory,
   mounts, auctions, crafting, parties — reach the kernel via `lens:run` plus
   the play verbs already on the socket (party, dungeon, gift, dodge).
+  `skills.mastery` now covers the T3.1 67-skill overlay (catalog + live
+  `player_skill_levels`); Unity consumes it instead of kit arts.
 - In-world terminals later: hacking, trivia, mahjong, karaoke, code-puzzle —
   engines stay; no page port.
 - Stay web: genuine dashboards.

--- a/docs/CONCORDIA_UNITY_WIRING_PLAN.md
+++ b/docs/CONCORDIA_UNITY_WIRING_PLAN.md
@@ -17,7 +17,7 @@ below, which is additive on both sides.
 
 | Surface | Exists | Three.js consumed | Unity consumes today |
 |---|---:|---:|---:|
-| Realtime broadcast events | 117 | 33 | ~6 handlers |
+| Realtime broadcast events | 117 | 33 | ~30+ handlers (consequence strip + faction/boss/season/gather/gossip; see `docs/CONCORDIA_UNITY_PRESENTATION_AUDIT.md`) |
 | Gateway RPC verbs | 13 | — | 13 (complete) |
 | REST `/api/` endpoints | 239 | 239 | 0 |
 

--- a/docs/CONCORDIA_UNITY_WIRING_PLAN.md
+++ b/docs/CONCORDIA_UNITY_WIRING_PLAN.md
@@ -17,7 +17,7 @@ below, which is additive on both sides.
 
 | Surface | Exists | Three.js consumed | Unity consumes today |
 |---|---:|---:|---:|
-| Realtime broadcast events | 117 | 33 | ~30+ handlers (consequence strip + faction/boss/season/gather/gossip; see `docs/CONCORDIA_UNITY_PRESENTATION_AUDIT.md`) |
+| Realtime broadcast events | 117 | 33 | ~30+ handlers + 3D collision (tombs/gossip/stress/banners/score/migration; see `docs/CONCORDIA_UNITY_PRESENTATION_AUDIT.md`) |
 | Gateway RPC verbs | 13 | — | 13 (complete) |
 | REST `/api/` endpoints | 239 | 239 | 0 |
 

--- a/server/domains/creatures.js
+++ b/server/domains/creatures.js
@@ -21,6 +21,7 @@ import {
 } from "../lib/creature-crossbreeding.js";
 import { buildCreaturePortraitSvg, summarizePartCounts } from "../lib/creature-portrait.js";
 import { registerCitation } from "../economy/royalty-cascade.js";
+import { announceCreatureBorn } from "../lib/concordia-creatures.js";
 
 // Deterministic coat colour from species id + dominant affinity, so a steam
 // variant reads cool-grey, a magma variant red, etc. — no per-species art asset.
@@ -410,6 +411,7 @@ export default function registerCreatureMacros(register) {
       const environment = biome ? { kind: biome } : null;
       const result = generateHybrid(db, { a: pa, b: pb, environment });
       if (!result.ok) return result;
+      try { announceCreatureBorn(result, worldId); } catch { /* presentation optional */ }
 
       // ── Creatures-C — the composition flywheel ────────────────────────
       // When a parent creature is a REAL owned creature (spawned via

--- a/server/domains/crisis.js
+++ b/server/domains/crisis.js
@@ -24,6 +24,7 @@
 import crypto from "node:crypto";
 import { cachedFetchJson } from "../lib/external-fetch.js";
 import { triggerCrisis, CRISIS_TYPES } from "../lib/world-crisis.js";
+import { mirrorToGateways } from "../lib/gateway-fanout.js";
 
 // Fail-CLOSED numeric guard (parity with server/domains/literary.js):
 // returns the first poisoned key (NaN/Infinity/1e308/negative/over-cap) or
@@ -231,7 +232,9 @@ export default function registerCrisisMacros(register) {
       } catch { /* best effort */ }
       try {
         if (globalThis?.__CONCORD_REALTIME__?.io) {
-          globalThis.__CONCORD_REALTIME__.io.emit("world:crisis-resolved", { crisisId, userId });
+          const payload = { crisisId, userId };
+          globalThis.__CONCORD_REALTIME__.io.emit("world:crisis-resolved", payload);
+          mirrorToGateways("world:crisis-resolved", payload);
         }
       } catch { /* sockets optional */ }
       return { ok: true, crisisId, resolvedBy: userId };
@@ -259,6 +262,7 @@ export default function registerCrisisMacros(register) {
     try {
       const emit = (name, payload) => {
         try { globalThis?.__CONCORD_REALTIME__?.io?.emit?.(name, payload); } catch { /* sockets optional */ }
+        mirrorToGateways(name, payload, { worldId: wid });
       };
       const res = triggerCrisis(db, type, wid, emit);
       if (!res?.ok) return { ok: false, reason: res?.error || "declare_failed", id: res?.id };

--- a/server/domains/secrets.js
+++ b/server/domains/secrets.js
@@ -13,6 +13,7 @@ import {
   rollSurveillance,
   listDiscoveredForUser,
   listWorldCatalog,
+  fanSecretWeaponised,
 } from "../lib/secrets.js";
 import { generateHookFromSecretDiscovery, getHooksHeldBy } from "../lib/hooks.js";
 
@@ -89,14 +90,11 @@ export default function registerSecretsMacros(register) {
     if (!userId || !input.secretId) return { ok: false, reason: "missing_inputs" };
     const r = weaponiseSecret(db, userId, input.secretId, input.againstNpcId);
     if (r?.ok) {
-      try {
-        const io = ctx?.app?.locals?.io || ctx?.io;
-        io?.emit?.("secret:weaponised", {
-          userId, secretId: input.secretId,
-          holder: r.holder, subject_kind: r.subject_kind, subject_id: r.subject_id,
-          kind: r.kind, ts: Math.floor(Date.now() / 1000),
-        });
-      } catch { /* socket optional */ }
+      fanSecretWeaponised({
+        userId, secretId: input.secretId,
+        holder: r.holder, subject_kind: r.subject_kind, subject_id: r.subject_id,
+        kind: r.kind, ts: Math.floor(Date.now() / 1000),
+      }, { io: ctx?.app?.locals?.io || ctx?.io, worldId: input.worldId || null });
     }
     return r;
   }, { note: "weaponise a discovered secret" });

--- a/server/domains/skills.js
+++ b/server/domains/skills.js
@@ -7,6 +7,7 @@
 // current user's most-at-risk skill DTU through it.
 
 import { getAtrophyRisk } from "../lib/skill-atrophy.js";
+import { getCatalogSkillMastery, getSkillMastery } from "../lib/skills/skill-mastery.js";
 
 export default function registerSkillsActions(registerLensAction) {
   registerLensAction("skills", "atrophy_risk", (ctx, _artifact, _params = {}) => {
@@ -50,5 +51,23 @@ export default function registerSkillsActions(registerLensAction) {
       ...getAtrophyRisk(row),
     })).sort((a, b) => b.projectedLoss - a.projectedLoss);
     return { ok: true, result: { skills } };
+  });
+
+  // T3.1 — full SKILL_CATALOG mastery overlay for Unity / lens:run.
+  // Untrained skills stay level-0 novice. Missing actor is an honest fail.
+  registerLensAction("skills", "mastery", (ctx, _a, params = {}) => {
+    const userId = (ctx && (ctx.userId || (ctx.actor && ctx.actor.userId))) || null;
+    if (!userId) return { ok: false, error: "authentication required" };
+    const skillType = typeof params.skillType === "string" ? params.skillType : "";
+    if (skillType) {
+      return {
+        ok: true,
+        ...getSkillMastery(ctx?.db, userId, skillType, {
+          element: typeof params.element === "string" ? params.element : "none",
+          kind: typeof params.kind === "string" ? params.kind : null,
+        }),
+      };
+    }
+    return { ok: true, ...getCatalogSkillMastery(ctx?.db, userId) };
   });
 }

--- a/server/emergent/faction-strategy-cycle.js
+++ b/server/emergent/faction-strategy-cycle.js
@@ -17,6 +17,7 @@
 
 import logger from "../logger.js";
 import { pickMove, applyMove, resolveFactionWorldId } from "../lib/embodied/faction-strategy.js";
+import { mirrorToGateways } from "../lib/gateway-fanout.js";
 import { ethicsEnabled, getSharedValueRuleIndex, factionMoveBias } from "../lib/viability/value-rule-index.js";
 import { collapseCascadeEnabled, cascadeCollapse } from "../lib/viability/collapse-cascade.js";
 
@@ -157,12 +158,14 @@ export async function runFactionStrategyCycle({ db, io, state: _state, tickCount
         // move — not just the wars/clashes below — emits a lightweight event so
         // the EmergentEventFeed can show "the world's factions are scheming"
         // (consolidate / expand / propose-alliance / seek-truce / …). Best-effort.
-        io?.emit?.("faction:strategy-move", {
+        const movePayload = {
           factionId: f.faction_id,
           move: applied.move,
           target: applied.target ?? null,
           ts: Date.now(),
-        });
+        };
+        io?.emit?.("faction:strategy-move", movePayload);
+        mirrorToGateways("faction:strategy-move", movePayload);
         // Legibility W2b — route a war move through any online player whose thread
         // it pulls on ("the faction you backed is on the move"). Global (factions
         // aren't per-world) → scans all online players. Best-effort, never blocks.

--- a/server/emergent/festival-trigger-cycle.js
+++ b/server/emergent/festival-trigger-cycle.js
@@ -13,6 +13,7 @@
 
 import logger from "../logger.js";
 import { runFestivalTriggerPass, loadFestivalsFromContent } from "../lib/festivals.js";
+import { mirrorToGateways } from "../lib/gateway-fanout.js";
 
 let _seeded = false;
 
@@ -32,12 +33,14 @@ export function runFestivalTriggerCycle({ db, worldId, io } = {}) {
     if (!r.ok) return r;
     for (const opened of r.opened) {
       try {
-        io?.emit?.("festival:started", {
+        const festPayload = {
           festivalId: opened.festivalId,
           name: opened.name,
           worldId,
           ts: Math.floor(Date.now() / 1000),
-        });
+        };
+        io?.emit?.("festival:started", festPayload);
+        mirrorToGateways("festival:started", festPayload, { worldId });
       } catch (err) {
         logger.debug?.("festival-trigger-cycle", "emit_failed", { error: err?.message });
       }

--- a/server/emergent/npc-conversation-initiator.js
+++ b/server/emergent/npc-conversation-initiator.js
@@ -13,6 +13,7 @@ import {
   sweepExpiredConversations,
   _internal,
 } from "../lib/embodied/npc-dialogue.js";
+import { mirrorToGateways } from "../lib/gateway-fanout.js";
 
 export async function runNpcConversationInitiator({ db, io } = {}) {
   if (!db) return { ok: false, reason: "no_db" };
@@ -34,14 +35,16 @@ export async function runNpcConversationInitiator({ db, io } = {}) {
         // pattern of emitting via app.locals.io). Floor-only — emit
         // failures must not stop the cycle.
         try {
-          io?.to(`world:${worldId}`)?.emit?.("npc:conversation-bid", {
+          const payload = {
             id: result.conversationId,
             worldId,
             npcA: result.npcA,
             npcB: result.npcB,
             opener: result.opener,
             expiresAt: result.expiresAt,
-          });
+          };
+          io?.to(`world:${worldId}`)?.emit?.("npc:conversation-bid", payload);
+          mirrorToGateways("npc:conversation-bid", payload, { worldId });
         } catch { /* socket emit best-effort */ }
       }
     }

--- a/server/emergent/scheme-overhear-cycle.js
+++ b/server/emergent/scheme-overhear-cycle.js
@@ -11,6 +11,7 @@
 
 import * as cityPresence from "../lib/city-presence.js";
 import { overhearForWorld, OVERHEAR_RADIUS_M } from "../lib/scheme-overhear.js";
+import { mirrorToGateways } from "../lib/gateway-fanout.js";
 
 export async function runSchemeOverhearCycle({ db, io } = {}) {
   if (process.env.CONCORD_SCHEME_OVERHEAR === "0") return { ok: false, reason: "disabled" };
@@ -91,6 +92,7 @@ export async function runSchemeOverhearCycle({ db, io } = {}) {
         io?.to?.(`world:${worldId}`)?.emit?.("scheme:overheard-ambient", {
           plotterId: f.plotterId, worldId, ts: payload.ts,
         });
+        mirrorToGateways("scheme:overheard", payload, { userId: f.userId });
       } catch { /* emit best-effort */ }
     }
   }

--- a/server/emergent/world-boss-cycle.js
+++ b/server/emergent/world-boss-cycle.js
@@ -40,6 +40,7 @@
 
 import logger from "../logger.js";
 import { runTriggerPass, sweepExpiredActive } from "../lib/world-bosses.js";
+import { mirrorToGateways } from "../lib/gateway-fanout.js";
 
 export function runWorldBossCycle({ db, worldId, io } = {}) {
   if (!db) return { ok: false, reason: "no_db" };
@@ -56,11 +57,13 @@ export function runWorldBossCycle({ db, worldId, io } = {}) {
     const opened = worldId ? r.opened.filter(o => o.worldId === worldId) : r.opened;
     for (const o of opened) {
       try {
-        io?.emit?.("world:boss-spawn", {
+        const spawnPayload = {
           activeId: o.activeId, scheduleId: o.scheduleId,
           worldId: o.worldId, bossTemplate: o.bossTemplate,
           ts: Math.floor(Date.now() / 1000),
-        });
+        };
+        io?.emit?.("world:boss-spawn", spawnPayload);
+        mirrorToGateways("world:boss-spawn", spawnPayload, o.worldId ? { worldId: o.worldId } : {});
       } catch (err) {
         logger.debug?.("world-boss-cycle", "emit_failed", { error: err?.message });
       }

--- a/server/lib/city-presence.js
+++ b/server/lib/city-presence.js
@@ -13,6 +13,7 @@ import logger from "../logger.js";
 import { maxFootSpeedFor, agilityLevelFor, awardSprintXp } from "./movement/foot-speed.js";
 import { speedScaledRadius } from "./movement/interest-management.js";
 import { sanitizeVector, clampToWorldBounds } from "./math-safety.js";
+import { applyHitToState } from "./combat-state.js";
 import {
   shouldRunHeavyMaintenance,
   registerIdleGate,
@@ -1793,7 +1794,32 @@ export function applyAttack({ attackerId, targetId, baseDamage = 10, range = 3, 
   // client-supplied baseDamage can never one-shot regardless of variance/crit.
   // maxDamage defaults to Infinity (NPC/legacy callers unaffected); the socket
   // PvP path passes resolvedDamageCap() to close the injection exploit.
-  const damage = Math.min(isCrit ? mitigated * 2 : mitigated, maxDamage);
+  let damage = Math.min(isCrit ? mitigated * 2 : mitigated, maxDamage);
+
+  if (isPlayerTarget) {
+    try {
+      const defMod = applyHitToState(targetId, { damage, isCrit });
+      if (defMod.iframed) {
+        attacker.stamina = Math.max(0, (attacker.stamina || 0) - STAMINA_COST);
+        attacker.dirty = true;
+        return {
+          ok: true,
+          damage: 0,
+          isCrit: false,
+          evaded: true,
+          iframed: true,
+          targetHealth: target.health ?? target.hp ?? 100,
+          targetMaxHealth: target.maxHealth ?? target.maxHp ?? 100,
+          targetKilled: false,
+          attackerStamina: attacker.stamina,
+          reason: "iframe",
+        };
+      }
+      if (defMod.damageMul !== 1 && Number.isFinite(damage)) {
+        damage = Math.max(0, Math.round(damage * defMod.damageMul));
+      }
+    } catch { /* combat-state optional */ }
+  }
 
   // Degrade zone armor — each hit reduces it; heavier hits + crits degrade more
   const armorDeg = Math.min(zoneArmorBefore, Math.ceil((damage / 3) + (isCrit ? 5 : 0)));

--- a/server/lib/combat-state.js
+++ b/server/lib/combat-state.js
@@ -16,7 +16,13 @@
  *
  * The combat-netcode validateHit() is extended to consult this state and
  * adjust damage / reject the hit when iframes are active.
+ *
+ * F1.3 — a live telegraph peril on the defender means i-frames from the
+ * WRONG counter do not whiff the hit. noteIncomingPeril stamps the window;
+ * grantIFrames records which defense was used.
  */
+
+import { counterNegates } from "./combat/telegraph-peril.js";
 
 const _state = new Map(); // actorId -> { poise, ... }
 
@@ -36,6 +42,9 @@ function _ensure(actorId) {
       knockbackVel: { x: 0, y: 0, z: 0 },
       iframeUntil: 0,
       blockUntil: 0,
+      perilKind: null,
+      perilUntil: 0,
+      defenseAction: "dodge",
       lastUpdate: Date.now(),
     };
     _state.set(actorId, s);
@@ -50,7 +59,11 @@ export function applyHitToState(actorId, { damage = 0, isCrit = false, knockback
   const now = Date.now();
 
   if (now < s.iframeUntil) {
-    return { damageMul: 0, staggered: false, blocked: false, iframed: true };
+    const perilLive = s.perilKind && now < (s.perilUntil || 0);
+    if (!perilLive || counterNegates(s.perilKind, s.defenseAction || "dodge")) {
+      return { damageMul: 0, staggered: false, blocked: false, iframed: true };
+    }
+    // Wrong counter during a perilous tell — i-frames do not save you.
   }
 
   let damageMul = 1.0;
@@ -110,10 +123,20 @@ export function getCombatState(actorId) {
   };
 }
 
+/** Stamp a typed telegraph on the defender so the next hit can gate i-frames. */
+export function noteIncomingPeril(actorId, perilKind, durationMs = 400) {
+  if (!actorId || !perilKind) return;
+  const s = _ensure(actorId);
+  s.perilKind = perilKind;
+  s.perilUntil = Date.now() + Math.max(80, Number(durationMs) || 400);
+}
+
 /** Set the actor's i-frame window (e.g. just after a successful dodge). */
-export function grantIFrames(actorId, durationMs = 350) {
+export function grantIFrames(actorId, durationMs = 350, defenseAction = "dodge") {
   const s = _ensure(actorId);
   s.iframeUntil = Math.max(s.iframeUntil, Date.now() + durationMs);
+  const a = String(defenseAction || "dodge").toLowerCase();
+  s.defenseAction = ["jump", "break", "block", "parry", "dodge"].includes(a) ? a : "dodge";
 }
 
 /** Set the actor's block window. Block reduces damage 50% and prevents stagger. */

--- a/server/lib/combat/match-chronicle.js
+++ b/server/lib/combat/match-chronicle.js
@@ -149,5 +149,19 @@ export function mintMatchChronicle(db, {
   });
 
   if (!result.ok) return { ok: false, error: result.error };
-  return { ok: true, chronicleId: result.dtu?.id ?? null };
+  const chronicleId = result.dtu?.id ?? null;
+  try {
+    const emit = globalThis._concordRealtimeEmit;
+    if (typeof emit === "function" && chronicleId) {
+      emit("combat:chronicle", {
+        chronicleId,
+        title,
+        summary: human.summary,
+        worldId,
+        winnerId: winnerId || null,
+        loserId: loserId || null,
+      }, { worldId });
+    }
+  } catch { /* presentation optional */ }
+  return { ok: true, chronicleId };
 }

--- a/server/lib/concordia-creatures.js
+++ b/server/lib/concordia-creatures.js
@@ -1,0 +1,216 @@
+/**
+ * Concordia creature pillar — presentation of the existing genome / lineage /
+ * ecology substrate on /unity-ws.
+ *
+ * Does not spawn creatures. Does not invent species. Compact cards come from
+ * world_npcs (fauna-spawner) + creature_lineage (crossbreed) +
+ * creature_population (food-web counts). Empty tables stay [].
+ *
+ *   cd server && node --test tests/concordia-creatures.test.js
+ */
+
+import { topologyForSpecies, taxonomyForSpecies } from "./species-taxonomy.js";
+import { lifestyleForSpecies } from "./ecosystem/loot-tables.js";
+
+const LIVE_CAP = 24;
+const ECOLOGY_CAP = 16;
+
+function parseBlueprint(raw) {
+  if (!raw) return null;
+  if (typeof raw === "object") return raw;
+  try { return JSON.parse(String(raw)); } catch { return null; }
+}
+
+function gaitKindFor(topology) {
+  const t = String(topology || "");
+  if (t.startsWith("winged") || t === "avian") return "winged";
+  if (t === "serpentine" || t === "eel" || t === "fish" || t === "shark" || t === "cephalopod") return t;
+  if (t === "polyped") return "polyped";
+  if (t === "amorphous") return "amorphous";
+  if (t === "humanoid") return "biped";
+  return "quadruped";
+}
+
+function isFly(topology, gaitKind) {
+  const g = gaitKind || gaitKindFor(topology);
+  return g === "winged" || String(topology || "").startsWith("winged");
+}
+
+function isPredator(lifestyle) {
+  return lifestyle === "carnivore";
+}
+
+function compactFromBlueprint(bp, row, lineage) {
+  const speciesId = bp.species_id
+    || bp.provenance?.baselineId
+    || row?.species_id
+    || String(row?.archetype || "").replace(/^creature:/, "")
+    || "";
+  const topology = bp.topology || topologyForSpecies(speciesId);
+  const lifestyle = bp.lifestyle
+    || taxonomyForSpecies(speciesId).diet
+    || lifestyleForSpecies(speciesId)
+    || "omnivore";
+  const gait = bp.gait || {};
+  const geno = bp.genotype || {};
+  return {
+    id: String(bp.id || row?.id || ""),
+    speciesId,
+    x: Number.isFinite(row?.x) ? row.x : null,
+    y: Number.isFinite(row?.y) ? row.y : null,
+    z: Number.isFinite(row?.z) ? row.z : null,
+    topology,
+    massKg: Number.isFinite(bp.massKg) ? bp.massKg : null,
+    heightM: Number.isFinite(bp.heightM) ? bp.heightM : null,
+    generation: Number.isInteger(lineage?.generation) ? lineage.generation : (Number(lineage?.generation) || 0),
+    parentA: lineage?.parent_a || null,
+    parentB: lineage?.parent_b || null,
+    dominant: geno.dominant || geno.affinity || null,
+    variant: bp.variant || geno.variant || null,
+    affinity: geno.affinity || geno.dominant || null,
+    gaitKind: gait.kind || gaitKindFor(topology),
+    walkMps: Number.isFinite(gait.walkMps) ? gait.walkMps : null,
+    lifestyle,
+    predator: isPredator(lifestyle),
+    fly: isFly(topology, gait.kind),
+    stability: Number.isFinite(lineage?.stability) ? lineage.stability
+      : (Number.isFinite(bp.genotype?.stability) ? bp.genotype.stability : null),
+  };
+}
+
+function compactFromRow(row, lineage) {
+  const bp = parseBlueprint(lineage?.blueprint);
+  if (bp) return compactFromBlueprint(bp, row, lineage);
+  const speciesId = row.species_id || String(row.archetype || "").replace(/^creature:/, "");
+  const tax = taxonomyForSpecies(speciesId);
+  const lifestyle = tax.diet || lifestyleForSpecies(speciesId) || "omnivore";
+  const topology = tax.topology || topologyForSpecies(speciesId);
+  return {
+    id: String(row.id || ""),
+    speciesId,
+    x: Number.isFinite(row.x) ? row.x : null,
+    y: Number.isFinite(row.y) ? row.y : null,
+    z: Number.isFinite(row.z) ? row.z : null,
+    topology,
+    massKg: null,
+    heightM: null,
+    generation: Number(lineage?.generation) || 0,
+    parentA: lineage?.parent_a || null,
+    parentB: lineage?.parent_b || null,
+    dominant: null,
+    variant: null,
+    affinity: null,
+    gaitKind: gaitKindFor(topology),
+    walkMps: null,
+    lifestyle,
+    predator: isPredator(lifestyle),
+    fly: isFly(topology),
+    stability: Number.isFinite(lineage?.stability) ? lineage.stability : null,
+  };
+}
+
+/**
+ * Live fauna + lineage cards for a world. Missing tables → []. Never fabricates
+ * a creature that is not a world_npcs fauna row or a creature_lineage child.
+ */
+export function snapshotCreatures(db, worldId) {
+  if (!db || !worldId) return [];
+  const out = [];
+  const seen = new Set();
+  try {
+    const live = db.prepare(`
+      SELECT id, world_id, archetype, species_id, x, y, z
+      FROM world_npcs
+      WHERE world_id = ?
+        AND is_dead = 0
+        AND (archetype LIKE 'creature:%' OR species_id IS NOT NULL)
+      LIMIT ?
+    `).all(worldId, LIVE_CAP);
+    for (const row of live) {
+      const arch = String(row.archetype || "");
+      if (!arch.startsWith("creature:") && !row.species_id) continue;
+      let lineage = null;
+      try {
+        lineage = db.prepare(`SELECT * FROM creature_lineage WHERE child_id = ?`).get(row.id);
+      } catch { /* lineage optional */ }
+      const card = compactFromRow(row, lineage);
+      if (!card.id) continue;
+      seen.add(card.id);
+      out.push(card);
+    }
+  } catch { /* world_npcs / is_dead optional on minimal builds */ }
+
+  try {
+    const kids = db.prepare(`
+      SELECT child_id, parent_a, parent_b, generation, stability, blueprint
+      FROM creature_lineage
+      ORDER BY created_at DESC
+      LIMIT ?
+    `).all(LIVE_CAP);
+    for (const lin of kids) {
+      if (seen.has(lin.child_id)) continue;
+      const bp = parseBlueprint(lin.blueprint);
+      if (bp?.worldId && bp.worldId !== worldId && worldId !== "concordia-hub") continue;
+      const card = compactFromBlueprint(bp || { id: lin.child_id }, null, lin);
+      if (!card.id) continue;
+      seen.add(card.id);
+      out.push(card);
+      if (out.length >= LIVE_CAP) break;
+    }
+  } catch { /* lineage optional */ }
+
+  return out;
+}
+
+/**
+ * Per-(biome, species) counts the fauna spawner already writes.
+ * Empty / missing table → [].
+ */
+export function snapshotEcology(db, worldId) {
+  if (!db || !worldId) return [];
+  try {
+    const rows = db.prepare(`
+      SELECT species_id, biome, current_count, target_count, lifestyle
+      FROM creature_population
+      WHERE world_id = ?
+      ORDER BY current_count DESC
+      LIMIT ?
+    `).all(worldId, ECOLOGY_CAP);
+    return rows.map((r) => ({
+      speciesId: r.species_id || "",
+      biome: r.biome || "",
+      count: Number(r.current_count) || 0,
+      target: Number(r.target_count) || 0,
+      lifestyle: r.lifestyle || lifestyleForSpecies(r.species_id) || "",
+    })).filter((c) => c.speciesId);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Thin emit of a real generateHybrid result. No invented child, no invented xz.
+ */
+export function announceCreatureBorn(result, worldId) {
+  if (!result?.ok || !result.hybrid?.id) return { ok: false, reason: "no_hybrid" };
+  const emit = globalThis._concordRealtimeEmit;
+  if (typeof emit !== "function") return { ok: false, reason: "no_emit" };
+  const hybrid = result.hybrid;
+  const lineage = {
+    generation: result.generation,
+    parent_a: result.parents?.[0] || null,
+    parent_b: result.parents?.[1] || null,
+    stability: result.stability,
+    blueprint: hybrid,
+  };
+  const card = compactFromBlueprint(hybrid, null, lineage);
+  const wid = worldId || hybrid.worldId || "concordia-hub";
+  emit("creature:born", {
+    ...card,
+    worldId: wid,
+    childId: hybrid.id,
+  }, { worldId: wid });
+  return { ok: true, childId: hybrid.id };
+}
+
+export default { snapshotCreatures, snapshotEcology, announceCreatureBorn };

--- a/server/lib/concordia-play.js
+++ b/server/lib/concordia-play.js
@@ -86,8 +86,12 @@ export function handleDodge(userId, data = {}) {
   if (!userId) return { ok: false, reason: "missing_user" };
   const perfect = data.perfect === true || data.wasParry === true;
   const ms = perfect ? 500 : 350;
-  try { grantIFrames(userId, ms); } catch { /* in-memory optional */ }
-  return { ok: true, iframeMs: ms, perfect: !!perfect };
+  const raw = String(data.action || "").toLowerCase();
+  const defense = ["jump", "break", "block", "parry", "dodge"].includes(raw)
+    ? raw
+    : (data.wasParry ? "parry" : "dodge");
+  try { grantIFrames(userId, ms, defense); } catch { /* in-memory optional */ }
+  return { ok: true, iframeMs: ms, perfect: !!perfect, action: defense };
 }
 
 export function handleDungeonOpen(db, userId, data = {}) {

--- a/server/lib/concordia-play.js
+++ b/server/lib/concordia-play.js
@@ -9,6 +9,10 @@ import { getInheritanceForHeir, getInheritanceFromDeceased } from "./npc-legacy.
 import { joinSession } from "./concordia-session.js";
 import { grantIFrames } from "./combat-state.js";
 import { openInstance, DUNGEON_ENCOUNTERS } from "./dungeon-instance.js";
+import { getMyParty } from "./parties.js";
+import { startHorde, getActiveHorde } from "./horde-mode.js";
+import { startRun as startExtraction, getActiveRun as getActiveExtraction } from "./extraction.js";
+import { runParticipants } from "./run-coop.js";
 
 export function handleGiftGive(db, userId, data = {}) {
   const npcId = String(data.npcId || "");
@@ -116,6 +120,62 @@ export function handleDungeonOpen(db, userId, data = {}) {
   return { ok: true, source: "presenter", encounterId, boss: catalog };
 }
 
+export function handleRunStart(db, userId, data = {}) {
+  const kind = String(data.kind || data.mode || "").toLowerCase();
+  const worldId = String(data.worldId || "concordia-hub");
+  if (!userId) return { ok: false, reason: "missing_user" };
+  if (kind !== "horde" && kind !== "extraction") return { ok: false, reason: "unknown_kind" };
+  if (!db) return { ok: false, reason: "no_db" };
+
+  let partyId = data.partyId ? String(data.partyId) : "";
+  if (!partyId) {
+    try {
+      const mine = getMyParty(db, userId);
+      if (mine?.party_id) partyId = mine.party_id;
+    } catch { /* parties table optional */ }
+  }
+  partyId = partyId || null;
+
+  try {
+    if (kind === "horde") {
+      const r = startHorde(db, userId, { worldId, partyId });
+      if (!r?.ok) return { ok: false, reason: r?.error || "start_failed", kind };
+      const run = getActiveHorde(db, userId);
+      const roster = runParticipants(db, "horde", r.runId);
+      return {
+        ok: true,
+        kind,
+        source: "kernel",
+        runId: r.runId,
+        joined: !!r.joined,
+        alreadyActive: !!r.alreadyActive,
+        partyId: r.partyId || partyId,
+        roster,
+        wave: run?.wave_reached ?? 0,
+        kills: run?.kills ?? 0,
+        score: run?.score ?? 0,
+      };
+    }
+    const r = startExtraction(db, userId, { worldId, partyId });
+    if (!r?.ok) return { ok: false, reason: r?.error || "start_failed", kind };
+    const run = getActiveExtraction(db, userId);
+    const roster = runParticipants(db, "extraction", r.runId);
+    return {
+      ok: true,
+      kind,
+      source: "kernel",
+      runId: r.runId,
+      joined: !!r.joined,
+      alreadyActive: !!r.alreadyActive,
+      partyId: r.partyId || partyId,
+      roster,
+      timeoutAt: r.timeoutAt || run?.timeout_at,
+    };
+  } catch (e) {
+    return { ok: false, reason: String(e?.message || e), kind };
+  }
+}
+
 export default {
   handleGiftGive,
   handleSchemeIntervene,
@@ -123,4 +183,5 @@ export default {
   handleInheritanceRequest,
   handleDodge,
   handleDungeonOpen,
+  handleRunStart,
 };

--- a/server/lib/concordia-play.js
+++ b/server/lib/concordia-play.js
@@ -1,0 +1,126 @@
+// Concordia presenter verbs on /godot-ws and /unity-ws.
+// Gift, barge-in, party snapshot, inheritance, dodge i-frames — same libs the
+// HTTP/macro paths already use. Kitchen clients (no row yet) still get the
+// authored giftReaction math; they never get a fabricated kernel consume.
+
+import { giveGift, giftReaction, GIFT_DELTA } from "./gifting.js";
+import { interveneInScheme } from "./npc-schemes.js";
+import { getInheritanceForHeir, getInheritanceFromDeceased } from "./npc-legacy.js";
+import { joinSession } from "./concordia-session.js";
+import { grantIFrames } from "./combat-state.js";
+import { openInstance, DUNGEON_ENCOUNTERS } from "./dungeon-instance.js";
+
+export function handleGiftGive(db, userId, data = {}) {
+  const npcId = String(data.npcId || "");
+  const itemId = String(data.itemId || "");
+  if (!userId || !npcId || !itemId) return { ok: false, reason: "missing_inputs" };
+  if (db) {
+    const r = giveGift(db, {
+      userId,
+      npcId,
+      itemId,
+      worldId: data.worldId ? String(data.worldId) : "concordia-hub",
+    });
+    if (r.ok) return { ...r, source: "kernel", npcId };
+    if (r.reason === "npc_not_found" || r.reason === "item_not_owned" || r.reason === "no_inventory") {
+      const reaction = giftReaction(
+        { archetype: data.archetype },
+        data.itemName || itemId,
+      );
+      return {
+        ok: true,
+        reaction,
+        delta: GIFT_DELTA[reaction],
+        affinity: null,
+        source: "kit",
+        kernel: r.reason,
+        npcId,
+      };
+    }
+    return r;
+  }
+  const reaction = giftReaction({ archetype: data.archetype }, data.itemName || itemId);
+  return { ok: true, reaction, delta: GIFT_DELTA[reaction], source: "kit" };
+}
+
+export function handleSchemeIntervene(db, userId, data = {}) {
+  const schemeId = String(data.schemeId || data.id || "");
+  const action = String(data.action || "ignore");
+  if (!userId || !schemeId) return { ok: false, reason: "missing_inputs" };
+  if (!db) return { ok: true, action, source: "presenter", schemeId };
+  try {
+    const r = interveneInScheme(db, userId, schemeId, action);
+    return { ...r, source: r.ok ? "kernel" : (r.reason || "kernel") };
+  } catch (e) {
+    const msg = String(e?.message || e);
+    if (/no such table/i.test(msg) || /npc_schemes/i.test(msg))
+      return { ok: false, reason: "scheme_not_found" };
+    return { ok: false, reason: msg };
+  }
+}
+
+export function handlePartyRequest(userId, data = {}) {
+  const worldId = String(data.worldId || "concordia-hub");
+  if (!userId) return { ok: false, reason: "missing_user" };
+  const x = Number(data.x || 0);
+  const z = Number(data.z || 0);
+  return joinSession(worldId, userId, { x, z });
+}
+
+export function handleInheritanceRequest(db, data = {}) {
+  const heirId = data.heirId ? String(data.heirId) : "";
+  const deceasedId = data.deceasedId ? String(data.deceasedId) : "";
+  if (!heirId && !deceasedId) return { ok: false, reason: "missing_inputs" };
+  if (!db) return { ok: true, links: [], source: "presenter" };
+  const links = heirId
+    ? getInheritanceForHeir(db, heirId)
+    : getInheritanceFromDeceased(db, deceasedId);
+  return { ok: true, links: Array.isArray(links) ? links : [], source: "kernel" };
+}
+
+export function handleDodge(userId, data = {}) {
+  if (!userId) return { ok: false, reason: "missing_user" };
+  const perfect = data.perfect === true || data.wasParry === true;
+  const ms = perfect ? 500 : 350;
+  try { grantIFrames(userId, ms); } catch { /* in-memory optional */ }
+  return { ok: true, iframeMs: ms, perfect: !!perfect };
+}
+
+export function handleDungeonOpen(db, userId, data = {}) {
+  const encounterId = String(data.encounterId || "hollow_warden");
+  const enc = DUNGEON_ENCOUNTERS[encounterId];
+  if (!enc) return { ok: false, reason: "unknown_encounter" };
+  const catalog = {
+    name: enc.name,
+    hp: enc.baseHp,
+    maxHp: enc.baseHp,
+    phase: enc.phases[0].name,
+    mechanic: enc.phases[0].mechanic,
+  };
+  if (!userId) return { ok: false, reason: "missing_user" };
+  if (db) {
+    try {
+      const r = openInstance(db, {
+        leaderUserId: userId,
+        worldId: data.worldId ? String(data.worldId) : "concordia-hub",
+        encounterId,
+        members: Array.isArray(data.members) ? data.members : [],
+      });
+      if (r.ok) return { ...r, source: "kernel" };
+      if (r.reason === "locked_out" || r.reason === "unknown_encounter") return r;
+      return { ok: true, source: "presenter", encounterId, boss: catalog, kernel: r.reason };
+    } catch (e) {
+      return { ok: true, source: "presenter", encounterId, boss: catalog, kernel: String(e?.message || e) };
+    }
+  }
+  return { ok: true, source: "presenter", encounterId, boss: catalog };
+}
+
+export default {
+  handleGiftGive,
+  handleSchemeIntervene,
+  handlePartyRequest,
+  handleInheritanceRequest,
+  handleDodge,
+  handleDungeonOpen,
+};

--- a/server/lib/concordia-play.js
+++ b/server/lib/concordia-play.js
@@ -8,7 +8,9 @@ import { interveneInScheme } from "./npc-schemes.js";
 import { getInheritanceForHeir, getInheritanceFromDeceased } from "./npc-legacy.js";
 import { joinSession } from "./concordia-session.js";
 import { grantIFrames } from "./combat-state.js";
-import { openInstance, DUNGEON_ENCOUNTERS } from "./dungeon-instance.js";
+import { openInstance, recordHit, DUNGEON_ENCOUNTERS } from "./dungeon-instance.js";
+import { mintMatchChronicle } from "./combat/match-chronicle.js";
+import { defeatBoss } from "./world-bosses.js";
 import { getMyParty } from "./parties.js";
 import { startHorde, getActiveHorde } from "./horde-mode.js";
 import { startRun as startExtraction, getActiveRun as getActiveExtraction } from "./extraction.js";
@@ -133,6 +135,44 @@ export function handleDungeonOpen(db, userId, data = {}) {
   return { ok: true, source: "presenter", encounterId, boss: catalog };
 }
 
+/**
+ * Thin presenter verb for the existing dungeon-instance recordHit.
+ * No second boss engine — HP / phase / clear already live in the instance row.
+ */
+export function handleDungeonHit(db, userId, data = {}) {
+  const instanceId = String(data.instanceId || "");
+  if (!userId) return { ok: false, reason: "missing_user" };
+  if (!instanceId) return { ok: false, reason: "missing_instance" };
+  if (!db) return { ok: false, reason: "no_db" };
+  try {
+    const r = recordHit(db, instanceId, userId, data.damage);
+    if (!r?.ok) return r;
+    const encounterId = String(data.encounterId || "");
+    const enc = DUNGEON_ENCOUNTERS[encounterId];
+    const mechanic = enc && Number.isInteger(r.phaseIdx) ? (enc.phases[r.phaseIdx]?.mechanic || "") : "";
+    if (r.cleared) {
+      try {
+        mintMatchChronicle(db, {
+          winnerId: userId,
+          loserId: encounterId || instanceId,
+          endedReason: "kill",
+          worldId: data.worldId ? String(data.worldId) : "concordia-hub",
+        });
+      } catch { /* chronicle optional */ }
+      const activeId = String(data.activeId || "");
+      if (activeId) {
+        try { defeatBoss(db, { activeId, participantUserIds: [userId] }); }
+        catch { /* world-boss row optional */ }
+      }
+    }
+    return { ...r, mechanic, encounterId };
+  } catch (e) {
+    const msg = String(e?.message || e);
+    if (/no such table/i.test(msg)) return { ok: false, reason: "unavailable" };
+    return { ok: false, reason: msg };
+  }
+}
+
 export function handleRunStart(db, userId, data = {}) {
   const kind = String(data.kind || data.mode || "").toLowerCase();
   const worldId = String(data.worldId || "concordia-hub");
@@ -196,5 +236,6 @@ export default {
   handleInheritanceRequest,
   handleDodge,
   handleDungeonOpen,
+  handleDungeonHit,
   handleRunStart,
 };

--- a/server/lib/concordia-play.js
+++ b/server/lib/concordia-play.js
@@ -114,7 +114,16 @@ export function handleDungeonOpen(db, userId, data = {}) {
         encounterId,
         members: Array.isArray(data.members) ? data.members : [],
       });
-      if (r.ok) return { ...r, source: "kernel" };
+      if (r.ok) {
+        const phaseName = r.boss?.phase || enc.phases[0].name;
+        const ph = enc.phases.find((p) => p.name === phaseName) || enc.phases[0];
+        return {
+          ...r,
+          source: "kernel",
+          encounterId,
+          boss: { ...r.boss, mechanic: ph.mechanic },
+        };
+      }
       if (r.reason === "locked_out" || r.reason === "unknown_encounter") return r;
       return { ok: true, source: "presenter", encounterId, boss: catalog, kernel: r.reason };
     } catch (e) {

--- a/server/lib/creature-crossbreeding.js
+++ b/server/lib/creature-crossbreeding.js
@@ -39,6 +39,7 @@ import { fuseTwoSkills, skillFusionEnabled } from "./skill-fusion.js";
 import { deriveProfileFromBlueprint, blendMaterialProfile } from "./ecosystem/material-profiles.js";
 import { isTopologyRideable } from "./ecosystem/mount-eligibility.js";
 import { resolveVariant } from "./creature-breed-alchemy.js";
+import { announceCreatureBorn } from "./concordia-creatures.js";
 
 /**
  * WS4: derive a normalized skill descriptor { name, element, maxDamage, rangeM }
@@ -414,7 +415,12 @@ export function maybeCrossbreed(db, { a, b, environment, sameEnvironmentBonus = 
   });
   const compat = checkCompatibility({ a, b, bond: getBond(db, a.id, b.id), environment });
   if (!compat.ok) return { ok: false, ...compat };
-  return generateHybrid(db, { a, b, environment });
+  const hybrid = generateHybrid(db, { a, b, environment });
+  if (hybrid?.ok) {
+    try { announceCreatureBorn(hybrid, a.worldId || b.worldId || "concordia-hub"); }
+    catch { /* presentation optional */ }
+  }
+  return hybrid;
 }
 
 /** Read lineage for a creature — direct parents and children. */

--- a/server/lib/embodied/faction-strategy.js
+++ b/server/lib/embodied/faction-strategy.js
@@ -500,23 +500,24 @@ export function applyMove(db, factionId, picked, peerStates) {
       const _factionWorldId = resolveFactionWorldId(db, factionId);
       const _worldIdField = _factionWorldId ? { worldId: _factionWorldId } : {};
       if (picked.move === "DECLARE_WAR" || picked.move === "RAID") {
+        const _emitOpts = _factionWorldId ? { worldId: _factionWorldId } : {};
         emitFn("faction:war-declared", {
           factionId, targetFactionId: picked.target ?? null,
           move: picked.move, summary: picked.summary, moveId,
           ..._worldIdField,
-        });
+        }, _emitOpts);
       } else if (picked.move === "PROPOSE_ALLIANCE" || picked.move === "FORM_ALLIANCE") {
         emitFn("faction:alliance-formed", {
           factionId, targetFactionId: picked.target ?? null,
           summary: picked.summary, moveId,
           ..._worldIdField,
-        });
+        }, _factionWorldId ? { worldId: _factionWorldId } : {});
       } else if (picked.move === "SEEK_TRUCE") {
         emitFn("faction:truce-sought", {
           factionId, targetFactionId: picked.target ?? null,
           summary: picked.summary, moveId,
           ..._worldIdField,
-        });
+        }, _factionWorldId ? { worldId: _factionWorldId } : {});
       }
     }
   } catch { /* emit failure never affects the cycle */ }

--- a/server/lib/event-shapes.js
+++ b/server/lib/event-shapes.js
@@ -423,6 +423,11 @@ export const EVENT_SHAPES = Object.freeze({
   "faction:alliance-formed":    { required: ["factionId", "targetFactionId", "summary", "moveId"], optional: ["worldId"] },
   "faction:truce-sought":       { required: ["factionId", "targetFactionId", "summary", "moveId"], optional: ["worldId"] },
   "npc:scheme-resolved":        { required: ["schemeId", "plotterKind", "plotterId", "kind", "outcome"], optional: ["targetKind", "targetId"] },
+  // T2.1 / T2.2 / T2.3 — Unity presenter consumes these over /unity-ws.
+  // @dead-event-ok: real consumer lives in unity-client ConcordClient.cs.
+  "secret:weaponised":          { required: ["kind"], optional: ["userId", "secretId", "holder", "subject_kind", "subject_id", "schemeId", "byNpc", "ts", "worldId"] },
+  "npc:heir-rose":              { required: ["heirId", "deceasedId"], optional: ["heirName", "deceasedName", "worldId", "inherited"] },
+  "scheme:overheard":           { required: ["schemeId"], optional: ["plotterId", "worldId", "snippet", "plotterArchetype", "plotterFaction", "targetArchetype", "targetFaction", "schemeKind", "ts"] },
   "dream:composed":             { required: ["userId", "dreamRowId", "dreamDtuId", "fragmentCount"], optional: ["worldId"] },
   "prediction:realised":        { required: ["predictionId"], optional: ["userId", "subjectKind", "subjectId", "outcome"] },
   "refusal:compound-threshold": { required: ["worldId", "strength"], optional: ["kind", "reason"] },

--- a/server/lib/event-shapes.js
+++ b/server/lib/event-shapes.js
@@ -432,6 +432,12 @@ export const EVENT_SHAPES = Object.freeze({
   // Thin emit of arriveAtDestination's existing fields. @dead-event-ok:
   // Unity ConcordClient.cs walks a matching GuestNpc toward the named gate.
   "npc:migrated":               { required: ["eventId", "npcId", "fromWorld", "toWorld"], optional: ["arrivalTime", "ok", "worldId"] },
+  // Thin emit of gatherAttendees after onNpcDeath. Empty attendees stay [].
+  // @dead-event-ok: real consumer lives in unity-client ConcordClient.cs.
+  "npc:funeral":                { required: ["deceasedId", "worldId"], optional: ["deceasedName", "lastWords", "tombX", "tombZ", "attendees", "beats"] },
+  // Minted match chronicle DTU. Plaque only when chronicleId is real.
+  // @dead-event-ok: real consumer lives in unity-client ConcordClient.cs.
+  "combat:chronicle":           { required: ["chronicleId"], optional: ["title", "summary", "worldId", "winnerId", "loserId"] },
   "scheme:overheard":           { required: ["schemeId"], optional: ["plotterId", "worldId", "snippet", "plotterArchetype", "plotterFaction", "targetArchetype", "targetFaction", "schemeKind", "ts"] },
   "dream:composed":             { required: ["userId", "dreamRowId", "dreamDtuId", "fragmentCount"], optional: ["worldId"] },
   "prediction:realised":        { required: ["predictionId"], optional: ["userId", "subjectKind", "subjectId", "outcome"] },

--- a/server/lib/event-shapes.js
+++ b/server/lib/event-shapes.js
@@ -429,6 +429,9 @@ export const EVENT_SHAPES = Object.freeze({
   "npc:heir-rose":              { required: ["heirId", "deceasedId"], optional: ["heirName", "deceasedName", "worldId", "inherited", "lastWords"] },
   // Unity consequence strip — existing broke write, now visible. @dead-event-ok
   "npc:stress-break":           { required: ["npcId", "copingTrait", "stress"], optional: ["eventKind", "worldId"] },
+  // Thin emit of arriveAtDestination's existing fields. @dead-event-ok:
+  // Unity ConcordClient.cs walks a matching GuestNpc toward the named gate.
+  "npc:migrated":               { required: ["eventId", "npcId", "fromWorld", "toWorld"], optional: ["arrivalTime", "ok", "worldId"] },
   "scheme:overheard":           { required: ["schemeId"], optional: ["plotterId", "worldId", "snippet", "plotterArchetype", "plotterFaction", "targetArchetype", "targetFaction", "schemeKind", "ts"] },
   "dream:composed":             { required: ["userId", "dreamRowId", "dreamDtuId", "fragmentCount"], optional: ["worldId"] },
   "prediction:realised":        { required: ["predictionId"], optional: ["userId", "subjectKind", "subjectId", "outcome"] },

--- a/server/lib/event-shapes.js
+++ b/server/lib/event-shapes.js
@@ -438,6 +438,9 @@ export const EVENT_SHAPES = Object.freeze({
   // Thin emit of gatherAttendees after romance-engine wed(). Empty attendees stay [].
   // @dead-event-ok: real consumer lives in unity-client ConcordClient.cs.
   "npc:wedding":                { required: ["marriageId", "worldId"], optional: ["celebrantId", "partnerKind", "partnerId", "attendees", "beats"] },
+  // Thin emit of generateHybrid. Empty lineage stays generation 0 / no parents.
+  // @dead-event-ok: real consumer lives in unity-client ConcordClient.cs.
+  "creature:born":              { required: ["childId", "worldId"], optional: ["id", "speciesId", "topology", "massKg", "heightM", "generation", "parentA", "parentB", "dominant", "variant", "affinity", "gaitKind", "walkMps", "lifestyle", "predator", "fly", "stability", "x", "y", "z"] },
   // Minted match chronicle DTU. Plaque only when chronicleId is real.
   // @dead-event-ok: real consumer lives in unity-client ConcordClient.cs.
   "combat:chronicle":           { required: ["chronicleId"], optional: ["title", "summary", "worldId", "winnerId", "loserId"] },

--- a/server/lib/event-shapes.js
+++ b/server/lib/event-shapes.js
@@ -435,6 +435,9 @@ export const EVENT_SHAPES = Object.freeze({
   // Thin emit of gatherAttendees after onNpcDeath. Empty attendees stay [].
   // @dead-event-ok: real consumer lives in unity-client ConcordClient.cs.
   "npc:funeral":                { required: ["deceasedId", "worldId"], optional: ["deceasedName", "lastWords", "tombX", "tombZ", "attendees", "beats"] },
+  // Thin emit of gatherAttendees after romance-engine wed(). Empty attendees stay [].
+  // @dead-event-ok: real consumer lives in unity-client ConcordClient.cs.
+  "npc:wedding":                { required: ["marriageId", "worldId"], optional: ["celebrantId", "partnerKind", "partnerId", "attendees", "beats"] },
   // Minted match chronicle DTU. Plaque only when chronicleId is real.
   // @dead-event-ok: real consumer lives in unity-client ConcordClient.cs.
   "combat:chronicle":           { required: ["chronicleId"], optional: ["title", "summary", "worldId", "winnerId", "loserId"] },

--- a/server/lib/event-shapes.js
+++ b/server/lib/event-shapes.js
@@ -426,7 +426,9 @@ export const EVENT_SHAPES = Object.freeze({
   // T2.1 / T2.2 / T2.3 — Unity presenter consumes these over /unity-ws.
   // @dead-event-ok: real consumer lives in unity-client ConcordClient.cs.
   "secret:weaponised":          { required: ["kind"], optional: ["userId", "secretId", "holder", "subject_kind", "subject_id", "schemeId", "byNpc", "ts", "worldId"] },
-  "npc:heir-rose":              { required: ["heirId", "deceasedId"], optional: ["heirName", "deceasedName", "worldId", "inherited"] },
+  "npc:heir-rose":              { required: ["heirId", "deceasedId"], optional: ["heirName", "deceasedName", "worldId", "inherited", "lastWords"] },
+  // Unity consequence strip — existing broke write, now visible. @dead-event-ok
+  "npc:stress-break":           { required: ["npcId", "copingTrait", "stress"], optional: ["eventKind", "worldId"] },
   "scheme:overheard":           { required: ["schemeId"], optional: ["plotterId", "worldId", "snippet", "plotterArchetype", "plotterFaction", "targetArchetype", "targetFaction", "schemeKind", "ts"] },
   "dream:composed":             { required: ["userId", "dreamRowId", "dreamDtuId", "fragmentCount"], optional: ["worldId"] },
   "prediction:realised":        { required: ["predictionId"], optional: ["userId", "subjectKind", "subjectId", "outcome"] },

--- a/server/lib/extraction.js
+++ b/server/lib/extraction.js
@@ -8,7 +8,7 @@
 
 import crypto from "node:crypto";
 import logger from "../logger.js";
-import { addRunParticipant, findActivePartyRun } from "./run-coop.js";
+import { addRunParticipant, findActivePartyRun, findActiveRunForUser } from "./run-coop.js";
 import { grantRunMeta } from "./run-difficulty.js";
 import { dreadFromDistance, tensionBand, TERROR_RADIUS_M } from "./horror-dread.js";
 
@@ -197,9 +197,7 @@ export function extractionDanger(db, runId, opts = {}) {
 export function getActiveRun(db, userId) {
   if (!db || !userId) return null;
   try {
-    return db.prepare(`
-      SELECT * FROM extraction_runs WHERE user_id = ? AND ended_at IS NULL
-    `).get(userId) || null;
+    return findActiveRunForUser(db, "extraction_runs", "extraction", userId);
   } catch { return null; }
 }
 

--- a/server/lib/gateway-fanout.js
+++ b/server/lib/gateway-fanout.js
@@ -1,0 +1,15 @@
+// server/lib/gateway-fanout.js
+//
+// Modules that still broadcast on `REALTIME.io.emit` (socket.io-only) would
+// otherwise never reach `/godot-ws` or `/unity-ws`. `realtimeEmit` cannot be
+// substituted blindly — it would double-fire socket.io for those callers.
+// This hook is gateway-only. server.js assigns `globalThis._concordGatewayMirror`
+// next to the two gateway emitters. A missing hook is a silent no-op so unit
+// tests of weather/clock without a boot still pass.
+
+export function mirrorToGateways(event, payload, opts = {}) {
+  try {
+    const fn = globalThis._concordGatewayMirror;
+    if (typeof fn === "function") fn(event, payload, opts);
+  } catch { /* survive */ }
+}

--- a/server/lib/gifting.js
+++ b/server/lib/gifting.js
@@ -83,9 +83,9 @@ function tableExists(db, name) {
 }
 
 /**
- * Give an NPC a gift: consume one of the item from the player's inventory in
- * this world, compute the reaction, and shift courtship affinity accordingly.
- * Per-world inventory invariant respected (scoped by user_id + world_id).
+ * Give an NPC a gift: consume one stack of the item from the player's
+ * inventory, compute the reaction, and shift courtship affinity accordingly.
+ * Inventory reads are user-global (world_id is acquisition metadata only).
  * Returns { ok, reaction, delta, affinity, status } or { ok:false, reason }.
  */
 export function giveGift(db, { userId, npcId, itemId, worldId = "concordia-hub" }) {
@@ -100,12 +100,13 @@ export function giveGift(db, { userId, npcId, itemId, worldId = "concordia-hub" 
   } catch { /* world_npcs optional */ }
   if (!npc) return { ok: false, reason: "npc_not_found" };
 
-  // Find a stack of the item the player owns in this world (oldest first).
+  // Inventory is user-global — world_id is acquisition metadata, never a
+  // visibility filter (player_inventory_user_global).
   const slot = db.prepare(`
     SELECT id, item_name, quantity FROM player_inventory
-    WHERE user_id = ? AND item_id = ? AND COALESCE(world_id, 'concordia-hub') = ?
+    WHERE user_id = ? AND item_id = ?
     ORDER BY acquired_at ASC LIMIT 1
-  `).get(userId, itemId, worldId);
+  `).get(userId, itemId);
   if (!slot || slot.quantity <= 0) return { ok: false, reason: "item_not_owned" };
 
   const reaction = giftReaction(npc, slot.item_name || itemId);

--- a/server/lib/godot-gateway.js
+++ b/server/lib/godot-gateway.js
@@ -536,13 +536,14 @@ function isBinaryMovePayload(p) {
         };
         try {
           const result = await runMacro(domain, name, input, ctx);
-          send(
-            client.ws,
-            "lens:result",
-            result && typeof result === "object"
-              ? result
-              : { ok: false, reason: "lens_run_failed" },
-          );
+          const payload = result && typeof result === "object"
+            ? result
+            : { ok: false, reason: "lens_run_failed" };
+          send(client.ws, "lens:result", {
+            ...payload,
+            lensDomain: domain,
+            lensName: name,
+          });
         } catch (e) {
           const msg = String(e?.message || e);
           send(client.ws, "lens:result", {

--- a/server/lib/godot-gateway.js
+++ b/server/lib/godot-gateway.js
@@ -36,6 +36,8 @@ import {
 } from "./concordia-play.js";
 import { getWeather } from "./weather.js";
 import { getWorldPhase, getDayPhase, WORLD_CLOCK_CONSTANTS } from "./world-clock.js";
+import { getVillageGossipFeed } from "./npc-relationships.js";
+import { getTombsForWorld } from "./npc-legacy.js";
 
 const ROOM_RE = /^(world|user):[A-Za-z0-9_.-]{1,64}$/;
 
@@ -478,6 +480,8 @@ function isBinaryMovePayload(p) {
         try {
           const phase = getWorldPhase();
           const weather = getWeather(worldId);
+          const gossipRows = getVillageGossipFeed(db, worldId, { limit: 8 }) || [];
+          const tombRows = getTombsForWorld(db, worldId, 8) || [];
           send(client.ws, "world:snapshot", {
             ok: true,
             worldId,
@@ -494,6 +498,17 @@ function isBinaryMovePayload(p) {
                   since: weather.since,
                 }
               : null,
+            gossip: gossipRows.map((r) => ({
+              summary: r.summary || "",
+              kind: r.event_kind || "",
+              relation: r.relationship_kind || "",
+            })),
+            tombs: tombRows.map((r) => ({
+              npcId: r.npc_id || "",
+              lastWords: r.last_words || "",
+              x: r.tomb_x,
+              z: r.tomb_z,
+            })),
           });
         } catch (e) {
           send(client.ws, "world:snapshot", {

--- a/server/lib/godot-gateway.js
+++ b/server/lib/godot-gateway.js
@@ -32,6 +32,7 @@ import {
   handleInheritanceRequest,
   handleDodge,
   handleDungeonOpen,
+  handleDungeonHit,
   handleRunStart,
 } from "./concordia-play.js";
 import { getWeather } from "./weather.js";
@@ -458,6 +459,12 @@ function isBinaryMovePayload(p) {
       case "dungeon:open": {
         const result = handleDungeonOpen(db, client.userId, data);
         send(client.ws, "dungeon:data", result);
+        return;
+      }
+
+      case "dungeon:hit": {
+        const result = handleDungeonHit(db, client.userId, data);
+        send(client.ws, "dungeon:hit:ack", result);
         return;
       }
 

--- a/server/lib/godot-gateway.js
+++ b/server/lib/godot-gateway.js
@@ -48,6 +48,12 @@ const nextClientId = () => `godot_${Date.now().toString(36)}_${(++_clientCounter
  * @param {(userId:string)=>({id:string,username?:string}|null|Promise)} deps.getUser REQUIRED — resolves a user record.
  * @param {(db:any, worldId:string)=>object} [deps.exportScene]  scene:request handler; omit → honest scene_export_unavailable.
  * @param {(db:any, worldId:string)=>object} [deps.exportKingdom]  kingdom:request handler; omit → honest kingdom_export_unavailable.
+ * @param {(domain:string, name:string, input:object, ctx:object)=>object|Promise<object>} [deps.runMacro]
+ *   lens:run handler. MUST be the real `runMacro` (or the HTTP-identical
+ *   LENS_ACTIONS-then-runMacro wrapper). The gateway does NOT reimplement
+ *   publicReadDomains or Chicken2 — those gates live inside runMacro. Omit →
+ *   honest `lens_run_unavailable`. Never call without an actor: runMacro
+ *   defaults a missing actor to `{role:"system", internal:true}`.
  * @param {(input:object)=>object|Promise<object>} [deps.composeDialogue]  dialogue:request → Concord 2B; omit → built-in composeTwoBDialogue.
  * @param {any} [deps.db]  passed verbatim to exportScene / exportKingdom.
  * @param {string} [deps.path="/godot-ws"]  upgrade path this gateway claims.
@@ -67,6 +73,7 @@ export function mountGodotGateway(httpServer, deps = {}) {
     getUser,
     exportScene,
     exportKingdom,
+    runMacro,
     composeDialogue = composeTwoBDialogue,
     db = null,
     path = "/godot-ws",
@@ -445,6 +452,62 @@ function isBinaryMovePayload(p) {
       case "dungeon:open": {
         const result = handleDungeonOpen(db, client.userId, data);
         send(client.ws, "dungeon:data", result);
+        return;
+      }
+
+      case "lens:run": {
+        // Phase 1 of docs/CONCORDIA_UNITY_WIRING_PLAN.md — one verb covers
+        // the entire /api/lens/* macro surface. Permission gates are the
+        // load-bearing part: this case MUST NOT reimplement Gate 2 or Gate 3.
+        // It forwards to deps.runMacro with an HTTP-shaped ctx (path
+        // `/api/lens/run`, method POST, authenticated actor) so the same
+        // three gates the REST route runs, run here. A missing actor would
+        // make runMacro default to system/internal — never omit it.
+        if (typeof runMacro !== "function") {
+          send(client.ws, "lens:result", { ok: false, reason: "lens_run_unavailable" });
+          return;
+        }
+        const domain = typeof data.domain === "string" ? data.domain : "";
+        // Same alias rule as POST /api/lens/run: `action` wins, then `name`.
+        const name = typeof data.action === "string"
+          ? data.action
+          : (typeof data.name === "string" ? data.name : "");
+        if (!domain || !name) {
+          send(client.ws, "lens:result", { ok: false, reason: "domain_and_name_required" });
+          return;
+        }
+        const input = data.input && typeof data.input === "object" && !Array.isArray(data.input)
+          ? data.input
+          : {};
+        const ctx = {
+          actor: {
+            userId: client.userId,
+            id: client.userId,
+            role: "user",
+            kind: "user",
+            scopes: ["read", "write"],
+          },
+          userId: client.userId,
+          db,
+          reqMeta: { path: "/api/lens/run", method: "POST" },
+        };
+        try {
+          const result = await runMacro(domain, name, input, ctx);
+          send(
+            client.ws,
+            "lens:result",
+            result && typeof result === "object"
+              ? result
+              : { ok: false, reason: "lens_run_failed" },
+          );
+        } catch (e) {
+          const msg = String(e?.message || e);
+          send(client.ws, "lens:result", {
+            ok: false,
+            reason: msg.startsWith("forbidden") ? "forbidden" : "lens_run_failed",
+            error: msg,
+          });
+        }
         return;
       }
 

--- a/server/lib/godot-gateway.js
+++ b/server/lib/godot-gateway.js
@@ -40,6 +40,7 @@ import { getWorldPhase, getDayPhase, WORLD_CLOCK_CONSTANTS } from "./world-clock
 import { getVillageGossipFeed } from "./npc-relationships.js";
 import { getTombsForWorld } from "./npc-legacy.js";
 import { listActiveBosses } from "./world-bosses.js";
+import { snapshotCreatures, snapshotEcology } from "./concordia-creatures.js";
 
 const ROOM_RE = /^(world|user):[A-Za-z0-9_.-]{1,64}$/;
 
@@ -528,6 +529,8 @@ function isBinaryMovePayload(p) {
             })),
             gear: snapshotGear(db, client.userId),
             chronicles: snapshotChronicles(db, worldId),
+            creatures: snapshotCreatures(db, worldId),
+            ecology: snapshotEcology(db, worldId),
           });
         } catch (e) {
           send(client.ws, "world:snapshot", {

--- a/server/lib/godot-gateway.js
+++ b/server/lib/godot-gateway.js
@@ -502,6 +502,8 @@ function isBinaryMovePayload(p) {
               summary: r.summary || "",
               kind: r.event_kind || "",
               relation: r.relationship_kind || "",
+              npcA: r.npc_a_id || "",
+              npcB: r.npc_b_id || "",
             })),
             tombs: tombRows.map((r) => ({
               npcId: r.npc_id || "",

--- a/server/lib/godot-gateway.js
+++ b/server/lib/godot-gateway.js
@@ -33,6 +33,8 @@ import {
   handleDodge,
   handleDungeonOpen,
 } from "./concordia-play.js";
+import { getWeather } from "./weather.js";
+import { getWorldPhase, getDayPhase, WORLD_CLOCK_CONSTANTS } from "./world-clock.js";
 
 const ROOM_RE = /^(world|user):[A-Za-z0-9_.-]{1,64}$/;
 
@@ -452,6 +454,47 @@ function isBinaryMovePayload(p) {
       case "dungeon:open": {
         const result = handleDungeonOpen(db, client.userId, data);
         send(client.ws, "dungeon:data", result);
+        return;
+      }
+
+      case "world:snapshot": {
+        // Phase 2 — clock + weather reads that never go through runMacro.
+        // Same public-read surface as GET /api/world/clock and
+        // GET /api/world/weather/:worldId (Gate 1 allowlisted). Authenticated
+        // WS is stricter-or-equal. Missing worldId is an honest failure, never
+        // a fabricated climate.
+        const worldId = typeof data.worldId === "string" ? data.worldId : "";
+        if (!worldId) {
+          send(client.ws, "world:snapshot", { ok: false, reason: "missing_world" });
+          return;
+        }
+        try {
+          const phase = getWorldPhase();
+          const weather = getWeather(worldId);
+          send(client.ws, "world:snapshot", {
+            ok: true,
+            worldId,
+            clock: {
+              phase,
+              segment: getDayPhase(phase),
+              dayLengthMs: WORLD_CLOCK_CONSTANTS.dayLengthMs,
+            },
+            weather: weather && typeof weather === "object"
+              ? {
+                  type: weather.type,
+                  intensity: weather.intensity,
+                  windDirection: weather.windDirection,
+                  since: weather.since,
+                }
+              : null,
+          });
+        } catch (e) {
+          send(client.ws, "world:snapshot", {
+            ok: false,
+            reason: "snapshot_failed",
+            error: String(e?.message || e),
+          });
+        }
         return;
       }
 

--- a/server/lib/godot-gateway.js
+++ b/server/lib/godot-gateway.js
@@ -32,6 +32,7 @@ import {
   handleInheritanceRequest,
   handleDodge,
   handleDungeonOpen,
+  handleRunStart,
 } from "./concordia-play.js";
 import { getWeather } from "./weather.js";
 import { getWorldPhase, getDayPhase, WORLD_CLOCK_CONSTANTS } from "./world-clock.js";
@@ -454,6 +455,12 @@ function isBinaryMovePayload(p) {
       case "dungeon:open": {
         const result = handleDungeonOpen(db, client.userId, data);
         send(client.ws, "dungeon:data", result);
+        return;
+      }
+
+      case "run:start": {
+        const result = handleRunStart(db, client.userId, data);
+        send(client.ws, "run:data", result);
         return;
       }
 

--- a/server/lib/godot-gateway.js
+++ b/server/lib/godot-gateway.js
@@ -25,6 +25,14 @@ import { encodeFrame, decodeFrame, isBinaryFrame, encodeMove, decodeMove } from 
 import { WebSocketServer } from "ws";
 import { makeSocketRateLimiter } from "./socket-rate-limit.js";
 import { composeTwoBDialogue } from "./concordia-two-b.js";
+import {
+  handleGiftGive,
+  handleSchemeIntervene,
+  handlePartyRequest,
+  handleInheritanceRequest,
+  handleDodge,
+  handleDungeonOpen,
+} from "./concordia-play.js";
 
 const ROOM_RE = /^(world|user):[A-Za-z0-9_.-]{1,64}$/;
 
@@ -401,6 +409,42 @@ function isBinaryMovePayload(p) {
           return;
         }
         send(client.ws, "kingdom:data", kingdom);
+        return;
+      }
+
+      case "gift:give": {
+        const result = handleGiftGive(db, client.userId, data);
+        send(client.ws, "gift:result", result);
+        return;
+      }
+
+      case "scheme:intervene": {
+        const result = handleSchemeIntervene(db, client.userId, data);
+        send(client.ws, "scheme:intervened", result);
+        return;
+      }
+
+      case "party:request": {
+        const result = handlePartyRequest(client.userId, data);
+        send(client.ws, "party:data", result);
+        return;
+      }
+
+      case "inheritance:request": {
+        const result = handleInheritanceRequest(db, data);
+        send(client.ws, "inheritance:data", result);
+        return;
+      }
+
+      case "combat:dodge": {
+        const result = handleDodge(client.userId, data);
+        send(client.ws, "combat:dodge:ack", result);
+        return;
+      }
+
+      case "dungeon:open": {
+        const result = handleDungeonOpen(db, client.userId, data);
+        send(client.ws, "dungeon:data", result);
         return;
       }
 

--- a/server/lib/godot-gateway.js
+++ b/server/lib/godot-gateway.js
@@ -38,6 +38,7 @@ import { getWeather } from "./weather.js";
 import { getWorldPhase, getDayPhase, WORLD_CLOCK_CONSTANTS } from "./world-clock.js";
 import { getVillageGossipFeed } from "./npc-relationships.js";
 import { getTombsForWorld } from "./npc-legacy.js";
+import { listActiveBosses } from "./world-bosses.js";
 
 const ROOM_RE = /^(world|user):[A-Za-z0-9_.-]{1,64}$/;
 
@@ -482,6 +483,7 @@ function isBinaryMovePayload(p) {
           const weather = getWeather(worldId);
           const gossipRows = getVillageGossipFeed(db, worldId, { limit: 8 }) || [];
           const tombRows = getTombsForWorld(db, worldId, 8) || [];
+          const bossRows = listActiveBosses(db, worldId) || [];
           send(client.ws, "world:snapshot", {
             ok: true,
             worldId,
@@ -511,6 +513,14 @@ function isBinaryMovePayload(p) {
               x: r.tomb_x,
               z: r.tomb_z,
             })),
+            bosses: bossRows.map((r) => ({
+              activeId: r.id || "",
+              scheduleId: r.schedule_id || "",
+              bossTemplate: r.boss_template || "",
+              difficultyTier: r.difficulty_tier || "",
+            })),
+            gear: snapshotGear(db, client.userId),
+            chronicles: snapshotChronicles(db, worldId),
           });
         } catch (e) {
           send(client.ws, "world:snapshot", {
@@ -736,6 +746,79 @@ function isBinaryMovePayload(p) {
     clients,
     getSeq: () => gatewaySeq,
   };
+}
+
+/** Read-only equipped affixes. Never inserts a default loadout row. Empty stays []. */
+function snapshotGear(db, userId) {
+  if (!db || !userId) return [];
+  try {
+    const row = db.prepare(`SELECT * FROM player_equipment WHERE user_id = ?`).get(userId);
+    if (!row) return [];
+    const slots = [
+      ["rightHand", row.right_hand_id],
+      ["leftHand", row.left_hand_id],
+      ["head", row.head_id],
+      ["body", row.body_id],
+      ["accessory", row.accessory_id],
+    ];
+    const items = [];
+    for (const [slot, invId] of slots) {
+      if (!invId) continue;
+      const it = db.prepare(
+        `SELECT id, item_name, affixes_json FROM player_inventory WHERE id = ? AND user_id = ?`,
+      ).get(invId, userId);
+      if (!it) continue;
+      let affixes = [];
+      try {
+        const parsed = JSON.parse(it.affixes_json || "[]");
+        if (Array.isArray(parsed)) {
+          affixes = parsed.map((a) => ({
+            id: a.id || "",
+            label: a.label || "",
+            stat: a.stat || "",
+            value: a.value,
+            element: a.element || null,
+          }));
+        }
+      } catch { affixes = []; }
+      items.push({
+        id: String(it.id),
+        name: it.item_name || "",
+        slot,
+        affixes,
+      });
+    }
+    return items;
+  } catch { return []; }
+}
+
+/** Recent match chronicles for this world. Empty stays []. */
+function snapshotChronicles(db, worldId) {
+  if (!db || !worldId) return [];
+  try {
+    const rows = db.prepare(`
+      SELECT id, title, content FROM dtus
+      WHERE content_type = 'match_chronicle'
+      ORDER BY rowid DESC LIMIT 8
+    `).all();
+    const tag = `world:${worldId}`;
+    const out = [];
+    for (const r of rows) {
+      let summary = "";
+      let blob = "";
+      try {
+        const content = typeof r.content === "string" ? JSON.parse(r.content) : r.content;
+        summary = content?.human?.summary || "";
+        blob = typeof r.content === "string" ? r.content : JSON.stringify(content || {});
+      } catch {
+        blob = String(r.content || "");
+      }
+      if (!blob.includes(worldId) && !blob.includes(tag) && !(r.title || "").includes(worldId)) continue;
+      out.push({ id: r.id, title: r.title || "", summary });
+      if (out.length >= 4) break;
+    }
+    return out;
+  } catch { return []; }
 }
 
 /**

--- a/server/lib/horde-mode.js
+++ b/server/lib/horde-mode.js
@@ -21,6 +21,7 @@
 
 import crypto from "node:crypto";
 import logger from "../logger.js";
+import { addRunParticipant, findActivePartyRun, findActiveRunForUser } from "./run-coop.js";
 import { grantRunMeta } from "./run-difficulty.js";
 import { rollDraft, recordPick, getRunModifiers, nearSynergyHints } from "./run-draft.js";
 
@@ -56,20 +57,38 @@ export function spawnRateAtWave(wave) {
 
 export function startHorde(db, userId, opts = {}) {
   if (!db || !userId) return { ok: false, error: "missing_inputs" };
-  const { worldId } = opts;
+  const { worldId, partyId = null } = opts;
   if (!worldId) return { ok: false, error: "missing_worldId" };
   try {
     const active = db.prepare(`
       SELECT id FROM horde_runs WHERE user_id = ? AND ended_at IS NULL
     `).get(userId);
-    if (active) return { ok: true, runId: active.id, alreadyActive: true };
+    if (active) {
+      addRunParticipant(db, "horde", active.id, userId);
+      return { ok: true, runId: active.id, alreadyActive: true, partyId };
+    }
+
+    if (partyId) {
+      const partyRun = findActivePartyRun(db, "horde_runs", partyId);
+      if (partyRun) {
+        addRunParticipant(db, "horde", partyRun, userId);
+        logger.info?.("horde-mode", "run_joined", { runId: partyRun, userId, partyId });
+        return { ok: true, runId: partyRun, joined: true, partyId };
+      }
+    }
 
     const id = `hrd_${crypto.randomBytes(6).toString("hex")}`;
-    db.prepare(`
-      INSERT INTO horde_runs (id, user_id, world_id) VALUES (?, ?, ?)
-    `).run(id, userId, worldId);
-    logger.info?.("horde-mode", "run_started", { runId: id, userId });
-    return { ok: true, runId: id, alreadyActive: false };
+    const hasPartyCol = db.prepare(`PRAGMA table_info(horde_runs)`).all().some((c) => c.name === "party_id");
+    if (hasPartyCol) {
+      db.prepare(`INSERT INTO horde_runs (id, user_id, world_id, party_id) VALUES (?, ?, ?, ?)`)
+        .run(id, userId, worldId, partyId);
+    } else {
+      db.prepare(`INSERT INTO horde_runs (id, user_id, world_id) VALUES (?, ?, ?)`)
+        .run(id, userId, worldId);
+    }
+    addRunParticipant(db, "horde", id, userId);
+    logger.info?.("horde-mode", "run_started", { runId: id, userId, partyId });
+    return { ok: true, runId: id, alreadyActive: false, partyId };
   } catch (err) {
     return { ok: false, error: err?.message };
   }
@@ -174,13 +193,8 @@ export function endHorde(db, runId, opts = {}) {
 export function getActiveHorde(db, userId) {
   if (!db || !userId) return null;
   try {
-    const run = db.prepare(`
-      SELECT id, world_id, started_at, wave_reached, kills, score, auto_attack
-      FROM horde_runs WHERE user_id = ? AND ended_at IS NULL
-    `).get(userId) || null;
+    const run = findActiveRunForUser(db, "horde_runs", "horde", userId);
     if (!run) return null;
-    // Wave 4 — surface the live accumulated modifier bundle alongside the run
-    // so the HUD can show real "damage +X%" numbers without a second request.
     try {
       const bundle = getRunModifiers(db, "horde", run.id);
       run.modifiers = bundle.modifiers;

--- a/server/lib/npc-legacy.js
+++ b/server/lib/npc-legacy.js
@@ -30,6 +30,7 @@ import { birthTemperament } from "./ecosystem/temperament.js";
 import { DRIVE_KINDS } from "./ecosystem/drives.js";
 import { appraiseExperience } from "./felt-per.js";
 import { qualeOf } from "./qualia-space.js";
+import { gatherAttendees } from "./social-gatherings.js";
 
 // Living Society Phase 1.5c — open a settlement vacancy when a role-holder dies.
 function _openSettlementVacancyOnDeath(db, npc, opts) {
@@ -456,6 +457,30 @@ export function onNpcDeath(db, npc, opts = {}) {
         lastWords,
         worldId,
         inherited,
+      }, { worldId });
+    }
+  } catch { /* presentation optional */ }
+
+  // Thin emit of the existing funeral composition — not a new mourner engine.
+  // Empty attendees stay empty; Unity only HeadFors matching GuestNpcs.
+  try {
+    const gathering = gatherAttendees(db, { kind: "funeral", focalKind: "npc", focalId: npc.id });
+    const emit = globalThis._concordRealtimeEmit;
+    if (typeof emit === "function") {
+      const worldId = npc.world_id || "concordia-hub";
+      emit("npc:funeral", {
+        deceasedId: npc.id,
+        deceasedName: npc.name || npc.archetype || gathering.focalName || null,
+        lastWords,
+        tombX,
+        tombZ,
+        worldId,
+        attendees: (gathering.attendees || []).map((a) => ({
+          id: a.id || null,
+          name: a.name || "",
+          role: a.role || "",
+        })),
+        beats: gathering.beats || [],
       }, { worldId });
     }
   } catch { /* presentation optional */ }

--- a/server/lib/npc-legacy.js
+++ b/server/lib/npc-legacy.js
@@ -462,7 +462,7 @@ export function onNpcDeath(db, npc, opts = {}) {
   } catch { /* presentation optional */ }
 
   // Thin emit of the existing funeral composition — not a new mourner engine.
-  // Empty attendees stay empty; Unity only HeadFors matching GuestNpcs.
+  // Empty attendees stay empty; Unity Attends matching GuestNpcs at the tomb.
   try {
     const gathering = gatherAttendees(db, { kind: "funeral", focalKind: "npc", focalId: npc.id });
     const emit = globalThis._concordRealtimeEmit;

--- a/server/lib/npc-legacy.js
+++ b/server/lib/npc-legacy.js
@@ -443,6 +443,22 @@ export function onNpcDeath(db, npc, opts = {}) {
     } catch { inherited.memories = 0; }
   }
 
+  try {
+    const emit = globalThis._concordRealtimeEmit;
+    if (typeof emit === "function" && heirs.length > 0) {
+      const primary = heirs[0];
+      const worldId = npc.world_id || "concordia-hub";
+      emit("npc:heir-rose", {
+        heirId: primary.id,
+        heirName: primary.name || primary.archetype || null,
+        deceasedId: npc.id,
+        deceasedName: npc.name || npc.archetype || null,
+        worldId,
+        inherited,
+      }, { worldId });
+    }
+  } catch { /* presentation optional */ }
+
   return { ok: true, legacyId, heirs: heirs.map(h => h.id), inherited };
 }
 

--- a/server/lib/npc-legacy.js
+++ b/server/lib/npc-legacy.js
@@ -453,6 +453,7 @@ export function onNpcDeath(db, npc, opts = {}) {
         heirName: primary.name || primary.archetype || null,
         deceasedId: npc.id,
         deceasedName: npc.name || npc.archetype || null,
+        lastWords,
         worldId,
         inherited,
       }, { worldId });

--- a/server/lib/npc-quest-runner.js
+++ b/server/lib/npc-quest-runner.js
@@ -9,6 +9,7 @@
 //   listOpenAcceptable(db)                — quests no NPC has accepted yet
 
 import crypto from 'node:crypto';
+import { mirrorToGateways } from "./gateway-fanout.js";
 
 /** Returns activeQuestId on accept, null on reject. */
 export function tryAcceptQuestForNpc(db, npc, quest) {
@@ -33,7 +34,9 @@ export function tryAcceptQuestForNpc(db, npc, quest) {
 
   try {
     if (globalThis?.__CONCORD_REALTIME__?.io) {
-      globalThis.__CONCORD_REALTIME__.io.emit('npc:quest-accepted', { npcId: npc.id, questId: quest.id, activeQuestId: id });
+      const payload = { npcId: npc.id, questId: quest.id, activeQuestId: id };
+      globalThis.__CONCORD_REALTIME__.io.emit('npc:quest-accepted', payload);
+      mirrorToGateways('npc:quest-accepted', payload);
     }
   } catch { /* sockets optional */ }
 
@@ -53,7 +56,9 @@ export function advanceNpcQuest(db, activeQuestId, evidence = {}) {
     db.prepare(`UPDATE npc_active_quests SET status = 'completed', current_step = ? WHERE id = ?`).run(next, activeQuestId);
     try {
       if (globalThis?.__CONCORD_REALTIME__?.io) {
-        globalThis.__CONCORD_REALTIME__.io.emit('npc:quest-completed', { activeQuestId, npcId: row.npc_id, questId: row.quest_id });
+        const payload = { activeQuestId, npcId: row.npc_id, questId: row.quest_id };
+        globalThis.__CONCORD_REALTIME__.io.emit('npc:quest-completed', payload);
+        mirrorToGateways('npc:quest-completed', payload);
       }
     } catch { /* sockets optional */ }
     return { completed: true, step: next };

--- a/server/lib/npc-simulator.js
+++ b/server/lib/npc-simulator.js
@@ -32,6 +32,7 @@ import { resolveAggro, temperamentEnabled } from "./npc-temperament.js";
 import { targetRung, stepRung, isEngaged, barkFor } from "./temperament-ladder.js";
 import { bountyTier, arrestOffer, wantedLevelFor } from "./authority-heat.js";
 import { LruMap, LruSet } from "./lru-map.js";
+import { mirrorToGateways } from "./gateway-fanout.js";
 
 // ──────────────────────────────────────────────────────────────────────────────
 // NPC Combat AI — state machine for alert/pursue/attack/retreat behavior
@@ -620,13 +621,9 @@ function _emitGather(npc, worldId, gathered) {
   if (!gathered) return;
   try {
     const io = globalThis._concordREALTIME?.io;
-    io?.to(`world:${worldId}`).emit('world:npc-gather', {
+    const gatherPayload = {
       worldId,
       npcId:        npc.id,
-      // Node position, NOT npc.location — the tool-swing/particle burst
-      // should land at the resource node the NPC is actually gathering
-      // from, which can be up to 30m away (getNearbyNodes' search radius),
-      // not "wherever the NPC happens to be standing" per npc.location.
       x:            gathered.x,
       y:            gathered.y,
       z:            gathered.z,
@@ -635,7 +632,9 @@ function _emitGather(npc, worldId, gathered) {
       resourceId:   gathered.resourceId,
       resourceName: gathered.resourceName,
       amount:       gathered.amount,
-    });
+    };
+    io?.to(`world:${worldId}`).emit('world:npc-gather', gatherPayload);
+    mirrorToGateways("world:npc-gather", gatherPayload, { worldId });
   } catch { /* non-fatal */ }
 }
 

--- a/server/lib/npc-skill-progression.js
+++ b/server/lib/npc-skill-progression.js
@@ -16,6 +16,7 @@
 // user_skills. A level-10 NPC has ~3162 XP banked.
 
 import crypto from 'node:crypto';
+import { mirrorToGateways } from "./gateway-fanout.js";
 
 const XP_CURVE_FACTOR = 100;
 const XP_CURVE_EXP    = 1.5;
@@ -49,9 +50,9 @@ export function awardNpcXp(db, npcId, skillId, xp) {
   if (newLevel > prevLevel) {
     try {
       if (globalThis?.__CONCORD_REALTIME__?.io) {
-        globalThis.__CONCORD_REALTIME__.io.emit('npc:level-up', {
-          npcId, skillId, level: newLevel, xp: newXp,
-        });
+        const payload = { npcId, skillId, level: newLevel, xp: newXp };
+        globalThis.__CONCORD_REALTIME__.io.emit('npc:level-up', payload);
+        mirrorToGateways('npc:level-up', payload);
       }
     } catch { /* sockets are optional */ }
   }

--- a/server/lib/npc-stress.js
+++ b/server/lib/npc-stress.js
@@ -95,6 +95,21 @@ export function bumpStress(db, npcId, eventKind, magnitudeOverride = null) {
       WHERE npc_id = ?
     `).run(next, copingTrait, now, copingUntil, npcId);
     try { logger.info?.("npc_stress_break", { npcId, eventKind, stress: next, copingTrait }); } catch { /* noop */ }
+    try {
+      const emit = globalThis._concordRealtimeEmit;
+      if (typeof emit === "function") {
+        let worldId;
+        try { worldId = db.prepare(`SELECT world_id FROM world_npcs WHERE id = ?`).get(npcId)?.world_id; }
+        catch { worldId = null; }
+        emit("npc:stress-break", {
+          npcId,
+          copingTrait,
+          stress: next,
+          eventKind,
+          ...(worldId ? { worldId } : {}),
+        }, worldId ? { worldId } : {});
+      }
+    } catch { /* presentation optional */ }
   } else {
     db.prepare(`
       UPDATE npc_stress SET stress = ?, updated_at = unixepoch() WHERE npc_id = ?

--- a/server/lib/population-migration.js
+++ b/server/lib/population-migration.js
@@ -126,14 +126,36 @@ export function arriveAtDestination(db, eventId, opts = {}) {
   });
   tx();
 
-  return {
+  const result = {
     ok: true,
-    eventId,
+    eventId: String(eventId),
     npcId: event.npc_id,
     fromWorld: event.from_world_id,
     toWorld: event.to_world_id,
     arrivalTime,
   };
+  try {
+    const emit = globalThis._concordRealtimeEmit;
+        if (typeof emit === "function") {
+          // Thin emit of fields this function already returns. Destination
+          // first so the arrival world can present it; origin second so a
+          // hub player can see someone walk a named gate. @dead-event-ok:
+          // Unity ConcordClient.cs consumes npc:migrated.
+          const payload = {
+            ok: true,
+            eventId: String(eventId),
+            npcId: event.npc_id,
+            fromWorld: event.from_world_id,
+            toWorld: event.to_world_id,
+            arrivalTime,
+          };
+          emit("npc:migrated", payload, { worldId: event.to_world_id });
+          if (event.from_world_id && event.from_world_id !== event.to_world_id) {
+            emit("npc:migrated", payload, { worldId: event.from_world_id });
+          }
+        }
+  } catch { /* presentation optional */ }
+  return result;
 }
 
 // ── Sweep helpers for the heartbeat ───────────────────────────────

--- a/server/lib/romance-engine.js
+++ b/server/lib/romance-engine.js
@@ -16,6 +16,7 @@
 
 import crypto from "node:crypto";
 import { checkHeartEvent } from "./heart-events.js";
+import { gatherAttendees } from "./social-gatherings.js";
 
 const COURT_AFFINITY_DELTA = 0.05;
 const ENGAGE_THRESHOLD     = 0.70;
@@ -111,6 +112,34 @@ export function wed(db, playerUserId, partnerKind, partnerId) {
     `).run(playerUserId, partnerKind, partnerId);
   });
   tx();
+
+  // Thin emit of the existing wedding composition — not a new guest engine.
+  // Empty attendees stay empty; Unity only Attends matching GuestNpcs.
+  try {
+    const gathering = gatherAttendees(db, { kind: "wedding", focalKind: "player", focalId: playerUserId });
+    const emit = globalThis._concordRealtimeEmit;
+    if (typeof emit === "function") {
+      let worldId = "concordia-hub";
+      try {
+        const row = db.prepare("SELECT world_id FROM city_presence WHERE user_id = ? LIMIT 1").get(playerUserId);
+        if (row && row.world_id) worldId = String(row.world_id);
+      } catch { /* presence optional */ }
+      emit("npc:wedding", {
+        marriageId,
+        celebrantId: playerUserId,
+        partnerKind,
+        partnerId,
+        worldId,
+        attendees: (gathering.attendees || []).map((a) => ({
+          id: a.id || null,
+          name: a.name || "",
+          role: a.role || "",
+        })),
+        beats: gathering.beats || [],
+      }, { worldId });
+    }
+  } catch { /* presentation optional */ }
+
   return { ok: true, marriageId, status: "married" };
 }
 

--- a/server/lib/run-coop.js
+++ b/server/lib/run-coop.js
@@ -19,6 +19,29 @@ export function addRunParticipant(db, runKind, runId, userId) {
   return { ok: true };
 }
 
+/**
+ * Active run the user owns OR joined via run_participants. Owner row wins.
+ * `runTable` is extraction_runs / horde_runs. Returns the row or null.
+ */
+export function findActiveRunForUser(db, runTable, runKind, userId) {
+  if (!db || !userId || !runTable || !tableExists(db, runTable)) return null;
+  try {
+    const owned = db.prepare(
+      `SELECT * FROM ${runTable} WHERE user_id = ? AND ended_at IS NULL`
+    ).get(userId);
+    if (owned) return owned;
+    if (!tableExists(db, "run_participants")) return null;
+    return db.prepare(`
+      SELECT r.* FROM ${runTable} r
+      JOIN run_participants p ON p.run_id = r.id AND p.run_kind = ?
+      WHERE p.user_id = ? AND r.ended_at IS NULL
+      ORDER BY r.rowid DESC LIMIT 1
+    `).get(runKind, userId) || null;
+  } catch {
+    return null;
+  }
+}
+
 /** The user ids sharing a run. */
 export function runParticipants(db, runKind, runId) {
   if (!db || !tableExists(db, "run_participants")) return [];

--- a/server/lib/seasons.js
+++ b/server/lib/seasons.js
@@ -10,6 +10,7 @@
 
 import crypto from "node:crypto";
 import logger from "../logger.js";
+import { mirrorToGateways } from "./gateway-fanout.js";
 
 export const SEASONS = Object.freeze([
   { idx: 0, name: "spring",   tempBias: -2,  humidityBias: +5,  lightBias: 0,    narrative: "Spring breaks the lockstep of winter; herbs come back to the grove." },
@@ -105,16 +106,18 @@ export function advanceSeasonForWorld(db, worldId, opts = {}) {
 
   // Realtime: emit world:season-transition. Best-effort.
   try {
+    const seasonPayload = {
+      worldId,
+      seasonIdx: expected.idx,
+      seasonName: expected.name,
+      year: expectedYear,
+      narrative: expected.narrative,
+      ts: Date.now(),
+    };
     if (globalThis?.__CONCORD_REALTIME__?.io) {
-      globalThis.__CONCORD_REALTIME__.io.to(`world:${worldId}`).emit("world:season-transition", {
-        worldId,
-        seasonIdx: expected.idx,
-        seasonName: expected.name,
-        year: expectedYear,
-        narrative: expected.narrative,
-        ts: Date.now(),
-      });
+      globalThis.__CONCORD_REALTIME__.io.to(`world:${worldId}`).emit("world:season-transition", seasonPayload);
     }
+    mirrorToGateways("world:season-transition", seasonPayload, { worldId });
   } catch { /* socket optional */ }
 
   return { ok: true, transitioned: true, season: expected.name, year: expectedYear, narrative: expected.narrative };

--- a/server/lib/secrets.js
+++ b/server/lib/secrets.js
@@ -19,6 +19,7 @@ import crypto from "node:crypto";
 import logger from "../logger.js";
 import { recordOpinionEvent } from "./npc-opinions.js";
 import { seedRumor } from "./social/gossip.js";
+import { mirrorToGateways } from "./gateway-fanout.js";
 
 const KIND_FALLBACK = "grudge_origin";
 
@@ -161,6 +162,25 @@ export function discoverSecret(db, userId, secretId, via = "dialogue") {
     } catch { /* gossip optional — never block discovery */ }
   }
   return { ok: true, action: r.changes > 0 ? "discovered" : "already_known", secret: exists };
+}
+
+/**
+ * Fan `secret:weaponised` to socket.io AND /unity-ws. Prefer the realtime
+ * emit hook (already mirrored); fall back to io + gateway-only mirror so
+ * unit tests without a boot still observe the event.
+ */
+export function fanSecretWeaponised(payload, { worldId = null, io = null } = {}) {
+  const body = payload && typeof payload === "object" ? payload : {};
+  try {
+    const emit = globalThis._concordRealtimeEmit;
+    if (typeof emit === "function") {
+      emit("secret:weaponised", body, worldId ? { worldId } : {});
+      return;
+    }
+    if (worldId) io?.to?.(`world:${worldId}`)?.emit?.("secret:weaponised", body);
+    else io?.emit?.("secret:weaponised", body);
+    mirrorToGateways("secret:weaponised", body, worldId ? { worldId } : {});
+  } catch { /* socket optional */ }
 }
 
 /**
@@ -382,12 +402,10 @@ export function weaponiseHeldSecrets(db, { proposeScheme, io = null, worldId = n
       db.prepare(`UPDATE secrets SET weaponised_holder_at = unixepoch() WHERE id = ?`).run(r.secret_id);
     } catch { /* column may be absent on a pre-migration build; scheme still opened */ }
 
-    try {
-      io?.to?.(worldId ? `world:${worldId}` : undefined)?.emit?.("secret:weaponised", {
-        holder: r.holder_npc_id, subject_kind: "npc", subject_id: r.subject_id,
-        kind: r.kind, schemeId, byNpc: true, ts: Math.floor(Date.now() / 1000),
-      });
-    } catch { /* socket optional */ }
+    fanSecretWeaponised({
+      holder: r.holder_npc_id, subject_kind: "npc", subject_id: r.subject_id,
+      kind: r.kind, schemeId, byNpc: true, ts: Math.floor(Date.now() / 1000),
+    }, { worldId, io });
 
     weaponised.push({ secretId: r.secret_id, holderNpcId: r.holder_npc_id, subjectId: r.subject_id, schemeId });
   }

--- a/server/lib/skills/skill-mastery.js
+++ b/server/lib/skills/skill-mastery.js
@@ -16,9 +16,12 @@
 //     scaling: particle count, scale, trail, glow, finisher flag) the client
 //     renders verbatim, so a master's cast genuinely looks bigger.
 //   - getSkillMastery / getAllSkillMastery: DB reads over player_skill_levels.
+//   - getCatalogSkillMastery: every SKILL_CATALOG key, untrained at L0 novice.
 //
 // All pure/deterministic (no RNG) so it's testable and a client can't inflate
 // its own mastery.
+
+import { SKILL_TREE_CONSTANTS } from "../skill-tree-engine.js";
 
 /**
  * Mastery tiers. `minLevel` is inclusive. Bonuses are small, stacking-by-tier
@@ -173,4 +176,58 @@ export function getAllSkillMastery(db, userId) {
       vfx: skillVfxDescriptor({ skillType: r.skill_type, level: r.level || 0 }),
     };
   });
+}
+
+function elementForCatalogSkill(skillType, group) {
+  const key = String(skillType || "");
+  if (key.startsWith("elemental_")) return key.slice("elemental_".length) || "none";
+  if (group === "combat") return "physical";
+  return "none";
+}
+
+/**
+ * T3.1 catalog overlay: every SKILL_CATALOG key, including untrained
+ * skills at level-0 novice. Trained rows overlay the live
+ * player_skill_levels aggregate. Never invents XP.
+ */
+export function getCatalogSkillMastery(db, userId) {
+  const trained = new Map();
+  for (const row of getAllSkillMastery(db, userId)) {
+    if (row?.skillType) trained.set(row.skillType, row);
+  }
+  const catalog = SKILL_TREE_CONSTANTS.SKILL_CATALOG || {};
+  const groups = [];
+  let catalogCount = 0;
+  for (const [group, list] of Object.entries(catalog)) {
+    const skills = (Array.isArray(list) ? list : []).map((skillType) => {
+      catalogCount += 1;
+      const element = elementForCatalogSkill(skillType, group);
+      const live = trained.get(skillType);
+      if (live) {
+        return {
+          ...live,
+          group,
+          vfx: skillVfxDescriptor({
+            skillType,
+            element,
+            level: live.level || 0,
+          }),
+        };
+      }
+      const mastery = masteryForLevel(0);
+      return {
+        skillType,
+        xp: 0,
+        group,
+        ...mastery,
+        vfx: skillVfxDescriptor({ skillType, element, level: 0 }),
+      };
+    });
+    groups.push({ group, skills });
+  }
+  return {
+    catalogCount,
+    trainedCount: trained.size,
+    groups,
+  };
 }

--- a/server/lib/social-gatherings.js
+++ b/server/lib/social-gatherings.js
@@ -11,26 +11,37 @@
 
 export const GATHERING_KINDS = Object.freeze(["wedding", "funeral", "festival"]);
 
-const person = (name, role, id = null) => ({ id, name: String(name), role });
+const person = (name, role, id = null) => ({ id: id || null, name: String(name), role });
+
+/** Accepts a display string or `{ id, name }` from gatherAttendees. */
+function asPeople(list) {
+  return (list || []).map((x) => {
+    if (x && typeof x === "object") {
+      const name = String(x.name || x.id || "");
+      return { id: x.id != null && x.id !== "" ? String(x.id) : null, name };
+    }
+    return { id: null, name: String(x) };
+  }).filter((p) => p.name);
+}
 
 /**
  * Compose a gathering from the live relationship web.
  * @param {object} cfg
  * @param {'wedding'|'funeral'|'festival'} cfg.kind
  * @param {string} cfg.focalName            the celebrant / deceased / host
- * @param {string[]} [cfg.partners]         courtship/marriage partners
- * @param {string[]} [cfg.family]           kin
- * @param {string[]} [cfg.friends]          allies / friendly NPCs
- * @param {string[]} [cfg.grudgeHolders]    those who bear the focal a grudge
+ * @param {string[]|{id?:string,name?:string}[]} [cfg.partners]
+ * @param {string[]|{id?:string,name?:string}[]} [cfg.family]
+ * @param {string[]|{id?:string,name?:string}[]} [cfg.friends]
+ * @param {string[]|{id?:string,name?:string}[]} [cfg.grudgeHolders]
  * @returns {{ kind:string, attendees:object[], beats:string[], triggersGrief:boolean }}
  */
 export function composeGathering(cfg = {}) {
   const kind = GATHERING_KINDS.includes(cfg.kind) ? cfg.kind : "festival";
   const focalName = String(cfg.focalName || "Someone");
-  const partners = (cfg.partners || []).map(String);
-  const family = (cfg.family || []).map(String);
-  const friends = (cfg.friends || []).map(String);
-  const grudgeHolders = (cfg.grudgeHolders || []).map(String);
+  const partners = asPeople(cfg.partners);
+  const family = asPeople(cfg.family);
+  const friends = asPeople(cfg.friends);
+  const grudgeHolders = asPeople(cfg.grudgeHolders);
 
   const attendees = [];
   const beats = [];
@@ -38,30 +49,30 @@ export function composeGathering(cfg = {}) {
 
   if (kind === "wedding") {
     attendees.push(person(focalName, "celebrant"));
-    partners.forEach((p) => attendees.push(person(p, "partner")));
-    family.forEach((f) => attendees.push(person(f, "family")));
-    friends.forEach((f) => attendees.push(person(f, "guest")));
+    partners.forEach((p) => attendees.push(person(p.name, "partner", p.id)));
+    family.forEach((f) => attendees.push(person(f.name, "family", f.id)));
+    friends.forEach((f) => attendees.push(person(f.name, "guest", f.id)));
     beats.push(`${focalName} exchanges vows`, "a toast to the union");
     // one grudge-holder attends for tension (the uninvited rival who came anyway)
     if (grudgeHolders.length) {
-      attendees.push(person(grudgeHolders[0], "uninvited"));
-      beats.push(`${grudgeHolders[0]} watches from the back, unsmiling`);
+      attendees.push(person(grudgeHolders[0].name, "uninvited", grudgeHolders[0].id));
+      beats.push(`${grudgeHolders[0].name} watches from the back, unsmiling`);
     } else {
       beats.push("the hall is warm with celebration");
     }
   } else if (kind === "funeral") {
-    family.forEach((f) => attendees.push(person(f, "bereaved")));
-    partners.forEach((p) => attendees.push(person(p, "bereaved")));
-    friends.forEach((f) => attendees.push(person(f, "mourner")));
+    family.forEach((f) => attendees.push(person(f.name, "bereaved", f.id)));
+    partners.forEach((p) => attendees.push(person(p.name, "bereaved", p.id)));
+    friends.forEach((f) => attendees.push(person(f.name, "mourner", f.id)));
     // rivals come to confirm the death / make peace
-    grudgeHolders.forEach((g) => attendees.push(person(g, "rival")));
+    grudgeHolders.forEach((g) => attendees.push(person(g.name, "rival", g.id)));
     beats.push(`a eulogy for ${focalName}`, "the bereaved lay their tokens");
-    if (grudgeHolders.length) beats.push(`${grudgeHolders[0]} lingers — old grudges outlive the dead`);
+    if (grudgeHolders.length) beats.push(`${grudgeHolders[0].name} lingers — old grudges outlive the dead`);
     triggersGrief = true; // caller fires npc-legacy onNpcDeath / grief path
   } else {
     // festival — a broad community sample (everyone the host knows)
     attendees.push(person(focalName, "host"));
-    [...family, ...friends, ...partners].forEach((n) => attendees.push(person(n, "reveler")));
+    [...family, ...friends, ...partners].forEach((n) => attendees.push(person(n.name, "reveler", n.id)));
     beats.push(`${focalName} opens the festival`, "music and shared food", "the season turns");
   }
 
@@ -115,17 +126,17 @@ export function gatherAttendees(db, cfg = {}) {
           "SELECT related_id, rel_type, strength FROM npc_relationships WHERE npc_id = ?",
         ).all(focalId);
         for (const r of rels) {
-          const nm = _npcName(db, r.related_id);
-          if (r.rel_type === "spouse") partners.push(nm);
-          else if (r.rel_type === "parent" || r.rel_type === "child" || r.rel_type === "sibling") family.push(nm);
-          else if (r.rel_type === "friend" && Number(r.strength ?? 1) >= 0.5) friends.push(nm);
+          const named = { id: r.related_id, name: _npcName(db, r.related_id) };
+          if (r.rel_type === "spouse") partners.push(named);
+          else if (r.rel_type === "parent" || r.rel_type === "child" || r.rel_type === "sibling") family.push(named);
+          else if (r.rel_type === "friend" && Number(r.strength ?? 1) >= 0.5) friends.push(named);
         }
       } catch { /* relationship graph optional */ }
       try {
         const holders = db.prepare(
           "SELECT DISTINCT npc_id FROM npc_grudges WHERE target_kind = 'npc' AND target_id = ? AND resolved_at IS NULL ORDER BY severity DESC LIMIT 5",
         ).all(focalId);
-        for (const h of holders) grudgeHolders.push(_npcName(db, h.npc_id));
+        for (const h of holders) grudgeHolders.push({ id: h.npc_id, name: _npcName(db, h.npc_id) });
       } catch { /* grudges optional */ }
     } else {
       // player focal — resolve username + active courtship partners + grudge-holders
@@ -137,17 +148,27 @@ export function gatherAttendees(db, cfg = {}) {
         const ps = db.prepare(
           "SELECT partner_kind, partner_id, status FROM player_courtship WHERE player_user_id = ? AND status IN ('courting','engaged','married')",
         ).all(focalId);
-        for (const p of ps) partners.push(p.partner_kind === "npc" ? _npcName(db, p.partner_id) : String(p.partner_id));
+        for (const p of ps) {
+          partners.push({
+            id: p.partner_id,
+            name: p.partner_kind === "npc" ? _npcName(db, p.partner_id) : String(p.partner_id),
+          });
+        }
       } catch { /* courtship optional */ }
       try {
         const holders = db.prepare(
           "SELECT DISTINCT npc_id FROM npc_grudges WHERE target_kind = 'player' AND target_id = ? AND resolved_at IS NULL ORDER BY severity DESC LIMIT 5",
         ).all(focalId);
-        for (const h of holders) grudgeHolders.push(_npcName(db, h.npc_id));
+        for (const h of holders) grudgeHolders.push({ id: h.npc_id, name: _npcName(db, h.npc_id) });
       } catch { /* grudges optional */ }
     }
   }
 
   const composed = composeGathering({ kind, focalName, partners, family, friends, grudgeHolders });
+  if (focalId && composed.attendees) {
+    for (const a of composed.attendees) {
+      if ((a.role === "celebrant" || a.role === "host") && !a.id) a.id = focalId;
+    }
+  }
   return { ...composed, focalKind, focalId };
 }

--- a/server/lib/weather.js
+++ b/server/lib/weather.js
@@ -16,6 +16,7 @@
 
 import logger from "../logger.js";
 import { LruMap, LruSet } from "./lru-map.js";
+import { mirrorToGateways } from "./gateway-fanout.js";
 
 const WEATHER_TYPES = Object.freeze(["clear", "overcast", "rain", "storm", "snow", "fog", "wind"]);
 
@@ -82,11 +83,15 @@ export function advanceWeather(REALTIME = null) {
     // Broadcast a per-world weather event so subscribers in that world re-tune.
     if (REALTIME?.io) {
       try {
-        REALTIME.io.emit("world:weather", {
+        const payload = {
           worldId,
           ...state,
           ts: new Date(now).toISOString(),
-        });
+        };
+        REALTIME.io.emit("world:weather", payload);
+        // socket.io stays global (Three.js listens without a world room).
+        // Gateways join `world:<id>` on connect — mirror world-scoped.
+        mirrorToGateways("world:weather", payload, { worldId });
       } catch { /* socket best-effort */ }
     }
   }

--- a/server/lib/world-clock.js
+++ b/server/lib/world-clock.js
@@ -14,6 +14,8 @@
  * NPC's behavior tree can switch tracks based on time.
  */
 
+import { mirrorToGateways } from "./gateway-fanout.js";
+
 const WORLD_DAY_LENGTH_MS = 24 * 60 * 1000;       // 24 real minutes
 let _worldEpoch = Date.now();                      // can be reset for testing
 
@@ -49,13 +51,17 @@ export function startWorldClockBroadcast(REALTIME, { intervalMs = 30_000 } = {})
   const tick = () => {
     try {
       const phase = getWorldPhase();
-      REALTIME.io.emit("world:clock", {
+      const payload = {
         phase,
         segment:  getDayPhase(phase),
         epochMs:  _worldEpoch,
         dayLengthMs: WORLD_DAY_LENGTH_MS,
         ts:       new Date().toISOString(),
-      });
+      };
+      REALTIME.io.emit("world:clock", payload);
+      // Clock is global on socket.io (every connected browser). Gateways
+      // have no default room — broadcast to every authenticated WS client.
+      mirrorToGateways("world:clock", payload);
     } catch { /* socket.io may be disposed mid-shutdown */ }
   };
   tick(); // immediate emit so newcomers don't wait

--- a/server/routes/worlds.js
+++ b/server/routes/worlds.js
@@ -2826,13 +2826,25 @@ export default function createWorldsRouter({ requireAuth, db, emitToWorld }) {
             currentHp: bossRow.current_hp, maxHp: bossRow.max_hp,
             phases: bossPhases, defeated: !!kill,
           });
-          req.app.locals.io?.to(`world:${worldId}`).emit('boss:state', payload);
+          emitWorldEvent({
+            io: req.app.locals.io,
+            emitToWorld,
+            worldId,
+            event: "boss:state",
+            payload,
+          });
           // The discrete phase-transition beat alongside the continuous HUD
           // state. Returns null unless THIS hit actually crossed a threshold,
           // so the feed gets one row per phase change, not one per landed hit.
           const phaseEnter = bossPhaseEnterPayload(payload);
           if (phaseEnter) {
-            req.app.locals.io?.to(`world:${worldId}`).emit('boss:phase-enter', phaseEnter);
+            emitWorldEvent({
+              io: req.app.locals.io,
+              emitToWorld,
+              worldId,
+              event: "boss:phase-enter",
+              payload: phaseEnter,
+            });
           }
         }
       } catch { /* boss HUD emit best-effort — never blocks combat */ }

--- a/server/server.js
+++ b/server/server.js
@@ -9903,6 +9903,28 @@ let _godotGatewayEmitter = null;
 // same stream Godot already gets.
 let _unityGatewayEmitter = null;
 
+// Gateway-only fan-out for modules that still call `REALTIME.io.emit` directly
+// (world:clock, world:weather, npc:quest-*, world:crisis-resolved). Those
+// cannot switch to realtimeEmit without double-firing socket.io. Assigned
+// immediately so a heartbeat that fires before the WS mounts no-ops instead
+// of throwing. Pinned by tests/invariants/gateway-realtime-mirror-parity.test.js.
+function _mirrorRealtimeToGateways(event, payload, { worldId = "", userId = "" } = {}) {
+  const data = payload && typeof payload === "object" ? payload : {};
+  if (userId) {
+    try { _godotGatewayEmitter?.emitToRoom(`user:${userId}`, event, data); } catch { /* survive */ }
+    try { _unityGatewayEmitter?.emitToRoom(`user:${userId}`, event, data); } catch { /* survive */ }
+    return;
+  }
+  if (worldId) {
+    try { _godotGatewayEmitter?.emitToRoom(`world:${worldId}`, event, data); } catch { /* survive */ }
+    try { _unityGatewayEmitter?.emitToRoom(`world:${worldId}`, event, data); } catch { /* survive */ }
+    return;
+  }
+  try { _godotGatewayEmitter?.broadcast(event, data); } catch { /* survive */ }
+  try { _unityGatewayEmitter?.broadcast(event, data); } catch { /* survive */ }
+}
+globalThis._concordGatewayMirror = _mirrorRealtimeToGateways;
+
 // Per-user emit helper — uses the user:${userId} room joined on socket auth
 // (see io.on("connection") handler). Established in Phase 3 of polish-to-ten;
 // reused by trade, party, and any emergent system that needs to push to one

--- a/server/server.js
+++ b/server/server.js
@@ -9890,6 +9890,19 @@ const REALTIME = {
 // time — so this is not a TDZ hazard despite the forward reference.
 let _godotGatewayEmitter = null;
 
+// Unity gateway mirror — same contract as _godotGatewayEmitter above, same
+// TDZ reasoning. Added 2026-09-12 after an audit found the realtime fan-out
+// was Godot-only: `createGatewayEmitter` was called on the Godot handle and
+// never on the Unity one, so /unity-ws clients received ZERO realtime
+// broadcasts — only direct responses to the ~13 RPC verbs they send. That
+// left real, correctly-written client handlers permanently dead (Unity's
+// ConcordClient.HandleFrame has cases for `secret:weaponised` /
+// `npc:scheme-resolved` / `npc:conversation-bid`, all emitted through
+// realtimeEmit, none of which could ever arrive). Unity is now the canonical
+// World Lens web client (docs/ART_DIRECTION_UNITY_WEB.md), so it needs the
+// same stream Godot already gets.
+let _unityGatewayEmitter = null;
+
 // Per-user emit helper — uses the user:${userId} room joined on socket auth
 // (see io.on("connection") handler). Established in Phase 3 of polish-to-ten;
 // reused by trade, party, and any emergent system that needs to push to one
@@ -10015,6 +10028,9 @@ function emitToWorld(worldId, event, payload) {
     // Godot clients. Best-effort: a gateway hiccup must never affect the
     // socket.io emit above, which is why this is its own try/catch.
     try { _godotGatewayEmitter?.emitToRoom(`world:${worldId}`, event, enriched); } catch { /* survive */ }
+    // Unity gateway mirror — separate try/catch for the same reason: one
+    // gateway's hiccup must not starve the other, or the socket.io emit.
+    try { _unityGatewayEmitter?.emitToRoom(`world:${worldId}`, event, enriched); } catch { /* survive */ }
     return { ok: true };
   } catch (e) {
     return { ok: false, reason: String(e?.message || e) };
@@ -10096,6 +10112,7 @@ function realtimeEmit(event, payload, { sessionId = "", orgId = "", userId = "",
       // Godot gateway mirror — same room grammar (user:<id>) the gateway
       // supports. Best-effort; never affects the socket.io transport above.
       try { _godotGatewayEmitter?.emitToRoom(`user:${userId}`, event, enrichedPayload); } catch { /* survive */ }
+      try { _unityGatewayEmitter?.emitToRoom(`user:${userId}`, event, enrichedPayload); } catch { /* survive */ }
     } else if (sessionId) {
       REALTIME.io.to(`session:${sessionId}`).emit(event, enrichedPayload);
       // No gateway mirror: the gateway's room grammar is world:*/user:* only
@@ -10119,10 +10136,12 @@ function realtimeEmit(event, payload, { sessionId = "", orgId = "", userId = "",
       // dropped all three.
       REALTIME.io.to(`world:${worldId}`).emit(event, enrichedPayload);
       try { _godotGatewayEmitter?.emitToRoom(`world:${worldId}`, event, enrichedPayload); } catch { /* survive */ }
+      try { _unityGatewayEmitter?.emitToRoom(`world:${worldId}`, event, enrichedPayload); } catch { /* survive */ }
     } else {
       REALTIME.io.emit(event, enrichedPayload);
       // Godot gateway mirror — global broadcast to every authenticated client.
       try { _godotGatewayEmitter?.broadcast(event, enrichedPayload); } catch { /* survive */ }
+      try { _unityGatewayEmitter?.broadcast(event, enrichedPayload); } catch { /* survive */ }
     }
     return { ok: true, seq: enrichedPayload._seq, transport: "socketio" };
   }
@@ -73013,6 +73032,44 @@ async function _dispatchDesignCommand(domain, action, params, ctx) {
   return { ok: false, error: "unknown_macro", domain, action };
 }
 
+// Gateway `lens:run` (docs/CONCORDIA_UNITY_WIRING_PLAN.md Phase 1).
+// The gateway module itself never reimplements Gate 2 (publicReadDomains)
+// or Gate 3 (Chicken2) — those live inside runMacro. This wrapper:
+//   1. Rebuilds ctx through makeCtx so the actor is the authenticated WS
+//      user (never runMacro's system/internal default).
+//   2. Pins reqMeta to POST /api/lens/run so Chicken2's path/method
+//      checks see the same surface the HTTP route does.
+//   3. Applies the H1 anon gate the HTTP handler runs before dispatch.
+//   4. Dispatches through the SAME LENS_ACTIONS-then-runMacro lookup
+//      `/api/lens/run` uses (`_dispatchDesignCommand`). No AI catchall —
+//      unknown macros stay `{ok:false, error:"unknown_macro"}`.
+async function _runMacroFromGateway(domain, name, input, gatewayCtx) {
+  const userId = gatewayCtx?.userId || gatewayCtx?.actor?.userId;
+  if (!userId) {
+    return { ok: false, reason: "authentication required", error: "authentication required", code: "LENS_AUTH" };
+  }
+  const ctx = makeCtx({
+    user: { id: userId },
+    headers: {},
+    query: {},
+    method: "POST",
+    path: "/api/lens/run",
+    originalUrl: "/api/lens/run",
+    ip: "gateway",
+    get: () => undefined,
+  });
+  ctx.reqMeta = { ...(ctx.reqMeta || {}), path: "/api/lens/run", method: "POST" };
+  if (ctx.actor) {
+    ctx.actor.internal = false;
+    ctx.actor.kind = ctx.actor.kind || "user";
+  }
+  if (_lensActionForbiddenForAnon(ctx)) {
+    return { ok: false, reason: "authentication required", error: "authentication required", code: "LENS_AUTH" };
+  }
+  const rest = _peelRedundantArtifactWrapper(input && typeof input === "object" ? input : {});
+  return _dispatchDesignCommand(domain, name, rest, ctx);
+}
+
 // Shared by the `design_command` and `design:mode` cases below — a Godot
 // client only ever reaches either post-auth (godot-gateway.js rejects
 // pre-auth frames itself), so `userId` is always a real authenticated user.
@@ -73596,6 +73653,7 @@ if (server) {
       getUser: (userId) => AuthDB.getUser(userId),
       exportScene,
       exportKingdom: buildKingdomSnapshot,
+      runMacro: _runMacroFromGateway,
       db: STATE?.db || db,
       onClientMessage: _onGodotClientMessage,
       verifyApiKeyPair: _godotVerifyApiKeyPair,
@@ -73621,10 +73679,16 @@ if (server) {
       getUser: (userId) => AuthDB.getUser(userId),
       exportScene,
       exportKingdom: buildKingdomSnapshot,
+      runMacro: _runMacroFromGateway,
       db: STATE?.db || db,
       onClientMessage: _onGodotClientMessage,
       verifyApiKeyPair: _godotVerifyApiKeyPair,
     });
+    // Realtime fan-out for Unity, mirroring the Godot mount above. Without
+    // this the gateway serves RPC replies only and every realtimeEmit-driven
+    // world event is invisible to /unity-ws — see the _unityGatewayEmitter
+    // declaration for the full finding.
+    _unityGatewayEmitter = createGatewayEmitter(unityGatewayHandle);
     globalThis._concordUnityGateway = unityGatewayHandle;
     structuredLog("info", "unity_gateway_mounted", { path: "/unity-ws" });
   } catch (e) {

--- a/server/server.js
+++ b/server/server.js
@@ -11314,6 +11314,9 @@ async function tryInitWebSockets(server) {
             perilKind:  _peril.perilKind,
             counter:    _peril.counter,
           });
+          if (_peril.perilKind && data.targetId) {
+            try { _noteIncomingPeril(data.targetId, _peril.perilKind, _anticipationMs + 120); } catch { /* window optional */ }
+          }
         } catch { /* telegraph is best-effort presentation */ }
 
         // Broadcast the hit event so everyone in the attacker's
@@ -11657,7 +11660,13 @@ async function tryInitWebSockets(server) {
           if (r?.dodged) { perfectDodge = !!r.perfect; dodgeDilation = r.time_dilation_pct || 0; }
         }
       } catch { /* scoring optional — baseline i-frames still granted */ }
-      try { _grantIFrames(userId, perfectDodge ? 500 : 350); } catch { /* in-memory state optional */ }
+      try {
+        const raw = String(data?.action || "").toLowerCase();
+        const defense = ["jump", "break", "block", "parry", "dodge"].includes(raw)
+          ? raw
+          : (data?.wasParry ? "parry" : "dodge");
+        _grantIFrames(userId, perfectDodge ? 500 : 350, defense);
+      } catch { /* in-memory state optional */ }
 
       try {
         realtimeEmit("combat:dodge:ack", { userId, direction, t: now, iframeMs: perfectDodge ? 500 : 350, perfect: perfectDodge });
@@ -39277,7 +39286,7 @@ try {
 import { startWorldClockBroadcast, getWorldPhase, getDayPhase, WORLD_CLOCK_CONSTANTS } from "./lib/world-clock.js";
 import { getCurrentBehavior as getNPCCurrentBehavior, setNPCSchedule, NPC_SCHEDULE_ARCHETYPES, batchCurrentBehaviors } from "./lib/npc-schedules.js";
 import { advanceWeather as advanceWorldWeather, getWeather as getWorldWeather, WEATHER_CONSTANTS } from "./lib/weather.js";
-import { applyHitToState, tickCombatState, getCombatState, grantIFrames as _grantIFrames, setBlock as _setBlock, resetCombatState } from "./lib/combat-state.js";
+import { applyHitToState, tickCombatState, getCombatState, grantIFrames as _grantIFrames, setBlock as _setBlock, resetCombatState, noteIncomingPeril as _noteIncomingPeril } from "./lib/combat-state.js";
 // Sprint 1 (Connection) — the dodge/block socket handlers echoed :ack but never
 // granted i-frames or scored a perfect dodge/parry, so the entire defensive
 // combat loop was built-but-unwired. attemptDodge/attemptParry score the timing
@@ -73417,7 +73426,13 @@ async function _dispatchGodotCombatDodge(userId, data) {
       if (r?.dodged) { perfectDodge = !!r.perfect; dodgeDilation = r.time_dilation_pct || 0; }
     }
   } catch { /* scoring optional — baseline i-frames still granted */ }
-  try { _grantIFrames(userId, perfectDodge ? 500 : 350); } catch { /* in-memory state optional */ }
+  try {
+    const raw = String(data.action || "").toLowerCase();
+    const defense = ["jump", "break", "block", "parry", "dodge"].includes(raw)
+      ? raw
+      : (wasParry ? "parry" : "dodge");
+    _grantIFrames(userId, perfectDodge ? 500 : 350, defense);
+  } catch { /* in-memory state optional */ }
 
   const iframeMs = perfectDodge ? 500 : 350;
   // Two distinct payloads on purpose: the BROADCAST reuses the exact field

--- a/server/tests/combat-state-netcode.test.js
+++ b/server/tests/combat-state-netcode.test.js
@@ -13,6 +13,7 @@ import {
   grantIFrames,
   setBlock,
   resetCombatState,
+  noteIncomingPeril,
   COMBAT_STATE_CONSTANTS,
 } from "../lib/combat-state.js";
 import {
@@ -36,6 +37,22 @@ describe("combat-state: applyHitToState", () => {
     const r = applyHitToState("v", { damage: 999 });
     assert.strictEqual(r.damageMul, 0);
     assert.strictEqual(r.iframed, true);
+  });
+
+  it("F1.3 — a dodge does not negate a sweep tell", () => {
+    noteIncomingPeril("v", "sweep", 800);
+    grantIFrames("v", 500, "dodge");
+    const r = applyHitToState("v", { damage: 40 });
+    assert.strictEqual(r.iframed, false);
+    assert.ok(r.damageMul > 0);
+  });
+
+  it("F1.3 — a jump negates a sweep tell", () => {
+    noteIncomingPeril("v", "sweep", 800);
+    grantIFrames("v", 500, "jump");
+    const r = applyHitToState("v", { damage: 40 });
+    assert.strictEqual(r.iframed, true);
+    assert.strictEqual(r.damageMul, 0);
   });
 
   it("halves damage while blocking", () => {

--- a/server/tests/concordia-creatures.test.js
+++ b/server/tests/concordia-creatures.test.js
@@ -1,0 +1,153 @@
+// Creature pillar: snapshot of live fauna + lineage, ecology counts,
+// and thin creature:born emit from generateHybrid. Empty stays empty.
+//
+//   cd server && node --test tests/concordia-creatures.test.js
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+import { snapshotCreatures, snapshotEcology, announceCreatureBorn } from "../lib/concordia-creatures.js";
+import { ensureCrossbreedingTables, generateHybrid, recordEncounter } from "../lib/creature-crossbreeding.js";
+
+function fresh() {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE world_npcs (
+      id TEXT PRIMARY KEY,
+      world_id TEXT,
+      archetype TEXT,
+      species_id TEXT,
+      x REAL, y REAL, z REAL,
+      is_dead INTEGER DEFAULT 0
+    );
+    CREATE TABLE creature_population (
+      id TEXT PRIMARY KEY,
+      world_id TEXT,
+      biome TEXT,
+      species_id TEXT,
+      target_count INTEGER,
+      current_count INTEGER,
+      lifestyle TEXT
+    );
+  `);
+  ensureCrossbreedingTables(db);
+  return db;
+}
+
+test("snapshotCreatures is empty without fauna rows — never invents a pack", () => {
+  const db = fresh();
+  assert.deepEqual(snapshotCreatures(db, "concordia-hub"), []);
+  assert.deepEqual(snapshotCreatures(null, "concordia-hub"), []);
+  assert.deepEqual(snapshotCreatures(db, ""), []);
+});
+
+test("snapshotCreatures cards a live fauna row with topology from taxonomy", () => {
+  const db = fresh();
+  db.prepare(`
+    INSERT INTO world_npcs (id, world_id, archetype, species_id, x, y, z, is_dead)
+    VALUES ('cr_wolf_1', 'fantasy', 'creature:wolf', 'wolf', 4.2, 0, 3.1, 0)
+  `).run();
+  const cards = snapshotCreatures(db, "fantasy");
+  assert.equal(cards.length, 1);
+  assert.equal(cards[0].id, "cr_wolf_1");
+  assert.equal(cards[0].speciesId, "wolf");
+  assert.equal(cards[0].topology, "quadruped");
+  assert.equal(cards[0].x, 4.2);
+  assert.equal(cards[0].z, 3.1);
+  assert.equal(cards[0].generation, 0);
+  assert.equal(cards[0].parentA, null);
+});
+
+test("snapshotCreatures joins lineage generation and parents", () => {
+  const db = fresh();
+  db.prepare(`
+    INSERT INTO world_npcs (id, world_id, archetype, species_id, x, y, z, is_dead)
+    VALUES ('child_1', 'fantasy', 'creature:wolf', 'wolf', 2, 0, 2, 0)
+  `).run();
+  db.prepare(`
+    INSERT INTO creature_lineage (child_id, parent_a, parent_b, generation, stability, blueprint)
+    VALUES ('child_1', 'wolf_a', 'hound_b', 4, 0.7, ?)
+  `).run(JSON.stringify({
+    id: "child_1",
+    worldId: "fantasy",
+    topology: "quadruped",
+    massKg: 72,
+    heightM: 1.1,
+    genotype: { dominant: "frost", variant: "ice" },
+    gait: { kind: "quadruped", walkMps: 2.4 },
+    species_id: "wolf",
+  }));
+  const cards = snapshotCreatures(db, "fantasy");
+  assert.equal(cards.length, 1);
+  assert.equal(cards[0].generation, 4);
+  assert.equal(cards[0].parentA, "wolf_a");
+  assert.equal(cards[0].parentB, "hound_b");
+  assert.equal(cards[0].massKg, 72);
+  assert.equal(cards[0].dominant, "frost");
+  assert.equal(cards[0].variant, "ice");
+});
+
+test("snapshotEcology is empty without population rows", () => {
+  const db = fresh();
+  assert.deepEqual(snapshotEcology(db, "fantasy"), []);
+});
+
+test("snapshotEcology reports real counts, not fabricated herds", () => {
+  const db = fresh();
+  db.prepare(`
+    INSERT INTO creature_population (id, world_id, biome, species_id, target_count, current_count, lifestyle)
+    VALUES ('p1', 'fantasy', 'forest', 'wolf', 2, 1, 'carnivore')
+  `).run();
+  const eco = snapshotEcology(db, "fantasy");
+  assert.equal(eco.length, 1);
+  assert.equal(eco[0].speciesId, "wolf");
+  assert.equal(eco[0].count, 1);
+  assert.equal(eco[0].target, 2);
+  assert.equal(eco[0].biome, "forest");
+});
+
+test("announceCreatureBorn emits the hybrid id, never a fabricated child", () => {
+  const db = fresh();
+  const a = {
+    id: "wolf_a", topology: "quadruped", massKg: 80, heightM: 1.4,
+    worldId: "fantasy", skillIds: [], abilitySeeds: [],
+  };
+  const b = {
+    id: "hound_b", topology: "quadruped", massKg: 70, heightM: 1.2,
+    worldId: "fantasy", skillIds: [], abilitySeeds: [],
+  };
+  for (let i = 0; i < 25; i++) {
+    recordEncounter(db, { aId: a.id, bId: b.id, worldA: "fantasy", worldB: "fantasy" });
+  }
+  const seen = [];
+  const prev = globalThis._concordRealtimeEmit;
+  globalThis._concordRealtimeEmit = (event, payload) => seen.push({ event, payload });
+  try {
+    const r = generateHybrid(db, { a, b, generation: 3 });
+    assert.equal(r.ok, true);
+    const announced = announceCreatureBorn(r, "fantasy");
+    assert.equal(announced.ok, true);
+    assert.equal(announced.childId, r.hybrid.id);
+  } finally {
+    globalThis._concordRealtimeEmit = prev;
+  }
+  const born = seen.find((s) => s.event === "creature:born");
+  assert.ok(born, "hybrid emit is creature:born");
+  assert.equal(born.payload.childId.length > 0, true);
+  assert.equal(born.payload.generation, 3);
+  assert.equal(born.payload.parentA, "wolf_a");
+  assert.equal(born.payload.worldId, "fantasy");
+  assert.equal(born.payload.topology, "quadruped");
+});
+
+test("announceCreatureBorn without emit is an honest no-op", () => {
+  const prev = globalThis._concordRealtimeEmit;
+  globalThis._concordRealtimeEmit = undefined;
+  try {
+    const r = announceCreatureBorn({ ok: true, hybrid: { id: "x" }, generation: 1, parents: ["a", "b"] }, "hub");
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "no_emit");
+  } finally {
+    globalThis._concordRealtimeEmit = prev;
+  }
+});

--- a/server/tests/creatures-lens-macros.test.js
+++ b/server/tests/creatures-lens-macros.test.js
@@ -123,6 +123,26 @@ describe("creatures lens macros", () => {
     assert.ok(lin.lineage.self && lin.lineage.self.child_id === r.hybrid.id);
   });
 
+  it("breed emits creature:born with the hybrid id", async () => {
+    const seen = [];
+    const prev = globalThis._concordRealtimeEmit;
+    globalThis._concordRealtimeEmit = (event, payload) => seen.push({ event, payload });
+    try {
+      const r = await macros.get("breed")(ctxFor(db), {
+        a: { id: "wolf_a", species_id: "wolf" },
+        b: { id: "bear_b", species_id: "bear" },
+        worldId: WORLD,
+      });
+      assert.equal(r.ok, true);
+      const born = seen.find((s) => s.event === "creature:born");
+      assert.ok(born, "pen-pairing emits creature:born");
+      assert.equal(born.payload.childId, r.hybrid.id);
+      assert.equal(born.payload.worldId, WORLD);
+    } finally {
+      globalThis._concordRealtimeEmit = prev;
+    }
+  });
+
   it("offspring species is a real, derived species (not fabricated)", async () => {
     const r = await macros.get("breed")(ctxFor(db), {
       a: { id: "deer_x", species_id: "deer" },

--- a/server/tests/horde-mode.test.js
+++ b/server/tests/horde-mode.test.js
@@ -10,6 +10,8 @@ import {
 } from "../lib/horde-mode.js";
 import { up as upHorde } from "../migrations/246_horde_mode.js";
 import { up as upRunDraft } from "../migrations/267_run_draft.js";
+import { up as up270 } from "../migrations/270_run_coop.js";
+import { runParticipants, findActivePartyRun } from "../lib/run-coop.js";
 
 // Wave 4 — pickUpgrade/tickWave now delegate to the shared run-draft engine
 // (run_draft_picks table, migration 267), so tests need both migrations.
@@ -145,5 +147,36 @@ describe("Phase CB2 — horde mode", () => {
     const juggernautHint = t.synergyHints.find((h) => h.id === "juggernaut");
     assert.ok(juggernautHint, "expected a juggernaut near-synergy hint after picking iron_hide");
     assert.equal(juggernautHint.missingBoonId, "thorned_aura");
+  });
+});
+
+describe("C4 — party shares one horde run", () => {
+  it("a party-mate joins the leader's horde, not a new one", () => {
+    const db = new Database(":memory:");
+    upHorde(db);
+    upRunDraft(db);
+    up270(db);
+    const leader = startHorde(db, "leader", { worldId: "tunya", partyId: "party-1" });
+    assert.equal(leader.ok, true);
+    assert.equal(leader.alreadyActive, false);
+    const mate = startHorde(db, "mate", { worldId: "tunya", partyId: "party-1" });
+    assert.equal(mate.ok, true);
+    assert.equal(mate.joined, true);
+    assert.equal(mate.runId, leader.runId);
+    assert.deepEqual(runParticipants(db, "horde", leader.runId).sort(), ["leader", "mate"]);
+    assert.equal(findActivePartyRun(db, "horde_runs", "party-1"), leader.runId);
+    assert.equal(getActiveHorde(db, "mate")?.id, leader.runId);
+    db.close();
+  });
+
+  it("a solo player (no party) opens their own horde", () => {
+    const db = new Database(":memory:");
+    upHorde(db);
+    upRunDraft(db);
+    up270(db);
+    const a = startHorde(db, "solo-a", { worldId: "tunya" });
+    const b = startHorde(db, "solo-b", { worldId: "tunya" });
+    assert.notEqual(a.runId, b.runId);
+    db.close();
   });
 });

--- a/server/tests/integration/gift-system.test.js
+++ b/server/tests/integration/gift-system.test.js
@@ -111,4 +111,16 @@ describe("F1.2 — giveGift consumes + shifts affinity", () => {
     assert.equal(r.reason, "npc_not_found");
     db.close();
   });
+
+  it("consumes a stack acquired in another world (inventory is user-global)", () => {
+    const db = freshDb();
+    npc(db, "kestra", "scholar");
+    give(db, "u1", "tome01", "Ancient Tome", 1, "tunya");
+    const r = giveGift(db, { userId: "u1", npcId: "kestra", itemId: "tome01", worldId: "concordia-hub" });
+    assert.equal(r.ok, true);
+    assert.equal(r.reaction, "loved");
+    const left = db.prepare(`SELECT * FROM player_inventory WHERE user_id='u1' AND item_id='tome01'`).get();
+    assert.equal(left, undefined);
+    db.close();
+  });
 });

--- a/server/tests/integration/run-coop.test.js
+++ b/server/tests/integration/run-coop.test.js
@@ -16,6 +16,9 @@ import { up as up258 } from "../../migrations/258_extraction_runs.js";
 import { up as up270 } from "../../migrations/270_run_coop.js";
 import { addRunParticipant, runParticipants, findActivePartyRun } from "../../lib/run-coop.js";
 import { startRun } from "../../lib/extraction.js";
+import { startHorde } from "../../lib/horde-mode.js";
+import { up as up246 } from "../../migrations/246_horde_mode.js";
+import { up as up267 } from "../../migrations/267_run_draft.js";
 
 function freshDb() {
   const db = new Database(":memory:");
@@ -57,6 +60,19 @@ describe("C4 — party shares one extraction run", () => {
     const a = startRun(db, "solo-a", { worldId: "w1" });
     const b = startRun(db, "solo-b", { worldId: "w1" });
     assert.notEqual(a.runId, b.runId);
+    db.close();
+  });
+});
+
+describe("C4 — party shares one horde run", () => {
+  it("a party-mate joins the leader's horde, not a new one", () => {
+    const db = new Database(":memory:");
+    up246(db); up267(db); up270(db);
+    const leader = startHorde(db, "leader", { worldId: "w1", partyId: "party-1" });
+    const mate = startHorde(db, "mate", { worldId: "w1", partyId: "party-1" });
+    assert.equal(mate.joined, true);
+    assert.equal(mate.runId, leader.runId);
+    assert.deepEqual(runParticipants(db, "horde", leader.runId).sort(), ["leader", "mate"]);
     db.close();
   });
 });

--- a/server/tests/integration/secret-weaponise-npc.test.js
+++ b/server/tests/integration/secret-weaponise-npc.test.js
@@ -105,4 +105,24 @@ describe("T2.1 — weaponiseHeldSecrets", () => {
     assert.equal(weaponiseHeldSecrets(db, { proposeScheme }).weaponised.length, 0);
     db.close();
   });
+
+  it("fans secret:weaponised through the realtime hook", () => {
+    const db = freshDb();
+    npc(db, "cruel-holder"); npc(db, "victim-a");
+    secret(db, "s1", "cruel-holder", "victim-a");
+    stress(db, "cruel-holder", 70, "cruel");
+    const seen = [];
+    const prev = globalThis._concordRealtimeEmit;
+    globalThis._concordRealtimeEmit = (event, payload) => seen.push({ event, payload });
+    try {
+      weaponiseHeldSecrets(db, { proposeScheme, worldId: "w1" });
+    } finally {
+      globalThis._concordRealtimeEmit = prev;
+    }
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].event, "secret:weaponised");
+    assert.equal(seen[0].payload.kind, "crime");
+    assert.equal(seen[0].payload.byNpc, true);
+    db.close();
+  });
 });

--- a/server/tests/integration/skill-mastery.test.js
+++ b/server/tests/integration/skill-mastery.test.js
@@ -22,8 +22,9 @@ import { up as up064 } from "../../migrations/064_crafting_and_skills.js";
 import {
   MASTERY_TIERS, ELEMENT_VFX,
   masteryForLevel, skillVfxDescriptor,
-  getSkillMastery, getAllSkillMastery,
+  getSkillMastery, getAllSkillMastery, getCatalogSkillMastery,
 } from "../../lib/skills/skill-mastery.js";
+import { SKILL_TREE_CONSTANTS } from "../../lib/skill-tree-engine.js";
 
 function freshDb() {
   const db = new Database(":memory:");
@@ -142,5 +143,52 @@ describe("T3.1 — DB reads over player_skill_levels", () => {
     const bare = new Database(":memory:");
     assert.deepEqual(getAllSkillMastery(bare, "x"), []);
     bare.close();
+  });
+});
+
+describe("T3.1 — catalog overlay for Unity", () => {
+  it("getCatalogSkillMastery returns every SKILL_CATALOG key at least at novice", () => {
+    const expected = Object.values(SKILL_TREE_CONSTANTS.SKILL_CATALOG)
+      .reduce((n, list) => n + list.length, 0);
+    const db = freshDb();
+    const u = "catalog-user";
+    addSkill(db, u, "swords", "concordia-hub", 46, 200);
+    const overlay = getCatalogSkillMastery(db, u);
+    assert.equal(overlay.catalogCount, expected);
+    assert.ok(overlay.catalogCount >= 67, `catalog should be the 67-skill lattice, got ${overlay.catalogCount}`);
+    assert.equal(overlay.trainedCount, 1);
+    const combat = overlay.groups.find((g) => g.group === "combat");
+    assert.ok(combat);
+    const swords = combat.skills.find((s) => s.skillType === "swords");
+    const fists = combat.skills.find((s) => s.skillType === "fists");
+    assert.equal(swords.tier, "expert");
+    assert.equal(swords.level, 46);
+    assert.equal(fists.tier, "novice");
+    assert.equal(fists.level, 0);
+    assert.equal(fists.xp, 0);
+    const fire = combat.skills.find((s) => s.skillType === "elemental_fire");
+    assert.equal(fire.vfx.element, "fire");
+    db.close();
+  });
+
+  it("skills.mastery lens action requires an actor and returns the catalog", async () => {
+    const { default: registerSkillsActions } = await import("../../domains/skills.js");
+    const expected = Object.values(SKILL_TREE_CONSTANTS.SKILL_CATALOG)
+      .reduce((n, list) => n + list.length, 0);
+    const ACTIONS = new Map();
+    registerSkillsActions((domain, name, fn) => ACTIONS.set(`${domain}.${name}`, fn));
+    const fn = ACTIONS.get("skills.mastery");
+    assert.ok(fn, "skills.mastery must be registered");
+    const denied = fn({}, { id: null, data: {}, meta: {} }, {});
+    assert.equal(denied.ok, false);
+    const db = freshDb();
+    const allowed = fn({ userId: "u-lens", db }, { id: null, data: {}, meta: {} }, {});
+    assert.equal(allowed.ok, true);
+    assert.equal(allowed.catalogCount, expected);
+    const one = fn({ userId: "u-lens", db }, { id: null, data: {}, meta: {} }, { skillType: "fists" });
+    assert.equal(one.ok, true);
+    assert.equal(one.skillType, "fists");
+    assert.equal(one.tier, "novice");
+    db.close();
   });
 });

--- a/server/tests/invariants/gateway-realtime-mirror-parity.test.js
+++ b/server/tests/invariants/gateway-realtime-mirror-parity.test.js
@@ -1,0 +1,119 @@
+// server/tests/invariants/gateway-realtime-mirror-parity.test.js
+//
+// Pins that the realtime fan-out mirrors into BOTH raw-WebSocket gateways
+// (`/godot-ws` and `/unity-ws`), not just Godot's.
+//
+// ── The bug this closes (root-caused 2026-09-12) ───────────────────────────
+// server.js created a gateway emitter for Godot only:
+//
+//     _godotGatewayEmitter = createGatewayEmitter(godotGatewayHandle);   // ✓
+//     globalThis._concordUnityGateway = unityGatewayHandle;              // ← no emitter
+//
+// `realtimeEmit`/`emitToWorld` fan every world/user/global event into
+// `_godotGatewayEmitter`, so a connected Godot client received the entire
+// realtime stream while a connected Unity client received NOTHING but direct
+// replies to the ~13 RPC verbs it sends (auth, scene:request, kingdom:request,
+// dialogue:request, player:move, combat:attack, …).
+//
+// That left correctly-written Unity client code permanently dead:
+// `ConcordClient.HandleFrame` (unity-client/Assets/Concordia/Scripts) has
+// cases for `secret:weaponised`, `npc:scheme-resolved` and
+// `npc:conversation-bid`, all three of which are emitted through the
+// realtimeEmit path (`domains/secrets.js`, `lib/npc-schemes.js`,
+// `emergent/npc-conversation-initiator.js`) and therefore could never arrive.
+// The handlers looked live in a code read; only the wiring proved otherwise.
+//
+// This matters more now that Unity — not Three.js — is the canonical World
+// Lens web client (docs/ART_DIRECTION_UNITY_WEB.md), with Godot demoted to
+// the presenter/spectator role. The client that gets the FULL event stream
+// should not be the secondary one.
+//
+// This is a source-form pin (same genre as
+// tests/invariants/gateway-getuser-binding.test.js, which pins the other
+// half of these same two mount sites) because the failure mode is silent:
+// nothing throws, no test goes red, the Unity client simply never hears
+// anything and looks "connected but inert."
+//
+// Run: node --test tests/invariants/gateway-realtime-mirror-parity.test.js
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SERVER_JS = join(import.meta.dirname, "..", "..", "server.js");
+const rawSrc = readFileSync(SERVER_JS, "utf-8");
+
+// Strip `//` line comments before scanning — the mount sites and the emitter
+// declarations carry explanatory comments that NAME these symbols, and those
+// would otherwise be counted as real call sites. Same comment-blindness class
+// (and same fix) as gateway-getuser-binding.test.js.
+const src = rawSrc
+  .split("\n")
+  .map((line) => line.replace(/\/\/.*$/, ""))
+  .join("\n");
+
+test("a gateway emitter is created for BOTH the Godot and Unity handles", () => {
+  const godot = /_godotGatewayEmitter\s*=\s*createGatewayEmitter\(\s*godotGatewayHandle\s*\)/.test(src);
+  const unity = /_unityGatewayEmitter\s*=\s*createGatewayEmitter\(\s*unityGatewayHandle\s*\)/.test(src);
+  assert.ok(
+    godot,
+    "no `_godotGatewayEmitter = createGatewayEmitter(godotGatewayHandle)` in server.js — " +
+    "the Godot gateway would receive no realtime events.",
+  );
+  assert.ok(
+    unity,
+    "no `_unityGatewayEmitter = createGatewayEmitter(unityGatewayHandle)` in server.js — " +
+    "/unity-ws clients get RPC replies only and are deaf to every realtimeEmit " +
+    "world/user/global event. Unity is the canonical World Lens client; it must " +
+    "not be wired as a lesser citizen than the Godot presenter.",
+  );
+});
+
+test("every Godot mirror call site has a matching Unity mirror call site", () => {
+  // Count by operation so a mismatch names WHICH fan-out tier drifted, rather
+  // than just reporting a total that's off by one.
+  const tiers = [
+    { op: "emitToRoom(`world:", re: /GatewayEmitter\?\.emitToRoom\(`world:\$\{worldId\}`/g },
+    { op: "emitToRoom(`user:", re: /GatewayEmitter\?\.emitToRoom\(`user:\$\{userId\}`/g },
+    { op: "broadcast(", re: /GatewayEmitter\?\.broadcast\(/g },
+  ];
+
+  for (const { op, re } of tiers) {
+    const all = src.match(re) || [];
+    // Re-scan the same tier scoped to each emitter to split the count.
+    const godotRe = new RegExp(re.source.replace("GatewayEmitter", "_godotGatewayEmitter"), "g");
+    const unityRe = new RegExp(re.source.replace("GatewayEmitter", "_unityGatewayEmitter"), "g");
+    const godotN = (src.match(godotRe) || []).length;
+    const unityN = (src.match(unityRe) || []).length;
+
+    assert.ok(
+      godotN > 0,
+      `expected at least one Godot mirror for \`${op}\`, found 0 — the fan-out tier was removed?`,
+    );
+    assert.equal(
+      unityN,
+      godotN,
+      `realtime mirror parity broken for \`${op}\`: ${godotN} Godot site(s) but ` +
+      `${unityN} Unity site(s) (total matched: ${all.length}). Every place the ` +
+      "realtime stream fans into the Godot gateway must fan into the Unity " +
+      "gateway too, or /unity-ws silently misses that class of event.",
+    );
+  }
+});
+
+test("each mirror call is individually try/catch-guarded", () => {
+  // A gateway hiccup must never break the socket.io emit beside it, nor
+  // starve the other gateway. The established shape at every site is a
+  // one-line `try { ... } catch { }`.
+  const lines = src.split("\n").filter((l) => /GatewayEmitter\?\./.test(l));
+  assert.ok(lines.length >= 8, `expected >= 8 mirror call lines, found ${lines.length}`);
+  for (const line of lines) {
+    assert.match(
+      line.trim(),
+      /^try\s*\{.*\}\s*catch\s*\{/,
+      `unguarded gateway mirror call — one gateway's failure would take down the ` +
+      `other, or the socket.io emit beside it:\n    ${line.trim()}`,
+    );
+  }
+});

--- a/server/tests/invariants/gateway-realtime-mirror-parity.test.js
+++ b/server/tests/invariants/gateway-realtime-mirror-parity.test.js
@@ -136,4 +136,14 @@ test("io.emit-only modules have a gateway-only mirror hook (clock/weather do not
   assert.match(overhear, /mirrorToGateways\(\s*"scheme:overheard"/);
   const bid = readFileSync(join(import.meta.dirname, "..", "..", "emergent", "npc-conversation-initiator.js"), "utf8");
   assert.match(bid, /mirrorToGateways\(\s*"npc:conversation-bid"/);
+  const factionCycle = readFileSync(join(import.meta.dirname, "..", "..", "emergent", "faction-strategy-cycle.js"), "utf8");
+  assert.match(factionCycle, /mirrorToGateways\(\s*"faction:strategy-move"/);
+  const bosses = readFileSync(join(import.meta.dirname, "..", "..", "emergent", "world-boss-cycle.js"), "utf8");
+  assert.match(bosses, /mirrorToGateways\(\s*"world:boss-spawn"/);
+  const festivals = readFileSync(join(import.meta.dirname, "..", "..", "emergent", "festival-trigger-cycle.js"), "utf8");
+  assert.match(festivals, /mirrorToGateways\(\s*"festival:started"/);
+  const seasons = readFileSync(join(import.meta.dirname, "..", "..", "lib", "seasons.js"), "utf8");
+  assert.match(seasons, /mirrorToGateways\(\s*"world:season-transition"/);
+  const gather = readFileSync(join(import.meta.dirname, "..", "..", "lib", "npc-simulator.js"), "utf8");
+  assert.match(gather, /mirrorToGateways\(\s*"world:npc-gather"/);
 });

--- a/server/tests/invariants/gateway-realtime-mirror-parity.test.js
+++ b/server/tests/invariants/gateway-realtime-mirror-parity.test.js
@@ -129,4 +129,11 @@ test("io.emit-only modules have a gateway-only mirror hook (clock/weather do not
   const clock = readFileSync(join(import.meta.dirname, "..", "..", "lib", "world-clock.js"), "utf8");
   assert.match(weather, /mirrorToGateways\(\s*"world:weather"/);
   assert.match(clock, /mirrorToGateways\(\s*"world:clock"/);
+  const secrets = readFileSync(join(import.meta.dirname, "..", "..", "lib", "secrets.js"), "utf8");
+  assert.match(secrets, /fanSecretWeaponised/);
+  assert.match(secrets, /mirrorToGateways\(\s*"secret:weaponised"/);
+  const overhear = readFileSync(join(import.meta.dirname, "..", "..", "emergent", "scheme-overhear-cycle.js"), "utf8");
+  assert.match(overhear, /mirrorToGateways\(\s*"scheme:overheard"/);
+  const bid = readFileSync(join(import.meta.dirname, "..", "..", "emergent", "npc-conversation-initiator.js"), "utf8");
+  assert.match(bid, /mirrorToGateways\(\s*"npc:conversation-bid"/);
 });

--- a/server/tests/invariants/gateway-realtime-mirror-parity.test.js
+++ b/server/tests/invariants/gateway-realtime-mirror-parity.test.js
@@ -117,3 +117,16 @@ test("each mirror call is individually try/catch-guarded", () => {
     );
   }
 });
+
+test("io.emit-only modules have a gateway-only mirror hook (clock/weather do not go through realtimeEmit)", () => {
+  assert.match(
+    src,
+    /globalThis\._concordGatewayMirror\s*=\s*_mirrorRealtimeToGateways/,
+    "server.js must assign globalThis._concordGatewayMirror so weather/clock/npc-quest " +
+    "io.emit paths can reach /unity-ws without double-firing socket.io via realtimeEmit",
+  );
+  const weather = readFileSync(join(import.meta.dirname, "..", "..", "lib", "weather.js"), "utf8");
+  const clock = readFileSync(join(import.meta.dirname, "..", "..", "lib", "world-clock.js"), "utf8");
+  assert.match(weather, /mirrorToGateways\(\s*"world:weather"/);
+  assert.match(clock, /mirrorToGateways\(\s*"world:clock"/);
+});

--- a/server/tests/npc-legacy.test.js
+++ b/server/tests/npc-legacy.test.js
@@ -318,6 +318,27 @@ describe("onNpcDeath — legacy + inheritance cascade", () => {
     const r = onNpcDeath(null, null);
     assert.equal(r.ok, false);
   });
+
+  it("emits npc:heir-rose when an heir exists", () => {
+    const db = makeFakeDb();
+    const dead = makeNpc({ id: "npc:dad2" });
+    const heir = makeNpc({ id: "npc:son2" });
+    db._tables.world_npcs.set(dead.id, dead);
+    db._tables.world_npcs.set(heir.id, heir);
+    db._tables.npc_relations.set("r-heir", { npc_id: "npc:son2", related_to: "npc:dad2", relation_kind: "child" });
+    const seen = [];
+    const prev = globalThis._concordRealtimeEmit;
+    globalThis._concordRealtimeEmit = (event, payload) => seen.push({ event, payload });
+    try {
+      onNpcDeath(db, dead);
+    } finally {
+      globalThis._concordRealtimeEmit = prev;
+    }
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].event, "npc:heir-rose");
+    assert.equal(seen[0].payload.heirId, "npc:son2");
+    assert.equal(seen[0].payload.deceasedId, "npc:dad2");
+  });
 });
 
 describe("getTombsForWorld + getInheritanceForHeir", () => {

--- a/server/tests/npc-legacy.test.js
+++ b/server/tests/npc-legacy.test.js
@@ -338,6 +338,8 @@ describe("onNpcDeath — legacy + inheritance cascade", () => {
     assert.equal(seen[0].event, "npc:heir-rose");
     assert.equal(seen[0].payload.heirId, "npc:son2");
     assert.equal(seen[0].payload.deceasedId, "npc:dad2");
+    assert.equal(typeof seen[0].payload.lastWords, "string");
+    assert.ok(seen[0].payload.lastWords.length > 0);
   });
 });
 

--- a/server/tests/npc-legacy.test.js
+++ b/server/tests/npc-legacy.test.js
@@ -334,12 +334,16 @@ describe("onNpcDeath — legacy + inheritance cascade", () => {
     } finally {
       globalThis._concordRealtimeEmit = prev;
     }
-    assert.equal(seen.length, 1);
-    assert.equal(seen[0].event, "npc:heir-rose");
-    assert.equal(seen[0].payload.heirId, "npc:son2");
-    assert.equal(seen[0].payload.deceasedId, "npc:dad2");
-    assert.equal(typeof seen[0].payload.lastWords, "string");
-    assert.ok(seen[0].payload.lastWords.length > 0);
+    const rose = seen.find((s) => s.event === "npc:heir-rose");
+    assert.ok(rose, "heir-rose still fires when an heir exists");
+    assert.equal(rose.payload.heirId, "npc:son2");
+    assert.equal(rose.payload.deceasedId, "npc:dad2");
+    assert.equal(typeof rose.payload.lastWords, "string");
+    assert.ok(rose.payload.lastWords.length > 0);
+    const funeral = seen.find((s) => s.event === "npc:funeral");
+    assert.ok(funeral, "death also emits the existing funeral composition");
+    assert.equal(funeral.payload.deceasedId, "npc:dad2");
+    assert.ok(Array.isArray(funeral.payload.attendees));
   });
 });
 

--- a/server/tests/npc-stress.test.js
+++ b/server/tests/npc-stress.test.js
@@ -79,6 +79,25 @@ describe("Sprint C / A1 — mental break + coping_trait", () => {
     assert.ok(row.coping_until > Math.floor(Date.now() / 1000));
   });
 
+  it("emits npc:stress-break with the locked coping_trait when a break lands", () => {
+    const db = setupDb();
+    bumpStress(db, "npc-break-emit", "custom_event", 49);
+    const seen = [];
+    const prev = globalThis._concordRealtimeEmit;
+    globalThis._concordRealtimeEmit = (event, payload) => seen.push({ event, payload });
+    try {
+      const r = bumpStress(db, "npc-break-emit", "grudge_severe");
+      assert.equal(r.broke, true);
+    } finally {
+      globalThis._concordRealtimeEmit = prev;
+    }
+    const evt = seen.find((s) => s.event === "npc:stress-break");
+    assert.ok(evt, "mental break must emit npc:stress-break so Unity can present it");
+    assert.equal(evt.payload.npcId, "npc-break-emit");
+    assert.ok(STRESS_CONSTANTS.COPING_TRAITS.includes(evt.payload.copingTrait));
+    assert.ok(evt.payload.stress >= 80);
+  });
+
   it("does not re-lock while existing coping_trait window is active", () => {
     const db = setupDb();
     bumpStress(db, "npc-3", "custom_event", 90); // breaks

--- a/server/tests/population-migration-acceptance.test.js
+++ b/server/tests/population-migration-acceptance.test.js
@@ -326,3 +326,33 @@ test("conservation across many migrations of varied lengths — invariant always
   assert.equal(final.totalResidents, 90);
   assert.equal(final.inTransit, 0);
 });
+
+test("arriveAtDestination emits npc:migrated with the existing arrival fields", () => {
+  const db = setup();
+  seedWorld(db, "tunya", 1, "tu");
+  const init = initiateMigration(db, {
+    npcId: "tu_npc_0", fromWorld: "tunya", toWorld: "fantasy", reason: "voluntary",
+  });
+  assert.equal(init.ok, true);
+  const seen = [];
+  const prev = globalThis._concordRealtimeEmit;
+  globalThis._concordRealtimeEmit = (event, payload, opts) => seen.push({ event, payload, opts });
+  try {
+    const r = arriveAtDestination(db, init.eventId, {
+      forceTime: Math.floor(Date.now() / 1000) + 100000,
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.npcId, "tu_npc_0");
+    assert.equal(r.fromWorld, "tunya");
+    assert.equal(r.toWorld, "fantasy");
+  } finally {
+    globalThis._concordRealtimeEmit = prev;
+  }
+  const evts = seen.filter((s) => s.event === "npc:migrated");
+  assert.ok(evts.length >= 1, "arrival must emit npc:migrated so Unity can present it");
+  assert.equal(evts[0].payload.npcId, "tu_npc_0");
+  assert.equal(evts[0].payload.fromWorld, "tunya");
+  assert.equal(evts[0].payload.toWorld, "fantasy");
+  assert.equal(evts[0].payload.eventId, String(init.eventId));
+  assert.equal(evts[0].opts.worldId, "fantasy");
+});

--- a/server/tests/romance-engine.test.js
+++ b/server/tests/romance-engine.test.js
@@ -114,6 +114,24 @@ describe("romance-engine library", () => {
     assert.equal(marriages[0].partner_id, "bob");
   });
 
+  it("wed emits npc:wedding from the existing gathering composition", () => {
+    pumpAffinity("alice", "bob", 25);
+    propose(db, "alice", "npc", "bob");
+    const seen = [];
+    const prev = globalThis._concordRealtimeEmit;
+    globalThis._concordRealtimeEmit = (event, payload) => seen.push({ event, payload });
+    try {
+      const w = wed(db, "alice", "npc", "bob");
+      assert.equal(w.ok, true);
+    } finally {
+      globalThis._concordRealtimeEmit = prev;
+    }
+    const wedding = seen.find((s) => s.event === "npc:wedding");
+    assert.ok(wedding, "marriage emits the existing wedding composition");
+    assert.equal(wedding.payload.marriageId?.length > 0, true);
+    assert.ok(Array.isArray(wedding.payload.attendees));
+  });
+
   it("wed rejects if not engaged", () => {
     pumpAffinity("alice", "bob", 25);
     const r = wed(db, "alice", "npc", "bob");

--- a/server/tests/social-gatherings.test.js
+++ b/server/tests/social-gatherings.test.js
@@ -82,6 +82,10 @@ describe("gatherAttendees — db-reader (SL5 caller)", () => {
     assert.ok(names.includes("Sprout"), "bereaved kin attends");
     assert.ok(names.includes("Kel the Spurned"), "rival attends a funeral");
     assert.ok(g.beats.some((b) => b.includes("Old Seam")), "eulogy names the deceased");
+    const sprout = g.attendees.find((a) => a.name === "Sprout");
+    assert.equal(sprout.id, "n_kid", "Unity matches mourners by kernel id, not a fabricated crowd");
+    const rival = g.attendees.find((a) => a.name === "Kel the Spurned");
+    assert.equal(rival.id, "n_rival");
   });
 
   it("degrades to a sparse-but-valid gathering with no relations", () => {

--- a/server/tests/unity-lens-run.test.js
+++ b/server/tests/unity-lens-run.test.js
@@ -1,0 +1,250 @@
+// Unity / Godot `lens:run` gateway verb — Phase 1 of
+// docs/CONCORDIA_UNITY_WIRING_PLAN.md.
+//
+// The load-bearing claim: this verb is NOT a parallel permission path.
+// It forwards to deps.runMacro with an HTTP-shaped ctx (POST /api/lens/run,
+// authenticated actor) so Gate 2 (publicReadDomains) and Gate 3 (Chicken2)
+// inside runMacro fire identically. The gateway never reimplements those
+// gates. A missing actor would make runMacro default to system/internal —
+// this file pins that that default is unreachable from this verb.
+//
+//   cd server && node --test tests/unity-lens-run.test.js
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import http from "node:http";
+import { WebSocket } from "ws";
+import { mountUnityGateway } from "../lib/unity-bridge.js";
+
+const GATEWAY_SRC = readFileSync(join(import.meta.dirname, "..", "lib", "godot-gateway.js"), "utf8");
+const SERVER_SRC = readFileSync(join(import.meta.dirname, "..", "server.js"), "utf8");
+
+function startGateway(depOverrides = {}) {
+  const server = http.createServer();
+  const calls = [];
+  const gateway = mountUnityGateway(server, {
+    verifyToken: (token) => (token === "good-token" ? { userId: "u1" } : null),
+    getUser: (userId) => (userId === "u1" ? { id: "u1", username: "tester" } : null),
+    exportScene: () => ({ ok: true, worldId: "concordia-hub", nodes: [] }),
+    exportKingdom: () => ({ ok: true, title: "Hub", staple: "lanterns", settlements: [] }),
+    db: {},
+    runMacro: async (domain, name, input, ctx) => {
+      calls.push({ domain, name, input, ctx });
+      return { ok: true, domain, name, input, echoedUser: ctx?.actor?.userId };
+    },
+    ...depOverrides,
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const port = server.address().port;
+      resolve({
+        url: `ws://127.0.0.1:${port}/unity-ws`,
+        calls,
+        async stop() {
+          try { gateway.close(); } catch { /* */ }
+          await new Promise((r) => server.close(r));
+        },
+      });
+    });
+  });
+}
+
+function connect(url) {
+  const ws = new WebSocket(url);
+  return new Promise((resolve, reject) => {
+    ws.once("open", () => resolve(ws));
+    ws.once("error", reject);
+  });
+}
+
+function nextFrame(ws, timeoutMs = 2000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => { cleanup(); reject(new Error("nextFrame timeout")); }, timeoutMs);
+    function onMsg(raw) { cleanup(); try { resolve(JSON.parse(raw.toString())); } catch (e) { reject(e); } }
+    function cleanup() { clearTimeout(timer); ws.off("message", onMsg); }
+    ws.on("message", onMsg);
+  });
+}
+
+function sendMsg(ws, evt, data) { ws.send(JSON.stringify({ evt, data })); }
+
+async function authAs(url) {
+  const ws = await connect(url);
+  sendMsg(ws, "auth", { token: "good-token" });
+  const hello = await nextFrame(ws);
+  assert.equal(hello.evt, "hello");
+  return ws;
+}
+
+describe("lens:run gateway verb — same three gates as HTTP", () => {
+  it("unauthenticated lens:run is rejected by existing auth (Gate 1)", async () => {
+    const h = await startGateway();
+    try {
+      const ws = await connect(h.url);
+      sendMsg(ws, "lens:run", { domain: "lore", name: "list", input: {} });
+      const frame = await nextFrame(ws);
+      assert.equal(frame.evt, "error");
+      assert.equal(frame.data.reason, "auth_required");
+      assert.equal(h.calls.length, 0, "runMacro must not run before auth");
+      ws.close();
+    } finally { await h.stop(); }
+  });
+
+  it("forwards to runMacro with HTTP-shaped ctx (path POST /api/lens/run, authenticated actor)", async () => {
+    const h = await startGateway();
+    try {
+      const ws = await authAs(h.url);
+      sendMsg(ws, "lens:run", { domain: "lore", name: "list", input: { q: "hub" } });
+      const frame = await nextFrame(ws);
+      assert.equal(frame.evt, "lens:result");
+      assert.equal(frame.data.ok, true);
+      assert.equal(h.calls.length, 1);
+      const call = h.calls[0];
+      assert.equal(call.domain, "lore");
+      assert.equal(call.name, "list");
+      assert.deepEqual(call.input, { q: "hub" });
+      assert.equal(call.ctx.reqMeta.path, "/api/lens/run");
+      assert.equal(call.ctx.reqMeta.method, "POST");
+      assert.equal(call.ctx.actor.userId, "u1");
+      assert.equal(call.ctx.userId, "u1");
+      assert.notEqual(call.ctx.actor.role, "system");
+      assert.notEqual(call.ctx.actor.internal, true);
+      assert.ok(!call.ctx.actor.scopes?.includes("*"), "must not mint a root actor");
+      ws.close();
+    } finally { await h.stop(); }
+  });
+
+  it("accepts HTTP's action alias for name", async () => {
+    const h = await startGateway();
+    try {
+      const ws = await authAs(h.url);
+      sendMsg(ws, "lens:run", { domain: "lore", action: "facets", input: {} });
+      const frame = await nextFrame(ws);
+      assert.equal(frame.evt, "lens:result");
+      assert.equal(h.calls[0].name, "facets");
+      ws.close();
+    } finally { await h.stop(); }
+  });
+
+  it("missing domain/name is an honest failure, not a runMacro call", async () => {
+    const h = await startGateway();
+    try {
+      const ws = await authAs(h.url);
+      sendMsg(ws, "lens:run", { input: { anything: true } });
+      const frame = await nextFrame(ws);
+      assert.equal(frame.evt, "lens:result");
+      assert.equal(frame.data.ok, false);
+      assert.equal(frame.data.reason, "domain_and_name_required");
+      assert.equal(h.calls.length, 0);
+      ws.close();
+    } finally { await h.stop(); }
+  });
+
+  it("forwards an injected {ok:false} verbatim — never rewrites to success", async () => {
+    const h = await startGateway({
+      runMacro: async () => ({ ok: false, reason: "forbidden", error: "forbidden: sovereign.tick" }),
+    });
+    try {
+      const ws = await authAs(h.url);
+      sendMsg(ws, "lens:run", { domain: "sovereign", name: "tick", input: {} });
+      const frame = await nextFrame(ws);
+      assert.equal(frame.evt, "lens:result");
+      assert.equal(frame.data.ok, false);
+      assert.equal(frame.data.reason, "forbidden");
+      ws.close();
+    } finally { await h.stop(); }
+  });
+
+  it("a thrown forbidden from runMacro becomes honest {ok:false}, not a fabricated success", async () => {
+    const h = await startGateway({
+      runMacro: async () => { throw new Error("forbidden: council.convene"); },
+    });
+    try {
+      const ws = await authAs(h.url);
+      sendMsg(ws, "lens:run", { domain: "council", name: "convene", input: {} });
+      const frame = await nextFrame(ws);
+      assert.equal(frame.evt, "lens:result");
+      assert.equal(frame.data.ok, false);
+      assert.equal(frame.data.reason, "forbidden");
+      ws.close();
+    } finally { await h.stop(); }
+  });
+
+  it("missing runMacro dep → honest lens_run_unavailable", async () => {
+    const h = await startGateway({ runMacro: null });
+    try {
+      const ws = await authAs(h.url);
+      sendMsg(ws, "lens:run", { domain: "lore", name: "list", input: {} });
+      const frame = await nextFrame(ws);
+      assert.equal(frame.evt, "lens:result");
+      assert.equal(frame.data.ok, false);
+      assert.equal(frame.data.reason, "lens_run_unavailable");
+      ws.close();
+    } finally { await h.stop(); }
+  });
+});
+
+describe("lens:run does not reimplement the three gates", () => {
+  it("the gateway lens:run case only forwards to deps.runMacro", () => {
+    // Isolate the lens:run case body so a comment elsewhere naming
+    // publicReadDomains / inLatticeReality cannot trip this pin.
+    const caseBody = GATEWAY_SRC.match(/case\s+"lens:run"\s*:[\s\S]*?case\s+"dialogue:request"/);
+    assert.ok(caseBody, "could not locate the lens:run switch case in godot-gateway.js");
+    // Strip comments so a documenting note that NAMES Gate 2/3 cannot trip
+    // the pin it's describing (same comment-blindness class as
+    // gateway-getuser-binding.test.js).
+    const body = caseBody[0]
+      .split("\n")
+      .map((line) => line.replace(/\/\/.*$/, ""))
+      .join("\n");
+    assert.match(body, /runMacro\(/, "lens:run must call the injected runMacro");
+    assert.doesNotMatch(
+      body,
+      /publicReadDomains/,
+      "gateway must not reimplement Gate 2 — publicReadDomains lives inside runMacro",
+    );
+    assert.doesNotMatch(
+      body,
+      /inLatticeReality|safeReadBypass|_safeReadPaths/,
+      "gateway must not reimplement Gate 3 — Chicken2 lives inside runMacro",
+    );
+    assert.match(
+      body,
+      /path:\s*"\/api\/lens\/run"/,
+      "ctx.reqMeta.path must be the HTTP route so Chicken2 sees the same surface",
+    );
+    assert.match(
+      body,
+      /userId:\s*client\.userId/,
+      "actor.userId must be the authenticated WS user, never the system default",
+    );
+  });
+
+  it("both production mounts inject _runMacroFromGateway (HTTP-identical dispatch)", () => {
+    const stripped = SERVER_SRC
+      .split("\n")
+      .map((line) => line.replace(/\/\/.*$/, ""))
+      .join("\n");
+    const hits = stripped.match(/runMacro\s*:\s*_runMacroFromGateway/g) || [];
+    assert.equal(
+      hits.length,
+      2,
+      `expected both /godot-ws and /unity-ws mounts to inject runMacro: _runMacroFromGateway, found ${hits.length}`,
+    );
+    assert.match(
+      stripped,
+      /async function _runMacroFromGateway/,
+      "_runMacroFromGateway must exist — it is the HTTP-identical wrapper (makeCtx + H1 + LENS_ACTIONS-then-runMacro)",
+    );
+    // The wrapper itself must go through the shared HTTP lookup, not a
+    // parallel dispatcher, and must pin reqMeta to the HTTP path.
+    const wrapper = SERVER_SRC.match(/async function _runMacroFromGateway[\s\S]*?^function /m);
+    assert.ok(wrapper, "could not isolate _runMacroFromGateway");
+    assert.match(wrapper[0], /_dispatchDesignCommand\(/);
+    assert.match(wrapper[0], /_lensActionForbiddenForAnon\(/);
+    assert.match(wrapper[0], /path:\s*"\/api\/lens\/run"/);
+    assert.doesNotMatch(wrapper[0], /role:\s*"system"/);
+  });
+});

--- a/server/tests/unity-lens-run.test.js
+++ b/server/tests/unity-lens-run.test.js
@@ -109,6 +109,8 @@ describe("lens:run gateway verb — same three gates as HTTP", () => {
       assert.equal(call.ctx.reqMeta.method, "POST");
       assert.equal(call.ctx.actor.userId, "u1");
       assert.equal(call.ctx.userId, "u1");
+      assert.equal(frame.data.lensDomain, "lore");
+      assert.equal(frame.data.lensName, "list");
       assert.notEqual(call.ctx.actor.role, "system");
       assert.notEqual(call.ctx.actor.internal, true);
       assert.ok(!call.ctx.actor.scopes?.includes("*"), "must not mint a root actor");

--- a/server/tests/unity-play-verbs.test.js
+++ b/server/tests/unity-play-verbs.test.js
@@ -9,7 +9,7 @@ import Database from "better-sqlite3";
 import { WebSocket } from "ws";
 import { mountUnityGateway } from "../lib/unity-bridge.js";
 import { giftReaction, GIFT_DELTA, giveGift } from "../lib/gifting.js";
-import { handleDodge, handleDungeonOpen } from "../lib/concordia-play.js";
+import { handleDodge, handleDungeonOpen, handleRunStart } from "../lib/concordia-play.js";
 import { applyHitToState, resetCombatState } from "../lib/combat-state.js";
 import { resetSessionsForTest } from "../lib/concordia-session.js";
 import { up as up050 } from "../migrations/050_player_inventory.js";
@@ -152,5 +152,29 @@ describe("Unity play verbs", () => {
     assert.equal(r.source, "presenter");
     assert.equal(r.boss.name, "The Hollow Warden");
     assert.equal(handleDungeonOpen(null, "u1", { encounterId: "nope" }).reason, "unknown_encounter");
+  });
+
+  it("run:start without a db is an honest failure, never a fabricated wave", () => {
+    const r = handleRunStart(null, "u1", { kind: "horde", worldId: "concordia-hub" });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "no_db");
+    assert.equal(handleRunStart(db, "u1", { kind: "raid" }).reason, "unknown_kind");
+  });
+
+  it("run:start horde on /unity-ws opens a kernel run", async () => {
+    const { up: upHorde } = await import("../migrations/246_horde_mode.js");
+    const { up: upDraft } = await import("../migrations/267_run_draft.js");
+    const { up: upCoop } = await import("../migrations/270_run_coop.js");
+    upHorde(db); upDraft(db); upCoop(db);
+    const ws = await authAs(gw.url);
+    sendMsg(ws, "run:start", { kind: "horde", worldId: "concordia-hub" });
+    const frame = await nextFrame(ws);
+    assert.equal(frame.evt, "run:data");
+    assert.equal(frame.data.ok, true);
+    assert.equal(frame.data.kind, "horde");
+    assert.equal(frame.data.source, "kernel");
+    assert.ok(frame.data.runId);
+    assert.equal(frame.data.alreadyActive, false);
+    ws.close();
   });
 });

--- a/server/tests/unity-play-verbs.test.js
+++ b/server/tests/unity-play-verbs.test.js
@@ -130,6 +130,12 @@ describe("Unity play verbs", () => {
     assert.equal(hit.damageMul, 0);
   });
 
+  it("combat:dodge action:jump is the recorded defense", () => {
+    const ack = handleDodge("u-jump", { action: "jump" });
+    assert.equal(ack.ok, true);
+    assert.equal(ack.action, "jump");
+  });
+
   it("scheme:intervene without a row is not a fabricated success", async () => {
     const ws = await authAs(gw.url);
     sendMsg(ws, "scheme:intervene", { schemeId: "missing", action: "expose" });

--- a/server/tests/unity-play-verbs.test.js
+++ b/server/tests/unity-play-verbs.test.js
@@ -9,7 +9,7 @@ import Database from "better-sqlite3";
 import { WebSocket } from "ws";
 import { mountUnityGateway } from "../lib/unity-bridge.js";
 import { giftReaction, GIFT_DELTA, giveGift } from "../lib/gifting.js";
-import { handleDodge, handleDungeonOpen, handleRunStart } from "../lib/concordia-play.js";
+import { handleDodge, handleDungeonOpen, handleDungeonHit, handleRunStart } from "../lib/concordia-play.js";
 import { applyHitToState, resetCombatState } from "../lib/combat-state.js";
 import { resetSessionsForTest } from "../lib/concordia-session.js";
 import { up as up050 } from "../migrations/050_player_inventory.js";
@@ -150,6 +150,13 @@ describe("Unity play verbs", () => {
     const r = giveGift(db, { userId: "u1", npcId: "kestra", itemId: "nope" });
     assert.equal(r.ok, false);
     assert.equal(r.reason, "item_not_owned");
+  });
+
+  it("dungeon:hit without a db is an honest failure, never a fabricated kill", () => {
+    const r = handleDungeonHit(null, "u1", { instanceId: "dng_x", damage: 20 });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "no_db");
+    assert.equal(handleDungeonHit(db, "u1", { damage: 20 }).reason, "missing_instance");
   });
 
   it("dungeon:open without a kernel table still names the authored encounter", () => {

--- a/server/tests/unity-play-verbs.test.js
+++ b/server/tests/unity-play-verbs.test.js
@@ -1,0 +1,156 @@
+// Unity / Godot presenter verbs on /unity-ws: gift, barge-in, party, dodge, inheritance.
+//
+//   cd server && node --test tests/unity-play-verbs.test.js
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import Database from "better-sqlite3";
+import { WebSocket } from "ws";
+import { mountUnityGateway } from "../lib/unity-bridge.js";
+import { giftReaction, GIFT_DELTA, giveGift } from "../lib/gifting.js";
+import { handleDodge, handleDungeonOpen } from "../lib/concordia-play.js";
+import { applyHitToState, resetCombatState } from "../lib/combat-state.js";
+import { resetSessionsForTest } from "../lib/concordia-session.js";
+import { up as up050 } from "../migrations/050_player_inventory.js";
+import { up as up206 } from "../migrations/206_romance.js";
+
+function freshDb() {
+  const db = new Database(":memory:");
+  db.exec(`CREATE TABLE users (id TEXT PRIMARY KEY);`);
+  up050(db); up206(db);
+  db.prepare(`INSERT INTO users (id) VALUES ('u1')`).run();
+  db.exec(`CREATE TABLE world_npcs (id TEXT PRIMARY KEY, archetype TEXT, npc_type TEXT, state TEXT);`);
+  try { db.exec(`ALTER TABLE player_inventory ADD COLUMN world_id TEXT DEFAULT 'concordia-hub'`); } catch { /* */ }
+  db.prepare(`INSERT INTO world_npcs (id, archetype, npc_type, state) VALUES ('kestra', 'scholar', 'npc', ?)`).run(JSON.stringify({ name: "Kestra" }));
+  db.prepare(`
+    INSERT INTO player_inventory (id, user_id, item_type, item_id, item_name, quantity, world_id)
+    VALUES ('row1', 'u1', 'material', 'tome01', 'Ancient Tome', 1, 'tunya')
+  `).run();
+  return db;
+}
+
+async function startGateway(db) {
+  const server = http.createServer();
+  const gateway = mountUnityGateway(server, {
+    verifyToken: (token) => (token === "good-token" ? { userId: "u1" } : null),
+    getUser: (userId) => (userId === "u1" ? { id: "u1", username: "tester" } : null),
+    exportScene: () => ({ ok: true, worldId: "concordia-hub", nodes: [] }),
+    exportKingdom: () => ({ ok: true, title: "Hub", staple: "lanterns", settlements: [] }),
+    db,
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = server.address().port;
+  return {
+    url: `ws://127.0.0.1:${port}/unity-ws`,
+    async stop() {
+      try { gateway.close(); } catch { /* */ }
+      await new Promise((resolve) => server.close(resolve));
+    },
+  };
+}
+
+function connect(url) {
+  const ws = new WebSocket(url);
+  return new Promise((resolve, reject) => {
+    ws.once("open", () => resolve(ws));
+    ws.once("error", reject);
+  });
+}
+
+function nextFrame(ws, timeoutMs = 2000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => { cleanup(); reject(new Error("nextFrame timeout")); }, timeoutMs);
+    function onMsg(raw) { cleanup(); try { resolve(JSON.parse(raw.toString())); } catch (e) { reject(e); } }
+    function cleanup() { clearTimeout(timer); ws.off("message", onMsg); }
+    ws.on("message", onMsg);
+  });
+}
+
+function sendMsg(ws, evt, data) { ws.send(JSON.stringify({ evt, data })); }
+
+async function authAs(url) {
+  const ws = await connect(url);
+  sendMsg(ws, "auth", { token: "good-token" });
+  const hello = await nextFrame(ws);
+  assert.equal(hello.evt, "hello");
+  return ws;
+}
+
+describe("Unity play verbs", () => {
+  let db, gw;
+
+  before(async () => {
+    resetSessionsForTest();
+    db = freshDb();
+    gw = await startGateway(db);
+  });
+  after(async () => {
+    await gw.stop();
+    try { db.close(); } catch { /* */ }
+  });
+
+  it("gift:give consumes a user-global stack even when world_id is another world", async () => {
+    const ws = await authAs(gw.url);
+    sendMsg(ws, "gift:give", { npcId: "kestra", itemId: "tome01", worldId: "concordia-hub" });
+    const frame = await nextFrame(ws);
+    assert.equal(frame.evt, "gift:result");
+    assert.equal(frame.data.ok, true);
+    assert.equal(frame.data.reaction, "loved");
+    assert.equal(frame.data.source, "kernel");
+    const left = db.prepare(`SELECT quantity FROM player_inventory WHERE item_id='tome01'`).get();
+    assert.equal(left, undefined);
+    ws.close();
+  });
+
+  it("giftReaction scholar+flower is liked via herb category", () => {
+    assert.equal(giftReaction({ archetype: "scholar" }, "a lantern flower"), "neutral");
+    assert.equal(giftReaction({ archetype: "healer" }, "a lantern flower"), "loved");
+    assert.equal(GIFT_DELTA.loved > GIFT_DELTA.neutral, true);
+  });
+
+  it("party:request joins the world session", async () => {
+    const ws = await authAs(gw.url);
+    sendMsg(ws, "party:request", { worldId: "concordia-hub", x: 1, z: 2 });
+    const frame = await nextFrame(ws);
+    assert.equal(frame.evt, "party:data");
+    assert.equal(frame.data.ok, true);
+    assert.ok(frame.data.count >= 1);
+    assert.equal(frame.data.members[0].id, "u1");
+    ws.close();
+  });
+
+  it("combat:dodge grants i-frames that zero the next hit", () => {
+    resetCombatState("u-dodge");
+    const ack = handleDodge("u-dodge", { perfect: false });
+    assert.equal(ack.ok, true);
+    assert.equal(ack.iframeMs, 350);
+    const hit = applyHitToState("u-dodge", { damage: 40 });
+    assert.equal(hit.iframed, true);
+    assert.equal(hit.damageMul, 0);
+  });
+
+  it("scheme:intervene without a row is not a fabricated success", async () => {
+    const ws = await authAs(gw.url);
+    sendMsg(ws, "scheme:intervene", { schemeId: "missing", action: "expose" });
+    const frame = await nextFrame(ws);
+    assert.equal(frame.evt, "scheme:intervened");
+    assert.equal(frame.data.ok, false);
+    assert.equal(frame.data.reason, "scheme_not_found");
+    ws.close();
+  });
+
+  it("giveGift still rejects a missing stack", () => {
+    const r = giveGift(db, { userId: "u1", npcId: "kestra", itemId: "nope" });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "item_not_owned");
+  });
+
+  it("dungeon:open without a kernel table still names the authored encounter", () => {
+    const r = handleDungeonOpen(null, "u1", { encounterId: "hollow_warden" });
+    assert.equal(r.ok, true);
+    assert.equal(r.source, "presenter");
+    assert.equal(r.boss.name, "The Hollow Warden");
+    assert.equal(handleDungeonOpen(null, "u1", { encounterId: "nope" }).reason, "unknown_encounter");
+  });
+});

--- a/server/tests/unity-play-verbs.test.js
+++ b/server/tests/unity-play-verbs.test.js
@@ -157,6 +157,7 @@ describe("Unity play verbs", () => {
     assert.equal(r.ok, true);
     assert.equal(r.source, "presenter");
     assert.equal(r.boss.name, "The Hollow Warden");
+    assert.equal(r.boss.mechanic, "tank holds aggro");
     assert.equal(handleDungeonOpen(null, "u1", { encounterId: "nope" }).reason, "unknown_encounter");
   });
 

--- a/server/tests/unity-tiers-foundation.test.js
+++ b/server/tests/unity-tiers-foundation.test.js
@@ -160,3 +160,87 @@ test("Unity presents remaining kernel consequences without inventing engines", (
   assert.match(chronicle, /"combat:chronicle"/);
   assert.match(legacy, /"npc:funeral"/);
 });
+
+test("Level 1 funeral gathering uses real attendee ids, not invented mourners", () => {
+  const life = readFileSync(join(
+    import.meta.dirname,
+    "../../apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/NpcLife.cs",
+  ), "utf8");
+  const romance = readFileSync(join(import.meta.dirname, "../lib/romance-engine.js"), "utf8");
+  const shapes = readFileSync(join(import.meta.dirname, "../lib/event-shapes.js"), "utf8");
+  assert.match(life, /public void Attend\(/);
+  assert.match(client, /life\.Attend\(/);
+  assert.match(client, /GatheringTell\.PlaceAt/);
+  assert.match(client, /evt == "npc:wedding"/);
+  assert.match(client, /PresentWedding/);
+  assert.match(romance, /"npc:wedding"/);
+  assert.match(romance, /kind: "wedding"/);
+  assert.match(shapes, /"npc:wedding"/);
+});
+
+test("Level 1 boss body fights at the hold and dies into a chronicle", () => {
+  const gate = readFileSync(join(
+    import.meta.dirname,
+    "../../apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldGate.cs",
+  ), "utf8");
+  const play = readFileSync(join(import.meta.dirname, "../lib/concordia-play.js"), "utf8");
+  const gw = readFileSync(join(import.meta.dirname, "../lib/godot-gateway.js"), "utf8");
+  const dummy = readFileSync(join(
+    import.meta.dirname,
+    "../../apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/TrainingDummy.cs",
+  ), "utf8");
+  assert.match(gate, /AddComponent<TrainingDummy>/);
+  assert.match(gate, /AddComponent<Hostile>/);
+  assert.match(gate, /public void Fall\(\)/);
+  assert.match(gate, /No invented xz/);
+  assert.match(dummy, /GetComponent<WorldBoss>/);
+  assert.match(client, /dungeon:hit:ack/);
+  assert.match(client, /SendDungeonHit/);
+  assert.match(play, /export function handleDungeonHit/);
+  assert.match(play, /recordHit\(/);
+  assert.match(play, /mintMatchChronicle/);
+  assert.match(gw, /case "dungeon:hit"/);
+});
+
+test("Level 1 Mixamo styles stance anticipation strike impact recovery", () => {
+  const mixamo = readFileSync(join(
+    import.meta.dirname,
+    "../../apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/MixamoAvatar.cs",
+  ), "utf8");
+  const canon = readFileSync(join(
+    import.meta.dirname,
+    "../../apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/Canon.cs",
+  ), "utf8");
+  const person = readFileSync(join(
+    import.meta.dirname,
+    "../../apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ModularPerson.cs",
+  ), "utf8");
+  assert.match(canon, /enum FightStyle/);
+  assert.match(canon, /PickFight/);
+  assert.match(canon, /FightStyle\.Karate/);
+  assert.match(canon, /FightStyle\.MuayThai/);
+  assert.match(canon, /FightStyle\.WingChun/);
+  assert.match(canon, /FightStyle\.Capoeira/);
+  assert.match(canon, /FightStyle\.Sword/);
+  assert.match(mixamo, /public void Anticipate\(\)/);
+  assert.match(mixamo, /public void Knockdown\(\)/);
+  assert.match(mixamo, /void ApplyStance\(\)/);
+  assert.match(mixamo, /FightStyle\.WingChun/);
+  assert.match(mixamo, /FightStyle\.Capoeira/);
+  assert.match(person, /public void BindStyle\(/);
+  assert.match(person, /public void Anticipate\(\)/);
+});
+
+test("Level 2 world silhouettes differ by architecture, not only palette", () => {
+  const fill = readFileSync(join(
+    import.meta.dirname,
+    "../../apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/RealmFill.cs",
+  ), "utf8");
+  assert.match(fill, /HubLook\.Point\(root, "NeonA"/);
+  const crime = fill.split("case WorldId.Crime:")[1]?.split("case WorldId.Cyber:")[0] || "";
+  assert.equal(crime.includes("Horizon("), false, "Crime is low-rise; no skyscraper horizon");
+  assert.match(crime, /building-type-h/);
+  assert.match(fill, /Ring\(root, DressVocab\.House\(WorldId\.Fantasy\)/);
+  assert.match(fill, /Ring\(root, DressVocab\.House\(WorldId\.Frontier\)/);
+  assert.match(fill, /w\.id == WorldId\.Crime \|\| w\.id == WorldId\.Sere/);
+});

--- a/server/tests/unity-tiers-foundation.test.js
+++ b/server/tests/unity-tiers-foundation.test.js
@@ -80,3 +80,31 @@ test("ConcordClient consequence strip consumes gossip + lastWords", () => {
   assert.match(client, /JsonString\(text, "lastWords"\)/);
   assert.match(client, /PushFeed\(/);
 });
+
+test("Unity collides kernel gossip, tombs, stress, banners, and inherited score in 3D", () => {
+  const gate = readFileSync(join(
+    import.meta.dirname,
+    "../../apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldGate.cs",
+  ), "utf8");
+  const life = readFileSync(join(
+    import.meta.dirname,
+    "../../apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/NpcLife.cs",
+  ), "utf8");
+  const gw = readFileSync(join(import.meta.dirname, "../lib/godot-gateway.js"), "utf8");
+  assert.match(gate, /class KernelTomb/);
+  assert.match(gate, /class GossipEar/);
+  assert.match(gate, /class GatheringTell/);
+  assert.match(life, /public void Cope\(/);
+  assert.match(life, /public void HeadFor\(/);
+  assert.match(client, /AdaptiveScore\.Apply\("faction:war-declared"\)/);
+  assert.match(client, /setMusicCombatIntensity/);
+  assert.match(client, /intensity = 0\.85f/);
+  assert.match(client, /holdMs = 12000f/);
+  assert.match(client, /evt == "npc:migrated"/);
+  assert.match(client, /RealmFill\.MarkWar/);
+  assert.match(client, /life\.Cope\(trait\)/);
+  assert.match(client, /KernelTomb\.Place/);
+  assert.match(client, /GossipEar\.Attach/);
+  assert.match(gw, /npcA: r\.npc_a_id/);
+  assert.match(gw, /npcB: r\.npc_b_id/);
+});

--- a/server/tests/unity-tiers-foundation.test.js
+++ b/server/tests/unity-tiers-foundation.test.js
@@ -1,0 +1,55 @@
+// Unity tiers-plan foundations: ConcordClient must consume kernel events
+// that this pass wired onto /unity-ws (scheme:overheard, perilKind, heir-rose).
+//
+//   cd server && node --test tests/unity-tiers-foundation.test.js
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const CLIENT = join(
+  import.meta.dirname,
+  "../../apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs",
+);
+const HOSTILE = join(
+  import.meta.dirname,
+  "../../apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/Hostile.cs",
+);
+const PLOTS = join(
+  import.meta.dirname,
+  "../../apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/HubObjectives.cs",
+);
+
+const client = readFileSync(CLIENT, "utf8");
+const hostile = readFileSync(HOSTILE, "utf8");
+const plots = readFileSync(PLOTS, "utf8");
+
+test("ConcordClient consumes scheme:overheard with the kernel schemeId", () => {
+  assert.match(client, /evt == "scheme:overheard"/);
+  assert.match(client, /Plots\.Seed\(line, schemeId\)/);
+});
+
+test("ConcordClient reads combat:telegraph perilKind, not a local style hash", () => {
+  assert.match(client, /JsonString\(text, "perilKind"\)/);
+  assert.match(client, /Hostile\.BindKernel/);
+  assert.match(hostile, /public static void BindKernel/);
+});
+
+test("ConcordClient does not barge-in on npc:conversation-bid", () => {
+  assert.match(client, /evt == "npc:conversation-bid"/);
+  assert.doesNotMatch(
+    client,
+    /evt == "npc:scheme-resolved" \|\| evt == "npc:conversation-bid"/,
+  );
+});
+
+test("Plots only SendIntervene for a kernel scheme id", () => {
+  assert.match(plots, /if \(_live\.kernel\)/);
+  assert.match(plots, /client\.SendIntervene\(_live\.id, action\)/);
+});
+
+test("ConcordClient applies combat:impact momentum", () => {
+  assert.match(client, /impactMomentum/);
+  assert.match(client, /TakeHit\(/);
+});

--- a/server/tests/unity-tiers-foundation.test.js
+++ b/server/tests/unity-tiers-foundation.test.js
@@ -53,3 +53,30 @@ test("ConcordClient applies combat:impact momentum", () => {
   assert.match(client, /impactMomentum/);
   assert.match(client, /TakeHit\(/);
 });
+
+test("ConcordClient presents faction diplomacy from the kernel, not a local bar", () => {
+  assert.match(client, /evt == "faction:war-declared"/);
+  assert.match(client, /evt == "faction:alliance-formed"/);
+  assert.match(client, /evt == "faction:truce-sought"/);
+  assert.match(client, /JsonString\(text, "summary"\)/);
+});
+
+test("ConcordClient presents gatherings, bosses, seasons, festivals, stress-break", () => {
+  assert.match(client, /evt == "world:gathering-detected"/);
+  assert.match(client, /evt == "world:boss-spawn"/);
+  assert.match(client, /evt == "world:season-transition"/);
+  assert.match(client, /evt == "festival:started"/);
+  assert.match(client, /evt == "npc:stress-break"/);
+});
+
+test("ConcordClient does not relabel an NPC harvest as a social gathering", () => {
+  assert.match(client, /evt == "world:npc-gather"/);
+  assert.match(client, /resourceName/);
+  assert.doesNotMatch(client, /NoteAct\("a gathering"\)/);
+});
+
+test("ConcordClient consequence strip consumes gossip + lastWords", () => {
+  assert.match(client, /PushFeed\("gossip"/);
+  assert.match(client, /JsonString\(text, "lastWords"\)/);
+  assert.match(client, /PushFeed\(/);
+});

--- a/server/tests/unity-tiers-foundation.test.js
+++ b/server/tests/unity-tiers-foundation.test.js
@@ -244,3 +244,37 @@ test("Level 2 world silhouettes differ by architecture, not only palette", () =>
   assert.match(fill, /Ring\(root, DressVocab\.House\(WorldId\.Frontier\)/);
   assert.match(fill, /w\.id == WorldId\.Crime \|\| w\.id == WorldId\.Sere/);
 });
+
+test("creature pillar compiles kernel genome, not a catalog kind", () => {
+  const compiler = readFileSync(join(
+    import.meta.dirname,
+    "../../apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/CreatureCompiler.cs",
+  ), "utf8");
+  const spawn = readFileSync(join(
+    import.meta.dirname,
+    "../../apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/EvoSpawner.cs",
+  ), "utf8");
+  const fauna = readFileSync(join(
+    import.meta.dirname,
+    "../../apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/EvoSpawner.cs",
+  ), "utf8");
+  const gw = readFileSync(join(import.meta.dirname, "../lib/godot-gateway.js"), "utf8");
+  const shapes = readFileSync(join(import.meta.dirname, "../lib/event-shapes.js"), "utf8");
+  const creatures = readFileSync(join(import.meta.dirname, "../lib/concordia-creatures.js"), "utf8");
+  assert.match(compiler, /class CreatureGenome/);
+  assert.match(compiler, /class CreatureCard/);
+  assert.match(compiler, /PresentKernel/);
+  assert.match(compiler, /DressMorphology/);
+  assert.match(spawn, /CreatureCompiler\.FromCritter/);
+  assert.match(fauna, /BindGenome/);
+  assert.match(client, /evt == "creature:born"/);
+  assert.match(client, /PresentKernelCreatures/);
+  assert.match(client, /PresentEcology/);
+  assert.match(gw, /creatures: snapshotCreatures/);
+  assert.match(gw, /ecology: snapshotEcology/);
+  assert.match(shapes, /"creature:born"/);
+  assert.match(creatures, /export function snapshotCreatures/);
+  assert.match(creatures, /export function snapshotEcology/);
+  assert.match(creatures, /export function announceCreatureBorn/);
+  assert.doesNotMatch(spawn, /hint\.Contains\("quad"\) \? "wolf"/);
+});

--- a/server/tests/unity-tiers-foundation.test.js
+++ b/server/tests/unity-tiers-foundation.test.js
@@ -98,8 +98,8 @@ test("Unity collides kernel gossip, tombs, stress, banners, and inherited score 
   assert.match(life, /public void HeadFor\(/);
   assert.match(client, /AdaptiveScore\.Apply\("faction:war-declared"\)/);
   assert.match(client, /setMusicCombatIntensity/);
-  assert.match(client, /intensity = 0\.85f/);
-  assert.match(client, /holdMs = 12000f/);
+  assert.match(client, /Intensity\(0\.85f\)/);
+  assert.match(client, /Mode\("minor", 12000f\)/);
   assert.match(client, /evt == "npc:migrated"/);
   assert.match(client, /RealmFill\.MarkWar/);
   assert.match(client, /life\.Cope\(trait\)/);

--- a/server/tests/unity-tiers-foundation.test.js
+++ b/server/tests/unity-tiers-foundation.test.js
@@ -108,3 +108,55 @@ test("Unity collides kernel gossip, tombs, stress, banners, and inherited score 
   assert.match(gw, /npcA: r\.npc_a_id/);
   assert.match(gw, /npcB: r\.npc_b_id/);
 });
+
+test("Unity presents remaining kernel consequences without inventing engines", () => {
+  const gate = readFileSync(join(
+    import.meta.dirname,
+    "../../apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldGate.cs",
+  ), "utf8");
+  const mixamo = readFileSync(join(
+    import.meta.dirname,
+    "../../apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/MixamoAvatar.cs",
+  ), "utf8");
+  const packs = readFileSync(join(
+    import.meta.dirname,
+    "../../apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/FreePacks.cs",
+  ), "utf8");
+  const play = readFileSync(join(import.meta.dirname, "../lib/concordia-play.js"), "utf8");
+  const gw = readFileSync(join(import.meta.dirname, "../lib/godot-gateway.js"), "utf8");
+  const worlds = readFileSync(join(import.meta.dirname, "../routes/worlds.js"), "utf8");
+  const chronicle = readFileSync(join(import.meta.dirname, "../lib/combat/match-chronicle.js"), "utf8");
+  const legacy = readFileSync(join(import.meta.dirname, "../lib/npc-legacy.js"), "utf8");
+  assert.match(client, /evt == "npc:funeral"/);
+  assert.match(client, /PresentFuneral/);
+  assert.match(client, /WorldBoss\.Present/);
+  assert.match(client, /evt == "combat:chronicle"/);
+  assert.match(client, /ChroniclePlaque\.Place/);
+  assert.match(client, /CraftedTell\.PlaceAtStation/);
+  assert.match(client, /KitBag\.BindKernel/);
+  assert.match(client, /evt == "kingdom:decree-enacted"/);
+  assert.match(client, /evt == "dream:composed"/);
+  assert.match(client, /evt == "prediction:realised"/);
+  assert.match(client, /evt == "world:refusal-field"/);
+  assert.match(client, /reason == "locked_out"/);
+  assert.match(client, /DungeonGate\.EjectIfInside/);
+  assert.match(gate, /class WorldBoss/);
+  assert.match(gate, /No invented xz/);
+  assert.match(gate, /class ChroniclePlaque/);
+  assert.match(gate, /class CraftedTell/);
+  assert.match(gate, /EjectIfInside/);
+  assert.match(mixamo, /public void Hit\(\)/);
+  assert.match(mixamo, /public void Stagger\(\)/);
+  assert.match(packs, /cityIndex <= 2 \? 2 : 0/);
+  assert.match(packs, /unique authored \.glb per world: none in tree/);
+  assert.match(play, /reason === "locked_out"/);
+  assert.match(play, /mechanic: ph\.mechanic/);
+  assert.match(gw, /bosses: bossRows\.map/);
+  assert.match(gw, /gear: snapshotGear/);
+  assert.match(gw, /chronicles: snapshotChronicles/);
+  assert.match(gw, /Never inserts a default loadout row/);
+  assert.match(worlds, /event: "boss:state"/);
+  assert.match(worlds, /event: "boss:phase-enter"/);
+  assert.match(chronicle, /"combat:chronicle"/);
+  assert.match(legacy, /"npc:funeral"/);
+});

--- a/server/tests/unity-world-spine.test.js
+++ b/server/tests/unity-world-spine.test.js
@@ -5,6 +5,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { WebSocket } from "ws";
 import { mountUnityGateway } from "../lib/unity-bridge.js";
 import { getWeather } from "../lib/weather.js";
@@ -107,6 +109,14 @@ describe("world:snapshot", () => {
       assert.equal(frame.data.tombs.length, 0);
       ws.close();
     } finally { await h.stop(); }
+  });
+});
+
+describe("gossip snapshot ids", () => {
+  it("gateway maps npc_a_id / npc_b_id onto npcA / npcB for 3D overheard", () => {
+    const src = readFileSync(join(import.meta.dirname, "../lib/godot-gateway.js"), "utf8");
+    assert.match(src, /npcA: r\.npc_a_id/);
+    assert.match(src, /npcB: r\.npc_b_id/);
   });
 });
 

--- a/server/tests/unity-world-spine.test.js
+++ b/server/tests/unity-world-spine.test.js
@@ -107,6 +107,12 @@ describe("world:snapshot", () => {
       assert.equal(frame.data.gossip.length, 0, "empty substrate stays empty");
       assert.ok(Array.isArray(frame.data.tombs), "tombs must be an array");
       assert.equal(frame.data.tombs.length, 0);
+      assert.ok(Array.isArray(frame.data.bosses), "bosses must be an array, never invented");
+      assert.equal(frame.data.bosses.length, 0, "empty substrate stays empty");
+      assert.ok(Array.isArray(frame.data.gear), "gear must be an array");
+      assert.equal(frame.data.gear.length, 0);
+      assert.ok(Array.isArray(frame.data.chronicles), "chronicles must be an array");
+      assert.equal(frame.data.chronicles.length, 0);
       ws.close();
     } finally { await h.stop(); }
   });

--- a/server/tests/unity-world-spine.test.js
+++ b/server/tests/unity-world-spine.test.js
@@ -101,6 +101,10 @@ describe("world:snapshot", () => {
       const live = getWeather("concordia-hub");
       assert.equal(frame.data.weather.type, live.type);
       assert.equal(frame.data.weather.intensity, live.intensity);
+      assert.ok(Array.isArray(frame.data.gossip), "gossip must be an array, never omitted as fake rumor");
+      assert.equal(frame.data.gossip.length, 0, "empty substrate stays empty");
+      assert.ok(Array.isArray(frame.data.tombs), "tombs must be an array");
+      assert.equal(frame.data.tombs.length, 0);
       ws.close();
     } finally { await h.stop(); }
   });

--- a/server/tests/unity-world-spine.test.js
+++ b/server/tests/unity-world-spine.test.js
@@ -1,0 +1,131 @@
+// Phase 2 world-spine: world:snapshot + gateway mirror of clock/weather.
+//
+//   cd server && node --test tests/unity-world-spine.test.js
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { WebSocket } from "ws";
+import { mountUnityGateway } from "../lib/unity-bridge.js";
+import { getWeather } from "../lib/weather.js";
+import { getWorldPhase, getDayPhase, WORLD_CLOCK_CONSTANTS } from "../lib/world-clock.js";
+import { mirrorToGateways } from "../lib/gateway-fanout.js";
+
+async function startGateway() {
+  const server = http.createServer();
+  const gateway = mountUnityGateway(server, {
+    verifyToken: (token) => (token === "good-token" ? { userId: "u1" } : null),
+    getUser: (userId) => (userId === "u1" ? { id: "u1", username: "tester" } : null),
+    exportScene: () => ({ ok: true, worldId: "concordia-hub", nodes: [] }),
+    exportKingdom: () => ({ ok: true, title: "Hub", staple: "lanterns", settlements: [] }),
+    db: {},
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = server.address().port;
+  return {
+    url: `ws://127.0.0.1:${port}/unity-ws`,
+    async stop() {
+      try { gateway.close(); } catch { /* */ }
+      await new Promise((r) => server.close(r));
+    },
+  };
+}
+
+function connect(url) {
+  const ws = new WebSocket(url);
+  return new Promise((resolve, reject) => {
+    ws.once("open", () => resolve(ws));
+    ws.once("error", reject);
+  });
+}
+
+function nextFrame(ws, timeoutMs = 2000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => { cleanup(); reject(new Error("nextFrame timeout")); }, timeoutMs);
+    function onMsg(raw) { cleanup(); try { resolve(JSON.parse(raw.toString())); } catch (e) { reject(e); } }
+    function cleanup() { clearTimeout(timer); ws.off("message", onMsg); }
+    ws.on("message", onMsg);
+  });
+}
+
+function sendMsg(ws, evt, data) { ws.send(JSON.stringify({ evt, data })); }
+
+async function authAs(url) {
+  const ws = await connect(url);
+  sendMsg(ws, "auth", { token: "good-token" });
+  const hello = await nextFrame(ws);
+  assert.equal(hello.evt, "hello");
+  return ws;
+}
+
+describe("world:snapshot", () => {
+  it("unauthenticated snapshot is rejected by existing auth", async () => {
+    const h = await startGateway();
+    try {
+      const ws = await connect(h.url);
+      sendMsg(ws, "world:snapshot", { worldId: "concordia-hub" });
+      const frame = await nextFrame(ws);
+      assert.equal(frame.evt, "error");
+      assert.equal(frame.data.reason, "auth_required");
+      ws.close();
+    } finally { await h.stop(); }
+  });
+
+  it("missing worldId is an honest failure, not a fabricated climate", async () => {
+    const h = await startGateway();
+    try {
+      const ws = await authAs(h.url);
+      sendMsg(ws, "world:snapshot", {});
+      const frame = await nextFrame(ws);
+      assert.equal(frame.evt, "world:snapshot");
+      assert.equal(frame.data.ok, false);
+      assert.equal(frame.data.reason, "missing_world");
+      ws.close();
+    } finally { await h.stop(); }
+  });
+
+  it("returns the real clock + weather engines, not a stub climate", async () => {
+    const h = await startGateway();
+    try {
+      const ws = await authAs(h.url);
+      sendMsg(ws, "world:snapshot", { worldId: "concordia-hub" });
+      const frame = await nextFrame(ws);
+      assert.equal(frame.evt, "world:snapshot");
+      assert.equal(frame.data.ok, true);
+      assert.equal(frame.data.worldId, "concordia-hub");
+      const phase = getWorldPhase();
+      assert.equal(typeof frame.data.clock.phase, "number");
+      assert.ok(Math.abs(frame.data.clock.phase - phase) < 0.05);
+      assert.equal(frame.data.clock.segment, getDayPhase(frame.data.clock.phase));
+      assert.equal(frame.data.clock.dayLengthMs, WORLD_CLOCK_CONSTANTS.dayLengthMs);
+      const live = getWeather("concordia-hub");
+      assert.equal(frame.data.weather.type, live.type);
+      assert.equal(frame.data.weather.intensity, live.intensity);
+      ws.close();
+    } finally { await h.stop(); }
+  });
+});
+
+describe("gateway-only mirror hook", () => {
+  it("mirrorToGateways is a no-op when no hook is assigned", () => {
+    const prev = globalThis._concordGatewayMirror;
+    delete globalThis._concordGatewayMirror;
+    assert.doesNotThrow(() => mirrorToGateways("world:weather", { worldId: "x" }, { worldId: "x" }));
+    globalThis._concordGatewayMirror = prev;
+  });
+
+  it("mirrorToGateways forwards event + worldId to the assigned hook", () => {
+    const prev = globalThis._concordGatewayMirror;
+    const seen = [];
+    globalThis._concordGatewayMirror = (event, payload, opts) => seen.push({ event, payload, opts });
+    try {
+      mirrorToGateways("world:weather", { type: "rain" }, { worldId: "concordia-hub" });
+      assert.equal(seen.length, 1);
+      assert.equal(seen[0].event, "world:weather");
+      assert.equal(seen[0].payload.type, "rain");
+      assert.equal(seen[0].opts.worldId, "concordia-hub");
+    } finally {
+      globalThis._concordGatewayMirror = prev;
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Concordia Unity presenter

Unity WebGL is the canonical World Lens web client. This branch presents existing Concordia kernel systems rather than inventing new MMO engines.

### HUD / feed first wave (`ddf90a3c7`)

Gateway mirrors + consequence strip for faction diplomacy, gatherings, bosses, seasons, festivals, economy, stress-break, heir last words. Snapshot includes `gossip[]` and `tombs[]`. Empty stays empty.

### 3D collision (`3271ba20d`)

Kernel tombs, overheard gossip, stress acting, gathering markers, faction banners, inherited adaptive score, migration walks.

### Remaining unclaimed systems (`be1dc5fe2`)

- **World bosses** — body only at an existing `DungeonGate` mouth; HP/phase from `dungeon:data` / `boss:state`. No invented xz.
- **Funerals** — thin `npc:funeral` emit of `gatherAttendees`; matching GuestNpcs `HeadFor` the real tomb. No fake mourners.
- **Mixamo** — `Hit()` / `Stagger()` overlays on `combat:impact` / `TakeHit`; specials now slash.
- **Interiors** — hero city keeps 4 playable rooms; cities 1–2 get 2 via existing `BuildingInterior.Open`.
- **F2 affixes** — snapshot `gear[]` from equipped `affixes_json`; kit overlay shows kernel labels only.
- **F5.1 lockout** — `dungeon:data` `locked_out` ejects the player from the hold.
- **Combat chronicle** — plaque at the Arena when `mintMatchChronicle` actually mints.
- **Crafted DTUs** — tell at an existing cook station when `npc:economy-batch` crafts > 0.
- **Unique GLB** — none in the tree; `DressVocab.Culture` + `Kit` remains the honest unique-per-world presentation.
- **HUD leftovers** — decree / fallen / contested, dream, prediction, refusal-field.

### Level 1 — make the existing simulation visible (`a17718e4f`)

- **A. Funeral / wedding gathering** — `NpcLife.Attend` walks matching `GuestNpc`s to a ring around a real tomb (funeral) or tavern door / plaza (wedding). Attendee IDs come from `gatherAttendees`. Empty attendees → tomb only. `romance-engine.wed` emits `npc:wedding` with the same composition. No invented mourners.
- **B. Boss embodiment** — the hold-mouth capsule is now a `TrainingDummy` + `Hostile`. Kernel HP/phase paint the body; `dungeon:hit` → existing `recordHit` (phase/clear). A real clear mints a chronicle plaque at the mouth and optionally `defeatBoss`. No second raid engine, no fabricated spawn coords.
- **C. Fight-style overlays** — stance → anticipation → strike → impact → recovery. Five styles actually read differently (karate, Muay Thai, Wing Chun, capoeira, sword) via procedural Mixamo/ModularPerson overlays. Mixamo FBX packs are still not in the tree.

### Level 2 — nine worlds by architecture, not only palette (`a17718e4f`)

Existing FreePacks stems, no fabricated GLBs:

- **Cyber** — stacked neon rings + point lights
- **Crime** — low-rise alleys; no skyscraper horizon
- **Fantasy / Frontier / Tunya** — timber house rings + existing vegetation/tents
- **Ruins** — extra ruined-house scatter on crypts/columns

### Creature / Evo compiler (`148b31dc5`)

Creatures are a first-class pillar: genome → phenotype → Unity body. Unity no longer maps fauna to collapsed catalog kinds (`wolf` / `hound`).

- **Kernel cards** — `snapshotCreatures` / `snapshotEcology` on `world:snapshot`. Empty tables stay `[]`. `creature:born` emits the real hybrid id from pen `breed` / `maybeCrossbreed` (world-kernel synthetic ticks do not flood).
- **Unity compiler** — `CreatureCompiler` stamps `CreatureGenome` (id, species, topology, generation, parents, gait, fly). Morphology (wings / tail / coils / polyp legs) comes from authored topology. `EvoSpawner` delegates here.
- **Playthrough (Fantasy, Unity 6000.5.9f1)** — Hub fauna stays empty. After `Travel(Fantasy)`: 8 genomes with authored ids (`mana_drake`, `griffin`, `basilisk`, `gloom_stalker`, `thorn_wolf`, `crystal_elemental`, `bone_sentinel`, `wolf`). `mana_drake` / `griffin` fly with `winged_quadruped` gait; `gloom_stalker` is `amorphous`; `basilisk` is serpentine with coil morphs. Compiled live hybrid `gloom_stalker · gen 4 · ice` (winged, carnivore, wander). Ecology feed recorded the same facts. No invented species.

### Honesty

- `world:npc-gather` remains a harvest, not a funeral.
- Empty gossip/tombs/bosses/gear/chronicles/fauna stay empty.
- World bosses still have no spawn coordinates — they bind to the world's existing hold or they do not appear.
- Unique authored `.glb` files are not fabricated.
- HTTP `EvoResolver` is not the live path; Unity rides `/unity-ws`.

### Not this PR

Levels 3–9 of the original embodiment plan, the full AAA consequence graph, living-NPC unification, 67-skill descriptors, Mixamo FBX packs, 72-hour/7-day alive certification, physical occupancy of buildings/territory, and scheme barge-in as a complete agency loop. This pass is the creature compiler spine plus Level 1–2 presentation only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aec3ca7e-e6cd-47ee-b356-868b740a0bfa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aec3ca7e-e6cd-47ee-b356-868b740a0bfa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

