### PR TITLE
Persistent megaworld playable loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **DHTP Representation Sufficiency (cloud agents):** If the task is the DHTP-RS benchmark, read **`docs/DHTP_RS_CLOUD_AGENT.md`** first. Entry point: `node server/scripts/run-dhtp-rs.mjs resume` (auto-loads keys from `.env.runpod` / `server/.env`). Status: `node server/scripts/run-dhtp-rs.mjs status`. Phase 1 complete; **Phase 2 pending** (6 probes × 20 trials).
 
-**Concordia persistent megaworld:** `docs/CONCORDIA_PERSISTENT_MEGAWORLD.md` — one continuous universe; worlds are regions; Hub is Flower Law only; abandon ≠ delete. Spine pinned by `server/tests/concordia-megaworld.test.js`.
+**Concordia persistent megaworld:** `docs/CONCORDIA_PERSISTENT_MEGAWORLD.md` — one continuous universe; worlds are regions; Hub is Flower Law only; abandon ≠ delete; world identity is a spatial field. Spine pinned by `server/tests/concordia-megaworld.test.js` and `server/tests/concordia-world-field.test.js`.
 
 The v1 release arc is merged (PR #841, 2026-07-02). The live arc is now
 **`docs/NEXT_ARC_PLAN.md`** (the "🟢 HANDOFF — start here" block at the top): Wave 1 =

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **DHTP Representation Sufficiency (cloud agents):** If the task is the DHTP-RS benchmark, read **`docs/DHTP_RS_CLOUD_AGENT.md`** first. Entry point: `node server/scripts/run-dhtp-rs.mjs resume` (auto-loads keys from `.env.runpod` / `server/.env`). Status: `node server/scripts/run-dhtp-rs.mjs status`. Phase 1 complete; **Phase 2 pending** (6 probes × 20 trials).
 
+**Concordia persistent megaworld:** `docs/CONCORDIA_PERSISTENT_MEGAWORLD.md` — one continuous universe; worlds are regions; Hub is Flower Law only; abandon ≠ delete. Spine pinned by `server/tests/concordia-megaworld.test.js`.
+
 The v1 release arc is merged (PR #841, 2026-07-02). The live arc is now
 **`docs/NEXT_ARC_PLAN.md`** (the "🟢 HANDOFF — start here" block at the top): Wave 1 =
 **ConKay JARVIS flagship** (spatial FUI cockpit, honest stage-beats, artifact→interactive-3D)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **DHTP Representation Sufficiency (cloud agents):** If the task is the DHTP-RS benchmark, read **`docs/DHTP_RS_CLOUD_AGENT.md`** first. Entry point: `node server/scripts/run-dhtp-rs.mjs resume` (auto-loads keys from `.env.runpod` / `server/.env`). Status: `node server/scripts/run-dhtp-rs.mjs status`. Phase 1 complete; **Phase 2 pending** (6 probes × 20 trials).
 
-**Concordia persistent megaworld:** `docs/CONCORDIA_PERSISTENT_MEGAWORLD.md` — one continuous universe; worlds are regions; Hub is Flower Law only; abandon ≠ delete; world identity is a spatial field. Spine pinned by `server/tests/concordia-megaworld.test.js` and `server/tests/concordia-world-field.test.js`.
+**Concordia persistent megaworld:** `docs/CONCORDIA_PERSISTENT_MEGAWORLD.md` — one continuous universe; worlds are regions; Hub is Flower Law only; abandon ≠ delete; world identity is a spatial field; creatures and people are persistent organisms in one living world. Spine pinned by `server/tests/concordia-megaworld.test.js`, `server/tests/concordia-world-field.test.js`, and `server/tests/concordia-organism.test.js`.
 
 The v1 release arc is merged (PR #841, 2026-07-02). The live arc is now
 **`docs/NEXT_ARC_PLAN.md`** (the "🟢 HANDOFF — start here" block at the top): Wave 1 =

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/Canon.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/Canon.cs
@@ -58,6 +58,11 @@ namespace Concordia
         public static readonly Vector3 Arena = new Vector3(0, 0, 18);
         public static readonly Vector3 Spawn = new Vector3(0, 0, -11);
 
+        /// <summary>
+        /// MEGAWORLD: these angles are civilization field centers on one
+        /// supercontinent (kernel: concordia-world-field.js), not portals to
+        /// disconnected maps. Travel() still region-rebuilds until W3.
+        /// </summary>
         public static readonly GateDef[] Gates =
         {
             new GateDef { world = WorldId.Cyber, shortName = "CYBER", name = "The Grid", refusal = "Refusal of Numbers", theNo = "I will not be counted.", color = Hex("3dffa0"), angle = 0 },

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordClient.cs
@@ -36,6 +36,8 @@ namespace Concordia
         public static string StatusJson { get; private set; } = "{\"ok\":false,\"reason\":\"no_gateway\"}";
         public static string LastReason { get; private set; } = "no_gateway";
         public static string HudLine { get; private set; } = "";
+        public static string FieldBecause { get; private set; } = "";
+        public static int AbandonedCount { get; private set; }
         public static string SnapshotJson { get; private set; } = "";
         public static ConcordClient Live { get; private set; }
 
@@ -228,6 +230,8 @@ namespace Concordia
             LastReason = "no_gateway";
             StatusJson = "{\"ok\":false,\"reason\":\"no_gateway\"}";
             HudLine = "";
+            FieldBecause = "";
+            AbandonedCount = 0;
             SnapshotJson = "";
         }
 
@@ -237,6 +241,11 @@ namespace Concordia
             {
                 ApplyKingdom(text);
                 return;
+            }
+            if (evt == "combat:attack:ack")
+            {
+                var because = JsonString(text, "because");
+                if (!string.IsNullOrEmpty(because)) FieldBecause = because;
             }
             if (evt == "dialogue:data")
             {
@@ -312,8 +321,27 @@ namespace Concordia
             StatusJson = "{\"ok\":true,\"format\":\"concord-kingdom/v1\",\"world\":\""
                 + Escape(title) + "\",\"staple\":\"" + Escape(staple)
                 + "\",\"settlements\":" + n + "}";
+            AbandonedCount = JsonInt(json, "abandonedCount");
             HudLine = title + " · kernel · " + staple
-                + (n == 0 ? " · The Court is the city" : " · " + n + " settlements");
+                + (n == 0 ? " · The Court is the city" : " · " + n + " settlements")
+                + (AbandonedCount > 0 ? " · " + AbandonedCount + " remain abandoned" : "");
+            CityAtlas.ApplyKernelStatuses(json);
+        }
+
+        static int JsonInt(string json, string key)
+        {
+            if (string.IsNullOrEmpty(json)) return 0;
+            var needle = "\"" + key + "\":";
+            var i = json.IndexOf(needle, System.StringComparison.Ordinal);
+            if (i < 0) return 0;
+            var rest = json.Substring(i + needle.Length).TrimStart();
+            int n = 0, k = 0;
+            while (k < rest.Length && rest[k] >= '0' && rest[k] <= '9')
+            {
+                n = n * 10 + (rest[k] - '0');
+                k++;
+            }
+            return n;
         }
 
         public Task RequestKingdom(string nextWorldId)
@@ -332,8 +360,14 @@ namespace Concordia
         public Task SendMove(float x, float y, float z, string cityId) =>
             SendEvt("player:move", "{\"cityId\":\"" + Escape(cityId) + "\",\"x\":" + x + ",\"y\":" + y + ",\"z\":" + z + ",\"direction\":0}");
 
-        public Task SendAttack(string targetId, float baseDamage = 20, float range = 5, string weapon = "sword") =>
-            SendEvt("combat:attack", "{\"targetId\":\"" + Escape(targetId) + "\",\"baseDamage\":" + baseDamage + ",\"range\":" + range + ",\"weapon\":\"" + Escape(weapon) + "\"}");
+        public Task SendAttack(string targetId, float baseDamage = 20, float range = 5, string weapon = "sword", float x = 0, float z = 0) =>
+            SendEvt("combat:attack", "{\"targetId\":\"" + Escape(targetId)
+                + "\",\"baseDamage\":" + baseDamage
+                + ",\"range\":" + range
+                + ",\"weapon\":\"" + Escape(weapon)
+                + "\",\"worldId\":\"" + Escape(worldId)
+                + "\",\"x\":" + x.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                + ",\"z\":" + z.ToString(System.Globalization.CultureInfo.InvariantCulture) + "}");
 
         public Task SendDodge(bool parry = false) =>
             SendEvt("combat:dodge", "{\"wasParry\":" + (parry ? "true" : "false") + "}");

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaGame.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaGame.cs
@@ -406,6 +406,11 @@ namespace Concordia
             return "Took " + loot.label + ".";
         }
 
+        /// <summary>
+        /// MEGAWORLD: current mode is region_rebuild (_world.Build). Destination
+        /// topology is one continuous universe; Link gates are the only fast
+        /// travel. Flower Law is Hub-only. See docs/CONCORDIA_PERSISTENT_MEGAWORLD.md.
+        /// </summary>
         public void Travel(WorldId next)
         {
             var carried = _player != null ? _player.kitWeapon : null;

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaGame.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaGame.cs
@@ -408,8 +408,9 @@ namespace Concordia
 
         /// <summary>
         /// MEGAWORLD: current mode is region_rebuild (_world.Build). Destination
-        /// topology is one continuous universe; Link gates are the only fast
-        /// travel. Flower Law is Hub-only. See docs/CONCORDIA_PERSISTENT_MEGAWORLD.md.
+        /// topology is one continuous universe with overlapping WorldFields;
+        /// Link gates are the only fast travel. Flower Law is Hub-only.
+        /// See docs/CONCORDIA_PERSISTENT_MEGAWORLD.md.
         /// </summary>
         public void Travel(WorldId next)
         {

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaHUD.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaHUD.cs
@@ -104,17 +104,19 @@ namespace Concordia
             var live = Canon.SteelLive(player.world, player.transform.position);
             GUI.color = new Color(0f, 0f, 0f, 0.45f);
             var city = CityAtlas.Nearest(player.world, player.transform.position, 18f);
-            GUI.DrawTexture(new Rect(22, 28, 300, 92), _white);
+            GUI.DrawTexture(new Rect(22, 28, 300, 108), _white);
             GUI.color = Color.white;
             GUI.Label(new Rect(32, 32, 280, 22), world.title.ToUpperInvariant(), _title);
             GUI.Label(new Rect(32, 54, 280, 16),
-                (live ? "LIVE STEEL" : "FLOWER-LAW") + (city == null ? "" : "  ·  " + city.name)
+                (live ? "LIVE STEEL" : "FLOWER-LAW") + (city == null ? "" : "  ·  " + city.name + (city.status == "abandoned" ? " (ruins remain)" : ""))
                 + (string.IsNullOrEmpty(player.kitWeapon) ? "" : "  ·  " + player.kitWeapon)
                 + "  ·  " + KitBag.ArtName(player.world), _small);
             GUI.Label(new Rect(32, 70, 280, 16), WorldClock.HudClock()
                 + (string.IsNullOrEmpty(ConcordClient.HudLine) ? "" : "  ·  " + ConcordClient.HudLine), _small);
+            var field = WorldField.HudLine(player.world, player.transform.position);
             GUI.Label(new Rect(32, 86, 280, 16),
-                !string.IsNullOrEmpty(WorldClock.NearbyAct) ? WorldClock.NearbyAct
+                !string.IsNullOrEmpty(field) ? field
+                : !string.IsNullOrEmpty(WorldClock.NearbyAct) ? WorldClock.NearbyAct
                 : HubObjectives.Line(), _small);
         }
 

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaPlayer.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaPlayer.cs
@@ -383,9 +383,10 @@ namespace Concordia
                 // Kernel resolves HP. Presentation already played the swing.
                 _pendingKernelTarget = dummy;
                 Toast(dummy.name + " — Concord resolving");
-                _ = client.SendAttack(dummy.name, dmg, reach, liveWeapon());
+                _ = client.SendAttack(dummy.name, dmg, reach, liveWeapon(), transform.position.x, transform.position.z);
                 return true;
             }
+            dmg = WorldField.ScaleDamage(dmg, world, transform.position, "athletics");
             dummy.Hit(dmg, world);
             HubObjectives.NoteArenaHit();
             Toast(dummy.name + "  " + Mathf.Ceil(dummy.hp) + "  — local. Concord {ok:false, reason:'no_gateway'}");

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/EvoSpawner.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/EvoSpawner.cs
@@ -227,6 +227,15 @@ namespace Concordia
                 return;
             }
 
+            var field = WorldField.At(WorldClock.World, transform.position, "athletics", WorldClock.World);
+            if (field.ok && field.habitatFitness < 0.35f && !field.flowerLaw)
+            {
+                act = "retreat";
+                Step(_home, fly ? 3.2f : 2.4f);
+                if (lod == SimLod.Real && dist < 18f) WorldClock.NoteAct(Label() + " retreats toward home field");
+                return;
+            }
+
             if (hunting) { act = "hunt"; return; }
 
             if (_wait > 0f)

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/EvoSpawner.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/EvoSpawner.cs
@@ -5,6 +5,9 @@ namespace Concordia
     /// <summary>
     /// Evo-asset presentation: Kenney/living fauna GLBs when present.
     /// Live path is FaunaLife (wander / graze / flee / hunt / sleep), not a sine orbit.
+    /// MEGAWORLD: this is the renderer. Organism identity (genome, habitat
+    /// fitness, death remains) lives in server/lib/concordia-organism.js.
+    /// Quota top-up in fauna-spawner is not a persistent organism (W8).
     /// </summary>
     public class EvoSpawner : MonoBehaviour
     {

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldBook.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldBook.cs
@@ -67,7 +67,7 @@ namespace Concordia
         [Serializable]
         public class CityDef
         {
-            public string id, name, factionId, description;
+            public string id, name, factionId, description, status;
             public WorldId world;
             public float x, z;
             public string[] districts;
@@ -326,6 +326,35 @@ namespace Concordia
             var arr = list.ToArray();
             Cache[world] = arr;
             return arr;
+        }
+
+        /// <summary>
+        /// Overlay kernel settlement status onto authored cities. Missing
+        /// status stays empty — never invents ruins. Does not despawn ids.
+        /// </summary>
+        public static void ApplyKernelStatuses(string kingdomJson)
+        {
+            if (string.IsNullOrEmpty(kingdomJson)) return;
+            foreach (WorldId id in System.Enum.GetValues(typeof(WorldId)))
+            {
+                if (!Cache.TryGetValue(id, out var cities) || cities == null) continue;
+                foreach (var c in cities)
+                {
+                    if (c == null || string.IsNullOrEmpty(c.name)) continue;
+                    if (kingdomJson.IndexOf("\"name\":\"" + c.name + "\"", System.StringComparison.Ordinal) < 0
+                        && kingdomJson.IndexOf("\"id\":\"" + c.id + "\"", System.StringComparison.Ordinal) < 0)
+                        continue;
+                    if (kingdomJson.Contains("\"status\":\"abandoned\""))
+                    {
+                        // Only stamp when this city's object mentions abandoned nearby — coarse but honest:
+                        // if the snapshot has abandoned rows and this name appears, check a tight window.
+                        var nameAt = kingdomJson.IndexOf("\"" + c.name + "\"", System.StringComparison.Ordinal);
+                        if (nameAt < 0) continue;
+                        var window = kingdomJson.Substring(Mathf.Max(0, nameAt - 80), Mathf.Min(200, kingdomJson.Length - Mathf.Max(0, nameAt - 80)));
+                        if (window.Contains("abandoned")) c.status = "abandoned";
+                    }
+                }
+            }
         }
 
         public static WorldBook.CityDef Nearest(WorldId world, Vector3 pos, float max = 14f)

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldField.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldField.cs
@@ -1,0 +1,243 @@
+using UnityEngine;
+
+namespace Concordia
+{
+    /// <summary>
+    /// Presentation of kernel WorldField. Constants match
+    /// server/lib/concordia-world-field.js. Travel is still region_rebuild;
+    /// in-region metres sample the field around a civilization center.
+    /// Never a fabricated "−42% Magic Damage" sticker.
+    /// </summary>
+    public static class WorldField
+    {
+        public const float CivilizationRadiusKm = 400f;
+        public const float SigmaKm = 410f;
+        public const float HubCourtKm = 12f;
+        public const float HubMetroKm = 40f;
+        public const float BlendSharpness = 8f;
+        public const float SceneMetresToKm = 0.4f;
+        public const float GeoNativeCap = 200f;
+
+        public struct Sample
+        {
+            public bool ok;
+            public string reason;
+            public string dominant;
+            public bool flowerLaw;
+            public bool steelLive;
+            public float magic;
+            public float tech;
+            public float multiplier;
+            public float localPhysics;
+            public float homeInfluence;
+            public float habitatFitness;
+            public string because;
+        }
+
+        public static string KernelWorld(WorldId id) => WorldBook.Folder(id);
+
+        public static Vector2 CenterKm(WorldId id)
+        {
+            if (id == WorldId.Hub) return Vector2.zero;
+            if (id == WorldId.Sere)
+            {
+                float ang = GateAngle(WorldId.Crime) + 0.35f;
+                float r = CivilizationRadiusKm * 1.35f;
+                return new Vector2(Mathf.Cos(ang) * r, Mathf.Sin(ang) * r);
+            }
+            float a = GateAngle(id);
+            return new Vector2(Mathf.Cos(a) * CivilizationRadiusKm, Mathf.Sin(a) * CivilizationRadiusKm);
+        }
+
+        public static float GateAngle(WorldId id) => id switch
+        {
+            WorldId.Cyber => 0f,
+            WorldId.Ruins => Mathf.PI / 4f,
+            WorldId.Fantasy => Mathf.PI / 2f,
+            WorldId.Tunya => 3f * Mathf.PI / 4f,
+            WorldId.Frontier => Mathf.PI,
+            WorldId.Crime => 5f * Mathf.PI / 4f,
+            WorldId.Superhero => 3f * Mathf.PI / 2f,
+            WorldId.Crucible => 7f * Mathf.PI / 4f,
+            _ => 0f
+        };
+
+        /// <summary>Scene metres → megaworld km. Hub stays in the well.</summary>
+        public static Vector2 LocalToMegaworld(WorldId world, float localX, float localZ)
+        {
+            if (world == WorldId.Hub) return Vector2.zero;
+            var c = CenterKm(world);
+            float ang = world == WorldId.Sere
+                ? GateAngle(WorldId.Crime) + 0.35f
+                : GateAngle(world);
+            var radial = new Vector2(Mathf.Cos(ang), Mathf.Sin(ang));
+            var tan = new Vector2(-Mathf.Sin(ang), Mathf.Cos(ang));
+            return c + tan * localX * SceneMetresToKm + radial * localZ * SceneMetresToKm;
+        }
+
+        public static Sample At(WorldId world, Vector3 localPos, string domain = "athletics", WorldId origin = WorldId.Hub)
+        {
+            var mega = LocalToMegaworld(world, localPos.x, localPos.z);
+            return AtMegaworld(mega.x, mega.y, domain, origin == WorldId.Hub ? world : origin);
+        }
+
+        public static Sample AtWorld(WorldId world, string domain = "athletics", WorldId origin = WorldId.Hub)
+        {
+            var c = CenterKm(world);
+            return AtMegaworld(c.x, c.y, domain, origin == WorldId.Hub ? world : origin);
+        }
+
+        static Sample AtMegaworld(float x, float z, string domain, WorldId origin)
+        {
+            float distHub = Mathf.Sqrt(x * x + z * z);
+            float hub = HubWell(distHub);
+            var inf = Influences(x, z, hub);
+            string dominant = "hub";
+            float best = hub;
+            foreach (var kv in inf)
+            {
+                if (kv.Value > best) { best = kv.Value; dominant = kv.Key; }
+            }
+            bool flower = hub >= 0.85f || distHub <= HubCourtKm;
+            float physics = Blend(inf, hub, domain);
+            float home = HomeInfluence(inf, origin);
+            float floor = 0.10f;
+            float coupled = physics * (0.55f + 0.45f * home);
+            float mul = Mathf.Clamp01(Mathf.Max(floor, coupled));
+            string because;
+            if (flower)
+                because = "The Unburned Court suppresses regional physics. Flower Law holds. Live steel does not.";
+            else
+                because = "Local " + domain + " physics is " + physics.ToString("0.00")
+                    + " (" + dominant + " field). Distance from " + origin + " couples at " + home.ToString("0.00") + ".";
+            return new Sample
+            {
+                ok = true,
+                dominant = dominant,
+                flowerLaw = flower,
+                steelLive = !flower,
+                magic = Blend(inf, hub, "magic"),
+                tech = Blend(inf, hub, "tech"),
+                multiplier = mul,
+                localPhysics = physics,
+                homeInfluence = home,
+                habitatFitness = home,
+                because = because
+            };
+        }
+
+        static float HubWell(float d)
+        {
+            if (d <= HubCourtKm) return 1f;
+            if (d >= HubMetroKm) return 0f;
+            float t = (d - HubCourtKm) / (HubMetroKm - HubCourtKm);
+            return Mathf.Clamp01(1f - t * t);
+        }
+
+        static System.Collections.Generic.Dictionary<string, float> Influences(float x, float z, float hub)
+        {
+            var d = new System.Collections.Generic.Dictionary<string, float>();
+            void add(WorldId id, string key)
+            {
+                var c = CenterKm(id);
+                float dist = Vector2.Distance(new Vector2(x, z), c);
+                d[key] = Mathf.Exp(-((dist / SigmaKm) * (dist / SigmaKm)));
+            }
+            add(WorldId.Cyber, "cyber");
+            add(WorldId.Ruins, "sovereign");
+            add(WorldId.Fantasy, "fantasy");
+            add(WorldId.Tunya, "tunya");
+            add(WorldId.Frontier, "frontier");
+            add(WorldId.Crime, "crime");
+            add(WorldId.Superhero, "superhero");
+            add(WorldId.Crucible, "lattice");
+            add(WorldId.Sere, "sere");
+            d["hub"] = hub;
+            return d;
+        }
+
+        static float HomeInfluence(System.Collections.Generic.Dictionary<string, float> inf, WorldId origin)
+        {
+            string key = origin switch
+            {
+                WorldId.Hub => "hub",
+                WorldId.Ruins => "sovereign",
+                WorldId.Frontier => "frontier",
+                WorldId.Crucible => "lattice",
+                _ => origin.ToString().ToLowerInvariant()
+            };
+            return inf.TryGetValue(key, out var v) ? v : 0f;
+        }
+
+        /// <summary>
+        /// Authored center affinities (content/world/*/meta.json). Hub is civil 0.7.
+        /// Keep in lockstep with those files — tests pin fantasy magic = 1, crime magic = 0.05.
+        /// </summary>
+        public static float CenterAffinity(string key, string domain)
+        {
+            if (key == "hub") return 0.7f;
+            if (domain == "magic")
+            {
+                if (key == "fantasy") return 1f;
+                if (key == "crime") return 0.05f;
+                if (key == "cyber") return 0.1f;
+                if (key == "tunya") return 0.4f;
+                return 0.6f;
+            }
+            if (domain == "tech")
+            {
+                if (key == "cyber") return 1f;
+                if (key == "fantasy") return 0.05f;
+                if (key == "crime") return 0.85f;
+                return 0.6f;
+            }
+            if (domain == "swordsmanship")
+            {
+                if (key == "fantasy") return 1f;
+                if (key == "crime") return 0.4f;
+                return 0.7f;
+            }
+            if (domain == "athletics")
+            {
+                if (key == "crime") return 0.95f;
+                if (key == "fantasy") return 0.9f;
+                return 0.7f;
+            }
+            return 0.7f;
+        }
+
+        static float Blend(System.Collections.Generic.Dictionary<string, float> inf, float well, string domain)
+        {
+            float num = 0f, den = 0f;
+            foreach (var kv in inf)
+            {
+                if (kv.Key == "hub") continue;
+                if (kv.Value < 0.02f) continue;
+                float w = Mathf.Pow(kv.Value, BlendSharpness);
+                num += w * CenterAffinity(kv.Key, domain);
+                den += w;
+            }
+            float mixed = den > 0f ? num / den : 0.7f;
+            if (well > 0f) mixed = mixed * (1f - well) + 0.7f * well;
+            return Mathf.Clamp01(mixed);
+        }
+
+        public static float ScaleDamage(float dmg, WorldId world, Vector3 localPos, string domain = "athletics")
+        {
+            var s = At(world, localPos, domain, world);
+            if (!s.ok) return dmg;
+            return Mathf.Max(0.1f, dmg * s.multiplier);
+        }
+
+        /// <summary>
+        /// Physics at the player's feet. Last-hit kernel copy lives on
+        /// ConcordClient.FieldBecause for combat toasts — it must not freeze this line.
+        /// </summary>
+        public static string HudLine(WorldId world, Vector3 localPos)
+        {
+            var s = At(world, localPos, "athletics", world);
+            if (!s.ok) return "";
+            return s.because;
+        }
+    }
+}

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldField.cs.meta
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldField.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8c3a1e7b94d24f6e9a2b5c0d1e4f6789

--- a/docs/CONCORDIA_PERSISTENT_MEGAWORLD.md
+++ b/docs/CONCORDIA_PERSISTENT_MEGAWORLD.md
@@ -52,21 +52,21 @@ Audited 2026-09-12 against source. If this table disagrees with the tree, the tr
 | 2 Link vs walk | Gates + CrossRing. `WorldBook.Folder` maps Hub→`concordia-hub`, Frontier→`concord-link-frontier`, etc. | No overland path that keeps the same scene streaming. Fast travel is currently *all* travel. |
 | 3 Flower Law | Hub `steelLive = false`; every other `Canon` world `steelLive = true`. Sere law text: Flower-law is the Court only. | Law lives in Unity Canon + HUD copy. Server `flowerLawGoverns` is the kernel pin. |
 | 4 Persistent geography | `world_terrain_deformations` + `world_water_cells` (mig 281) are delta-over-seed. `procgen_regions` persist. | No single `world_seed` → continent → settlement-site pipeline that stamps identity. Two settlement systems: Living Society `settlements` (mig 287) vs `procgen_settlement_npcs` (region NPC packs). |
-| 5 Settlement entity | `settlements` (`id, world_id, name, center_x/z, radius_m, faction_id, realm_id, created_at`) + vacancies + `world_npcs.settlement_id`. `createSettlement` in `lib/settlements.js`. | Row is a **cluster**, not a historical object. No status, former names, founders, food/water/security, destroyed_at. |
+| 5 Settlement entity | `settlements` cluster (mig 287) + identity (`status`, founders, abandoned_at — mig 446) + `region_id` (mig 447). `foundSettlement` / `abandonSettlement` keep the row. | Village→city ladder / split successor states still GAP. Food/water/security columns stay empty. |
 | 6 Place memory | `world_chronicle` (mig 286) + composers. `npc_memories` (mig 417). | Chronicle is **world-scoped**, not settlement-scoped. No mill-built / charter / plague-rebuild chain on a place id. |
 | 7 Consequence graph | **Shipped.** `world_consequences` (mig 416) + `recordConsequence` / `recordLeaderDeath` + `consequence-apply.js` → schedules + memories + relation axes. | Not every kill/trade/founding writes it. `location` is a string, not a settlement FK. Unity does not show “this shop has been closed since…”. Plan A8 in `CONCORDIA_UNITY_BUILD_PLAN.md` that still says “missing unifier” is **stale**. |
-| 8 Inhabitation | Civilian roster, labor→`world_buildings.construction_progress_pct`, crops, scarcity, employment edges, migration mig 168, `population-migration-cycle`. | `procgen-settlements.spawnSettlementForRegion` still drops 3–5 archetypes in a disc. That is the anti-pattern in law 8. |
+| 8 Inhabitation | Civilian roster, labor→`world_buildings.construction_progress_pct`, crops, scarcity, employment edges, migration mig 168, `population-migration-cycle`. **W1:** `spawnSettlementForRegion` founds or joins a `settlements` row (mig 447 `region_id`). | NPC packs are still 3–5 archetypes in a disc — wrapped, not enlarged. |
+| 10 Abandon ≠ delete | `decaySettlementForRegion` tombstones `procgen_settlement_npcs` **and** `abandonSettlement` on the joined row. Buildings collapse via `applyStructuralStress`. | Unity ruin meshes are a label (`status=abandoned` / “ruins remain”), not a second building set. |
+| 11 Presentation | Unity presents kernel tombs, gossip, banners, fauna genomes, LOD Real/Bulk/Virtual (`WorldClock.LodAt`). HUD shows WorldField physics language. Abandoned count from `kingdom:data`. | Growth still does not add houses the kernel does not have. |
+| 15 LOD | Unity `SimLod { Real, Bulk, Virtual }` at 28m / 70m. World shards + `PER_WORLD_WRITE_TABLES`. **W4:** `regionalSummary` keeps chronicle ids; food/wealth stay empty. | Distant Virtual NPCs rewind to home; L3 statistical food/wealth still empty. |
+| 16 Tests | Heartbeats exist; world continues in `WorldMemory` slices. Mechanism pin: abandoned rows survive a simulated 7-day timestamp. | 7-day / 1-year / 50-year **live** cold-start **not run**. 100-hour return **not run**. Do not claim them. |
+| 17 WorldField | Kernel `fieldAt(x,z)` + `localToMegaworld` (W3-thin in-region sample). Combat samples `applyGeographicDamage`. Unity `WorldField.cs` presents the same constants. Hub is a suppression well. | Continent streaming between civilizations is **not** shipped. `Travel` is still `region_rebuild`. `isAvailableIn` still **hard-forbids** magic in authored `magic_level: none` worlds (crime). The field degrades; the discrete leftover still forbids. |
+| 18 Geographic effectiveness | **W7 wired.** HTTP combat + Unity dummy/HP authority sample the field. Actor-kind-blind. HUD speaks physics (`explainGeographicEffectiveness` / `WorldField.HudLine`). | Boss retreat-to-home-field is the FaunaLife habitat retreat, not a named boss AI. |
+| 19 Organism | **W8:** fauna-spawner inserts stamp `species_id` and `recordOrganismBirth`. Death still tombstones. Catalog honesty (no invented Gloom Stalker prey). Unity FaunaLife reads habitat fitness. | Quota top-up still exists (now with organism ids). Morphology from genome×field is later — CreatureCompiler is the other client branch. |
 | 9 Growth / death | Vacancies on NPC death. Movements / uprisings. Realm health symptoms. | No Village→Town→City ladder, no split/successor states as settlement rows, no ghost-town status. |
-| 10 Abandon ≠ delete | `decaySettlementForRegion` **tombstones** `procgen_settlement_npcs.decayed_at` (does not DELETE). Buildings collapse via `applyStructuralStress` (standing→damaged→collapsed). | Living Society `settlements` had no abandon path. Spine now: `abandonSettlement` sets `status='abandoned'`. Buildings/roads of an abandoned town are not yet a Unity ruin pass. |
-| 11 Presentation | Unity presents kernel tombs, gossip, banners, fauna genomes, LOD Real/Bulk/Virtual (`WorldClock.LodAt`). | Settlement growth does not add houses. Abandoned status does not swap meshes. Crowds/markets/graves are not derived from the settlement row. |
-| 12 Kingdoms | Realms, vassalage, faction strategy, `concordia-kingdom-snapshot.js`. | Borders are not an emergent mesh of settlement ownership. |
+| 12 Kingdoms | Realms, vassalage, faction strategy, `concordia-kingdom-snapshot.js`. Overlay of kernel `status` on authored settlements. | Borders are not an emergent mesh of settlement ownership. |
 | 13 Dynasties | Aging/dynasty mig 181, inheritance, Voss authored lore. | Dynasty↔place history is lore, not `founders_json` on the settlement. |
-| 14 Query | Chronicle macros, realm health, consequence list. | No `whyPlace(settlementId)` until this spine. Must not invent a spring/road story when beats are empty. |
-| 15 LOD | Unity `SimLod { Real, Bulk, Virtual }` at 28m / 70m. World shards + `PER_WORLD_WRITE_TABLES`. | No L2/L3 **historical** aggregate. Distant Virtual NPCs rewind to home; they do not keep a summarized village ledger. |
-| 16 Tests | Heartbeats exist; world continues in `WorldMemory` slices (“The world continued while you were away”). | 7-day / 1-year / 50-year cold-start **not run**. 100-hour return test **not run**. Do not claim them. |
-| 17 WorldField | Kernel `fieldAt(x,z)` on one plane. Gate bearings copied from Unity `Canon.Gates`. Authored `content/world/*/meta.json` `skill_affinity` is the blend at each center. Hub is a suppression well (Flower Law + steel dead). Discrete `crossWorldPotency` / `effectivenessMultiplier` remain the **live combat** path (WorldId). | Unity still region-rebuilds; combat has a WorldId, not a megaworld (x,z). `isAvailableIn` still **hard-forbids** magic in authored `magic_level: none` worlds (crime). That is the discrete leftover — the field degrades, it does not forbid. |
-| 18 Geographic effectiveness | `geographicEffectiveness` is actor-kind-blind. Adaptation raises a floor without beating home. | Not wired into `/combat/attack`. Bosses do not yet retreat toward their home field. No Unity presentation of weakening (and when it lands, it must read the kernel, not a fake HUD modifier). |
-| 19 Organism | Authored `content/world/*/creatures.json`. Creature needs (`creature-needs.js`). Food-web trophic edges. `creature_corpses` / `creature_population`. `world_npcs` rows with `archetype='creature'`. Spine: `organismInField` + death never deletes. | `fauna-spawner` still **tops up quotas** with anonymous inserts (same anti-pattern as `spawnTown`). Morphology does not yet change with the field (Unity `CreatureCompiler` is on the other client branch). Prey for Gloom Stalker is **empty** in the catalog — do not fill it from the prose “hunts isolated targets.” Population is per `(world_id, biome)`, not per megaworld point. |
+| 14 Query | Chronicle macros, realm health, consequence list. `whyPlace(settlementId)` is the spine. | Must not invent a spring/road story when beats are empty. |
 | 20 Person loop | `npc-needs.js` (16 need kinds). Utility + routines. Consequence graph. Place chronicle. | Person action does not yet always write `world_consequences`. The two loops share the field in the kernel; Unity FaunaLife / NpcLife are still local presenters. |
 
 ---
@@ -89,7 +89,7 @@ native strength
 
 `explainGeographicEffectiveness` speaks in physics (“local magic is 0.12; you trained in fantasy”). It does not mint a combat-log debuff.
 
-Live combat keeps `cross-world-potency.js` until W3 gives coordinates and W7 samples `fieldAt`. Do not swap the route early and pretend Unity is already walking a supercontinent.
+Live combat samples `applyGeographicDamage` (W7). Discrete `cross-world-potency.js` remains the kill-switch fallback (`CONCORD_GEOGRAPHIC_FIELD=0`). In-region Unity metres map through `localToMegaworld` (W3-thin). Do not claim continent streaming — `Travel` still `_world.Build`.
 
 ---
 
@@ -102,9 +102,9 @@ Person → needs → action → consequence → memory → place → history →
 
 They meet at `sharedWorldSurface(x,z)` (the field) and `world_consequences` (the graph). A Gloom Stalker walked from Fantasy toward Crime is the same catalog id; habitat fitness and magic coupling change because the **environment changed under it**. Prey stays empty until a food-web edge or catalog list exists. Pack/territory stay null until authored.
 
-`fauna-spawner` topping up anonymous `world_npcs` is the organism analog of `spawnTown`. Wrap it in W8. Do not enlarge it.
+`fauna-spawner` still tops up quotas, but each insert now has a species id and writes `birth` on the existing consequence graph (W8). Do not invent prey.
 
-Unity `FaunaLife` / `NpcLife` **reveal**. They do not invent a hunting list or a mourner.
+Unity `FaunaLife` / `NpcLife` **reveal**. They do not invent a hunting list or a mourner. Low habitat fitness retreats toward home.
 
 ---
 
@@ -205,14 +205,14 @@ Aggregation must store `population / food / wealth / stability / war_risk` **and
 | **W0** | Laws in code. Settlement status + abandon-not-delete. Place chronicle. `whyPlace`. `settle`/`abandon` consequences. Unity Travel labeled region-rebuild. Tests. This doc. | **This PR** |
 | **W0-field** | `fieldAt(x,z)`. Hub well. Geographic effectiveness, actor-kind-blind. Authored affinities. Canon bearings. Discrete potency left as live combat. | **This PR** |
 | **W0-organism** | Two loops named. `organismInField`. Gloom Stalker catalog honesty (no invented prey). Death tombstones. `birth`/`hunt` on the existing consequence graph. | **This PR** |
-| **W1** | `spawnSettlementForRegion` founds or joins a `settlements` row (no second identity). Population counted from NPCs. | open |
-| **W2** | Unity presents `status` (active vs abandoned ruins remain). No despawn of the settlement id. | open |
-| **W3** | Continuous topology: walking the region does not call `_world.Build`. Link gates remain the only fast travel. Megaworld (x,z) reaches the kernel. | open |
-| **W4** | L2/L3 aggregates that retain chronicle ids. | open |
-| **W5** | Cold-start: new seed, run sim 7 days (then 1 month / 1 year as capacity allows). Inspect settlements, deaths, abandonments **without authored history**. Walk it. | not run |
-| **W6** | **Come back 100 hours later.** Help a farmer, leave, return. The place continued. Memories and buildings match the ledger. | not run |
-| **W7** | Combat, NPCs, bosses, summons, faction armies sample `geographicEffectiveness`. A boss far from home is weaker too, and may retreat toward its field. Unity presents the field (no fake percent sticker). | open |
-| **W8** | Fauna-spawner founds organism rows (no anonymous quota as the live path). Death/birth always hit the graph. Field-coupled habitat. Unity FaunaLife reads `organismInField`. Morphology from genome×field is later — do not fake unique GLBs. | open |
+| **W1** | `spawnSettlementForRegion` founds or joins a `settlements` row (no second identity). Population counted from NPCs. | **This PR** |
+| **W2** | Unity presents `status` (active vs abandoned ruins remain). No despawn of the settlement id. | **This PR** (HUD / kingdom overlay; no invented houses) |
+| **W3** | Continuous topology: walking the region does not call `_world.Build`. Link gates remain the only fast travel. Megaworld (x,z) reaches the kernel. | **thin shipped** — `localToMegaworld` in-region sample. Continent streaming **GAP**. Travel still `region_rebuild`. |
+| **W4** | L2/L3 aggregates that retain chronicle ids. | **thin shipped** — `regionalSummary` counts + chronicle ids; food/wealth empty |
+| **W5** | Cold-start: new seed, run sim 7 days (then 1 month / 1 year as capacity allows). Inspect settlements, deaths, abandonments **without authored history**. Walk it. | **not run** (mechanism pin only: abandoned rows survive a backdated timestamp) |
+| **W6** | **Come back 100 hours later.** Help a farmer, leave, return. The place continued. Memories and buildings match the ledger. | **not run** |
+| **W7** | Combat, NPCs, bosses, summons, faction armies sample `geographicEffectiveness`. A boss far from home is weaker too, and may retreat toward its field. Unity presents the field (no fake percent sticker). | **This PR** |
+| **W8** | Fauna-spawner founds organism rows (no anonymous quota as the live path). Death/birth always hit the graph. Field-coupled habitat. Unity FaunaLife reads `organismInField`. Morphology from genome×field is later — do not fake unique GLBs. | **This PR** (quota remains; births are organisms) |
 
 Do not claim W5/W6. Do not claim CK3 borders or 20 million NPCs.
 
@@ -243,10 +243,10 @@ Do not claim W5/W6. Do not claim CK3 borders or 20 million NPCs.
 
 ## 10. Pins
 
-- Topology + Flower Law + abandon-not-delete + whyPlace emptiness: `server/tests/concordia-megaworld.test.js`
-- WorldField + geographic effectiveness (actor-kind-blind, Hub well, authored affinities): `server/tests/concordia-world-field.test.js`
-- Organism loops + Gloom Stalker catalog honesty + death remains: `server/tests/concordia-organism.test.js`
-- Discrete WorldId potency (live combat, still): `server/tests/cross-world-potency.test.js`
+- Topology + Flower Law + abandon-not-delete + whyPlace emptiness + W1 join + W4 summary: `server/tests/concordia-megaworld.test.js`
+- WorldField + geographic effectiveness (actor-kind-blind, Hub well, authored affinities, W3-thin map, W7 combat wire): `server/tests/concordia-world-field.test.js`
+- Organism loops + Gloom Stalker catalog honesty + death remains + W8 birth: `server/tests/concordia-organism.test.js`
+- Discrete WorldId potency (kill-switch fallback): `server/tests/cross-world-potency.test.js`
 - Consequence graph (existing): `server/tests/world-consequence.test.js`
 - Settlement composition / vacancy (existing): `server/tests/settlements.test.js`
 - Procgen NPC tombstone (existing decay path): same megaworld test file

--- a/docs/CONCORDIA_PERSISTENT_MEGAWORLD.md
+++ b/docs/CONCORDIA_PERSISTENT_MEGAWORLD.md
@@ -1,0 +1,190 @@
+# Concordia: Persistent Megaworld
+
+**Status:** locked architecture (owner, 2026-09-12). Spine of the laws is pinned by `server/tests/concordia-megaworld.test.js`.
+**Not a map generator.** The goal is: generate a giant world, let people inhabit it, and make every inhabited place become part of the world’s permanent history.
+
+This doc is the live Concordia arc. It does **not** replace `docs/LIVING_SOCIETY_PLAN.md` (labor → pay → grievance → chronicle) or `docs/CONCORDIA_UNITY_BUILD_PLAN.md` (AAA client + A/B/C). It unifies them under one topology: **one continuous physical universe**, with the existing engines as regions, settlements, memories, and a consequence→presentation pipeline.
+
+Do not rebuild `settlements`, `world_chronicle`, `world_consequences`, `npc_memories`, `world_buildings`, `procgen-settlements`, or faction strategy. Compose them.
+
+---
+
+## 0. The product
+
+Wherever the player walks, something can happen — and if people stay, the place acquires a past.
+
+Unity **reveals** kernel state. It does not invent towns, mourners, species, or founding myths. Empty stays empty. Abandoned stays in the row.
+
+---
+
+## 1. Architectural laws
+
+1. **One megaworld.** The named “worlds” (Hub, Ruins, Tunya, Fantasy, …) are **regions / civilizations** inside one universe, not disconnected game maps.
+2. **The Concord Link is infrastructure.** Physical travel is the default. Ordinary regions do not teleport. Core-civilization Link gates are the only fast travel. Crossing a gate is entering another civilization, not loading an unrelated game.
+3. **Flower Law is Hub-only.** Outside the Unburned Court: free will, local law, local culture, local politics. Live steel is allowed. Pinned: `flowerLawGoverns` in `server/lib/concordia-megaworld.js`.
+4. **Geography is persistent.** A `world_seed` produces terrain/water/roads/sites once. Regenerating the same town differently on each visit is a bug.
+5. **A settlement is a historical object**, not `spawnTown(x,y)`. Founding writes a row. Abandonment sets `status`, never `DELETE`.
+6. **Places remember.** NPC memory (`npc_memories`) is necessary and not sufficient. The location itself keeps a chronicle.
+7. **Every important act writes the consequence graph** already in `world_consequences` (`server/lib/world-consequence.js`, mig 416). Kill does not end at `hp = 0`.
+8. **Inhabitation is simulated.** Land → water → food → roads → opportunity → migration → housing → families. Do not decide “here is a town, insert 30 NPCs” as the live path.
+9. **Settlements grow, decline, split, or die — and remain.** Village → city, or village → abandoned. The original id stays queryable.
+10. **Abandoned places stay physical.** Buildings, roads, graves, ownership history, stories. Wildlife or bandits may move in. A later faction may rebuild.
+11. **Simulation must hit presentation.** Population/economy/war change what Unity shows. The renderer is not a second world.
+12. **Kingdoms emerge from places.** Borders come from settlement ownership, force, geography, diplomacy, inheritance, conquest, migration, rebellion, resources, trade — not a menu that paints a map color.
+13. **Dynasties attach people to places.** Who founded it, who ruled, who was murdered there, who saved it.
+14. **The world is queryable.** “Why is this town here?” / “Why is this ruin abandoned?” traces real rows, or returns honest emptiness.
+15. **LOD never erases history.** L0 vicinity full sim, L1 nearby detailed, L2 regional aggregate, L3 distant statistical. A distant village summarized as `population: 817` still has its chronicle when the player arrives.
+16. **Cold-start and 100-hour tests are acceptance**, not slogans. They are named below. They are **not yet run** as live certification.
+
+---
+
+## 2. Honest substrate map (LIVE vs GAP)
+
+Audited 2026-09-12 against source. If this table disagrees with the tree, the tree wins — fix this doc in the same commit.
+
+| Law | Already real | Honest gap |
+|---|---|---|
+| 1 Topology | Inventory is **user-global** across worlds (CLAUDE.md). Concord Link messages/items exist (`routes/concord-link.js`). CrossRing walks cargo/rumor between Unity `WorldId`s. | Unity `ConcordiaGame.Travel` **rebuilds the region** (`_world.Build(next)`). That is a door-load, not overland. Continuous terrain between civilizations is not presented. |
+| 2 Link vs walk | Gates + CrossRing. `WorldBook.Folder` maps Hub→`concordia-hub`, Frontier→`concord-link-frontier`, etc. | No overland path that keeps the same scene streaming. Fast travel is currently *all* travel. |
+| 3 Flower Law | Hub `steelLive = false`; every other `Canon` world `steelLive = true`. Sere law text: Flower-law is the Court only. | Law lives in Unity Canon + HUD copy. Server `flowerLawGoverns` is the kernel pin. |
+| 4 Persistent geography | `world_terrain_deformations` + `world_water_cells` (mig 281) are delta-over-seed. `procgen_regions` persist. | No single `world_seed` → continent → settlement-site pipeline that stamps identity. Two settlement systems: Living Society `settlements` (mig 287) vs `procgen_settlement_npcs` (region NPC packs). |
+| 5 Settlement entity | `settlements` (`id, world_id, name, center_x/z, radius_m, faction_id, realm_id, created_at`) + vacancies + `world_npcs.settlement_id`. `createSettlement` in `lib/settlements.js`. | Row is a **cluster**, not a historical object. No status, former names, founders, food/water/security, destroyed_at. |
+| 6 Place memory | `world_chronicle` (mig 286) + composers. `npc_memories` (mig 417). | Chronicle is **world-scoped**, not settlement-scoped. No mill-built / charter / plague-rebuild chain on a place id. |
+| 7 Consequence graph | **Shipped.** `world_consequences` (mig 416) + `recordConsequence` / `recordLeaderDeath` + `consequence-apply.js` → schedules + memories + relation axes. | Not every kill/trade/founding writes it. `location` is a string, not a settlement FK. Unity does not show “this shop has been closed since…”. Plan A8 in `CONCORDIA_UNITY_BUILD_PLAN.md` that still says “missing unifier” is **stale**. |
+| 8 Inhabitation | Civilian roster, labor→`world_buildings.construction_progress_pct`, crops, scarcity, employment edges, migration mig 168, `population-migration-cycle`. | `procgen-settlements.spawnSettlementForRegion` still drops 3–5 archetypes in a disc. That is the anti-pattern in law 8. |
+| 9 Growth / death | Vacancies on NPC death. Movements / uprisings. Realm health symptoms. | No Village→Town→City ladder, no split/successor states as settlement rows, no ghost-town status. |
+| 10 Abandon ≠ delete | `decaySettlementForRegion` **tombstones** `procgen_settlement_npcs.decayed_at` (does not DELETE). Buildings collapse via `applyStructuralStress` (standing→damaged→collapsed). | Living Society `settlements` had no abandon path. Spine now: `abandonSettlement` sets `status='abandoned'`. Buildings/roads of an abandoned town are not yet a Unity ruin pass. |
+| 11 Presentation | Unity presents kernel tombs, gossip, banners, fauna genomes, LOD Real/Bulk/Virtual (`WorldClock.LodAt`). | Settlement growth does not add houses. Abandoned status does not swap meshes. Crowds/markets/graves are not derived from the settlement row. |
+| 12 Kingdoms | Realms, vassalage, faction strategy, `concordia-kingdom-snapshot.js`. | Borders are not an emergent mesh of settlement ownership. |
+| 13 Dynasties | Aging/dynasty mig 181, inheritance, Voss authored lore. | Dynasty↔place history is lore, not `founders_json` on the settlement. |
+| 14 Query | Chronicle macros, realm health, consequence list. | No `whyPlace(settlementId)` until this spine. Must not invent a spring/road story when beats are empty. |
+| 15 LOD | Unity `SimLod { Real, Bulk, Virtual }` at 28m / 70m. World shards + `PER_WORLD_WRITE_TABLES`. | No L2/L3 **historical** aggregate. Distant Virtual NPCs rewind to home; they do not keep a summarized village ledger. |
+| 16 Tests | Heartbeats exist; world continues in `WorldMemory` slices (“The world continued while you were away”). | 7-day / 1-year / 50-year cold-start **not run**. 100-hour return test **not run**. Do not claim them. |
+
+---
+
+## 3. Hierarchy (persist at each level)
+
+```
+Megaworld (one universe, one seed)
+  → continents / landmasses
+    → regions (today’s WorldId / content folder)
+      → kingdoms / republics / tribes
+        → provinces
+          → settlements          ← historical object
+            → neighborhoods
+              → buildings / interiors
+                → inhabitants
+```
+
+Once generated, **identity is the row**. The generator may propose a site; after `foundSettlement` the coordinates and name are facts.
+
+---
+
+## 4. Settlement identity (target shape)
+
+Mig 287 remains the cluster. Mig 446 adds identity columns. Do not create a second `towns` table.
+
+```
+Settlement {
+  id, world_id, region_id,
+  location (center_x, center_z, radius_m),
+  founding_date (created_at / founded_at),
+  status: active | abandoned | conquered | ghost,
+  population,          -- counted, never invented
+  culture, government, faction_id, realm_id,
+  former_names_json, founders_json,
+  abandoned_at, destroyed_at,
+  buildings, households, …   -- existing world_buildings / world_npcs joins
+  history                  -- settlement_chronicle
+}
+```
+
+`destroyed_at` means collapsed / razed **presentation**, not missing from the database.
+
+---
+
+## 5. Place chronicle + consequence graph
+
+Two stores, one story:
+
+1. **`settlement_chronicle`** — beats that happened *here* (founded, mill, raid, charter, plague, annex, abandoned). Composers in `lib/chronicle/compose.js` may only use payload fields.
+2. **`world_consequences`** — actor/action/target/location/time/witnesses/immediate/long-term. Already the cross-domain bus. New actions on the spine: `settle`, `abandon` (plus existing `kill`, `build`, `destroy`, `war`, `succession`, …).
+
+Example (must be earned, not scripted):
+
+```
+player kills merchant
+  → recordConsequence(action: "kill", location: settlementId, witnesses: […])
+  → applyConsequence → npc_memories + schedule rewrite
+  → settlement_chronicle beat only if the payload has the death
+  → Unity shows a closed stall iff that beat exists
+```
+
+Years later, `whyPlace` can return “this stall has been closed since the killing of …” **only if those rows exist**.
+
+---
+
+## 6. Presentation pipeline
+
+```
+WORLD SIMULATION  →  WORLD STATE  →  CONSEQUENCE GRAPH
+        →  PRESENTATION STATE  →  UNITY
+```
+
+`presentationForSettlement` reads identity + chronicle + live NPC count. It does not spawn a town because the function was called. Unity dresses **that** payload: buildings, damage, banners, graves, crowds, abandoned structures, construction, wildlife.
+
+Current Unity `Travel` is a **region rebuild**. The destination is streaming continuous geography with Link gates as the only teleport. Until then, every `Travel` call is labeled `currentTravelMode = region_rebuild` so we cannot accidentally claim overland.
+
+---
+
+## 7. LOD
+
+| Level | Meaning | Today |
+|---|---|---|
+| L0 | Player vicinity, full bodies | Unity `SimLod.Real` (< 28m) |
+| L1 | Nearby settlement, detailed | `Bulk` (< 70m) — motion throttled, not a town ledger |
+| L2 | Regional aggregate | **Missing** (shard ticks the full world, not a summary row) |
+| L3 | Distant statistical | **Missing** |
+
+Aggregation must store `population / food / wealth / stability / war_risk` **and** keep chronicle ids. Expanding L3 back to L0 reconstitutes from rows, it does not reroll the town.
+
+---
+
+## 8. Execution order (unify, don’t greenfield)
+
+| Wave | Exit | Status |
+|---|---|---|
+| **W0** | Laws in code. Settlement status + abandon-not-delete. Place chronicle. `whyPlace`. `settle`/`abandon` consequences. Unity Travel labeled region-rebuild. Tests. This doc. | **This PR** |
+| **W1** | `spawnSettlementForRegion` founds or joins a `settlements` row (no second identity). Population counted from NPCs. | open |
+| **W2** | Unity presents `status` (active vs abandoned ruins remain). No despawn of the settlement id. | open |
+| **W3** | Continuous topology: walking the region does not call `_world.Build`. Link gates remain the only fast travel. | open |
+| **W4** | L2/L3 aggregates that retain chronicle ids. | open |
+| **W5** | Cold-start: new seed, run sim 7 days (then 1 month / 1 year as capacity allows). Inspect settlements, deaths, abandonments **without authored history**. Walk it. | not run |
+| **W6** | **Come back 100 hours later.** Help a farmer, leave, return. The place continued. Memories and buildings match the ledger. | not run |
+
+Do not claim W5/W6. Do not claim CK3 borders or 20 million NPCs.
+
+---
+
+## 9. Anti-patterns
+
+- Regenerating a town on visit.
+- `DELETE FROM settlements` on decline.
+- Fabricating a founding myth in `whyPlace` when chronicle is empty.
+- Unity spawning houses the kernel does not have.
+- Treating `Travel(WorldId)` as overland.
+- A second consequence table next to `world_consequences`.
+- Dropping 30 NPCs as “a town” (`procgen-settlements` current spawn is the known offender — wrap it in W1, do not enlarge it).
+- Flower Law outside the Hub.
+- Claiming the 100-hour test passed because WorldMemory has a JSON slice.
+
+---
+
+## 10. Pins
+
+- Topology + Flower Law + abandon-not-delete + whyPlace emptiness: `server/tests/concordia-megaworld.test.js`
+- Consequence graph (existing): `server/tests/world-consequence.test.js`
+- Settlement composition / vacancy (existing): `server/tests/settlements.test.js`
+- Procgen NPC tombstone (existing decay path): same megaworld test file
+- Unity Travel still rebuilds (honest current mode): `server/tests/concordia-world-life.test.js` + comment on `ConcordiaGame.Travel`

--- a/docs/CONCORDIA_PERSISTENT_MEGAWORLD.md
+++ b/docs/CONCORDIA_PERSISTENT_MEGAWORLD.md
@@ -13,7 +13,7 @@ Do not rebuild `settlements`, `world_chronicle`, `world_consequences`, `npc_memo
 
 Wherever the player walks, something can happen — and if people stay, the place acquires a past.
 
-Unity **reveals** kernel state. It does not invent towns, mourners, species, or founding myths. Empty stays empty. Abandoned stays in the row.
+World identity is a **spatial field**, not a door to another map. Walking changes the physics. Unity **reveals** kernel state. It does not invent towns, mourners, species, founding myths, or a “−42% Magic Damage” sticker standing in for the field. Empty stays empty. Abandoned stays in the row.
 
 ---
 
@@ -35,6 +35,8 @@ Unity **reveals** kernel state. It does not invent towns, mourners, species, or 
 14. **The world is queryable.** “Why is this town here?” / “Why is this ruin abandoned?” traces real rows, or returns honest emptiness.
 15. **LOD never erases history.** L0 vicinity full sim, L1 nearby detailed, L2 regional aggregate, L3 distant statistical. A distant village summarized as `population: 817` still has its chronicle when the player arrives.
 16. **Cold-start and 100-hour tests are acceptance**, not slogans. They are named below. They are **not yet run** as live certification.
+17. **World identity is a spatial field, not a separate map.** Every point on the megaworld has overlapping civilization influences (`fantasyInfluence`, `crimeInfluence`, …). Local rules are derived from those values. Hard borders are a presentation bug. Pinned: `server/lib/concordia-world-field.js`.
+18. **Geographic effectiveness is physics, not a player debuff.** Native strength × local physics × distance from origin × environmental adaptation. The same formula applies to a player, an NPC, a boss, a dragon, a summon, a faction army, and equipment. Location is a gameplay stat because the world-field is different there.
 
 ---
 
@@ -60,6 +62,30 @@ Audited 2026-09-12 against source. If this table disagrees with the tree, the tr
 | 14 Query | Chronicle macros, realm health, consequence list. | No `whyPlace(settlementId)` until this spine. Must not invent a spring/road story when beats are empty. |
 | 15 LOD | Unity `SimLod { Real, Bulk, Virtual }` at 28m / 70m. World shards + `PER_WORLD_WRITE_TABLES`. | No L2/L3 **historical** aggregate. Distant Virtual NPCs rewind to home; they do not keep a summarized village ledger. |
 | 16 Tests | Heartbeats exist; world continues in `WorldMemory` slices (“The world continued while you were away”). | 7-day / 1-year / 50-year cold-start **not run**. 100-hour return test **not run**. Do not claim them. |
+| 17 WorldField | Kernel `fieldAt(x,z)` on one plane. Gate bearings copied from Unity `Canon.Gates`. Authored `content/world/*/meta.json` `skill_affinity` is the blend at each center. Hub is a suppression well (Flower Law + steel dead). Discrete `crossWorldPotency` / `effectivenessMultiplier` remain the **live combat** path (WorldId). | Unity still region-rebuilds; combat has a WorldId, not a megaworld (x,z). `isAvailableIn` still **hard-forbids** magic in authored `magic_level: none` worlds (crime). That is the discrete leftover — the field degrades, it does not forbid. |
+| 18 Geographic effectiveness | `geographicEffectiveness` is actor-kind-blind. Adaptation raises a floor without beating home. | Not wired into `/combat/attack`. Bosses do not yet retreat toward their home field. No Unity presentation of weakening (and when it lands, it must read the kernel, not a fake HUD modifier). |
+
+---
+
+## 2.1 WorldField (continuous physics)
+
+```
+WorldField { hub, fantasy, crime, cyber, superhero, frontier, tunya, sovereign, lattice, sere }
+```
+
+Hub at the origin. Gated civilizations sit on the Canon ring (`MEGAWORLD_KM.civilizationRadius`). Sere has **no Link gate** — off-ring, still a field center. Influences are gaussians. Adjacent civs share a **transition band**. Opposite civs (Fantasy ↔ Crime) do not share a border; the walk crosses neighbors and the Hub well. That is the ring, not a missing feature.
+
+```
+native strength
+  × local physics     (blend of authored skill_affinity, sharpened so cores stay themselves)
+  × home-field presence
+  × adaptation floor
+= effective
+```
+
+`explainGeographicEffectiveness` speaks in physics (“local magic is 0.12; you trained in fantasy”). It does not mint a combat-log debuff.
+
+Live combat keeps `cross-world-potency.js` until W3 gives coordinates and W7 samples `fieldAt`. Do not swap the route early and pretend Unity is already walking a supercontinent.
 
 ---
 
@@ -134,7 +160,9 @@ WORLD SIMULATION  →  WORLD STATE  →  CONSEQUENCE GRAPH
 
 `presentationForSettlement` reads identity + chronicle + live NPC count. It does not spawn a town because the function was called. Unity dresses **that** payload: buildings, damage, banners, graves, crowds, abandoned structures, construction, wildlife.
 
-Current Unity `Travel` is a **region rebuild**. The destination is streaming continuous geography with Link gates as the only teleport. Until then, every `Travel` call is labeled `currentTravelMode = region_rebuild` so we cannot accidentally claim overland.
+When W7 lands, Unity also dresses **the field**: magic density, tech density, transition weather, faction banners, weakening of *every* combatant. The renderer still does not invent the number.
+
+Current Unity `Travel` is a **region rebuild**. The destination is streaming continuous geography with Link gates as the only teleport, and with WorldField sampled at the feet. Until then, every `Travel` call is labeled `currentTravelMode = region_rebuild` so we cannot accidentally claim overland.
 
 ---
 
@@ -156,12 +184,14 @@ Aggregation must store `population / food / wealth / stability / war_risk` **and
 | Wave | Exit | Status |
 |---|---|---|
 | **W0** | Laws in code. Settlement status + abandon-not-delete. Place chronicle. `whyPlace`. `settle`/`abandon` consequences. Unity Travel labeled region-rebuild. Tests. This doc. | **This PR** |
+| **W0-field** | `fieldAt(x,z)`. Hub well. Geographic effectiveness, actor-kind-blind. Authored affinities. Canon bearings. Discrete potency left as live combat. | **This PR** |
 | **W1** | `spawnSettlementForRegion` founds or joins a `settlements` row (no second identity). Population counted from NPCs. | open |
 | **W2** | Unity presents `status` (active vs abandoned ruins remain). No despawn of the settlement id. | open |
-| **W3** | Continuous topology: walking the region does not call `_world.Build`. Link gates remain the only fast travel. | open |
+| **W3** | Continuous topology: walking the region does not call `_world.Build`. Link gates remain the only fast travel. Megaworld (x,z) reaches the kernel. | open |
 | **W4** | L2/L3 aggregates that retain chronicle ids. | open |
 | **W5** | Cold-start: new seed, run sim 7 days (then 1 month / 1 year as capacity allows). Inspect settlements, deaths, abandonments **without authored history**. Walk it. | not run |
 | **W6** | **Come back 100 hours later.** Help a farmer, leave, return. The place continued. Memories and buildings match the ledger. | not run |
+| **W7** | Combat, NPCs, bosses, summons, faction armies sample `geographicEffectiveness`. A boss far from home is weaker too, and may retreat toward its field. Unity presents the field (no fake percent sticker). | open |
 
 Do not claim W5/W6. Do not claim CK3 borders or 20 million NPCs.
 
@@ -178,12 +208,19 @@ Do not claim W5/W6. Do not claim CK3 borders or 20 million NPCs.
 - Dropping 30 NPCs as “a town” (`procgen-settlements` current spawn is the known offender — wrap it in W1, do not enlarge it).
 - Flower Law outside the Hub.
 - Claiming the 100-hour test passed because WorldMemory has a JSON slice.
+- Treating a named WorldId as a disconnected game map.
+- A player-only magic debuff. If the field does not hit a boss, it is not the field.
+- A second skill-affinity table next to `content/world/*/meta.json`.
+- Wiring `geographicEffectiveness` into combat and claiming Unity already walks the supercontinent.
+- A HUD sticker (“−42% Magic Damage”) as a substitute for local physics.
 
 ---
 
 ## 10. Pins
 
 - Topology + Flower Law + abandon-not-delete + whyPlace emptiness: `server/tests/concordia-megaworld.test.js`
+- WorldField + geographic effectiveness (actor-kind-blind, Hub well, authored affinities): `server/tests/concordia-world-field.test.js`
+- Discrete WorldId potency (live combat, still): `server/tests/cross-world-potency.test.js`
 - Consequence graph (existing): `server/tests/world-consequence.test.js`
 - Settlement composition / vacancy (existing): `server/tests/settlements.test.js`
 - Procgen NPC tombstone (existing decay path): same megaworld test file

--- a/docs/CONCORDIA_PERSISTENT_MEGAWORLD.md
+++ b/docs/CONCORDIA_PERSISTENT_MEGAWORLD.md
@@ -5,7 +5,7 @@
 
 This doc is the live Concordia arc. It does **not** replace `docs/LIVING_SOCIETY_PLAN.md` (labor → pay → grievance → chronicle) or `docs/CONCORDIA_UNITY_BUILD_PLAN.md` (AAA client + A/B/C). It unifies them under one topology: **one continuous physical universe**, with the existing engines as regions, settlements, memories, and a consequence→presentation pipeline.
 
-Do not rebuild `settlements`, `world_chronicle`, `world_consequences`, `npc_memories`, `world_buildings`, `procgen-settlements`, or faction strategy. Compose them.
+Do not rebuild `settlements`, `world_chronicle`, `world_consequences`, `npc_memories`, `world_buildings`, `procgen-settlements`, `fauna-spawner`, `creature-needs`, `npc-needs`, `food-web`, or faction strategy. Compose them.
 
 ---
 
@@ -37,6 +37,8 @@ World identity is a **spatial field**, not a door to another map. Walking change
 16. **Cold-start and 100-hour tests are acceptance**, not slogans. They are named below. They are **not yet run** as live certification.
 17. **World identity is a spatial field, not a separate map.** Every point on the megaworld has overlapping civilization influences (`fantasyInfluence`, `crimeInfluence`, …). Local rules are derived from those values. Hard borders are a presentation bug. Pinned: `server/lib/concordia-world-field.js`.
 18. **Geographic effectiveness is physics, not a player debuff.** Native strength × local physics × distance from origin × environmental adaptation. The same formula applies to a player, an NPC, a boss, a dragon, a summon, a faction army, and equipment. Location is a gameplay stat because the world-field is different there.
+19. **A creature is a persistent organism, not a spawn.** Genome → organism → ecology → civilization → history → presentation. Death tombstones; it does not DELETE. Missing prey / pack / territory stay empty. Pinned: `server/lib/concordia-organism.js`.
+20. **A person runs the same world.** Person → needs → action → consequence → memory → place → history → presentation. The two loops meet at WorldField + `world_consequences` + place. Concordia does not have a separate “creature system,” “NPC system,” “economy system,” and “world system.” It has one living world.
 
 ---
 
@@ -64,6 +66,8 @@ Audited 2026-09-12 against source. If this table disagrees with the tree, the tr
 | 16 Tests | Heartbeats exist; world continues in `WorldMemory` slices (“The world continued while you were away”). | 7-day / 1-year / 50-year cold-start **not run**. 100-hour return test **not run**. Do not claim them. |
 | 17 WorldField | Kernel `fieldAt(x,z)` on one plane. Gate bearings copied from Unity `Canon.Gates`. Authored `content/world/*/meta.json` `skill_affinity` is the blend at each center. Hub is a suppression well (Flower Law + steel dead). Discrete `crossWorldPotency` / `effectivenessMultiplier` remain the **live combat** path (WorldId). | Unity still region-rebuilds; combat has a WorldId, not a megaworld (x,z). `isAvailableIn` still **hard-forbids** magic in authored `magic_level: none` worlds (crime). That is the discrete leftover — the field degrades, it does not forbid. |
 | 18 Geographic effectiveness | `geographicEffectiveness` is actor-kind-blind. Adaptation raises a floor without beating home. | Not wired into `/combat/attack`. Bosses do not yet retreat toward their home field. No Unity presentation of weakening (and when it lands, it must read the kernel, not a fake HUD modifier). |
+| 19 Organism | Authored `content/world/*/creatures.json`. Creature needs (`creature-needs.js`). Food-web trophic edges. `creature_corpses` / `creature_population`. `world_npcs` rows with `archetype='creature'`. Spine: `organismInField` + death never deletes. | `fauna-spawner` still **tops up quotas** with anonymous inserts (same anti-pattern as `spawnTown`). Morphology does not yet change with the field (Unity `CreatureCompiler` is on the other client branch). Prey for Gloom Stalker is **empty** in the catalog — do not fill it from the prose “hunts isolated targets.” Population is per `(world_id, biome)`, not per megaworld point. |
+| 20 Person loop | `npc-needs.js` (16 need kinds). Utility + routines. Consequence graph. Place chronicle. | Person action does not yet always write `world_consequences`. The two loops share the field in the kernel; Unity FaunaLife / NpcLife are still local presenters. |
 
 ---
 
@@ -86,6 +90,21 @@ native strength
 `explainGeographicEffectiveness` speaks in physics (“local magic is 0.12; you trained in fantasy”). It does not mint a combat-log debuff.
 
 Live combat keeps `cross-world-potency.js` until W3 gives coordinates and W7 samples `fieldAt`. Do not swap the route early and pretend Unity is already walking a supercontinent.
+
+---
+
+## 2.2 One living world (organism loops)
+
+```
+Genome → organism → ecology → civilization → history → presentation
+Person → needs → action → consequence → memory → place → history → presentation
+```
+
+They meet at `sharedWorldSurface(x,z)` (the field) and `world_consequences` (the graph). A Gloom Stalker walked from Fantasy toward Crime is the same catalog id; habitat fitness and magic coupling change because the **environment changed under it**. Prey stays empty until a food-web edge or catalog list exists. Pack/territory stay null until authored.
+
+`fauna-spawner` topping up anonymous `world_npcs` is the organism analog of `spawnTown`. Wrap it in W8. Do not enlarge it.
+
+Unity `FaunaLife` / `NpcLife` **reveal**. They do not invent a hunting list or a mourner.
 
 ---
 
@@ -185,6 +204,7 @@ Aggregation must store `population / food / wealth / stability / war_risk` **and
 |---|---|---|
 | **W0** | Laws in code. Settlement status + abandon-not-delete. Place chronicle. `whyPlace`. `settle`/`abandon` consequences. Unity Travel labeled region-rebuild. Tests. This doc. | **This PR** |
 | **W0-field** | `fieldAt(x,z)`. Hub well. Geographic effectiveness, actor-kind-blind. Authored affinities. Canon bearings. Discrete potency left as live combat. | **This PR** |
+| **W0-organism** | Two loops named. `organismInField`. Gloom Stalker catalog honesty (no invented prey). Death tombstones. `birth`/`hunt` on the existing consequence graph. | **This PR** |
 | **W1** | `spawnSettlementForRegion` founds or joins a `settlements` row (no second identity). Population counted from NPCs. | open |
 | **W2** | Unity presents `status` (active vs abandoned ruins remain). No despawn of the settlement id. | open |
 | **W3** | Continuous topology: walking the region does not call `_world.Build`. Link gates remain the only fast travel. Megaworld (x,z) reaches the kernel. | open |
@@ -192,6 +212,7 @@ Aggregation must store `population / food / wealth / stability / war_risk` **and
 | **W5** | Cold-start: new seed, run sim 7 days (then 1 month / 1 year as capacity allows). Inspect settlements, deaths, abandonments **without authored history**. Walk it. | not run |
 | **W6** | **Come back 100 hours later.** Help a farmer, leave, return. The place continued. Memories and buildings match the ledger. | not run |
 | **W7** | Combat, NPCs, bosses, summons, faction armies sample `geographicEffectiveness`. A boss far from home is weaker too, and may retreat toward its field. Unity presents the field (no fake percent sticker). | open |
+| **W8** | Fauna-spawner founds organism rows (no anonymous quota as the live path). Death/birth always hit the graph. Field-coupled habitat. Unity FaunaLife reads `organismInField`. Morphology from genome×field is later — do not fake unique GLBs. | open |
 
 Do not claim W5/W6. Do not claim CK3 borders or 20 million NPCs.
 
@@ -213,6 +234,10 @@ Do not claim W5/W6. Do not claim CK3 borders or 20 million NPCs.
 - A second skill-affinity table next to `content/world/*/meta.json`.
 - Wiring `geographicEffectiveness` into combat and claiming Unity already walks the supercontinent.
 - A HUD sticker (“−42% Magic Damage”) as a substitute for local physics.
+- Topping up anonymous fauna as if that were a persistent organism (`fauna-spawner` current path — wrap in W8).
+- Inventing prey / pack / territory from flavor prose (`starting_behavior`).
+- `DELETE FROM world_npcs` on a creature death.
+- A second creature identity table next to `world_npcs`.
 
 ---
 
@@ -220,6 +245,7 @@ Do not claim W5/W6. Do not claim CK3 borders or 20 million NPCs.
 
 - Topology + Flower Law + abandon-not-delete + whyPlace emptiness: `server/tests/concordia-megaworld.test.js`
 - WorldField + geographic effectiveness (actor-kind-blind, Hub well, authored affinities): `server/tests/concordia-world-field.test.js`
+- Organism loops + Gloom Stalker catalog honesty + death remains: `server/tests/concordia-organism.test.js`
 - Discrete WorldId potency (live combat, still): `server/tests/cross-world-potency.test.js`
 - Consequence graph (existing): `server/tests/world-consequence.test.js`
 - Settlement composition / vacancy (existing): `server/tests/settlements.test.js`

--- a/docs/CONCORDIA_UNITY_BUILD_PLAN.md
+++ b/docs/CONCORDIA_UNITY_BUILD_PLAN.md
@@ -274,7 +274,7 @@ LOD L0–L3, streaming, shards (protocol exists), proc expansion, background sim
 | P7 | Standalone `/download` |
 | P8 | WebGL later |
 
-**Now:** persistent megaworld W0 (settlement identity + place chronicle + whyPlace) then W1 wrapping `procgen-settlements` onto `settlements` rows. Consequence graph substrate is already in-tree. Do not claim the 100-hour test.
+**Now:** persistent megaworld W0 + W0-field (settlement identity, place chronicle, whyPlace, WorldField). Then W1 wrapping `procgen-settlements` onto `settlements` rows. Combat still uses discrete `crossWorldPotency` until W3 streams (x,z) and W7 samples the field. Do not claim the 100-hour test. Do not claim bosses already retreat toward home.
 
 ---
 

--- a/docs/CONCORDIA_UNITY_BUILD_PLAN.md
+++ b/docs/CONCORDIA_UNITY_BUILD_PLAN.md
@@ -1,7 +1,7 @@
 # Concordia — AAA Living-World north star + build plan
 
-**Status:** living. Read before any Concordia / Unity work.
-**Date:** 2026-08-25
+**Status:** living. Concordia topology + settlement history: `docs/CONCORDIA_PERSISTENT_MEGAWORLD.md`.
+**Date:** 2026-09-12
 **Durable copy:** `docs/CONCORDIA_UNITY_BUILD_PLAN.md` (sync this file there on execute)
 
 **Unity client lives in this repo:** `apps/concordia-living-world/unity-client/`. Open `concord.code-workspace` so Unity Concordia sits next to Godot, frontend, server, and mobile. Do not copy the project out of the tree. `Library/` is gitignored and regenerates in Unity Hub.
@@ -234,7 +234,7 @@ Owner phases A–G **with repo binding**. Each step: find existing module → cl
 5. Faction strategy **already ticks** — wire succession + economy + rumors into it
 6. Settlement supply/demand cascade (npc-economy + scarcity exist)
 7. World events bus (EmergentEventFeed is UI; need **consequence graph** writer)
-8. **World Consequence Graph** — the missing unifier. Event sourcing: actor/action/target/location/time/evidence/witnesses/immediate/long-term → reducers
+8. **World Consequence Graph** — **SHIPPED as substrate** (`world_consequences` mig 416, `lib/world-consequence.js`, `consequence-apply.js`). The remaining work is writers + settlement location + Unity presentation, not a second graph. See `docs/CONCORDIA_PERSISTENT_MEGAWORLD.md`.
 
 **Alive test is the Phase A exit.**
 
@@ -274,7 +274,7 @@ LOD L0–L3, streaming, shards (protocol exists), proc expansion, background sim
 | P7 | Standalone `/download` |
 | P8 | WebGL later |
 
-**Now:** finish P0 presentation **and** start Phase A item 8 (consequence graph) + NPC LOD design so Unity has something true to show.
+**Now:** persistent megaworld W0 (settlement identity + place chronicle + whyPlace) then W1 wrapping `procgen-settlements` onto `settlements` rows. Consequence graph substrate is already in-tree. Do not claim the 100-hour test.
 
 ---
 

--- a/docs/CONCORDIA_UNITY_BUILD_PLAN.md
+++ b/docs/CONCORDIA_UNITY_BUILD_PLAN.md
@@ -274,7 +274,7 @@ LOD L0–L3, streaming, shards (protocol exists), proc expansion, background sim
 | P7 | Standalone `/download` |
 | P8 | WebGL later |
 
-**Now:** persistent megaworld W0 + W0-field (settlement identity, place chronicle, whyPlace, WorldField). Then W1 wrapping `procgen-settlements` onto `settlements` rows. Combat still uses discrete `crossWorldPotency` until W3 streams (x,z) and W7 samples the field. Do not claim the 100-hour test. Do not claim bosses already retreat toward home.
+**Now:** persistent megaworld W0 + W0-field + organism spine (settlement identity, WorldField, Gloom Stalker as catalog organism). Then W1 wrapping `procgen-settlements` and W8 wrapping `fauna-spawner` onto identity rows. Combat still uses discrete `crossWorldPotency` until W3 streams (x,z) and W7 samples the field. Do not claim the 100-hour test. Do not invent Gloom Stalker prey. Do not claim bosses already retreat toward home.
 
 ---
 

--- a/docs/NEXT_ARC_PLAN.md
+++ b/docs/NEXT_ARC_PLAN.md
@@ -6,11 +6,13 @@
 settlements as historical objects, place memory, consequence→Unity presentation,
 and **world identity as a spatial field** (not nine portal maps). Read
 **`docs/CONCORDIA_PERSISTENT_MEGAWORLD.md` first** for Concordia work.
-Spine pinned by `server/tests/concordia-megaworld.test.js` and
-`server/tests/concordia-world-field.test.js`. Do not rebuild
-`settlements` / `world_consequences` / `world_chronicle` / `cross-world-potency`.
-W5/W6 (cold-start and 100-hour return) and W7 (combat samples the field) are
-named and **not yet run / not yet wired**.
+Spine pinned by `server/tests/concordia-megaworld.test.js`,
+`server/tests/concordia-world-field.test.js`, and
+`server/tests/concordia-organism.test.js`. Do not rebuild
+`settlements` / `world_consequences` / `world_chronicle` / `cross-world-potency`
+/ `fauna-spawner` / `creature-needs` / `npc-needs`.
+W5/W6 (cold-start and 100-hour return), W7 (combat samples the field), and
+W8 (fauna-spawner becomes organism identity) are named and **not yet run / not yet wired**.
 
 **Status update (2026-07-03): Wave 1 is SHIPPED.** Every phase in Track K
 (K1–K6, K6-voice) and Track P (P-A, P-B, P-C, P-D) landed on this branch —

--- a/docs/NEXT_ARC_PLAN.md
+++ b/docs/NEXT_ARC_PLAN.md
@@ -2,6 +2,13 @@
 
 ## 🟢 HANDOFF — start here
 
+**Concordia live architecture (2026-09-12):** one continuous megaworld —
+settlements as historical objects, place memory, consequence→Unity presentation.
+Read **`docs/CONCORDIA_PERSISTENT_MEGAWORLD.md` first** for Concordia work.
+Spine pinned by `server/tests/concordia-megaworld.test.js`. Do not rebuild
+`settlements` / `world_consequences` / `world_chronicle`. W5/W6 (cold-start and
+100-hour return) are named and **not yet run**.
+
 **Status update (2026-07-03): Wave 1 is SHIPPED.** Every phase in Track K
 (K1–K6, K6-voice) and Track P (P-A, P-B, P-C, P-D) landed on this branch —
 see the per-phase SHIPPED markers in §B and §C for commit hashes and

--- a/docs/NEXT_ARC_PLAN.md
+++ b/docs/NEXT_ARC_PLAN.md
@@ -11,8 +11,10 @@ Spine pinned by `server/tests/concordia-megaworld.test.js`,
 `server/tests/concordia-organism.test.js`. Do not rebuild
 `settlements` / `world_consequences` / `world_chronicle` / `cross-world-potency`
 / `fauna-spawner` / `creature-needs` / `npc-needs`.
-W5/W6 (cold-start and 100-hour return), W7 (combat samples the field), and
-W8 (fauna-spawner becomes organism identity) are named and **not yet run / not yet wired**.
+W1–W4/W7/W8 playable loop is wired on this branch (in-region field sample,
+combat samples the field, settlements found/abandon, organism births).
+**W3 continent streaming is still GAP** (Travel remains `region_rebuild`).
+**W5/W6 live 7-day / 100-hour runs are not claimed.**
 
 **Status update (2026-07-03): Wave 1 is SHIPPED.** Every phase in Track K
 (K1–K6, K6-voice) and Track P (P-A, P-B, P-C, P-D) landed on this branch —

--- a/docs/NEXT_ARC_PLAN.md
+++ b/docs/NEXT_ARC_PLAN.md
@@ -3,11 +3,14 @@
 ## 🟢 HANDOFF — start here
 
 **Concordia live architecture (2026-09-12):** one continuous megaworld —
-settlements as historical objects, place memory, consequence→Unity presentation.
-Read **`docs/CONCORDIA_PERSISTENT_MEGAWORLD.md` first** for Concordia work.
-Spine pinned by `server/tests/concordia-megaworld.test.js`. Do not rebuild
-`settlements` / `world_consequences` / `world_chronicle`. W5/W6 (cold-start and
-100-hour return) are named and **not yet run**.
+settlements as historical objects, place memory, consequence→Unity presentation,
+and **world identity as a spatial field** (not nine portal maps). Read
+**`docs/CONCORDIA_PERSISTENT_MEGAWORLD.md` first** for Concordia work.
+Spine pinned by `server/tests/concordia-megaworld.test.js` and
+`server/tests/concordia-world-field.test.js`. Do not rebuild
+`settlements` / `world_consequences` / `world_chronicle` / `cross-world-potency`.
+W5/W6 (cold-start and 100-hour return) and W7 (combat samples the field) are
+named and **not yet run / not yet wired**.
 
 **Status update (2026-07-03): Wave 1 is SHIPPED.** Every phase in Track K
 (K1–K6, K6-voice) and Track P (P-A, P-B, P-C, P-D) landed on this branch —

--- a/server/lib/chronicle/compose.js
+++ b/server/lib/chronicle/compose.js
@@ -61,6 +61,27 @@ const COMPOSERS = {
     body: `${p.issued_by_id || "The ruler"} issued a ${p.kind || "decree"}. The people will feel it in the ledger.`,
     importance: 2,
   }),
+  settlement_founded: (p) => ({
+    title: `${p.name || "A settlement"} founded`,
+    body: `${p.name || "A settlement"} stands in ${p.world_id || "a region"}.`,
+    importance: 3,
+  }),
+  settlement_abandoned: (p) => ({
+    title: `${p.name || "A settlement"} abandoned`,
+    body: p.reason
+      ? `${p.name || "A settlement"} is empty after ${p.reason}. The row remains.`
+      : `${p.name || "A settlement"} is empty. The row remains.`,
+    importance: 4,
+  }),
+  place_event: (p) => {
+    const body = String(p.body || p.line || p.title || p.name || p.id || "").trim();
+    if (!body) throw new Error("empty_place_event");
+    return {
+      title: String(p.title || p.name || "At a place").slice(0, 200),
+      body,
+      importance: Number.isFinite(Number(p.importance)) ? Number(p.importance) : 1,
+    };
+  },
 };
 
 /**

--- a/server/lib/combat-hp-authority.js
+++ b/server/lib/combat-hp-authority.js
@@ -6,6 +6,7 @@
 // Unity client sends when the actor is not yet in presence.
 
 import { momentumFor, resolvePoiseStagger, poiseBudget } from "./combat-impact.js";
+import { stampGeographicOnHit, domainFromSkillKind } from "./concordia-world-field.js";
 
 /** @type {Map<string, {id:string, hp:number, maxHp:number, poise:number, worldId:string, x:number, z:number}>} */
 const actors = new Map();
@@ -45,6 +46,12 @@ export function applyAuthoritativeHit({
   baseDamage = 20,
   worldId = "concordia-hub",
   refuseHubCombat = false,
+  localX = null,
+  localZ = null,
+  origin = null,
+  skillKind = null,
+  nativeStrength = 0,
+  actorKind = "player",
 } = {}) {
   if (!targetId) return { ok: false, error: "missing_target" };
   const wid = String(worldId || "concordia-hub");
@@ -59,8 +66,7 @@ export function applyAuthoritativeHit({
   const hint = Math.max(0, Number(baseDamage) || 0);
   const damage = Math.max(1, Math.round(mom * 0.35 + hint * 0.15));
   const before = target.hp;
-  target.hp = Math.max(0, target.hp - damage);
-  return {
+  const result = {
     ok: true,
     authority: "combat-hp-authority",
     damage,
@@ -68,7 +74,7 @@ export function applyAuthoritativeHit({
     hpAfter: target.hp,
     targetHealth: target.hp,
     targetMaxHealth: target.maxHp,
-    targetKilled: target.hp <= 0,
+    targetKilled: false,
     momentum: mom,
     severity: stagger.severity,
     poise: stagger.poise,
@@ -79,6 +85,20 @@ export function applyAuthoritativeHit({
     worldId: wid,
     localHpApplied: false,
   };
+  stampGeographicOnHit(result, {
+    worldId: wid,
+    localX,
+    localZ,
+    origin: origin || wid,
+    domain: domainFromSkillKind(skillKind, "athletics"),
+    nativeStrength,
+    actorKind,
+  });
+  target.hp = Math.max(0, target.hp - result.damage);
+  result.hpAfter = target.hp;
+  result.targetHealth = target.hp;
+  result.targetKilled = target.hp <= 0;
+  return result;
 }
 
 export default { ensureActor, getActor, applyAuthoritativeHit, resetCombatHpAuthorityForTest };

--- a/server/lib/concordia-kingdom-snapshot.js
+++ b/server/lib/concordia-kingdom-snapshot.js
@@ -10,6 +10,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { regionalSummary } from "./concordia-megaworld.js";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
 const WORLD_ROOT = join(ROOT, "content", "world");
@@ -291,11 +292,48 @@ function gatesFor(canon, worldKey) {
   }];
 }
 
+function overlayKernelSettlements(db, worldKey, authored) {
+  const out = authored.map((s) => ({ ...s, status: s.status || null, chronicleIds: [] }));
+  if (!db) return { settlements: out, abandonedCount: 0, chronicleIds: [], kernelPopulation: null };
+  let summary;
+  try { summary = regionalSummary(db, worldKey); }
+  catch { return { settlements: out, abandonedCount: 0, chronicleIds: [], kernelPopulation: null }; }
+  if (!summary?.ok) return { settlements: out, abandonedCount: 0, chronicleIds: [], kernelPopulation: null };
+  const byName = new Map(out.map((s) => [String(s.name || "").toLowerCase(), s]));
+  const byId = new Map(out.map((s) => [String(s.id || "").toLowerCase(), s]));
+  for (const row of summary.settlements || []) {
+    const hit = byId.get(String(row.id || "").toLowerCase())
+      || byName.get(String(row.name || "").toLowerCase());
+    if (hit) {
+      hit.status = row.status || hit.status;
+      hit.kernelId = row.id;
+      hit.livePopulation = row.livePopulation;
+      continue;
+    }
+    out.push({
+      id: row.id,
+      name: row.name,
+      factionId: "",
+      districts: [],
+      source: "kernel",
+      status: row.status || "active",
+      kernelId: row.id,
+      livePopulation: row.livePopulation,
+    });
+  }
+  return {
+    settlements: out,
+    abandonedCount: summary.abandonedCount,
+    chronicleIds: summary.chronicleIds,
+    kernelPopulation: summary.population,
+  };
+}
+
 /**
- * @param {any} _db  unused — the graph is authored JSON, not a SQLite invention
+ * @param {any} db  overlay kernel settlement status when present; authored graph stays
  * @param {string} worldId  folder, enum, or alias
  */
-export function buildKingdomSnapshot(_db, worldId) {
+export function buildKingdomSnapshot(db, worldId) {
   const key = resolveWorldKey(worldId);
   if (!key) {
     return { ok: false, reason: "unknown_world", worldId: worldId || "" };
@@ -304,7 +342,9 @@ export function buildKingdomSnapshot(_db, worldId) {
   const folder = canon.folder;
   const factions = loadFactions(folder);
   const actors = loadPeople(folder);
-  const settlements = settlementsFromAuthored(folder, key, canon);
+  const authored = settlementsFromAuthored(folder, key, canon);
+  const overlay = overlayKernelSettlements(db, key, authored);
+  const settlements = overlay.settlements;
   const lore = readJson(folder, "lore");
   const notes = [];
   if (canon.hub) {
@@ -315,6 +355,9 @@ export function buildKingdomSnapshot(_db, worldId) {
   }
   notes.push("stock/need live on the client WorldMemory slice until persist-sync.");
   notes.push("caravans/tariffs stay empty here until the Ring economy persists them.");
+  if (overlay.abandonedCount > 0) {
+    notes.push(`${overlay.abandonedCount} settlement(s) remain as abandoned rows — ruins, not deletes.`);
+  }
 
   const regionName = canon.hub
     ? "The Unburned Court"
@@ -333,7 +376,7 @@ export function buildKingdomSnapshot(_db, worldId) {
       staple: canon.staple,
       stock: null,
       need: null,
-      population: actors.length,
+      population: overlay.kernelPopulation != null ? overlay.kernelPopulation : actors.length,
       stockNote: "slice_lives_on_client",
     },
     regions: [{
@@ -341,8 +384,11 @@ export function buildKingdomSnapshot(_db, worldId) {
       name: regionName,
       capital: canon.hub ? "The Court" : (settlements[0]?.name || canon.title),
       settlementCount: settlements.length,
+      chronicleIds: overlay.chronicleIds,
     }],
     settlements,
+    abandonedCount: overlay.abandonedCount,
+    chronicleIds: overlay.chronicleIds,
     districts: settlements.flatMap((s) => (s.districts || []).map((d) => ({ settlementId: s.id, id: d }))),
     buildings: [],
     actors,

--- a/server/lib/concordia-megaworld.js
+++ b/server/lib/concordia-megaworld.js
@@ -78,6 +78,14 @@ export function getSettlement(db, settlementId) {
   catch { return null; }
 }
 
+export function findSettlementByRegion(db, regionId) {
+  if (!db || !regionId) return null;
+  if (!hasColumn(db, "settlements", "region_id")) return null;
+  try {
+    return db.prepare(`SELECT * FROM settlements WHERE region_id = ?`).get(regionId) || null;
+  } catch { return null; }
+}
+
 function writePlaceBeat(db, settlementId, worldId, kind, payload) {
   const c = composeEntry(kind, payload);
   if (!c.ok) return c;
@@ -112,6 +120,11 @@ function tryConsequence(db, opts) {
 export function foundSettlement(db, opts = {}) {
   const made = createSettlement(db, opts);
   if (!made.ok) return made;
+  if (opts.regionId && hasColumn(db, "settlements", "region_id")) {
+    try {
+      db.prepare(`UPDATE settlements SET region_id = ? WHERE id = ?`).run(opts.regionId, made.id);
+    } catch { /* optional col */ }
+  }
   if (hasColumn(db, "settlements", "status")) {
     try {
       db.prepare(`UPDATE settlements SET status = 'active', founded_at = COALESCE(founded_at, unixepoch()) WHERE id = ?`)
@@ -241,5 +254,55 @@ export function presentationForSettlement(db, settlementId) {
     settlement: why.settlement,
     history: why.history,
     livePopulation: why.settlement.population,
+  };
+}
+
+/**
+ * L2 regional aggregate. Counts and chronicle ids only — food/wealth stay
+ * empty until those columns are real. Does not reroll a town.
+ */
+export function regionalSummary(db, worldId, limit = 50) {
+  if (!db || !worldId) return { ok: false, reason: "missing_inputs" };
+  const cap = Math.min(200, Math.max(1, Number(limit) || 50));
+  let settlements = [];
+  try {
+    settlements = db.prepare(`
+      SELECT id, name, status, region_id, population, center_x, center_z, founded_at, abandoned_at
+        FROM settlements
+       WHERE world_id = ?
+       ORDER BY founded_at ASC, created_at ASC
+       LIMIT ?
+    `).all(worldId, cap);
+  } catch {
+    return { ok: false, reason: "schema" };
+  }
+  const chronicleIds = [];
+  try {
+    const rows = db.prepare(`
+      SELECT id FROM settlement_chronicle
+       WHERE world_id = ?
+       ORDER BY created_at ASC, rowid ASC
+       LIMIT 200
+    `).all(worldId);
+    for (const r of rows) chronicleIds.push(r.id);
+  } catch { /* optional */ }
+  let population = 0;
+  for (const s of settlements) {
+    const live = countPopulation(db, s.id);
+    population += live;
+    s.livePopulation = live;
+  }
+  return {
+    ok: true,
+    worldId,
+    settlementCount: settlements.length,
+    abandonedCount: settlements.filter((s) => s.status === "abandoned").length,
+    population,
+    food: null,
+    wealth: null,
+    stability: null,
+    warRisk: null,
+    chronicleIds,
+    settlements,
   };
 }

--- a/server/lib/concordia-megaworld.js
+++ b/server/lib/concordia-megaworld.js
@@ -1,0 +1,245 @@
+/**
+ * Concordia persistent megaworld — topology laws + settlement identity.
+ *
+ * Worlds are regions in one universe. Flower Law is Hub-only. Abandoning a
+ * settlement sets status; it never DELETEs the row. whyPlace returns only
+ * beats that were recorded.
+ *
+ *   cd server && node --test tests/concordia-megaworld.test.js
+ */
+
+import crypto from "node:crypto";
+import { createSettlement } from "./settlements.js";
+import { composeEntry } from "./chronicle/compose.js";
+import { recordEntry } from "./chronicle/chronicle.js";
+import { recordConsequence } from "./world-consequence.js";
+
+export const FLOWER_LAW_WORLDS = Object.freeze(["hub", "concordia-hub"]);
+
+/** Content folders / kernel world ids for the core civilizations. */
+export const CORE_CIVILIZATIONS = Object.freeze([
+  "concordia-hub",
+  "sovereign-ruins",
+  "tunya",
+  "fantasy",
+  "crime",
+  "cyber",
+  "concord-link-frontier",
+  "superhero",
+  "sere",
+  "lattice-crucible",
+]);
+
+export const SETTLEMENT_STATUSES = Object.freeze(["active", "abandoned", "conquered", "ghost"]);
+
+/** What Unity Travel() does today. Overland streaming is not implemented. */
+export const CURRENT_TRAVEL_MODE = "region_rebuild";
+
+export function flowerLawGoverns(worldId) {
+  const id = String(worldId || "").trim().toLowerCase();
+  return FLOWER_LAW_WORLDS.includes(id);
+}
+
+/**
+ * Intended mode after W3. Hub crossings and core-to-core use the Link.
+ * Same-region travel should be overland. Not a claim that overland exists.
+ */
+export function intendedTravelMode(fromWorldId, toWorldId) {
+  const from = String(fromWorldId || "").trim().toLowerCase();
+  const to = String(toWorldId || "").trim().toLowerCase();
+  if (!from || !to) return { mode: "invalid", reason: "missing_world" };
+  if (from === to) return { mode: "stay" };
+  if (flowerLawGoverns(from) || flowerLawGoverns(to)) return { mode: "link_gate" };
+  return { mode: "overland" };
+}
+
+export function currentTravelMode() {
+  return { mode: CURRENT_TRAVEL_MODE };
+}
+
+export function countPopulation(db, settlementId) {
+  if (!db || !settlementId) return 0;
+  try {
+    return db.prepare(`
+      SELECT COUNT(*) AS n FROM world_npcs
+       WHERE settlement_id = ? AND COALESCE(is_dead,0)=0
+    `).get(settlementId)?.n ?? 0;
+  } catch { return 0; }
+}
+
+function hasColumn(db, table, col) {
+  try { return db.pragma(`table_info(${table})`).some((c) => c.name === col); }
+  catch { return false; }
+}
+
+export function getSettlement(db, settlementId) {
+  if (!db || !settlementId) return null;
+  try { return db.prepare(`SELECT * FROM settlements WHERE id = ?`).get(settlementId) || null; }
+  catch { return null; }
+}
+
+function writePlaceBeat(db, settlementId, worldId, kind, payload) {
+  const c = composeEntry(kind, payload);
+  if (!c.ok) return c;
+  const id = `sch_${crypto.randomUUID()}`;
+  try {
+    db.prepare(`
+      INSERT INTO settlement_chronicle
+        (id, settlement_id, world_id, kind, dedupe_key, title, body, actor_id, year_idx)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(settlement_id, dedupe_key) DO NOTHING
+    `).run(
+      id, settlementId, worldId, kind, c.dedupeKey, c.title, c.body,
+      payload.actor_id || payload.actorId || null,
+      Number.isInteger(payload.year_idx) ? payload.year_idx : null,
+    );
+  } catch (e) {
+    return { ok: false, reason: "place_persist_failed", error: e?.message };
+  }
+  try { recordEntry(db, worldId, kind, payload); } catch { /* world_chronicle optional */ }
+  return { ok: true, id, title: c.title, body: c.body, dedupeKey: c.dedupeKey };
+}
+
+function tryConsequence(db, opts) {
+  try { return recordConsequence(db, opts); }
+  catch { return { ok: false, reason: "consequence_unavailable" }; }
+}
+
+/**
+ * Found a settlement as a historical object. Wraps createSettlement.
+ * Empty founders stay empty. Does not invent a spring or a road.
+ */
+export function foundSettlement(db, opts = {}) {
+  const made = createSettlement(db, opts);
+  if (!made.ok) return made;
+  if (hasColumn(db, "settlements", "status")) {
+    try {
+      db.prepare(`UPDATE settlements SET status = 'active', founded_at = COALESCE(founded_at, unixepoch()) WHERE id = ?`)
+        .run(made.id);
+    } catch { /* optional cols */ }
+  }
+  if (Array.isArray(opts.founders) && hasColumn(db, "settlements", "founders_json")) {
+    try {
+      db.prepare(`UPDATE settlements SET founders_json = ? WHERE id = ?`)
+        .run(JSON.stringify(opts.founders), made.id);
+    } catch { /* noop */ }
+  }
+  const worldId = opts.worldId;
+  writePlaceBeat(db, made.id, worldId, "settlement_founded", {
+    id: made.id,
+    name: opts.name,
+    world_id: worldId,
+    dedupeKey: `settlement_founded:${made.id}`,
+  });
+  tryConsequence(db, {
+    worldId,
+    actorKind: opts.actorKind || "system",
+    actorId: opts.actorId || "inhabitation",
+    action: "settle",
+    targetKind: "settlement",
+    targetId: made.id,
+    location: made.id,
+    importance: 0.7,
+    immediate: { name: opts.name },
+  });
+  return { ok: true, id: made.id };
+}
+
+/**
+ * Abandon a settlement. The row remains. Buildings are not deleted here.
+ */
+export function abandonSettlement(db, settlementId, { reason = null, actorId = null } = {}) {
+  if (!db || !settlementId) return { ok: false, reason: "missing_inputs" };
+  const row = getSettlement(db, settlementId);
+  if (!row) return { ok: false, reason: "not_found" };
+  if (!hasColumn(db, "settlements", "status")) return { ok: false, reason: "schema" };
+  try {
+    db.prepare(`
+      UPDATE settlements
+         SET status = 'abandoned', abandoned_at = unixepoch()
+       WHERE id = ?
+    `).run(settlementId);
+  } catch (e) { return { ok: false, reason: "update_failed", error: e?.message }; }
+  writePlaceBeat(db, settlementId, row.world_id, "settlement_abandoned", {
+    id: settlementId,
+    name: row.name,
+    world_id: row.world_id,
+    reason,
+    dedupeKey: `settlement_abandoned:${settlementId}`,
+  });
+  tryConsequence(db, {
+    worldId: row.world_id,
+    actorKind: "system",
+    actorId: actorId || "inhabitation",
+    action: "abandon",
+    targetKind: "settlement",
+    targetId: settlementId,
+    location: settlementId,
+    importance: 0.8,
+    longTerm: { reason, buildings_remain: true },
+  });
+  return { ok: true, id: settlementId, status: "abandoned" };
+}
+
+export function listPlaceHistory(db, settlementId, limit = 50) {
+  if (!db || !settlementId) return [];
+  const cap = Math.min(200, Math.max(1, Number(limit) || 50));
+  try {
+    return db.prepare(`
+      SELECT id, kind, title, body, actor_id, year_idx, created_at
+        FROM settlement_chronicle
+       WHERE settlement_id = ?
+       ORDER BY created_at ASC, rowid ASC
+       LIMIT ?
+    `).all(settlementId, cap);
+  } catch { return []; }
+}
+
+/**
+ * Why is this place here? Identity + recorded beats only.
+ * Empty history is a valid answer — never a fabricated spring or mill.
+ */
+export function whyPlace(db, settlementId) {
+  if (!db || !settlementId) return { ok: false, reason: "missing_inputs" };
+  const row = getSettlement(db, settlementId);
+  if (!row) return { ok: false, reason: "not_found" };
+  const history = listPlaceHistory(db, settlementId);
+  const population = Number.isInteger(row.population) ? row.population : countPopulation(db, settlementId);
+  return {
+    ok: true,
+    settlement: {
+      id: row.id,
+      worldId: row.world_id,
+      name: row.name,
+      status: row.status || "active",
+      foundedAt: row.founded_at || row.created_at || null,
+      abandonedAt: row.abandoned_at || null,
+      population,
+      factionId: row.faction_id || null,
+      formerNames: row.former_names_json ? safeJson(row.former_names_json) : [],
+      founders: row.founders_json ? safeJson(row.founders_json) : [],
+    },
+    history,
+  };
+}
+
+function safeJson(raw) {
+  try {
+    const v = JSON.parse(raw);
+    return Array.isArray(v) ? v : [];
+  } catch { return []; }
+}
+
+/**
+ * Kernel → Unity card. No buildings invented. Missing tables → empty arrays.
+ */
+export function presentationForSettlement(db, settlementId) {
+  const why = whyPlace(db, settlementId);
+  if (!why.ok) return why;
+  return {
+    ok: true,
+    settlement: why.settlement,
+    history: why.history,
+    livePopulation: why.settlement.population,
+  };
+}

--- a/server/lib/concordia-organism.js
+++ b/server/lib/concordia-organism.js
@@ -1,0 +1,281 @@
+/**
+ * Concordia megaworld — a creature is a persistent organism, not a spawn.
+ *
+ * Two loops, one world:
+ *
+ *   Genome → organism → ecology → civilization → history → presentation
+ *   Person → needs → action → consequence → memory → place → history → presentation
+ *
+ * They meet at WorldField + world_consequences + place. Do not rebuild
+ * fauna-spawner, creature-needs, npc-needs, food-web, or the Unity
+ * CreatureCompiler (other branch). Compose them.
+ *
+ * Authored catalog fields are returned. Missing prey / pack / territory
+ * stay empty — never a fabricated hunting list.
+ *
+ *   cd server && node --test tests/concordia-organism.test.js
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { CREATURE_NEED_KINDS, freshCreatureNeeds } from "./ecosystem/creature-needs.js";
+import { NEED_KINDS as PERSON_NEED_KINDS, freshNeeds as freshPersonNeeds } from "./npc-needs.js";
+import { preyForPredator } from "./ecosystem/food-web.js";
+import { fieldAt, fieldKeyForWorld, geographicEffectiveness, localRules } from "./concordia-world-field.js";
+import { recordConsequence } from "./world-consequence.js";
+
+export const ORGANISM_LOOPS = Object.freeze({
+  creature: Object.freeze(["genome", "organism", "ecology", "civilization", "history", "presentation"]),
+  person: Object.freeze(["person", "needs", "action", "consequence", "memory", "place", "history", "presentation"]),
+});
+
+export { CREATURE_NEED_KINDS, PERSON_NEED_KINDS, freshCreatureNeeds, freshPersonNeeds };
+
+const CONTENT_WORLD = join(dirname(fileURLToPath(import.meta.url)), "../../content/world");
+
+const _species = [];
+let _catalogLoaded = false;
+
+function loadCatalog() {
+  if (_catalogLoaded) return;
+  _catalogLoaded = true;
+  let dirs = [];
+  try { dirs = readdirSync(CONTENT_WORLD); } catch { return; }
+  for (const folder of dirs) {
+    let items;
+    try {
+      items = JSON.parse(readFileSync(join(CONTENT_WORLD, folder, "creatures.json"), "utf8"));
+    } catch { continue; }
+    if (!Array.isArray(items)) continue;
+    for (const row of items) {
+      if (!row?.id) continue;
+      _species.push({
+        id: row.id,
+        name: row.name || row.id,
+        worldId: row.world_id || folder,
+        description: row.description || "",
+        topologyHint: row.topology_hint || null,
+        sizeBand: row.size_band || null,
+        startingBehavior: row.starting_behavior || null,
+        prey: Array.isArray(row.prey) ? row.prey : null,
+        pack: row.pack ?? row.pack_behavior ?? null,
+        territory: row.territory || null,
+      });
+    }
+  }
+}
+
+export function speciesById(id, worldId = null) {
+  loadCatalog();
+  const sid = String(id || "");
+  if (!sid) return { ok: false, reason: "unknown_species" };
+  const matches = _species.filter((s) => s.id === sid);
+  if (worldId) {
+    const hit = matches.find((s) => s.worldId === worldId);
+    if (!hit) return { ok: false, reason: "unknown_species" };
+    return { ok: true, species: hit };
+  }
+  if (matches.length === 1) return { ok: true, species: matches[0] };
+  if (matches.length === 0) return { ok: false, reason: "unknown_species" };
+  return {
+    ok: false,
+    reason: "ambiguous_species",
+    worlds: matches.map((s) => s.worldId),
+  };
+}
+
+/**
+ * Prey from the catalog, else food-web edges for a real biome roster.
+ * Unknown species → empty. Never invent "isolated targets" as a species id.
+ */
+export function preyOf(speciesId, { universe = null, biome = null } = {}) {
+  const cat = speciesById(speciesId);
+  if (cat.ok && Array.isArray(cat.species.prey)) return cat.species.prey.slice();
+  if (universe && biome) {
+    try {
+      const list = preyForPredator(universe, biome, speciesId);
+      return Array.isArray(list) ? list : [];
+    } catch { return []; }
+  }
+  return [];
+}
+
+export function habitatFitness({ originWorldId, x, z } = {}) {
+  const field = fieldAt(x, z);
+  if (!field.ok) return field;
+  const key = fieldKeyForWorld(originWorldId);
+  const fitness = key ? (field[key] || 0) : 0;
+  return {
+    ok: true,
+    origin: key,
+    fitness,
+    suppressed: field.flowerLaw === true,
+    flowerLaw: field.flowerLaw,
+    dominant: field.dominant,
+    field,
+  };
+}
+
+/**
+ * What the organism is *here*. Catalog + field + recorded needs.
+ * Does not invent pack, prey, or a census.
+ */
+export function organismInField(opts = {}) {
+  const {
+    kind = "creature",
+    speciesId = null,
+    personId = null,
+    originWorldId = null,
+    x, z,
+    nativeStrength = 0,
+    adaptation = 0,
+    needs = null,
+    universe = null,
+    biome = null,
+  } = opts;
+  const field = fieldAt(x, z);
+  if (!field.ok) return field;
+
+  const isPerson = kind === "person" || kind === "npc" || kind === "player";
+  let species = null;
+  if (!isPerson) {
+    const cat = speciesById(speciesId, originWorldId || null);
+    if (!cat.ok) return cat;
+    species = cat.species;
+  }
+
+  const origin = originWorldId || species?.worldId || null;
+  const habitat = habitatFitness({ originWorldId: origin, x, z });
+  const domain = isPerson ? (opts.domain || "athletics") : (opts.domain || "magic");
+  const geo = geographicEffectiveness({
+    origin,
+    x, z,
+    domain,
+    nativeStrength,
+    adaptation,
+    actorKind: isPerson ? (kind === "player" ? "player" : "person") : "creature",
+  });
+  const rules = localRules(field);
+  const prey = isPerson ? [] : preyOf(speciesId, { universe, biome });
+
+  return {
+    ok: true,
+    kind: isPerson ? "person" : "creature",
+    id: isPerson ? personId : speciesId,
+    species,
+    needs: needs == null
+      ? (isPerson ? freshPersonNeeds() : freshCreatureNeeds())
+      : needs,
+    habitatFitness: habitat.fitness,
+    habitatSuppressed: habitat.suppressed,
+    geographic: geo,
+    localPhysics: rules,
+    prey,
+    pack: species?.pack ?? null,
+    territory: species?.territory ?? null,
+    field,
+    loop: isPerson ? ORGANISM_LOOPS.person : ORGANISM_LOOPS.creature,
+  };
+}
+
+/**
+ * Same point → same field. This is where the two loops meet.
+ */
+export function sharedWorldSurface(x, z) {
+  const field = fieldAt(x, z);
+  if (!field.ok) return field;
+  return { ok: true, field, rules: localRules(field) };
+}
+
+export function explainOrganism(opts = {}) {
+  const o = organismInField(opts);
+  if (!o.ok) return o;
+  const name = o.species?.name || o.id || "someone";
+  let because;
+  if (o.kind === "person") {
+    because = o.habitatSuppressed
+      ? `${name} is under Flower Law. Local physics is civil.`
+      : `${name} acts in the ${o.field.dominant} field. Local ${o.geographic.domain} physics is ${o.geographic.localPhysics.toFixed(2)}.`;
+  } else if (o.habitatSuppressed) {
+    because = `${name} is in the Hub well. Wild hunting is suppressed. Habitat fitness ${o.habitatFitness.toFixed(2)}.`;
+  } else {
+    const preyLine = o.prey.length
+      ? ` Recorded prey: ${o.prey.join(", ")}.`
+      : " Prey is unknown — the catalog has no list.";
+    because = `${name} (authored ${o.species.worldId}). Habitat fitness ${o.habitatFitness.toFixed(2)} in the ${o.field.dominant} field. Magic coupling ${o.geographic.multiplier.toFixed(2)}.${preyLine}`;
+  }
+  return {
+    ok: true,
+    kind: o.kind,
+    habitatFitness: o.habitatFitness,
+    multiplier: o.geographic.multiplier,
+    prey: o.prey,
+    pack: o.pack,
+    because,
+  };
+}
+
+function tryConsequence(db, opts) {
+  try { return recordConsequence(db, opts); }
+  catch (e) { return { ok: false, reason: "consequence_unavailable", error: e?.message }; }
+}
+
+/**
+ * Death writes the graph and tombstones the row. It never DELETE.
+ */
+export function recordOrganismDeath(db, opts = {}) {
+  const targetId = opts.targetId || opts.id;
+  if (!db || !targetId) return { ok: false, reason: "missing_inputs" };
+  const actorKind = opts.actorKind || "system";
+  const actorId = opts.actorId || "ecology";
+  const action = opts.action === "hunt" ? "hunt" : "kill";
+  const con = tryConsequence(db, {
+    worldId: opts.worldId || "concordia-hub",
+    actorKind,
+    actorId,
+    action,
+    targetKind: opts.targetKind || (opts.kind === "person" ? "npc" : "creature"),
+    targetId,
+    location: opts.location || targetId,
+    importance: opts.importance ?? 0.55,
+    immediate: { speciesId: opts.speciesId || null, remains: true },
+    longTerm: { deleted: false },
+  });
+  let tombstoned = false;
+  try {
+    const r = db.prepare(`UPDATE world_npcs SET is_dead = 1 WHERE id = ?`).run(targetId);
+    tombstoned = (r?.changes || 0) > 0;
+  } catch { /* table optional */ }
+  let remaining = null;
+  try {
+    remaining = db.prepare(`SELECT id, is_dead FROM world_npcs WHERE id = ?`).get(targetId) || null;
+  } catch { remaining = null; }
+  return {
+    ok: con.ok !== false,
+    deleted: false,
+    tombstoned,
+    stillPresent: remaining != null,
+    consequence: con,
+  };
+}
+
+/**
+ * Birth writes the graph. Does not insert a fabricated NPC — the caller
+ * already has an id, or we refuse.
+ */
+export function recordOrganismBirth(db, opts = {}) {
+  const id = opts.id || opts.targetId;
+  if (!id) return { ok: false, reason: "missing_id" };
+  return tryConsequence(db, {
+    worldId: opts.worldId || "concordia-hub",
+    actorKind: opts.actorKind || "system",
+    actorId: opts.actorId || "ecology",
+    action: "birth",
+    targetKind: opts.targetKind || "creature",
+    targetId: id,
+    location: opts.location || id,
+    importance: opts.importance ?? 0.4,
+    immediate: { speciesId: opts.speciesId || null },
+  });
+}

--- a/server/lib/concordia-world-field.js
+++ b/server/lib/concordia-world-field.js
@@ -6,8 +6,10 @@
  * Geographic effectiveness is physics: the same formula for a player, an NPC,
  * a boss, a dragon, a summoned creature, a faction army, or equipment.
  *
- * Discrete WorldId combat (`cross-world-potency.js`) remains the live path
- * until travel streams continuous (x,z). This module is the continuous law.
+ * Live combat samples this module (W7). Discrete `cross-world-potency.js`
+ * remains the WorldId fallback when CONCORD_GEOGRAPHIC_FIELD=0.
+ * In-region Unity metres map onto the megaworld plane (W3-thin). Continent
+ * streaming between civilizations is still GAP — Travel stays region_rebuild.
  *
  * Hub is a suppression well (Flower Law), not a ninth combat physics.
  * Authored skill_affinity tables at field centers are the blend weights —
@@ -20,6 +22,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { NEUTRAL_AFFINITY } from "./skill-domains.js";
+import { SKILL_KIND_DOMAIN } from "./cross-world-potency.js";
 
 /** Actor kinds the field treats identically. Branching on kind is a bug. */
 export const FIELD_ACTOR_KINDS = Object.freeze([
@@ -77,6 +80,14 @@ export const MEGAWORLD_KM = Object.freeze({
   hubCourt: 12,
   hubMetro: 40,
 });
+
+/**
+ * Playable in-region sample, not continent streaming.
+ * 1 Unity scene metre → this many megaworld km around a civilization center.
+ * A ~80 m plaza walk is tens of km on the field — enough to feel a gradient
+ * without claiming the player walked to the next civilization.
+ */
+export const SCENE_METRES_TO_KM = 0.4;
 
 /** Softmax-ish: nearest center owns core physics; neighbors mix in the bands. */
 export const BLEND_SHARPNESS = 8;
@@ -407,12 +418,121 @@ export function explainGeographicEffectiveness(opts = {}) {
 }
 
 /**
- * Until W3 streams (x,z), live combat has a WorldId not a megaworld point.
- * Sample the civilization center. Not a claim that Unity already walks the field.
+ * Discrete WorldId fallback: sample the civilization center.
+ * Used when the caller has no local (x,z). Not a claim that Unity walks
+ * the supercontinent — Travel is still region_rebuild.
  */
 export function geographicEffectivenessAtWorld(opts = {}) {
   const key = fieldKeyForWorld(opts.worldId);
   if (!key) return { ok: false, reason: "unknown_world" };
   const c = key === "hub" ? { x: 0, z: 0 } : fieldCenter(key);
   return geographicEffectiveness({ ...opts, x: c.x, z: c.z });
+}
+
+export function domainFromSkillKind(skillKind, fallback = "athletics") {
+  if (!skillKind) return fallback;
+  return SKILL_KIND_DOMAIN[skillKind] || fallback;
+}
+
+/**
+ * Map Unity scene metres onto the megaworld plane around a civilization
+ * center. Hub stays in the well (Flower Law is the Court — plaza walking
+ * does not leave it). +localZ is radially outward from Hub; +localX is
+ * clockwise tangent. Cross-region walking is still Travel/Build.
+ */
+export function localToMegaworld(worldId, localX, localZ) {
+  const key = fieldKeyForWorld(worldId);
+  if (!key) return { ok: false, reason: "unknown_world" };
+  const lx = Number(localX);
+  const lz = Number(localZ);
+  if (!Number.isFinite(lx) || !Number.isFinite(lz)) {
+    return { ok: false, reason: "missing_position" };
+  }
+  if (key === "hub") {
+    return { ok: true, x: 0, z: 0, worldId: FIELD_WORLD_IDS.hub, fieldKey: "hub", hubWell: true };
+  }
+  const c = fieldCenter(key);
+  if (!c) return { ok: false, reason: "unknown_world" };
+  const km = SCENE_METRES_TO_KM;
+  const ang = c.angle;
+  const radialX = Math.cos(ang);
+  const radialZ = Math.sin(ang);
+  const tanX = -Math.sin(ang);
+  const tanZ = Math.cos(ang);
+  return {
+    ok: true,
+    x: c.x + tanX * lx * km + radialX * lz * km,
+    z: c.z + tanZ * lx * km + radialZ * lz * km,
+    worldId: FIELD_WORLD_IDS[key] || worldId,
+    fieldKey: key,
+    hubWell: false,
+  };
+}
+
+export function sampleCombatField(opts = {}) {
+  const { worldId, localX, localZ, x, z } = opts;
+  if (Number.isFinite(Number(x)) && Number.isFinite(Number(z))) {
+    return geographicEffectiveness(opts);
+  }
+  if (Number.isFinite(Number(localX)) && Number.isFinite(Number(localZ)) && worldId) {
+    const p = localToMegaworld(worldId, localX, localZ);
+    if (!p.ok) return p;
+    return geographicEffectiveness({ ...opts, x: p.x, z: p.z });
+  }
+  if (worldId) return geographicEffectivenessAtWorld(opts);
+  return { ok: false, reason: "missing_position" };
+}
+
+/**
+ * Scale a resolved hit by the field. Kill-switch CONCORD_GEOGRAPHIC_FIELD=0
+ * leaves damage unchanged. Missing field → unmodified, honest reason.
+ */
+export function applyGeographicDamage(baseDamage, opts = {}) {
+  const raw = Number(baseDamage);
+  if (!Number.isFinite(raw)) return { ok: false, reason: "invalid_damage" };
+  if (process.env.CONCORD_GEOGRAPHIC_FIELD === "0") {
+    return { ok: true, damage: raw, geographic: null, disabled: true };
+  }
+  const g = sampleCombatField(opts);
+  if (!g.ok) return { ok: true, damage: raw, geographic: null, reason: g.reason };
+  const damage = Math.round(raw * g.multiplier * 10) / 10;
+  const explained = explainGeographicEffectiveness({
+    origin: opts.origin,
+    x: g.x,
+    z: g.z,
+    domain: opts.domain || "athletics",
+    nativeStrength: opts.nativeStrength,
+    adaptation: opts.adaptation,
+    actorKind: opts.actorKind,
+  });
+  return {
+    ok: true,
+    damage,
+    geographic: g,
+    because: explained.ok ? explained.because : null,
+  };
+}
+
+export function stampGeographicOnHit(result, opts = {}) {
+  if (!result || result.ok === false || result.refused) return result;
+  if (!Number.isFinite(Number(result.damage))) return result;
+  const stamped = applyGeographicDamage(result.damage, opts);
+  if (!stamped.ok) return result;
+  result.damage = stamped.damage;
+  if (stamped.geographic) {
+    result.geographicEffectiveness = {
+      multiplier: stamped.geographic.multiplier,
+      localPhysics: stamped.geographic.localPhysics,
+      dominant: stamped.geographic.dominant,
+      flowerLaw: stamped.geographic.flowerLaw,
+      steelLive: stamped.geographic.steelLive,
+      because: stamped.because,
+    };
+  } else if (stamped.reason || stamped.disabled) {
+    result.geographicEffectiveness = {
+      ok: false,
+      reason: stamped.disabled ? "disabled" : stamped.reason,
+    };
+  }
+  return result;
 }

--- a/server/lib/concordia-world-field.js
+++ b/server/lib/concordia-world-field.js
@@ -23,7 +23,8 @@ import { NEUTRAL_AFFINITY } from "./skill-domains.js";
 
 /** Actor kinds the field treats identically. Branching on kind is a bug. */
 export const FIELD_ACTOR_KINDS = Object.freeze([
-  "player", "npc", "boss", "dragon", "summoned", "faction", "equipment", "infrastructure",
+  "player", "person", "npc", "boss", "dragon", "creature", "summoned",
+  "faction", "equipment", "infrastructure",
 ]);
 
 /**

--- a/server/lib/concordia-world-field.js
+++ b/server/lib/concordia-world-field.js
@@ -1,0 +1,417 @@
+/**
+ * Concordia megaworld — world identity is a spatial field, not a separate map.
+ *
+ * Every point on the supercontinent has overlapping civilization influences.
+ * Local rules (magic, tech, domain affinity) are derived from that field.
+ * Geographic effectiveness is physics: the same formula for a player, an NPC,
+ * a boss, a dragon, a summoned creature, a faction army, or equipment.
+ *
+ * Discrete WorldId combat (`cross-world-potency.js`) remains the live path
+ * until travel streams continuous (x,z). This module is the continuous law.
+ *
+ * Hub is a suppression well (Flower Law), not a ninth combat physics.
+ * Authored skill_affinity tables at field centers are the blend weights —
+ * do not invent a second affinity table.
+ *
+ *   cd server && node --test tests/concordia-world-field.test.js
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { NEUTRAL_AFFINITY } from "./skill-domains.js";
+
+/** Actor kinds the field treats identically. Branching on kind is a bug. */
+export const FIELD_ACTOR_KINDS = Object.freeze([
+  "player", "npc", "boss", "dragon", "summoned", "faction", "equipment", "infrastructure",
+]);
+
+/**
+ * Field channels. Keys are short; world ids map through FIELD_WORLD_IDS.
+ * Sere has no Link gate — it still has a center (off-ring, no teleport).
+ */
+export const FIELD_KEYS = Object.freeze([
+  "hub", "fantasy", "crime", "cyber", "superhero", "frontier", "tunya", "sovereign", "lattice", "sere",
+]);
+
+export const FIELD_WORLD_IDS = Object.freeze({
+  hub: "concordia-hub",
+  fantasy: "fantasy",
+  crime: "crime",
+  cyber: "cyber",
+  superhero: "superhero",
+  frontier: "concord-link-frontier",
+  tunya: "tunya",
+  sovereign: "sovereign-ruins",
+  lattice: "lattice-crucible",
+  sere: "sere",
+});
+
+const WORLD_TO_KEY = Object.freeze(Object.fromEntries([
+  ...Object.entries(FIELD_WORLD_IDS).map(([k, id]) => [id, k]),
+  ["hub", "hub"],
+  ["concordia-hub", "hub"],
+]));
+
+/**
+ * Gate bearings copied from Unity Canon.Gates (radians).
+ * These are civilization field centers on one plane, not portal destinations.
+ * Pin: tests/concordia-world-field.test.js reads Canon.cs.
+ */
+export const FIELD_GATE_ANGLES = Object.freeze({
+  cyber: 0,
+  sovereign: Math.PI / 4,
+  fantasy: Math.PI / 2,
+  tunya: 3 * Math.PI / 4,
+  frontier: Math.PI,
+  crime: 5 * Math.PI / 4,
+  superhero: 3 * Math.PI / 2,
+  lattice: 7 * Math.PI / 4,
+});
+
+/** Megaworld kilometres. Not Unity Hub plaza metres (Canon.RingRadius = 34). */
+export const MEGAWORLD_KM = Object.freeze({
+  civilizationRadius: 400,
+  sigma: 410,
+  hubCourt: 12,
+  hubMetro: 40,
+});
+
+/** Softmax-ish: nearest center owns core physics; neighbors mix in the bands. */
+export const BLEND_SHARPNESS = 8;
+
+/** Same cap as Pillar-3 MASTER_LEVEL default — Fire 94 → crime floor ≈ 0.29. */
+export const GEO_NATIVE_CAP = 200;
+
+const CONTENT_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../content/world");
+
+const FOLDER_FOR_KEY = Object.freeze({
+  fantasy: "fantasy",
+  crime: "crime",
+  cyber: "cyber",
+  superhero: "superhero",
+  frontier: "concord-link-frontier",
+  tunya: "tunya",
+  sovereign: "sovereign-ruins",
+  lattice: "lattice-crucible",
+  sere: "sere",
+  hub: null,
+});
+
+const _affinityCache = new Map();
+const _inject = new Map();
+
+export function fieldKeyForWorld(worldId) {
+  const id = String(worldId || "").trim().toLowerCase();
+  return WORLD_TO_KEY[id] || null;
+}
+
+export function worldIdForFieldKey(key) {
+  return FIELD_WORLD_IDS[key] || null;
+}
+
+/** Test-only: override a center's affinity table. */
+export function injectCenterAffinity(key, table) {
+  _inject.set(key, table && typeof table === "object" ? table : null);
+}
+
+export function resetCenterAffinityInjects() {
+  _inject.clear();
+}
+
+function clamp01(n) {
+  const x = Number(n);
+  if (!Number.isFinite(x)) return 0;
+  return Math.max(0, Math.min(1, x));
+}
+
+function hypot2(x, z) {
+  return Math.hypot(Number(x) || 0, Number(z) || 0);
+}
+
+function gaussian(distanceKm, sigmaKm) {
+  const s = sigmaKm || MEGAWORLD_KM.sigma;
+  const d = Number(distanceKm) || 0;
+  return Math.exp(-((d / s) * (d / s)));
+}
+
+/**
+ * Field-center coordinates. Hub is the origin. Gated civs sit on the
+ * Canon ring. Sere has no gate — off-ring, crime-adjacent, farther out.
+ */
+export function fieldCenter(key) {
+  if (key === "hub") return { key: "hub", x: 0, z: 0, hasLinkGate: true, radiusKm: 0 };
+  const R = MEGAWORLD_KM.civilizationRadius;
+  if (key === "sere") {
+    const angle = FIELD_GATE_ANGLES.crime + 0.35;
+    const r = R * 1.35;
+    return {
+      key, x: r * Math.cos(angle), z: r * Math.sin(angle),
+      hasLinkGate: false, radiusKm: r, angle,
+    };
+  }
+  const angle = FIELD_GATE_ANGLES[key];
+  if (angle == null) return null;
+  return {
+    key, x: R * Math.cos(angle), z: R * Math.sin(angle),
+    hasLinkGate: true, radiusKm: R, angle,
+  };
+}
+
+export function allFieldCenters() {
+  return FIELD_KEYS.map(fieldCenter).filter(Boolean);
+}
+
+function hubWell(distanceKm) {
+  const { hubCourt, hubMetro } = MEGAWORLD_KM;
+  if (distanceKm <= hubCourt) return 1;
+  if (distanceKm >= hubMetro) return 0;
+  const t = (distanceKm - hubCourt) / (hubMetro - hubCourt);
+  return clamp01(1 - t * t);
+}
+
+function loadAuthoredAffinity(key) {
+  if (_inject.has(key)) {
+    const inj = _inject.get(key);
+    return inj || { ...NEUTRAL_AFFINITY, default: 0.7 };
+  }
+  if (_affinityCache.has(key)) return _affinityCache.get(key);
+  const folder = FOLDER_FOR_KEY[key];
+  if (!folder) {
+    const hub = { ...NEUTRAL_AFFINITY, default: 0.7 };
+    _affinityCache.set(key, hub);
+    return hub;
+  }
+  try {
+    const raw = JSON.parse(readFileSync(join(CONTENT_ROOT, folder, "meta.json"), "utf8"));
+    const table = raw?.skill_affinity && typeof raw.skill_affinity === "object"
+      ? raw.skill_affinity
+      : { ...NEUTRAL_AFFINITY, default: 0.7 };
+    _affinityCache.set(key, table);
+    return table;
+  } catch {
+    const fallback = { ...NEUTRAL_AFFINITY, default: 0.7 };
+    _affinityCache.set(key, fallback);
+    return fallback;
+  }
+}
+
+export function centerAffinity(key, domain) {
+  const table = loadAuthoredAffinity(key);
+  if (table[domain] != null && Number.isFinite(Number(table[domain]))) {
+    return clamp01(table[domain]);
+  }
+  if (table.default != null && Number.isFinite(Number(table.default))) {
+    return clamp01(table.default);
+  }
+  return clamp01(NEUTRAL_AFFINITY[domain] ?? 0.7);
+}
+
+function pickTransition(influences, hubInfluence) {
+  if (hubInfluence >= 0.45) return { ok: false, reason: "hub_well" };
+  const ranked = FIELD_KEYS
+    .filter((k) => k !== "hub")
+    .map((k) => ({ key: k, v: influences[k] || 0 }))
+    .sort((a, b) => b.v - a.v);
+  const a = ranked[0];
+  const b = ranked[1];
+  if (!a || !b) return { ok: false, reason: "no_pair" };
+  if (a.v < 0.22 || b.v < 0.22) return { ok: false, reason: "single_dominant" };
+  if (Math.abs(a.v - b.v) > 0.35) return { ok: false, reason: "single_dominant" };
+  return { ok: true, a: a.key, b: b.key, aInfluence: a.v, bInfluence: b.v };
+}
+
+/**
+ * WorldField at a megaworld (x, z) in kilometres.
+ */
+export function fieldAt(x, z) {
+  const px = Number(x);
+  const pz = Number(z);
+  if (!Number.isFinite(px) || !Number.isFinite(pz)) {
+    return { ok: false, reason: "missing_position" };
+  }
+  const influences = {};
+  for (const key of FIELD_KEYS) {
+    if (key === "hub") continue;
+    const c = fieldCenter(key);
+    influences[key] = gaussian(Math.hypot(px - c.x, pz - c.z), MEGAWORLD_KM.sigma);
+  }
+  const distHub = hypot2(px, pz);
+  const hub = hubWell(distHub);
+  influences.hub = hub;
+  let dominant = "hub";
+  let best = hub;
+  for (const key of FIELD_KEYS) {
+    if ((influences[key] || 0) > best) {
+      best = influences[key];
+      dominant = key;
+    }
+  }
+  const flowerLaw = hub >= 0.85 || distHub <= MEGAWORLD_KM.hubCourt;
+  const transition = pickTransition(influences, hub);
+  return {
+    ok: true,
+    x: px,
+    z: pz,
+    ...influences,
+    dominant,
+    transition,
+    flowerLaw,
+    steelLive: !flowerLaw,
+    chaosSuppressed: hub,
+    distanceFromHubKm: distHub,
+  };
+}
+
+/**
+ * Discrete WorldId fallback: sample the field at that civilization's center.
+ * This is what live Unity Travel still implies (region rebuild).
+ */
+export function fieldAtWorld(worldId) {
+  const key = fieldKeyForWorld(worldId);
+  if (!key) return { ok: false, reason: "unknown_world" };
+  if (key === "hub") return fieldAt(0, 0);
+  const c = fieldCenter(key);
+  return fieldAt(c.x, c.z);
+}
+
+function blendAffinity(field, domain) {
+  let num = 0;
+  let den = 0;
+  for (const key of FIELD_KEYS) {
+    if (key === "hub") continue;
+    const inf = field[key] || 0;
+    if (inf < 0.02) continue;
+    const w = inf ** BLEND_SHARPNESS;
+    num += w * centerAffinity(key, domain);
+    den += w;
+  }
+  let mixed = den > 0 ? num / den : 0.7;
+  const well = field.chaosSuppressed || 0;
+  if (well > 0) mixed = mixed * (1 - well) + 0.7 * well;
+  return clamp01(mixed);
+}
+
+/**
+ * Local physics derived from the field. Magic/tech are the magic/tech affinities.
+ */
+export function localRules(field) {
+  if (!field?.ok) return { ok: false, reason: field?.reason || "no_field" };
+  const magic = blendAffinity(field, "magic");
+  const tech = blendAffinity(field, "tech");
+  return {
+    ok: true,
+    magic,
+    tech,
+    affinity: {
+      magic,
+      tech,
+      gun: blendAffinity(field, "gun"),
+      hacking: blendAffinity(field, "hacking"),
+      bio_powers: blendAffinity(field, "bio_powers"),
+    },
+    flowerLaw: field.flowerLaw,
+    steelLive: field.steelLive,
+    transition: field.transition,
+  };
+}
+
+export function localAffinity(field, domain) {
+  if (!field?.ok) return 0.7;
+  return blendAffinity(field, domain || "athletics");
+}
+
+function skillFloor(nativeStrength, adaptation) {
+  const native = Math.max(0, Number(nativeStrength) || 0);
+  const adapt = clamp01(adaptation);
+  const fromSkill = 0.10 + 0.40 * Math.min(1, native / GEO_NATIVE_CAP);
+  const fromAdapt = 0.10 + 0.50 * adapt;
+  return Math.max(fromSkill, fromAdapt);
+}
+
+/**
+ * Effective power at a point. Physics, not a player debuff.
+ * actorKind is recorded and MUST NOT change the multiplier.
+ */
+export function geographicEffectiveness(opts = {}) {
+  const {
+    origin = null,
+    x, z,
+    domain = "magic",
+    nativeStrength = 0,
+    adaptation = 0,
+    actorKind = "player",
+  } = opts;
+  const field = fieldAt(x, z);
+  if (!field.ok) return field;
+  const homeKey = fieldKeyForWorld(origin) || (FIELD_KEYS.includes(origin) ? origin : null);
+  const homeInfluence = homeKey ? (field[homeKey] || 0) : 0;
+  const physics = localAffinity(field, domain);
+  const floor = skillFloor(nativeStrength, adaptation);
+  const presence = homeKey ? homeInfluence : 1;
+  const coupled = physics * (0.55 + 0.45 * presence);
+  const multiplier = clamp01(Math.max(floor, coupled));
+  const native = Math.max(0, Number(nativeStrength) || 0);
+  const kind = FIELD_ACTOR_KINDS.includes(actorKind) ? actorKind : "player";
+  return {
+    ok: true,
+    actorKind: kind,
+    origin: homeKey,
+    domain,
+    nativeStrength: native,
+    adaptation: clamp01(adaptation),
+    x: field.x,
+    z: field.z,
+    homeInfluence,
+    localPhysics: physics,
+    coupled,
+    floor,
+    multiplier,
+    effective: native * multiplier,
+    flowerLaw: field.flowerLaw,
+    steelLive: field.steelLive,
+    transition: field.transition,
+    dominant: field.dominant,
+  };
+}
+
+/**
+ * Why is this weaker here? Causal, from field + authored affinity.
+ * Never a fabricated "-42% Magic Damage" popup as the mechanism.
+ */
+export function explainGeographicEffectiveness(opts = {}) {
+  const g = geographicEffectiveness(opts);
+  if (!g.ok) return g;
+  const originName = g.origin || "unknown origin";
+  let because;
+  if (g.flowerLaw) {
+    because = "The Unburned Court suppresses regional physics. Flower Law holds. Live steel does not.";
+  } else if (g.transition.ok) {
+    because = `Transition between ${g.transition.a} and ${g.transition.b}. Local ${g.domain} physics is ${g.localPhysics.toFixed(2)}.`;
+  } else if (g.multiplier === g.coupled || Math.abs(g.multiplier - (g.localPhysics * (0.55 + 0.45 * g.homeInfluence))) < 1e-9) {
+    because = `Local ${g.domain} physics is ${g.localPhysics.toFixed(2)} (${g.dominant} field). Distance from ${originName} couples at ${g.homeInfluence.toFixed(2)}.`;
+  } else {
+    because = `Local ${g.domain} physics is ${g.localPhysics.toFixed(2)}; residual competence from training holds a floor of ${g.floor.toFixed(2)}.`;
+  }
+  return {
+    ok: true,
+    effective: g.effective,
+    multiplier: g.multiplier,
+    localPhysics: g.localPhysics,
+    homeInfluence: g.homeInfluence,
+    floor: g.floor,
+    flowerLaw: g.flowerLaw,
+    because,
+  };
+}
+
+/**
+ * Until W3 streams (x,z), live combat has a WorldId not a megaworld point.
+ * Sample the civilization center. Not a claim that Unity already walks the field.
+ */
+export function geographicEffectivenessAtWorld(opts = {}) {
+  const key = fieldKeyForWorld(opts.worldId);
+  if (!key) return { ok: false, reason: "unknown_world" };
+  const c = key === "hub" ? { x: 0, z: 0 } : fieldCenter(key);
+  return geographicEffectiveness({ ...opts, x: c.x, z: c.z });
+}

--- a/server/lib/cross-world-potency.js
+++ b/server/lib/cross-world-potency.js
@@ -14,6 +14,10 @@
 //
 // Pure functions, reuse skill-domains' NEUTRAL_AFFINITY. Kill-switch
 // CONCORD_CROSS_WORLD_POTENCY=0 → potency always 1.0 (disabled).
+//
+// Continuous-megaworld law lives in lib/concordia-world-field.js (WorldField
+// at (x,z), same formula for every actor kind). This file stays the discrete
+// WorldId approximation used by live combat until W3 streams coordinates.
 
 import { NEUTRAL_AFFINITY, isKnownDomain } from "./skill-domains.js";
 

--- a/server/lib/ecosystem/fauna-spawner.js
+++ b/server/lib/ecosystem/fauna-spawner.js
@@ -8,6 +8,8 @@
 // Spawned creatures are written to the existing world_npcs table with
 // archetype='creature' so the existing world rendering / proximity
 // queries see them. creature_population tracks counts per species.
+// MEGAWORLD W8: this quota top-up is not organism identity
+// (lib/concordia-organism.js). Do not enlarge the anonymous insert path.
 //
 // Per CLAUDE.md heartbeat invariant: this module never throws.
 

--- a/server/lib/ecosystem/fauna-spawner.js
+++ b/server/lib/ecosystem/fauna-spawner.js
@@ -8,8 +8,9 @@
 // Spawned creatures are written to the existing world_npcs table with
 // archetype='creature' so the existing world rendering / proximity
 // queries see them. creature_population tracks counts per species.
-// MEGAWORLD W8: this quota top-up is not organism identity
-// (lib/concordia-organism.js). Do not enlarge the anonymous insert path.
+// MEGAWORLD W8: quota top-up still exists, but each insert is an organism
+// with a species_id. Birth writes world_consequences. Identity lives in
+// lib/concordia-organism.js — do not invent prey or unique GLBs here.
 //
 // Per CLAUDE.md heartbeat invariant: this module never throws.
 
@@ -23,6 +24,7 @@ import {
   gradientConfigFor, hubAnchorFor, dangerBandAt, bandLevelRange,
   spawnDensityFor, worldBoundsFor, radialWorldsEnabled,
 } from "../world-gradient.js";
+import { recordOrganismBirth } from "../concordia-organism.js";
 
 /**
  * WS2: deterministic per-species cluster center that sits in a specific danger
@@ -413,11 +415,29 @@ export function runFaunaSpawner({ state, db }) {
               level,
             );
             spawned++;
+            try {
+              recordOrganismBirth(db, {
+                id,
+                worldId,
+                speciesId: sp.id,
+                targetKind: "creature",
+                location: `${worldId}:${biome}`,
+              });
+            } catch { /* consequence table optional */ }
           } catch {
             // Stricter schema without a `level` column — retry the legacy shape.
             try {
               insertLegacy.run(id, worldId, `creature:${sp.id}`, sp.id, pos.x, 0, pos.z, 0);
               spawned++;
+              try {
+                recordOrganismBirth(db, {
+                  id,
+                  worldId,
+                  speciesId: sp.id,
+                  targetKind: "creature",
+                  location: `${worldId}:${biome}`,
+                });
+              } catch { /* consequence table optional */ }
             } catch {
               // world_npcs may have a stricter schema in some builds —
               // skip gracefully; spawner is best-effort.

--- a/server/lib/procgen-settlements.js
+++ b/server/lib/procgen-settlements.js
@@ -9,7 +9,9 @@
 //
 // When `spawnSettlementForRegion(db, region)` runs, it samples 3-5
 // NPC archetypes deterministically from sha1(regionId), drops them
-// inside the region radius, and tags them with the region id. NPCs
+// inside the region radius, and tags them with the region id. MEGAWORLD W1:
+// the same call founds or joins a Living Society `settlements` row (no second
+// identity table). Decay tombstones NPCs AND abandons the settlement row.
 // fade if the region itself decays (the lattice-quest-composer's
 // realiseLatticeBornQuest cascades into decayRegion → cascades into
 // decaySettlementForRegion below).
@@ -20,6 +22,11 @@
 
 import crypto from "node:crypto";
 import logger from "../logger.js";
+import {
+  foundSettlement,
+  abandonSettlement,
+  findSettlementByRegion,
+} from "./concordia-megaworld.js";
 
 const MAX_NPCS_PER_REGION = 5;
 const MIN_NPCS_PER_REGION = 3;
@@ -77,18 +84,68 @@ function seededRng(seed) {
   };
 }
 
+function settlementNameForRegion(region) {
+  if (region?.name) return String(region.name).slice(0, 80);
+  if (region?.region_kind) return String(region.region_kind).replace(/_/g, " ");
+  return `region ${region.id}`;
+}
+
+function tableExists(db, name) {
+  try {
+    return !!db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(name);
+  } catch { return false; }
+}
+
+/**
+ * Found or join the Living Society row for this region. Missing settlements
+ * table → null (procgen NPC packs still work). Never invents a mill/spring.
+ */
+function joinOrFoundSettlement(db, region) {
+  if (!db || !region?.id || !region?.world_id) return null;
+  if (!tableExists(db, "settlements")) return null;
+  try {
+    const existing = findSettlementByRegion(db, region.id);
+    if (existing) {
+      if (existing.status === "abandoned") {
+        try {
+          db.prepare(`UPDATE settlements SET status = 'active', abandoned_at = NULL WHERE id = ?`)
+            .run(existing.id);
+        } catch { /* status col optional */ }
+      }
+      return { ok: true, action: "joined", id: existing.id };
+    }
+    return foundSettlement(db, {
+      worldId: region.world_id,
+      name: settlementNameForRegion(region),
+      centerX: Number(region.anchor_x) || 0,
+      centerZ: Number(region.anchor_z) || 0,
+      radius: Math.max(20, Number(region.radius_m) || 100),
+      regionId: region.id,
+      actorKind: "system",
+      actorId: "procgen-region",
+    });
+  } catch (err) {
+    try { logger.warn?.("procgen-settlements", "found_failed", { regionId: region.id, error: err?.message }); }
+    catch { /* best-effort */ }
+    return null;
+  }
+}
+
 /**
  * Spawn (or return existing) settlement NPCs around the given region.
  *
  * @param {import("better-sqlite3").Database} db
- * @param {{ id: string, world_id: string, anchor_x: number, anchor_z: number, radius_m: number, region_kind?: string }} region
- * @returns {{ ok: boolean, action: 'created' | 'already_exists' | 'noop', npcs: Array }}
+ * @param {{ id: string, world_id: string, anchor_x: number, anchor_z: number, radius_m: number, region_kind?: string, name?: string }} region
+ * @returns {{ ok: boolean, action: 'created' | 'already_exists' | 'noop', npcs: Array, settlementId?: string }}
  */
 export function spawnSettlementForRegion(db, region) {
   if (!db) return { ok: false, reason: "no_db" };
   if (!region?.id || !region?.world_id) return { ok: false, reason: "invalid_region" };
 
   ensureSchema(db);
+
+  const identity = joinOrFoundSettlement(db, region);
+  const settlementId = identity?.id || null;
 
   // Idempotency: if any non-decayed NPC already exists for this region,
   // return them.
@@ -97,7 +154,7 @@ export function spawnSettlementForRegion(db, region) {
      WHERE region_id = ? AND decayed_at IS NULL
   `).all(region.id);
   if (existing.length > 0) {
-    return { ok: true, action: "already_exists", npcs: existing };
+    return { ok: true, action: "already_exists", npcs: existing, settlementId };
   }
 
   const rng = seededRng(`pgs_${region.id}`);
@@ -141,7 +198,7 @@ export function spawnSettlementForRegion(db, region) {
     }
   }
 
-  return { ok: true, action: "created", npcs: created };
+  return { ok: true, action: "created", npcs: created, settlementId };
 }
 
 /**
@@ -153,13 +210,18 @@ export function spawnSettlementForRegion(db, region) {
 export function decaySettlementForRegion(db, regionId, reason = "region_decayed") {
   if (!db || !regionId) return { ok: false, reason: "missing_args" };
   ensureSchema(db);
+  let abandoned = null;
+  try {
+    const row = findSettlementByRegion(db, regionId);
+    if (row?.id) abandoned = abandonSettlement(db, row.id, { reason });
+  } catch { /* settlements table optional */ }
   try {
     const result = db.prepare(`
       UPDATE procgen_settlement_npcs
          SET decayed_at = unixepoch()
        WHERE region_id = ? AND decayed_at IS NULL
     `).run(regionId);
-    return { ok: true, decayed: result.changes ?? 0, reason };
+    return { ok: true, decayed: result.changes ?? 0, reason, abandoned: abandoned?.ok === true, settlementId: abandoned?.id || null };
   } catch (err) {
     try { logger.warn?.("procgen-settlements", "decay_failed", { regionId, error: err?.message }); }
     catch { /* logger best-effort */ }

--- a/server/lib/world-consequence.js
+++ b/server/lib/world-consequence.js
@@ -29,6 +29,8 @@ const ACTIONS = new Set([
   "world_event",
   "settle",
   "abandon",
+  "birth",
+  "hunt",
 ]);
 
 function json(v) {

--- a/server/lib/world-consequence.js
+++ b/server/lib/world-consequence.js
@@ -27,6 +27,8 @@ const ACTIONS = new Set([
   "destroy",
   "crime",
   "world_event",
+  "settle",
+  "abandon",
 ]);
 
 function json(v) {

--- a/server/lib/world-shard-protocol.js
+++ b/server/lib/world-shard-protocol.js
@@ -50,6 +50,7 @@ export const PER_WORLD_WRITE_TABLES = Object.freeze(new Set([
   "world_chronicle_cursor",
   "settlements",
   "settlement_vacancies",
+  "settlement_chronicle",
   "vassalage",
   "world_emperors",
   "world_seasons",

--- a/server/migrations/446_settlement_identity.js
+++ b/server/migrations/446_settlement_identity.js
@@ -1,0 +1,61 @@
+// server/migrations/446_settlement_identity.js
+//
+// Persistent megaworld — settlement identity / place chronicle.
+// Extends mig 287. Does not replace it. Abandoned towns KEEP the row.
+
+function tableExists(db, name) {
+  return !!db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(name);
+}
+
+function hasColumn(db, table, col) {
+  try { return db.pragma(`table_info(${table})`).some((c) => c.name === col); }
+  catch { return false; }
+}
+
+export function up(db) {
+  if (tableExists(db, "settlements")) {
+    const cols = [
+      ["status", "TEXT NOT NULL DEFAULT 'active'"],
+      ["founded_at", "INTEGER"],
+      ["abandoned_at", "INTEGER"],
+      ["destroyed_at", "INTEGER"],
+      ["former_names_json", "TEXT"],
+      ["founders_json", "TEXT"],
+      ["culture", "TEXT"],
+      ["government", "TEXT"],
+      ["population", "INTEGER"],
+    ];
+    for (const [name, spec] of cols) {
+      if (!hasColumn(db, "settlements", name)) {
+        db.exec(`ALTER TABLE settlements ADD COLUMN ${name} ${spec}`);
+      }
+    }
+    try {
+      db.exec(`UPDATE settlements SET founded_at = created_at WHERE founded_at IS NULL`);
+    } catch { /* created_at absent on a stripped stub */ }
+  }
+
+  if (!tableExists(db, "settlement_chronicle")) {
+    db.exec(`
+      CREATE TABLE settlement_chronicle (
+        id             TEXT PRIMARY KEY,
+        settlement_id  TEXT NOT NULL,
+        world_id       TEXT NOT NULL,
+        kind           TEXT NOT NULL,
+        dedupe_key     TEXT NOT NULL,
+        title          TEXT NOT NULL,
+        body           TEXT NOT NULL,
+        actor_id       TEXT,
+        year_idx       INTEGER,
+        created_at     INTEGER NOT NULL DEFAULT (unixepoch()),
+        UNIQUE (settlement_id, dedupe_key)
+      );
+      CREATE INDEX idx_stl_chr_place ON settlement_chronicle(settlement_id, created_at);
+      CREATE INDEX idx_stl_chr_world ON settlement_chronicle(world_id, created_at);
+    `);
+  }
+}
+
+export function down(_db) {
+  // forward-only
+}

--- a/server/migrations/447_settlement_region.js
+++ b/server/migrations/447_settlement_region.js
@@ -1,0 +1,29 @@
+// Persistent megaworld W1 — join procgen regions to Living Society settlements.
+// Extends mig 287/446. Does not create a second towns table.
+
+function tableExists(db, name) {
+  return !!db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(name);
+}
+
+function hasColumn(db, table, col) {
+  try { return db.pragma(`table_info(${table})`).some((c) => c.name === col); }
+  catch { return false; }
+}
+
+export function up(db) {
+  if (!tableExists(db, "settlements")) return;
+  if (!hasColumn(db, "settlements", "region_id")) {
+    db.exec(`ALTER TABLE settlements ADD COLUMN region_id TEXT`);
+  }
+  try {
+    db.exec(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_settlements_region
+        ON settlements(region_id)
+        WHERE region_id IS NOT NULL
+    `);
+  } catch { /* index optional on stripped stubs */ }
+}
+
+export function down(_db) {
+  // forward-only
+}

--- a/server/routes/worlds.js
+++ b/server/routes/worlds.js
@@ -2565,30 +2565,55 @@ export default function createWorldsRouter({ requireAuth, db, emitToWorld }) {
         }
       } catch { /* Layer 7 disabled / migration not applied — neutral pass-through */ }
 
-      // Universal Move System Pillar 3 — cross-world potency. A move sags when
-      // used outside its native world unless the skill is highly leveled. Reads
-      // skillData.nativeWorld (stamped by move-descriptor.js at mint/evolve) +
-      // the skill DTU's level. Applied AFTER the cap, like env boost. Defensive:
-      // only activates for a move with a native stamp used in a DIFFERENT world;
-      // every pre-MS-P1 move (no stamp) is a complete no-op. KS CONCORD_CROSS_WORLD_POTENCY=0.
+      // Universal Move System Pillar 3 / W7 — geographic effectiveness.
+      // Field is the live damage scale (same formula for every actor kind).
+      // Discrete crossWorldPotency stays the kill-switch fallback
+      // (CONCORD_GEOGRAPHIC_FIELD=0). Do not multiply both.
       try {
-        const nativeWorld = skillData?.nativeWorld ?? null;
-        if (nativeWorld && nativeWorld !== worldId && Number.isFinite(damageResult.finalDamage)) {
-          const { crossWorldPotency } = await import("../lib/cross-world-potency.js");
-          const worldRow = db.prepare("SELECT rule_modulators FROM worlds WHERE id = ?").get(worldId);
-          const potency = crossWorldPotency({
-            skillLevel,
-            skillKind: skillData?.skill_kind,
-            nativeWorldId: nativeWorld,
-            targetWorldId: worldId,
-            targetWorld: worldRow,
-          });
-          if (potency !== 1.0) {
-            damageResult.finalDamage = Math.round(damageResult.finalDamage * potency * 10) / 10;
-            damageResult.crossWorldPotency = potency;
+        const nativeWorld = skillData?.nativeWorld ?? worldId;
+        const field = await import("../lib/concordia-world-field.js");
+        const domain = field.domainFromSkillKind(skillData?.skill_kind, "athletics");
+        const pos = npcPosRow || {};
+        if (Number.isFinite(damageResult.finalDamage)) {
+          if (process.env.CONCORD_GEOGRAPHIC_FIELD === "0") {
+            if (nativeWorld && nativeWorld !== worldId) {
+              const { crossWorldPotency } = await import("../lib/cross-world-potency.js");
+              const worldRow = db.prepare("SELECT rule_modulators FROM worlds WHERE id = ?").get(worldId);
+              const potency = crossWorldPotency({
+                skillLevel,
+                skillKind: skillData?.skill_kind,
+                nativeWorldId: nativeWorld,
+                targetWorldId: worldId,
+                targetWorld: worldRow,
+              });
+              if (potency !== 1.0) {
+                damageResult.finalDamage = Math.round(damageResult.finalDamage * potency * 10) / 10;
+                damageResult.crossWorldPotency = potency;
+              }
+            }
+          } else {
+            const stamped = field.applyGeographicDamage(damageResult.finalDamage, {
+              worldId,
+              localX: pos.x,
+              localZ: pos.z,
+              origin: nativeWorld,
+              domain,
+              nativeStrength: skillLevel,
+              actorKind: "player",
+            });
+            if (stamped.ok && stamped.geographic) {
+              damageResult.finalDamage = stamped.damage;
+              damageResult.geographicEffectiveness = {
+                multiplier: stamped.geographic.multiplier,
+                localPhysics: stamped.geographic.localPhysics,
+                dominant: stamped.geographic.dominant,
+                flowerLaw: stamped.geographic.flowerLaw,
+                because: stamped.because,
+              };
+            }
           }
         }
-      } catch { /* potency disabled / no native stamp — neutral pass-through */ }
+      } catch { /* field / potency disabled — neutral pass-through */ }
 
       // Wave 7a glue #4 — mounted combat overlay. When the attacker is mounted
       // (combat_actor_state.mount_state set by mount/dismount), apply the mount

--- a/server/server.js
+++ b/server/server.js
@@ -73182,6 +73182,12 @@ async function _dispatchGodotCombatAttack(userId, data) {
           weapon: data.weapon || "sword",
           baseDamage: clampBaseDamage(data.baseDamage, spellMaxDamage),
           worldId: String(worldId),
+          localX: Number.isFinite(Number(data.x)) ? Number(data.x) : null,
+          localZ: Number.isFinite(Number(data.z)) ? Number(data.z) : null,
+          origin: data.originWorldId || data.nativeWorld || worldId,
+          skillKind: data.skillKind || null,
+          nativeStrength: Number(data.skillLevel) || 0,
+          actorKind: "player",
         });
       }
     } catch (e) {
@@ -73189,6 +73195,25 @@ async function _dispatchGodotCombatAttack(userId, data) {
     }
   }
   if (limbMods?.limbVerbs) result.limbVerbs = limbMods.limbVerbs;
+
+  // W7: applyAttack PvP path samples the field. Dummy HP authority already
+  // stamped inside applyAuthoritativeHit — do not double-scale.
+  if (result?.ok && result.authority !== "combat-hp-authority") {
+    try {
+      const { stampGeographicOnHit, domainFromSkillKind } = await import("./lib/concordia-world-field.js");
+      const pos = cityPresence.getUserPosition?.(userId) || {};
+      const wid = pos.worldId || pos.cityId || data.worldId || "concordia-hub";
+      stampGeographicOnHit(result, {
+        worldId: String(wid),
+        localX: Number.isFinite(Number(data.x)) ? Number(data.x) : pos.x,
+        localZ: Number.isFinite(Number(data.z)) ? Number(data.z) : pos.z,
+        origin: data.originWorldId || data.nativeWorld || wid,
+        domain: domainFromSkillKind(data.skillKind, "athletics"),
+        nativeStrength: Number(data.skillLevel) || 0,
+        actorKind: "player",
+      });
+    } catch { /* field optional */ }
+  }
 
   if (!result.ok) return result;
 

--- a/server/tests/concordia-kingdom-snapshot.test.js
+++ b/server/tests/concordia-kingdom-snapshot.test.js
@@ -1,8 +1,15 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import Database from "better-sqlite3";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { up as up287 } from "../migrations/287_settlements.js";
+import { up as up286 } from "../migrations/286_chronicle.js";
+import { up as up416 } from "../migrations/416_world_consequences.js";
+import { up as up446 } from "../migrations/446_settlement_identity.js";
+import { up as up447 } from "../migrations/447_settlement_region.js";
+import { foundSettlement, abandonSettlement } from "../lib/concordia-megaworld.js";
 import { buildKingdomSnapshot, resolveWorldKey, KINGDOM_FORMAT } from "../lib/concordia-kingdom-snapshot.js";
 
 const src = readFileSync(
@@ -66,5 +73,33 @@ describe("concordia kingdom snapshot — authored graph only", () => {
     const hub = JSON.stringify(buildKingdomSnapshot(null, "hub"));
     assert.doesNotMatch(hub, /Aurelia/);
     assert.doesNotMatch(hub, /Concord admits he loves her/);
+  });
+
+  it("kernel overlay stamps abandoned status onto the authored name; does not invent a mill", () => {
+    const db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE world_npcs (
+        id TEXT PRIMARY KEY, world_id TEXT, name TEXT, archetype TEXT,
+        npc_type TEXT, state TEXT, is_dead INTEGER DEFAULT 0
+      );
+    `);
+    up287(db);
+    up286(db);
+    up416(db);
+    up446(db);
+    up447(db);
+    const authored = buildKingdomSnapshot(null, "tunya");
+    assert.ok(authored.settlements.some((c) => c.name === "Dinye Gate"));
+    const found = foundSettlement(db, { worldId: "tunya", name: "Dinye Gate", centerX: 0, centerZ: 0 });
+    assert.equal(found.ok, true);
+    abandonSettlement(db, found.id, { reason: "the grove went quiet" });
+    const live = buildKingdomSnapshot(db, "tunya");
+    const row = live.settlements.find((s) => s.name === "Dinye Gate");
+    assert.ok(row);
+    assert.equal(row.status, "abandoned");
+    assert.ok(live.abandonedCount >= 1);
+    assert.ok(live.notes.some((n) => /abandoned/i.test(n)));
+    assert.doesNotMatch(JSON.stringify(live), /mill was built/i);
+    db.close();
   });
 });

--- a/server/tests/concordia-megaworld.test.js
+++ b/server/tests/concordia-megaworld.test.js
@@ -14,6 +14,7 @@ import { up as up287 } from "../migrations/287_settlements.js";
 import { up as up286 } from "../migrations/286_chronicle.js";
 import { up as up416 } from "../migrations/416_world_consequences.js";
 import { up as up446 } from "../migrations/446_settlement_identity.js";
+import { up as up447 } from "../migrations/447_settlement_region.js";
 import {
   flowerLawGoverns,
   intendedTravelMode,
@@ -25,6 +26,8 @@ import {
   presentationForSettlement,
   countPopulation,
   getSettlement,
+  findSettlementByRegion,
+  regionalSummary,
 } from "../lib/concordia-megaworld.js";
 import { composeEntry } from "../lib/chronicle/compose.js";
 import { decaySettlementForRegion, spawnSettlementForRegion } from "../lib/procgen-settlements.js";
@@ -44,6 +47,7 @@ function mkDb() {
   up286(db);
   up416(db);
   up446(db);
+  up447(db);
   return db;
 }
 
@@ -152,16 +156,21 @@ describe("composers refuse empty place myths", () => {
 
 describe("procgen decay tombstones, it does not DELETE", () => {
   it("decayed NPCs remain queryable by count", () => {
-    const db = new Database(":memory:");
+    const db = mkDb();
     const spawned = spawnSettlementForRegion(db, {
       id: "reg_1",
       world_id: "fantasy",
       anchor_x: 0,
       anchor_z: 0,
       radius_m: 80,
+      region_kind: "haunted_glade",
     });
     assert.equal(spawned.ok, true);
     assert.ok(spawned.npcs.length >= 3);
+    assert.ok(spawned.settlementId, "W1 founds a settlements row");
+    const row = findSettlementByRegion(db, "reg_1");
+    assert.equal(row.status, "active");
+    assert.equal(row.name, "haunted glade");
     const before = db.prepare(`SELECT COUNT(*) AS n FROM procgen_settlement_npcs`).get().n;
     const d = decaySettlementForRegion(db, "reg_1");
     assert.equal(d.ok, true);
@@ -169,5 +178,50 @@ describe("procgen decay tombstones, it does not DELETE", () => {
     assert.equal(after, before);
     const live = db.prepare(`SELECT COUNT(*) AS n FROM procgen_settlement_npcs WHERE decayed_at IS NULL`).get().n;
     assert.equal(live, 0);
+    const gone = getSettlement(db, spawned.settlementId);
+    assert.equal(gone.status, "abandoned");
+    assert.equal(db.prepare(`SELECT COUNT(*) AS n FROM settlements WHERE id = ?`).get(spawned.settlementId).n, 1);
+  });
+
+  it("re-spawn after decay joins the same region row and does not mint a second town", () => {
+    const db = mkDb();
+    const first = spawnSettlementForRegion(db, {
+      id: "reg_2", world_id: "tunya", anchor_x: 1, anchor_z: 2, radius_m: 40, region_kind: "reed_bank",
+    });
+    decaySettlementForRegion(db, "reg_2");
+    const second = spawnSettlementForRegion(db, {
+      id: "reg_2", world_id: "tunya", anchor_x: 1, anchor_z: 2, radius_m: 40, region_kind: "reed_bank",
+    });
+    assert.equal(second.settlementId, first.settlementId);
+    assert.equal(getSettlement(db, first.settlementId).status, "active");
+    const n = db.prepare(`SELECT COUNT(*) AS n FROM settlements WHERE region_id = 'reg_2'`).get().n;
+    assert.equal(n, 1);
+  });
+});
+
+describe("regional summary keeps chronicle ids (W4)", () => {
+  it("empty stats stay empty; chronicle ids are the real rows", () => {
+    const db = mkDb();
+    const r = foundSettlement(db, { worldId: "fantasy", name: "Harrow" });
+    const sum = regionalSummary(db, "fantasy");
+    assert.equal(sum.ok, true);
+    assert.equal(sum.settlementCount, 1);
+    assert.equal(sum.food, null);
+    assert.equal(sum.wealth, null);
+    assert.ok(sum.chronicleIds.length >= 1);
+    assert.equal(sum.settlements[0].id, r.id);
+  });
+});
+
+describe("simulated 7-day gap does not DELETE abandoned places (W5 mechanism, not a live run)", () => {
+  it("an abandoned row is still there after now+7d", () => {
+    const db = mkDb();
+    const r = foundSettlement(db, { worldId: "crime", name: "Old Dock" });
+    abandonSettlement(db, r.id, { reason: "the bill arrived" });
+    db.prepare(`UPDATE settlements SET abandoned_at = unixepoch() - (7 * 86400) WHERE id = ?`).run(r.id);
+    const row = getSettlement(db, r.id);
+    assert.ok(row);
+    assert.equal(row.status, "abandoned");
+    assert.ok(row.abandoned_at < Date.now() / 1000 - 6 * 86400);
   });
 });

--- a/server/tests/concordia-megaworld.test.js
+++ b/server/tests/concordia-megaworld.test.js
@@ -1,0 +1,173 @@
+/**
+ * Persistent megaworld spine: topology laws, abandon-not-delete, whyPlace honesty.
+ *
+ *   cd server && node --test tests/concordia-megaworld.test.js
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import Database from "better-sqlite3";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { up as up287 } from "../migrations/287_settlements.js";
+import { up as up286 } from "../migrations/286_chronicle.js";
+import { up as up416 } from "../migrations/416_world_consequences.js";
+import { up as up446 } from "../migrations/446_settlement_identity.js";
+import {
+  flowerLawGoverns,
+  intendedTravelMode,
+  currentTravelMode,
+  CURRENT_TRAVEL_MODE,
+  foundSettlement,
+  abandonSettlement,
+  whyPlace,
+  presentationForSettlement,
+  countPopulation,
+  getSettlement,
+} from "../lib/concordia-megaworld.js";
+import { composeEntry } from "../lib/chronicle/compose.js";
+import { decaySettlementForRegion, spawnSettlementForRegion } from "../lib/procgen-settlements.js";
+import { listConsequences } from "../lib/world-consequence.js";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+function mkDb() {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE world_npcs (
+      id TEXT PRIMARY KEY, world_id TEXT, name TEXT, archetype TEXT,
+      npc_type TEXT, state TEXT, is_dead INTEGER DEFAULT 0
+    );
+  `);
+  up287(db);
+  up286(db);
+  up416(db);
+  up446(db);
+  return db;
+}
+
+describe("megaworld topology laws", () => {
+  it("Flower Law governs only the Hub", () => {
+    assert.equal(flowerLawGoverns("concordia-hub"), true);
+    assert.equal(flowerLawGoverns("Hub"), true);
+    assert.equal(flowerLawGoverns("fantasy"), false);
+    assert.equal(flowerLawGoverns("sere"), false);
+    assert.equal(flowerLawGoverns("tunya"), false);
+  });
+
+  it("current travel is region_rebuild; overland is intended, not claimed", () => {
+    assert.equal(currentTravelMode().mode, CURRENT_TRAVEL_MODE);
+    assert.equal(CURRENT_TRAVEL_MODE, "region_rebuild");
+    assert.equal(intendedTravelMode("fantasy", "fantasy").mode, "stay");
+    assert.equal(intendedTravelMode("concordia-hub", "fantasy").mode, "link_gate");
+    assert.equal(intendedTravelMode("fantasy", "tunya").mode, "overland");
+    const canon = readFileSync(
+      join(root, "apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/Canon.cs"),
+      "utf8",
+    );
+    assert.match(canon, /steelLive = false/);
+    assert.match(canon, /Flower-law is the Court only/);
+  });
+});
+
+describe("settlement identity", () => {
+  it("founding writes a row and a place beat; whyPlace does not invent a mill", () => {
+    const db = mkDb();
+    const r = foundSettlement(db, { worldId: "fantasy", name: "Harrow", centerX: 12, centerZ: -4 });
+    assert.equal(r.ok, true);
+    const why = whyPlace(db, r.id);
+    assert.equal(why.ok, true);
+    assert.equal(why.settlement.name, "Harrow");
+    assert.equal(why.settlement.status, "active");
+    assert.equal(why.settlement.population, 0);
+    assert.deepEqual(why.settlement.founders, []);
+    assert.equal(why.history.length, 1);
+    assert.equal(why.history[0].kind, "settlement_founded");
+    assert.doesNotMatch(why.history[0].body, /mill|spring|plague/i);
+    const card = presentationForSettlement(db, r.id);
+    assert.equal(card.livePopulation, 0);
+  });
+
+  it("abandon sets status and keeps the row", () => {
+    const db = mkDb();
+    const r = foundSettlement(db, { worldId: "fantasy", name: "Old Harrow" });
+    const gone = abandonSettlement(db, r.id, { reason: "Red Fever" });
+    assert.equal(gone.ok, true);
+    assert.equal(gone.status, "abandoned");
+    const row = getSettlement(db, r.id);
+    assert.ok(row, "abandoned settlement is still a row");
+    assert.equal(row.status, "abandoned");
+    assert.ok(row.abandoned_at > 0);
+    const n = db.prepare(`SELECT COUNT(*) AS n FROM settlements WHERE id = ?`).get(r.id).n;
+    assert.equal(n, 1);
+    const why = whyPlace(db, r.id);
+    assert.equal(why.settlement.status, "abandoned");
+    assert.equal(why.history.length, 2);
+    assert.match(why.history[1].body, /Red Fever/);
+    assert.match(why.history[1].body, /row remains/);
+    const settled = listConsequences(db, { action: "settle", worldId: "fantasy" });
+    const abandoned = listConsequences(db, { action: "abandon", worldId: "fantasy" });
+    assert.equal(settled.length, 1);
+    assert.equal(abandoned.length, 1);
+    assert.equal(abandoned[0].longTerm.buildings_remain, true);
+  });
+
+  it("whyPlace on a missing id is not_found, not a fabricated town", () => {
+    const db = mkDb();
+    const why = whyPlace(db, "stl_nobody");
+    assert.equal(why.ok, false);
+    assert.equal(why.reason, "not_found");
+  });
+
+  it("population is a live count, never a made-up census", () => {
+    const db = mkDb();
+    const r = foundSettlement(db, { worldId: "tunya", name: "Reedford" });
+    assert.equal(countPopulation(db, r.id), 0);
+    db.prepare(`
+      INSERT INTO world_npcs (id, world_id, name, archetype, npc_type, state, is_dead, settlement_id)
+      VALUES ('n1','tunya','Asha','farmer','npc','{}',0,?)
+    `).run(r.id);
+    db.prepare(`
+      INSERT INTO world_npcs (id, world_id, name, archetype, npc_type, state, is_dead, settlement_id)
+      VALUES ('n2','tunya','dead','farmer','npc','{}',1,?)
+    `).run(r.id);
+    assert.equal(countPopulation(db, r.id), 1);
+  });
+});
+
+describe("composers refuse empty place myths", () => {
+  it("place_event without a body is not composed", () => {
+    const c = composeEntry("place_event", {});
+    assert.equal(c.ok, false);
+  });
+
+  it("place_event uses only the supplied line", () => {
+    const c = composeEntry("place_event", { name: "Harrow", body: "A mill was built.", title: "Mill" });
+    assert.equal(c.ok, true);
+    assert.equal(c.body, "A mill was built.");
+    assert.equal(c.title, "Mill");
+  });
+});
+
+describe("procgen decay tombstones, it does not DELETE", () => {
+  it("decayed NPCs remain queryable by count", () => {
+    const db = new Database(":memory:");
+    const spawned = spawnSettlementForRegion(db, {
+      id: "reg_1",
+      world_id: "fantasy",
+      anchor_x: 0,
+      anchor_z: 0,
+      radius_m: 80,
+    });
+    assert.equal(spawned.ok, true);
+    assert.ok(spawned.npcs.length >= 3);
+    const before = db.prepare(`SELECT COUNT(*) AS n FROM procgen_settlement_npcs`).get().n;
+    const d = decaySettlementForRegion(db, "reg_1");
+    assert.equal(d.ok, true);
+    const after = db.prepare(`SELECT COUNT(*) AS n FROM procgen_settlement_npcs`).get().n;
+    assert.equal(after, before);
+    const live = db.prepare(`SELECT COUNT(*) AS n FROM procgen_settlement_npcs WHERE decayed_at IS NULL`).get().n;
+    assert.equal(live, 0);
+  });
+});

--- a/server/tests/concordia-organism.test.js
+++ b/server/tests/concordia-organism.test.js
@@ -155,12 +155,12 @@ describe("death remains; birth does not mint a fake body", () => {
   });
 });
 
-describe("fauna-spawner still tops up anonymous counts (W8, not claimed)", () => {
-  it("the live spawner is a population quota, not organism identity", () => {
+describe("fauna-spawner founds organism rows (W8)", () => {
+  it("the live spawner stamps species and writes birth on the existing graph", () => {
     const src = readFileSync(join(root, "server/lib/ecosystem/fauna-spawner.js"), "utf8");
     assert.match(src, /tops up/);
     assert.match(src, /archetype='creature'/);
-    assert.match(src, /not organism identity/);
-    assert.doesNotMatch(src, /from ["'].*concordia-organism/);
+    assert.match(src, /from ["'].*concordia-organism/);
+    assert.match(src, /recordOrganismBirth/);
   });
 });

--- a/server/tests/concordia-organism.test.js
+++ b/server/tests/concordia-organism.test.js
@@ -1,0 +1,166 @@
+/**
+ * Persistent organisms: genome/person → field → consequence → remains.
+ *
+ *   cd server && node --test tests/concordia-organism.test.js
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { up as up416 } from "../migrations/416_world_consequences.js";
+import { fieldCenter } from "../lib/concordia-world-field.js";
+import {
+  ORGANISM_LOOPS,
+  speciesById,
+  preyOf,
+  organismInField,
+  sharedWorldSurface,
+  explainOrganism,
+  recordOrganismDeath,
+  recordOrganismBirth,
+} from "../lib/concordia-organism.js";
+import { listConsequences } from "../lib/world-consequence.js";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+function mkDb() {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE world_npcs (
+      id TEXT PRIMARY KEY, world_id TEXT, name TEXT, archetype TEXT,
+      npc_type TEXT, state TEXT, is_dead INTEGER DEFAULT 0
+    );
+  `);
+  up416(db);
+  return db;
+}
+
+describe("two loops, one world", () => {
+  it("creature and person loops are named and meet at the field", () => {
+    assert.deepEqual(ORGANISM_LOOPS.creature, [
+      "genome", "organism", "ecology", "civilization", "history", "presentation",
+    ]);
+    assert.deepEqual(ORGANISM_LOOPS.person, [
+      "person", "needs", "action", "consequence", "memory", "place", "history", "presentation",
+    ]);
+    const f = fieldCenter("fantasy");
+    const surface = sharedWorldSurface(f.x, f.z);
+    const stalker = organismInField({
+      kind: "creature", speciesId: "gloom_stalker", originWorldId: "fantasy", x: f.x, z: f.z, nativeStrength: 70,
+    });
+    const person = organismInField({
+      kind: "person", personId: "asha", originWorldId: "fantasy", x: f.x, z: f.z, nativeStrength: 40,
+    });
+    assert.equal(surface.ok, true);
+    assert.equal(stalker.ok, true);
+    assert.equal(person.ok, true);
+    assert.equal(stalker.field.dominant, person.field.dominant);
+    assert.equal(stalker.localPhysics.magic, person.localPhysics.magic);
+    assert.equal(stalker.loop[stalker.loop.length - 1], "presentation");
+    assert.equal(person.loop[person.loop.length - 1], "presentation");
+  });
+});
+
+describe("Gloom Stalker is a catalog organism, not a fabricated spawn", () => {
+  it("unknown species is not_found, not a made-up beast", () => {
+    const r = speciesById("definitely_not_a_dragon_we_invented");
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "unknown_species");
+  });
+
+  it("authored gloom_stalker keeps empty prey rather than inventing a hunting list", () => {
+    const cat = speciesById("gloom_stalker", "fantasy");
+    assert.equal(cat.ok, true);
+    assert.equal(cat.species.worldId, "fantasy");
+    assert.match(cat.species.description, /fear/i);
+    const authored = JSON.parse(readFileSync(join(root, "content/world/fantasy/creatures.json"), "utf8"));
+    const row = authored.find((c) => c.id === "gloom_stalker");
+    assert.equal(row.prey, undefined);
+    assert.deepEqual(preyOf("gloom_stalker"), []);
+    const f = fieldCenter("fantasy");
+    const o = organismInField({
+      kind: "creature", speciesId: "gloom_stalker", originWorldId: "fantasy", x: f.x, z: f.z,
+    });
+    assert.deepEqual(o.prey, []);
+    assert.equal(o.pack, null);
+    assert.equal(o.territory, null);
+    const why = explainOrganism({
+      kind: "creature", speciesId: "gloom_stalker", originWorldId: "fantasy", x: f.x, z: f.z,
+    });
+    assert.match(why.because, /Prey is unknown/);
+    assert.doesNotMatch(why.because, /isolated targets/);
+  });
+
+  it("bare gloom_stalker id is ambiguous across authored worlds", () => {
+    const r = speciesById("gloom_stalker");
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "ambiguous_species");
+    assert.ok(r.worlds.includes("fantasy"));
+    assert.ok(r.worlds.includes("sovereign-ruins"));
+  });
+
+  it("the same stalker is weaker in Crime than in Fantasy — the field changed under it", () => {
+    const home = fieldCenter("fantasy");
+    const crime = fieldCenter("crime");
+    const atHome = organismInField({
+      kind: "creature", speciesId: "gloom_stalker", originWorldId: "fantasy",
+      x: home.x, z: home.z, nativeStrength: 80, domain: "magic",
+    });
+    const abroad = organismInField({
+      kind: "creature", speciesId: "gloom_stalker", originWorldId: "fantasy",
+      x: crime.x, z: crime.z, nativeStrength: 80, domain: "magic",
+    });
+    assert.ok(atHome.habitatFitness > 0.85, `home habitat ${atHome.habitatFitness}`);
+    assert.ok(abroad.habitatFitness < 0.15, `crime habitat ${abroad.habitatFitness}`);
+    assert.ok(abroad.geographic.effective < atHome.geographic.effective);
+    assert.equal(atHome.species.topologyHint, abroad.species.topologyHint);
+  });
+});
+
+describe("death remains; birth does not mint a fake body", () => {
+  it("killing a creature tombstones the row and writes the graph", () => {
+    const db = mkDb();
+    db.prepare(`
+      INSERT INTO world_npcs (id, world_id, name, archetype, is_dead)
+      VALUES ('gst_1', 'fantasy', 'Gloom Stalker', 'creature', 0)
+    `).run();
+    const r = recordOrganismDeath(db, {
+      worldId: "fantasy",
+      actorKind: "player",
+      actorId: "p1",
+      targetId: "gst_1",
+      speciesId: "gloom_stalker",
+      kind: "creature",
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.deleted, false);
+    assert.equal(r.stillPresent, true);
+    const row = db.prepare(`SELECT is_dead FROM world_npcs WHERE id = 'gst_1'`).get();
+    assert.equal(row.is_dead, 1);
+    const kills = listConsequences(db, { action: "kill", worldId: "fantasy" });
+    assert.equal(kills.length, 1);
+    assert.equal(kills[0].longTerm.deleted, false);
+  });
+
+  it("birth without an id is missing_id, not a spawned anonymous cub", () => {
+    const db = mkDb();
+    const r = recordOrganismBirth(db, { worldId: "fantasy", speciesId: "gloom_stalker" });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "missing_id");
+    const n = db.prepare(`SELECT COUNT(*) AS n FROM world_npcs`).get().n;
+    assert.equal(n, 0);
+  });
+});
+
+describe("fauna-spawner still tops up anonymous counts (W8, not claimed)", () => {
+  it("the live spawner is a population quota, not organism identity", () => {
+    const src = readFileSync(join(root, "server/lib/ecosystem/fauna-spawner.js"), "utf8");
+    assert.match(src, /tops up/);
+    assert.match(src, /archetype='creature'/);
+    assert.match(src, /not organism identity/);
+    assert.doesNotMatch(src, /from ["'].*concordia-organism/);
+  });
+});

--- a/server/tests/concordia-world-field.test.js
+++ b/server/tests/concordia-world-field.test.js
@@ -1,0 +1,216 @@
+/**
+ * World identity is a spatial field. Geographic effectiveness is physics.
+ *
+ *   cd server && node --test tests/concordia-world-field.test.js
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { isAvailableIn } from "../lib/cross-world-potency.js";
+import {
+  FIELD_ACTOR_KINDS,
+  FIELD_GATE_ANGLES,
+  MEGAWORLD_KM,
+  fieldCenter,
+  fieldAt,
+  fieldAtWorld,
+  localRules,
+  geographicEffectiveness,
+  geographicEffectivenessAtWorld,
+  explainGeographicEffectiveness,
+  centerAffinity,
+} from "../lib/concordia-world-field.js";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+function canonSource() {
+  return readFileSync(
+    join(root, "apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/Canon.cs"),
+    "utf8",
+  );
+}
+
+describe("field topology matches Canon gate bearings", () => {
+  it("kernel angles are the Hub ring, not disconnected maps", () => {
+    const canon = canonSource();
+    assert.match(canon, /angle = 0 \}/);
+    assert.match(canon, /angle = Mathf\.PI \/ 2 \}/);
+    assert.match(canon, /angle = 5 \* Mathf\.PI \/ 4 \}/);
+    assert.equal(FIELD_GATE_ANGLES.cyber, 0);
+    assert.equal(FIELD_GATE_ANGLES.fantasy, Math.PI / 2);
+    assert.equal(FIELD_GATE_ANGLES.crime, 5 * Math.PI / 4);
+    const fantasy = fieldCenter("fantasy");
+    const crime = fieldCenter("crime");
+    assert.ok(fantasy.hasLinkGate);
+    assert.ok(crime.hasLinkGate);
+    const sere = fieldCenter("sere");
+    assert.equal(sere.hasLinkGate, false);
+    assert.ok(sere.radiusKm > MEGAWORLD_KM.civilizationRadius);
+  });
+});
+
+describe("WorldField is continuous", () => {
+  it("fantasy center is high-magic; crime center is not a wall, it is thin magic", () => {
+    const f = fieldCenter("fantasy");
+    const c = fieldCenter("crime");
+    const atF = fieldAt(f.x, f.z);
+    const atC = fieldAt(c.x, c.z);
+    assert.equal(atF.ok, true);
+    assert.ok(atF.fantasy > 0.85, `fantasy at home ${atF.fantasy}`);
+    assert.ok(atF.crime < 0.15, `crime leak at fantasy ${atF.crime}`);
+    assert.ok(atC.crime > 0.85);
+    assert.ok(atC.fantasy < 0.15);
+    const rulesF = localRules(atF);
+    const rulesC = localRules(atC);
+    assert.ok(rulesF.magic > 0.85, `magic at fantasy ${rulesF.magic}`);
+    assert.ok(rulesC.magic < 0.20, `magic at crime ${rulesC.magic}`);
+    assert.ok(rulesC.magic > 0, "crime does not hard-zero magic on the field");
+    assert.ok(rulesC.tech > rulesF.tech);
+  });
+
+  it("adjacent civilizations share a transition band; opposites do not share a border", () => {
+    const f = fieldCenter("fantasy");
+    const t = fieldCenter("tunya");
+    const mid = fieldAt((f.x + t.x) / 2, (f.z + t.z) / 2);
+    assert.equal(mid.flowerLaw, false);
+    assert.equal(mid.transition.ok, true);
+    const pair = [mid.transition.a, mid.transition.b].sort();
+    assert.deepEqual(pair, ["fantasy", "tunya"]);
+    assert.ok(mid.fantasy > 0.35 && mid.tunya > 0.35);
+
+    const crime = fieldCenter("crime");
+    const opposite = fieldAt((f.x + crime.x) / 2, (f.z + crime.z) / 2);
+    const oppPair = opposite.transition.ok
+      ? [opposite.transition.a, opposite.transition.b]
+      : [];
+    assert.equal(oppPair.includes("fantasy") && oppPair.includes("crime"), false,
+      "Fantasy and Crime sit across the Hub; the walk crosses neighbors, not a shared border");
+  });
+
+  it("Hub is a suppression well: Flower Law, steel dead, physics flattened", () => {
+    const hub = fieldAt(0, 0);
+    assert.equal(hub.flowerLaw, true);
+    assert.equal(hub.steelLive, false);
+    assert.ok(hub.chaosSuppressed >= 0.85);
+    assert.equal(hub.dominant, "hub");
+    assert.equal(hub.transition.ok, false);
+    const rules = localRules(hub);
+    assert.ok(Math.abs(rules.magic - 0.7) < 0.08, `hub magic should sit near civil 0.7, got ${rules.magic}`);
+    const outskirts = fieldAt(0, MEGAWORLD_KM.hubMetro + 5);
+    assert.equal(outskirts.flowerLaw, false);
+    assert.equal(outskirts.steelLive, true);
+  });
+
+  it("missing position is not a fabricated field", () => {
+    const r = fieldAt(undefined, 10);
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, "missing_position");
+  });
+});
+
+describe("geographic effectiveness is physics, not a protagonist debuff", () => {
+  const native = 94;
+  const fantasy = fieldCenter("fantasy");
+  const crime = fieldCenter("crime");
+  const farther = { x: 0, z: fantasy.z * 0.62 };
+  const wild = { x: 0, z: MEGAWORLD_KM.hubMetro + 20 };
+
+  it("a Sundering mage weakens walking toward Crime, without a popup modifier", () => {
+    const home = geographicEffectiveness({
+      origin: "fantasy", domain: "magic", nativeStrength: native, x: fantasy.x, z: fantasy.z,
+    });
+    const away = geographicEffectiveness({
+      origin: "fantasy", domain: "magic", nativeStrength: native, x: farther.x, z: farther.z,
+    });
+    const between = geographicEffectiveness({
+      origin: "fantasy", domain: "magic", nativeStrength: native, x: wild.x, z: wild.z,
+    });
+    const deep = geographicEffectiveness({
+      origin: "fantasy", domain: "magic", nativeStrength: native, x: crime.x, z: crime.z,
+    });
+    assert.ok(home.effective > native * 0.97 && home.effective <= native + 1e-9, `home ${home.effective}`);
+    assert.ok(away.effective < home.effective, `farther ${away.effective} vs home ${home.effective}`);
+    assert.ok(between.effective < away.effective, `wild ${between.effective} vs farther ${away.effective}`);
+    assert.ok(deep.effective < between.effective, `crime ${deep.effective} vs wild ${between.effective}`);
+    assert.ok(deep.effective > 15 && deep.effective < 45, `crime residual ${deep.effective}`);
+    const why = explainGeographicEffectiveness({
+      origin: "fantasy", domain: "magic", nativeStrength: native, x: crime.x, z: crime.z,
+    });
+    assert.doesNotMatch(why.because, /-|−|\u2212\s*42%\s*Magic Damage/i);
+    assert.doesNotMatch(why.because, /debuff/i);
+    assert.match(why.because, /physics|floor|competence/i);
+  });
+
+  it("the same fire is the same number on a player, a boss, a dragon, a summoned thing", () => {
+    const args = { origin: "fantasy", domain: "magic", nativeStrength: native, x: crime.x, z: crime.z };
+    const sample = geographicEffectiveness({ ...args, actorKind: "player" });
+    for (const kind of FIELD_ACTOR_KINDS) {
+      const g = geographicEffectiveness({ ...args, actorKind: kind });
+      assert.equal(g.multiplier, sample.multiplier, kind);
+      assert.equal(g.effective, sample.effective, kind);
+      assert.equal(g.localPhysics, sample.localPhysics, kind);
+      assert.equal(g.actorKind, kind);
+    }
+  });
+
+  it("adaptation raises the floor in hostile physics without beating home", () => {
+    const home = geographicEffectiveness({
+      origin: "fantasy", domain: "magic", nativeStrength: native, adaptation: 0, x: fantasy.x, z: fantasy.z,
+    });
+    const untrained = geographicEffectiveness({
+      origin: "fantasy", domain: "magic", nativeStrength: native, adaptation: 0, x: crime.x, z: crime.z,
+    });
+    const trained = geographicEffectiveness({
+      origin: "fantasy", domain: "magic", nativeStrength: native, adaptation: 1, x: crime.x, z: crime.z,
+    });
+    assert.ok(trained.effective > untrained.effective);
+    assert.ok(trained.effective < home.effective);
+  });
+
+  it("a Crime tech user is stronger at home than in the Sundering", () => {
+    const home = geographicEffectiveness({
+      origin: "crime", domain: "tech", nativeStrength: 80, x: crime.x, z: crime.z,
+    });
+    const abroad = geographicEffectiveness({
+      origin: "crime", domain: "tech", nativeStrength: 80, x: fantasy.x, z: fantasy.z,
+    });
+    assert.ok(home.effective > abroad.effective, `crime-home ${home.effective} vs fantasy ${abroad.effective}`);
+  });
+});
+
+describe("compose with discrete potency; do not replace it yet", () => {
+  it("authored crime still hard-forbids magic on the WorldId path", () => {
+    const crimeMeta = JSON.parse(readFileSync(join(root, "content/world/crime/meta.json"), "utf8"));
+    const gate = isAvailableIn(crimeMeta, { domain: "magic" });
+    assert.equal(gate.available, false);
+    const fieldPath = geographicEffectivenessAtWorld({
+      worldId: "crime", origin: "fantasy", domain: "magic", nativeStrength: 94,
+    });
+    assert.equal(fieldPath.ok, true);
+    assert.ok(fieldPath.effective > 0, "the field degrades; it does not forbid");
+  });
+
+  it("fieldAtWorld(fantasy) samples the fantasy center", () => {
+    const c = fieldCenter("fantasy");
+    const a = fieldAtWorld("fantasy");
+    const b = fieldAt(c.x, c.z);
+    assert.equal(a.ok, true);
+    assert.ok(Math.abs(a.fantasy - b.fantasy) < 1e-9);
+  });
+
+  it("live combat route still does not import the field (W7)", () => {
+    const worlds = readFileSync(join(root, "server/routes/worlds.js"), "utf8");
+    assert.doesNotMatch(worlds, /concordia-world-field/);
+    assert.doesNotMatch(worlds, /geographicEffectiveness/);
+  });
+
+  it("center magic affinities come from authored meta, not invented tables", () => {
+    const fantasyMeta = JSON.parse(readFileSync(join(root, "content/world/fantasy/meta.json"), "utf8"));
+    const crimeMeta = JSON.parse(readFileSync(join(root, "content/world/crime/meta.json"), "utf8"));
+    assert.equal(centerAffinity("fantasy", "magic"), fantasyMeta.skill_affinity.magic);
+    assert.equal(centerAffinity("crime", "magic"), crimeMeta.skill_affinity.magic);
+  });
+});

--- a/server/tests/concordia-world-field.test.js
+++ b/server/tests/concordia-world-field.test.js
@@ -14,6 +14,7 @@ import {
   FIELD_ACTOR_KINDS,
   FIELD_GATE_ANGLES,
   MEGAWORLD_KM,
+  SCENE_METRES_TO_KM,
   fieldCenter,
   fieldAt,
   fieldAtWorld,
@@ -22,7 +23,10 @@ import {
   geographicEffectivenessAtWorld,
   explainGeographicEffectiveness,
   centerAffinity,
+  localToMegaworld,
+  applyGeographicDamage,
 } from "../lib/concordia-world-field.js";
+import { applyAuthoritativeHit, resetCombatHpAuthorityForTest } from "../lib/combat-hp-authority.js";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "../..");
 
@@ -201,10 +205,43 @@ describe("compose with discrete potency; do not replace it yet", () => {
     assert.ok(Math.abs(a.fantasy - b.fantasy) < 1e-9);
   });
 
-  it("live combat route still does not import the field (W7)", () => {
+  it("live combat route samples the field (W7)", () => {
     const worlds = readFileSync(join(root, "server/routes/worlds.js"), "utf8");
-    assert.doesNotMatch(worlds, /concordia-world-field/);
-    assert.doesNotMatch(worlds, /geographicEffectiveness/);
+    assert.match(worlds, /concordia-world-field/);
+    assert.match(worlds, /applyGeographicDamage/);
+    const cs = readFileSync(
+      join(root, "apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldField.cs"),
+      "utf8",
+    );
+    assert.match(cs, /CivilizationRadiusKm = 400/);
+    assert.match(cs, /SceneMetresToKm = 0\.4/);
+    assert.doesNotMatch(cs, /-42% Magic Damage/);
+  });
+
+  it("in-region local map moves toward Hub when localZ is negative", () => {
+    const c = fieldCenter("fantasy");
+    const towardHub = localToMegaworld("fantasy", 0, -50);
+    assert.equal(towardHub.ok, true);
+    const distCenter = Math.hypot(towardHub.x - c.x, towardHub.z - c.z);
+    assert.ok(Math.abs(distCenter - 50 * SCENE_METRES_TO_KM) < 1e-6);
+    assert.ok(Math.hypot(towardHub.x, towardHub.z) < Math.hypot(c.x, c.z));
+    const hub = localToMegaworld("concordia-hub", 12, -8);
+    assert.equal(hub.x, 0);
+    assert.equal(hub.z, 0);
+  });
+
+  it("applyGeographicDamage scales a fantasy-native magic hit down in crime", () => {
+    const home = applyGeographicDamage(100, {
+      worldId: "fantasy", origin: "fantasy", domain: "magic", nativeStrength: 94,
+    });
+    const abroad = applyGeographicDamage(100, {
+      worldId: "crime", origin: "fantasy", domain: "magic", nativeStrength: 94,
+    });
+    assert.equal(home.ok, true);
+    assert.equal(abroad.ok, true);
+    assert.ok(abroad.damage < home.damage, `crime ${abroad.damage} vs fantasy ${home.damage}`);
+    assert.match(abroad.because, /physics/i);
+    assert.doesNotMatch(abroad.because, /-42%/);
   });
 
   it("center magic affinities come from authored meta, not invented tables", () => {
@@ -212,5 +249,23 @@ describe("compose with discrete potency; do not replace it yet", () => {
     const crimeMeta = JSON.parse(readFileSync(join(root, "content/world/crime/meta.json"), "utf8"));
     assert.equal(centerAffinity("fantasy", "magic"), fantasyMeta.skill_affinity.magic);
     assert.equal(centerAffinity("crime", "magic"), crimeMeta.skill_affinity.magic);
+  });
+
+  it("dummy HP authority stamps the field before subtracting HP (W7)", () => {
+    resetCombatHpAuthorityForTest();
+    const home = applyAuthoritativeHit({
+      targetId: "d-home", worldId: "fantasy", localX: 0, localZ: 0,
+      origin: "fantasy", skillKind: "spell", nativeStrength: 94, baseDamage: 20,
+    });
+    resetCombatHpAuthorityForTest();
+    const abroad = applyAuthoritativeHit({
+      targetId: "d-abroad", worldId: "crime", localX: 0, localZ: 0,
+      origin: "fantasy", skillKind: "spell", nativeStrength: 94, baseDamage: 20,
+    });
+    assert.equal(home.ok, true);
+    assert.equal(abroad.ok, true);
+    assert.ok(abroad.geographicEffectiveness, "stamp is on the hit");
+    assert.ok(abroad.damage < home.damage, `crime ${abroad.damage} vs fantasy ${home.damage}`);
+    assert.match(String(abroad.geographicEffectiveness.because || ""), /physics/i);
   });
 });

--- a/server/tests/concordia-world-life.test.js
+++ b/server/tests/concordia-world-life.test.js
@@ -133,6 +133,25 @@ describe("Concordia world-life — source contracts", () => {
     assert.match(game, /MEGAWORLD: current mode is region_rebuild/);
     assert.match(game, /CONCORDIA_PERSISTENT_MEGAWORLD/);
     assert.match(game, /_world\.Build\(next\)/);
+    const field = src("WorldField.cs");
+    assert.match(field, /SceneMetresToKm = 0\.4f/);
+    assert.match(field, /Travel is still region_rebuild/);
+    assert.doesNotMatch(field, /-42% Magic Damage/);
+  });
+
+  it("HUD presents field physics and abandoned ruins, not a percent sticker", () => {
+    const hud = src("ConcordiaHUD.cs");
+    assert.match(hud, /WorldField\.HudLine/);
+    assert.match(hud, /ruins remain/);
+    assert.doesNotMatch(hud, /-42%/);
+    const player = src("ConcordiaPlayer.cs");
+    assert.match(player, /WorldField\.ScaleDamage/);
+    const evo = src("EvoSpawner.cs");
+    assert.match(evo, /retreats toward home field/);
+    const field = src("WorldField.cs");
+    assert.match(field, /HudLine\(WorldId world, Vector3 localPos\)/);
+    assert.match(field, /At\(world, localPos/);
+    assert.doesNotMatch(field, /ConcordClient\.Live && ConcordClient\.Live\.Connected/);
   });
 
   it("stock becomes a caravan with a real Ring tariff, never an invented city", () => {

--- a/server/tests/concordia-world-life.test.js
+++ b/server/tests/concordia-world-life.test.js
@@ -128,6 +128,13 @@ describe("Concordia world-life — source contracts", () => {
     assert.doesNotMatch(book, /Concord admits he loves her/);
   });
 
+  it("Travel is labeled region_rebuild until the megaworld streams continuously", () => {
+    const game = src("ConcordiaGame.cs");
+    assert.match(game, /MEGAWORLD: current mode is region_rebuild/);
+    assert.match(game, /CONCORDIA_PERSISTENT_MEGAWORLD/);
+    assert.match(game, /_world\.Build\(next\)/);
+  });
+
   it("stock becomes a caravan with a real Ring tariff, never an invented city", () => {
     const book = src("WorldBook.cs");
     const gate = src("WorldGate.cs");

--- a/server/tests/e2e/cross-world-potency-routes.test.js
+++ b/server/tests/e2e/cross-world-potency-routes.test.js
@@ -375,10 +375,15 @@ describe('E2E — Universal Move System Pillar 2/3 through the real combat/attac
     const res = await postJSON(base, '/api/worlds/cyber/combat/attack', { npcId, skillDtuId }, authHeaders);
     assert.equal(res.status, 200, 'a spell in cyber should be DAMPENED, not rejected outright: ' + JSON.stringify(res));
     assert.equal(res.body?.ok, true);
-    assert.equal(
-      res.body?.damageResult?.crossWorldPotency, predicted,
-      'the live route must echo back the EXACT crossWorldPotency() value computed on the same real world row: ' + JSON.stringify(res.body?.damageResult),
-    );
+    // W7: live damage samples geographicEffectiveness. Discrete crossWorldPotency
+    // remains the kill-switch fallback and is still unit-tested in
+    // tests/cross-world-potency.test.js.
+    const geo = res.body?.damageResult?.geographicEffectiveness;
+    assert.ok(geo, 'W7 stamps geographicEffectiveness on the live hit: ' + JSON.stringify(res.body?.damageResult));
+    assert.ok(Number(geo.multiplier) > 0 && Number(geo.multiplier) < 1,
+      'fantasy-native magic in cyber must sag: ' + JSON.stringify(geo));
+    assert.match(String(geo.because || ''), /physics/i);
+    assert.doesNotMatch(String(geo.because || ''), /-42%/);
   });
 
   it('Pillar 3 — a real world with FULL magic affinity (fantasy, magic affinity 1.0) is neither rejected nor dampened for a foreign novice caster, proving the live route does not apply a blanket cross-world penalty', async function () {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Playable loop for Concordia as one persistent megaworld.

**Shipped on this branch**
- W1: `spawnSettlementForRegion` founds or joins a Living Society `settlements` row (mig 447 `region_id`). Decay `abandonSettlement`s the same id; re-spawn rejoins.
- W2: Unity HUD / `CityAtlas.ApplyKernelStatuses` presents `abandoned` as ruins remain. Kingdom snapshot overlays kernel status onto authored names.
- W3-thin: `localToMegaworld` maps in-region Unity metres onto the field. HUD samples the field at the player's feet.
- W4-thin: `regionalSummary` keeps counts + chronicle ids. Food/wealth stay empty.
- W7: HTTP combat + Unity dummy HP authority sample `geographicEffectiveness`. Kill-switch `CONCORD_GEOGRAPHIC_FIELD=0` restores discrete potency. No `−42% Magic Damage` sticker.
- W8: fauna-spawner stamps `species_id` + `recordOrganismBirth`. FaunaLife retreats on low habitat fitness. No invented prey.

**Playtest (Unity 6000.5.9f1, Editor play mode, 2026-09-12)**
- Hub: Flower Law, live steel false, magic 0.70, HUD: “The Unburned Court suppresses regional physics.”
- Travel Fantasy (`region_rebuild`): live steel, magic 0.99, “Local athletics physics is 0.90 (fantasy field).” Dummy hit 14 → 12.54 HP 80 → 67.5. Gateway `{ok:false, reason:'no_gateway'}` (honest offline).
- Travel Crime: live steel, magic 0.12, magic hit 14 → 1.63 HP 80 → 78.4. HUD physics language, not a percent sticker. Abandoned count 0 (no invented ruins). 14th Precinct status empty.

Kernel tests: 71 pass / 0 fail (`concordia-megaworld/world-field/organism/world-life/kingdom-snapshot` + consequence + procgen).

**Still GAP (honest)**
- W3 continent streaming: `ConcordiaGame.Travel` is still `_world.Build` / `region_rebuild`.
- W5/W6 live 7-day and 100-hour certification are not run (mechanism pin only).
- CreatureCompiler unique genomes stay on the other client branch. A stale Editor compile entry for missing `CreatureCompiler.cs` blocked WorldField until a clean script compile; not claimed here.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aec3ca7e-e6cd-47ee-b356-868b740a0bfa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aec3ca7e-e6cd-47ee-b356-868b740a0bfa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

