### PR TITLE
Lock Concordia Playable Alive Slice: clips, grip, birds, fauna, one NPC reaction

### DIFF
--- a/docs/CONCORDIA_PLAYABLE_SLICE.md
+++ b/docs/CONCORDIA_PLAYABLE_SLICE.md
@@ -1,0 +1,140 @@
+# Concordia Unity — Playable Slice
+
+**Status:** OPEN (ticket lock, 2026-09-12). Not green.  
+**Pinned by:** `server/tests/concordia-playable-slice.test.js`  
+**One-line verdict:** Concordia currently renders a living-world simulator wearing a prototype costume and a puppet walk. Playable means **costume + clip locomotion + planted feet + non-scaffold Hub** before another kernel law gets locked.
+
+This is the only Concordia Unity work order until the acceptance captures below exist and the ban list is still holding.
+
+---
+
+## Owner sentence
+
+**Playable Slice = one Humanoid (or one retargeted) skeleton for hero + NPCs, one `AnimatorController` with Idle/Walk/Run/Sprint/JumpStart/JumpLand/Dodge/LightAttack, root-motion policy decided, zero LateUpdate bone hinging for locomotion, pack Hub underfoot, F8 HUD, one art contract.**
+
+If a 30-second Hub walk still smells like a marionette, the slice is not green. Systems/kernel work does not count.
+
+---
+
+## Why this, not another kernel pass
+
+The brain is ahead of the body. ExplosiveLLC / Kevin Iglesias / SoldierLocomotion sit on disk. Live bodies mostly run **procedural bone hinging** because Rocketbox is Generic/Biped, Mixamo clips need Humanoid, and the code prefers authored gait when clips skate. Humans smell a fake walk cycle in half a second.
+
+Checked against HEAD `concurrency-refactor` (2026-09-12), not memory:
+
+| Claim | Where it is true |
+|---|---|
+| Dual body pipelines on the player | `ConcordiaPlayer` calls `avatar?.SetGait` **and** `person?.SetGait` every move |
+| Clips almost never win | `ModularPerson` `_clipsFit = !_biped && ctrl && av && av.isHuman && av.isValid`. Rocketbox `Bip01` sets `_biped` → Animator disabled → `ApplyAuthoredGait` |
+| Pack controllers are leftovers | `LoadLocomotion()` loads `SoldierLocomotion` / StarterAssets / Kevin demo controller. ExplosiveLLC `RPG-Character-Animation-Controller` is not the required path |
+| LateUpdate panic hatch | `_clipsFit && _plantFrames == 6` hand-height check **nulls the Animator** |
+| Slash is a forearm Euler | `_slashT` rotates `_uArmR` / Mixamo `_rArm` |
+| Dodge is a velocity shove | `ConcordiaPlayer` `_vel += wish * 12.4f` |
+| Jump is velocity + procedural tuck | Space sets `_vel.y = 8.2f`; Mixamo `ApplyJump` / ModularPerson `BipedHinge` tuck |
+| Mixamo disables Animator in air | `animator.enabled = grounded` |
+| NpcLife lies about grounded | `_person?.SetGait(speed, true)` while walking |
+| SR2 **ratifies the puppet** | `concordia-sr2-streets.test.js` requires `BipedHinge(` and `_clipsFit = !_biped`. That pin is the defect, not the destination. The slice **retires** it. |
+| Grounding 4.5m hack (this base) | `Grounding.SnapPoint` drops hits outside `y ∈ [-0.2, 4.5]` to `0.08`. In-flight visual P0 (PR #975) removes it — still required here until merged. |
+| HubPlaza primitives (this base) | Court still ships `HubLook.Prim` cylinders/cubes unless PR #975 is in. Pack meshes are the Playable Slice floor, not optional polish. |
+
+Kevin Iglesias has Idle/Walk/Run/Jump/Turn/Talk FBX. ExplosiveLLC RPG FREE has Walk/Run/Attack/Idle/DiveRoll on a Humanoid. Neither is the live contract. `SoldierLocomotion.controller` is a Speed blend tree over soldier clips — thin leftover, not the slice controller.
+
+---
+
+## Brutal order (do not reorder)
+
+| Rank | Fix | Done when |
+|---|---|---|
+| **1** | One Humanoid + real `ConcordiaLocomotion` controller on the **hero** | Walk/run/idle are clips. Capture `ps-walk-cycle` |
+| **2** | Same controller (or LOD twin) on every `ModularPerson` NPC | Plaza walkers animate. Capture `ps-npc-pathing`. Empty dirt > mannequin crowd |
+| **3** | Delete procedural locomotion for authored bodies | No `ApplyAuthoredGait` / `ApplyPrimitiveGait` / Mixamo `ApplyProceduralGait` on the live path. Primitive fallback only if **no** mesh bound |
+| **4** | Hub plaza from imported packs, not Prim cylinders | `ps-hub-day` shows pack floor/gates. No floating rib cubes |
+| **5** | Grounding / spawn plant | No 4.5m ceiling hack. Feet on real ground. `ps-walk-cycle` pelvis never buried |
+| **6** | Attack / dodge / jump **clips** | `ps-jump` and a slash still. No forearm Euler as the hero melee |
+| **7** | OnGUI kernel behind F8 (default off). Night is darkness + lamps | `ps-hub-night` vs day is unmistakable. `ps-no-debug` has no kernel dump |
+| **8** | One art contract | `docs/UNITY_ART_LOCK.md` (PR #975) or this ticket’s copy: Hub may wear one Rocketbox adult; steel worlds wear pack costume; Kenney/toon is missing-prop |
+
+Ranks 4–8 overlap visual P0 (PR #975). If that PR is merged, do not rebuild them — verify the captures still hold, then spend the slice on **1–3–6**.
+
+---
+
+## Controller contract
+
+New asset: `Assets/Concordia/Anim/ConcordiaLocomotion.controller` (also copied under `Resources/Concordia/` if runtime load needs it).
+
+**Required states:** `Idle`, `Walk`, `Run`, `Sprint`, `JumpStart`, `JumpLand`, `Dodge`, `LightAttack`.  
+**Parameters:** `Speed` (float), `Grounded` (bool), `Jump` (trigger), `Dodge` (trigger), `Attack` (trigger), `Sit` (bool, optional).  
+**Root motion:** **off** for this slice (CharacterController owns translation). Feet must still plant visually — off is allowed; skating is not.  
+**Clip sources (in order, Humanoid only):** Kevin Iglesias Human Basic Motions (in-place Walk/Run/Idle/Jump) → ExplosiveLLC RPG FREE (attacks, roll) → Starter Assets third-person as last Humanoid fallback. Soldier.glb / Mixamo Vanguard is **not** the Hub hero mesh.
+
+`ModularPerson.LoadLocomotion` must load `ConcordiaLocomotion` first. `MixamoAvatar` is removed from the player, or becomes a no-op when `ModularPerson` is bound.
+
+**`_clipsFit` rule after the slice:** authored Humanoid with a valid avatar **plays clips**. Biped Generic is retargeted or replaced — not a reason to keep `BipedHinge` as the walk. The plant-frame-6 Animator-null is deleted, not tuned.
+
+`NpcLife` passes the real CharacterController grounded flag into `SetGait`. Hardcoded `true` is a bug.
+
+---
+
+## Locomotion feel (hero only, this slice)
+
+Not a full AAA character controller. Minimum so the walk sells:
+
+- Turn rate falls as planar speed rises (no instant spin at sprint).
+- Jump: clip + existing `_vel.y`; land recovers through `JumpLand`, not a snap to Idle.
+- Dodge: clip + short i-frame / velocity; not only `_vel += wish * 12.4`.
+- Mixamo `animator.enabled = grounded` is forbidden.
+
+Accel lerp may stay. Crouch / analog / lock-on are **out of slice**.
+
+---
+
+## Acceptance captures
+
+All under `apps/concordia-living-world/unity-client/Captures/`. Fail the slice if any still shows sin-wave knees, polo-in-fantasy, floating geometry, a floater NPC, or an OnGUI kernel dump.
+
+| File | Must show |
+|---|---|
+| `ps-walk-cycle.png` (or short webm) | Hero Idle→Walk→Run in Hub. Feet plant. No BipedHinge skating. Pelvis not buried |
+| `ps-jump.png` | JumpStart in air, JumpLand on contact. Animator stays enabled |
+| `ps-npc-pathing.png` | At least two Hub NPCs in Walk/Run clips on the plaza ring, not T-pose / mannequin idle while translating |
+| `ps-hub-day.png` | Pack Hub, F8 off, compass + rings + one prompt |
+| `ps-hub-night.png` | Same camera as day at night hour. Darkness + local lights. Not noon-minus-UI |
+| `ps-slash.png` | LightAttack clip, not a forearm Euler |
+
+**Playable bar (not optional):** 30 seconds of Hub walk where feet never slide, jump arcs read, land recovers, camera never shows a buried pelvis.
+
+---
+
+## Ban list (until this ticket is GREEN)
+
+**no new megaworld** features until this ticket is GREEN.
+
+Do **not** land any of the following while Playable Slice is OPEN:
+
+- New megaworld / world-field / organism / settlement-chronicle / LOD / continent-streaming features
+- New ConKay hologram / JARVIS stage work that touches the Unity client
+- New talk-affinity / rumor / kingdom-audit systems whose only Unity surface is more OnGUI
+- New fauna species, dungeon holds, or city kits whose bodies would join the puppet crowd
+- Softening `grade-*` / detector baselines to make a rugged frame look scored
+- Adding more `BipedHinge` / `ApplyPrimitiveGait` / Mixamo LateUpdate hinging
+- Treating `concordia-sr2-streets.test.js`’s `BipedHinge` pin as sacred — replace it when clips win
+
+Kernel docs (`CONCORDIA_PERSISTENT_MEGAWORLD` on stacked branches, organism tests, field math) stay **read-only**. Unity **reveals** that state after the walk is a walk.
+
+Allowed while OPEN: this ticket’s ranks 1–8, visual P0 merge from PR #975, bugfixes that unblock clips (Humanoid avatar, grounding, AnimatorController).
+
+---
+
+## Art lock (rank 8)
+
+If `docs/UNITY_ART_LOCK.md` is not on the branch yet, this sentence is the lock:
+
+> Unity client fidelity = store-pack realism: Hub may wear one modern Rocketbox adult; every steel world wears that world’s imported costume (KayKit Knight / dress); architecture and foliage come from imported packs; URP lighting. Kenney / primitive / toon is a missing-prop fallback, never the look.
+
+`docs/ART_STYLE_GUIDE.md` BotW/Palworld constants are retired for Unity.
+
+---
+
+## Explicitly not this slice
+
+Continent streaming, organism tombstones, settlement chronicle, ConKay, talk affinity, more world-field samples, 7-day / 100-hour certification. Those make the *doc* dope. They do not make the *walk* dope.

--- a/docs/CONCORDIA_PLAYABLE_SLICE.md
+++ b/docs/CONCORDIA_PLAYABLE_SLICE.md
@@ -1,8 +1,8 @@
-# Concordia Unity — Playable Slice
+# Concordia Unity — Playable Alive Slice
 
 **Status:** OPEN (ticket lock, 2026-09-12). Not green.  
 **Pinned by:** `server/tests/concordia-playable-slice.test.js`  
-**One-line verdict:** Concordia currently renders a living-world simulator wearing a prototype costume and a puppet walk. Playable means **costume + clip locomotion + planted feet + non-scaffold Hub** before another kernel law gets locked.
+**One-line verdict:** The simulation is alive in docs/server; the stage is mostly props. Playable-alive means **layer 3 is forced to express layer 1** — clips, grip, birds, fauna meshes, one NPC reaction — before another kernel law gets locked.
 
 This is the only Concordia Unity work order until the acceptance captures below exist and the ban list is still holding.
 
@@ -10,17 +10,29 @@ This is the only Concordia Unity work order until the acceptance captures below 
 
 ## Owner sentence
 
-**Playable Slice = one Humanoid (or one retargeted) skeleton for hero + NPCs, one `AnimatorController` with Idle/Walk/Run/Sprint/JumpStart/JumpLand/Dodge/LightAttack, root-motion policy decided, zero LateUpdate bone hinging for locomotion, pack Hub underfoot, F8 HUD, one art contract.**
+**Playable Alive Slice = one Humanoid + `ConcordiaLocomotion` (Idle/Walk/Run/Sprint/JumpStart/JumpLand/Dodge/LightAttack), root motion off, zero LateUpdate bone hinging for locomotion, real palm grip (no root-parented weapons), Living Birds in Hub air (or cull), fauna real meshes or no spawn, one NPC reaction to sim truth proven in Capture, pack Hub, F8 HUD, one art contract.**
 
-If a 30-second Hub walk still smells like a marionette, the slice is not green. Systems/kernel work does not count.
+If a 60-second Hub walk still smells like a marionette, a stick glued to a hip, primitive doves, Kenney balloons, or a ticker that the bodies ignore, the slice is not green. Systems/kernel work does not count.
+
+---
+
+## Three layers that don’t share a body
+
+1. **Kernel / docs** — megaworld laws, WorldField, organism birth/death, settlements/chronicle/consequences, kingdom snapshots, WorldMemory, CrossRing, talk/affinity. Rich, honest, locked.
+2. **Unity AI stubs** — `NpcLife` / `FaunaLife` / `CourtBird` orbits. Thin wire. Mostly writes HUD strings.
+3. **Pixels** — Rocketbox + primitives + ungeared hands + puppet gait. This is what the eye believes.
+
+Alive means layer 3 expresses layer 1. Not more laws.
 
 ---
 
 ## Why this, not another kernel pass
 
-The brain is ahead of the body. ExplosiveLLC / Kevin Iglesias / SoldierLocomotion sit on disk. Live bodies mostly run **procedural bone hinging** because Rocketbox is Generic/Biped, Mixamo clips need Humanoid, and the code prefers authored gait when clips skate. Humans smell a fake walk cycle in half a second.
+The brain is ahead of the body. ExplosiveLLC / Kevin Iglesias / SoldierLocomotion / Living Birds sit on disk. Live bodies mostly run **procedural bone hinging**, **prop-glued weapons**, **primitive doves**, and a **town-diorama clock**. Humans smell a fake walk in half a second and a floating glaive immediately.
 
 Checked against HEAD `concurrency-refactor` (2026-09-12), not memory:
+
+### Walk is a puppet
 
 | Claim | Where it is true |
 |---|---|
@@ -39,22 +51,65 @@ Checked against HEAD `concurrency-refactor` (2026-09-12), not memory:
 
 Kevin Iglesias has Idle/Walk/Run/Jump/Turn/Talk FBX. ExplosiveLLC RPG FREE has Walk/Run/Attack/Idle/DiveRoll on a Humanoid. Neither is the live contract. `SoldierLocomotion.controller` is a Speed blend tree over soldier clips — thin leftover, not the slice controller.
 
+### Weapons that aren’t gripped
+
+`CharacterGear.Grip` parents a mesh to a hand Transform and aims the longest axis with `FromToRotation`. That’s prop-gluing, not gripping.
+
+| Claim | Where it is true |
+|---|---|
+| No finger IK / hold pose | `Grip` is `SetParent(hand)` + `FromToRotation`. Hands stay open or idle. Blade floats through/near the palm. |
+| Socket falls back to **root** | `CharacterGear.Attach`: `if (!socket) socket = body.transform`. Kenney / bad bind in `ModularPerson`: `leftHand = rightHand = body.transform`. Weapon parents to hip/chest. |
+| Combat never re-grips | `Slash()` swings the upper arm with Eulers. Gear never re-grips, sheathes, or two-hands. |
+| Captures match the code | Polo guy with a stick that never looks *held*. |
+
+**Alive bar:** Weapon socket on palm + finger curl pose (or authored hold clip). If no hand bone → **don’t spawn a weapon**. Better empty hands than a floating glaive.
+
+### Birds / fauna — pack on disk, toys in the sky
+
+Living Birds Asset Store pack is on disk (`Assets/living birds`, `FreePacks.Bird()` → `lb_sparrow` / `lb_robin` / `lb_cardinal`). Hub does not use it.
+
+| Claim | Where it is true |
+|---|---|
+| Hub air is primitive doves | `WorldBuilder.SpawnFauna`: **24×** `Dove{i}` + `CourtBird` = Sphere body + Cube wings on a sine orbit (`radius` 10–22, `height` 6.5+) |
+| Grove birds only three, only two worlds | `DressGroveBirds` only Tunya/Fantasy, three stems |
+| Missing fauna mesh → CourtBird | Non-Hub `SpawnFauna` rabbit/dog miss → Sphere + `CourtBird` |
+| Evo stems are Kenney balloons | `EvoSpawner.StemFor`: wolf/hound → `Fox`, griffin → `Horse`, harpy → `Parrot`; miss → `CreatePrimitive` Sphere/Cube/Capsule |
+| Behavior can be real | `FaunaLife` wander/graze/flee/hunt/sleep + WorldField retreat is a real little brain wearing the wrong body |
+
+**Alive bar:** Living Birds prefabs in Hub air; fauna use real meshes or don’t spawn; disable `CourtBird` primitives in Captures forever.
+
+### NPCs are spectators of the simulation’s press release
+
+Plaza NPCs run `NpcLife` — a local hour schedule (sleep/work/stall/wander), walk-to-point, sit, talk proximity, `WorldClock.NoteAct("…")` lines for the HUD ticker. That’s a **town diorama clock**, not the kernel.
+
+| Sim truth | NPC presentation |
+|---|---|
+| Settlement founded / abandoned | HUD / WorldBook overlay strings — bodies don’t flee, mourn, or leave |
+| `world_consequences` / kills | Fauna may NoteKill; citizens don’t change jobs, trust, or routes |
+| Kingdom `settlements[]` | Counted for status JSON; crowd roster stays authored spawn list |
+| WorldField habitat / steel | FaunaLife samples field; ModularPerson crowd mostly ignores it |
+| Organism / fauna-spawner | Parallel to CourtBird + Kenney rings; not one living ecology on screen |
+| Talk / affinity / leverage | Panel works; body stays mannequin (no lean-in, gesture, look-at) |
+| Weather / night | Clock text; NPCs don’t light lamps, go inside, or change cloth |
+
+The ticker can say “Baron Hollow opens a shop” while the mesh doesn’t open anything.
+
+**Alive bar:** One causal chain visible in 60s of play — e.g. kill in steel world → nearby NPCs flee or draw → chronicle line → same bodies still displaced when you return. Until then, “living world” is marketing over a schedule bot.
+
 ---
 
 ## Brutal order (do not reorder)
 
 | Rank | Fix | Done when |
 |---|---|---|
-| **1** | One Humanoid + real `ConcordiaLocomotion` controller on the **hero** | Walk/run/idle are clips. Capture `ps-walk-cycle` |
-| **2** | Same controller (or LOD twin) on every `ModularPerson` NPC | Plaza walkers animate. Capture `ps-npc-pathing`. Empty dirt > mannequin crowd |
-| **3** | Delete procedural locomotion for authored bodies | No `ApplyAuthoredGait` / `ApplyPrimitiveGait` / Mixamo `ApplyProceduralGait` on the live path. Primitive fallback only if **no** mesh bound |
-| **4** | Hub plaza from imported packs, not Prim cylinders | `ps-hub-day` shows pack floor/gates. No floating rib cubes |
-| **5** | Grounding / spawn plant | No 4.5m ceiling hack. Feet on real ground. `ps-walk-cycle` pelvis never buried |
-| **6** | Attack / dodge / jump **clips** | `ps-jump` and a slash still. No forearm Euler as the hero melee |
-| **7** | OnGUI kernel behind F8 (default off). Night is darkness + lamps | `ps-hub-night` vs day is unmistakable. `ps-no-debug` has no kernel dump |
-| **8** | One art contract | `docs/UNITY_ART_LOCK.md` (PR #975) or this ticket’s copy: Hub may wear one Rocketbox adult; steel worlds wear pack costume; Kenney/toon is missing-prop |
+| **1** | Humanoid + real walk/run/idle clips (hero + NPCs). Same `ConcordiaLocomotion`. Jump/dodge/slash are clips. Zero LateUpdate bone hinging for locomotion | `ps-walk-cycle`, `ps-jump`, `ps-slash`, `ps-npc-pathing`. Empty dirt > mannequin crowd |
+| **2** | Real hand grip + ban root-parented weapons | Palm socket + finger curl / hold clip. No `socket = body.transform`. No weapon if no hand bone. Capture `ps-grip` |
+| **3** | Replace CourtBird primitives with Living Birds (or cull) | Hub air is `lb_sparrow` / `lb_robin` / `lb_cardinal` (or empty sky). `CourtBird` Sphere+Cube banned in Captures. Capture `ps-birds` |
+| **4** | Fauna meshes that match FaunaLife (or don’t spawn) | No `StemFor` Fox-for-wolf / Horse-for-griffin / `CreatePrimitive` bodies with a living brain. Capture `ps-fauna` |
+| **5** | One NPC reaction to sim truth (flee / shelter / mourn) | Proven in Capture: bodies move because the kernel did. Capture `ps-npc-react` |
+| **6** | Hub pack architecture + night lights + debug HUD off | `ps-hub-day` / `ps-hub-night` / `ps-no-debug`. Grounding without the 4.5m hack. One art contract |
 
-Ranks 4–8 overlap visual P0 (PR #975). If that PR is merged, do not rebuild them — verify the captures still hold, then spend the slice on **1–3–6**.
+Ranks 4–8 of the first lock overlap visual P0 (PR #975) and are now **rank 6**. If that PR is merged, verify those captures, then spend the slice on **1–5**.
 
 ---
 
@@ -75,6 +130,33 @@ New asset: `Assets/Concordia/Anim/ConcordiaLocomotion.controller` (also copied u
 
 ---
 
+## Grip contract
+
+- `CharacterGear.Attach` parents only to a resolved **hand bone**. If `leftHand` / `rightHand` is missing or equals `body.transform`, **return null** — do not spawn.
+- Hold is a finger-curl pose or an authored hold clip on the same Humanoid. `FromToRotation` longest-axis is not a grip.
+- `Slash` / sheathe / two-hand go through the controller (or a hold overlay), not forearm Eulers that leave the mesh floating.
+- Kenney / bad-bind bodies do not get a sword glued to the root.
+
+---
+
+## Birds / fauna contract
+
+- Hub `SpawnFauna` instantiates Living Birds prefabs (`FreePacks.Bird()` → `lb_sparrow` / `lb_robin` / `lb_cardinal`) or spawns **zero** birds. `CourtBird` primitive Sphere+Cube is retired from Hub and from Captures.
+- `EvoSpawner.StemFor` maps to a real mesh of that kind, or `Spawn` returns null. Wolf is not a Fox. Griffin is not a Horse. Missing mesh is not `CreatePrimitive`.
+- `FaunaLife` may stay. It must wear a matching body.
+
+---
+
+## One causal chain (rank 5)
+
+Minimum, not a second kernel:
+
+Pick **one** sim truth the plaza already has (a steel-world kill, a night hour, a consequence row) and make **the same bodies** do one visible thing: flee, draw, shelter, or mourn. Persist enough that returning still shows them displaced.
+
+Do **not** add chronicle schema, affinity copy, or new megaworld laws to make this true. Wire the body to a fact that already exists.
+
+---
+
 ## Locomotion feel (hero only, this slice)
 
 Not a full AAA character controller. Minimum so the walk sells:
@@ -90,18 +172,25 @@ Accel lerp may stay. Crouch / analog / lock-on are **out of slice**.
 
 ## Acceptance captures
 
-All under `apps/concordia-living-world/unity-client/Captures/`. Fail the slice if any still shows sin-wave knees, polo-in-fantasy, floating geometry, a floater NPC, or an OnGUI kernel dump.
+All under `apps/concordia-living-world/unity-client/Captures/`. Fail the slice if any still shows sin-wave knees, polo-in-fantasy, floating geometry, a floater NPC, a root-parented weapon, primitive doves, Kenney-balloon fauna, or an OnGUI kernel dump.
 
 | File | Must show |
 |---|---|
 | `ps-walk-cycle.png` (or short webm) | Hero Idle→Walk→Run in Hub. Feet plant. No BipedHinge skating. Pelvis not buried |
 | `ps-jump.png` | JumpStart in air, JumpLand on contact. Animator stays enabled |
 | `ps-npc-pathing.png` | At least two Hub NPCs in Walk/Run clips on the plaza ring, not T-pose / mannequin idle while translating |
+| `ps-slash.png` | LightAttack clip, not a forearm Euler |
+| `ps-grip.png` | Weapon in the palm, fingers curled or hold clip. Empty hands if no hand bone — never hip/chest glue |
+| `ps-birds.png` | Hub air is Living Birds prefabs, or empty sky. No Sphere+Cube `CourtBird` |
+| `ps-fauna.png` | A FaunaLife body whose mesh matches its kind, or no spawn. No Fox-for-wolf / primitive sphere with a brain |
+| `ps-npc-react.png` | One causal chain: sim event → nearby NPCs flee/draw/shelter/mourn → ticker/chronicle agrees → bodies still displaced on return |
 | `ps-hub-day.png` | Pack Hub, F8 off, compass + rings + one prompt |
 | `ps-hub-night.png` | Same camera as day at night hour. Darkness + local lights. Not noon-minus-UI |
-| `ps-slash.png` | LightAttack clip, not a forearm Euler |
+| `ps-no-debug.png` | No kernel dump overlay |
 
 **Playable bar (not optional):** 30 seconds of Hub walk where feet never slide, jump arcs read, land recovers, camera never shows a buried pelvis.
+
+**Alive bar (not optional):** 60 seconds of play where a weapon is held, Hub air is not primitive doves, fauna (if any) wear real meshes, and one NPC reaction to sim truth is visible.
 
 ---
 
@@ -109,23 +198,25 @@ All under `apps/concordia-living-world/unity-client/Captures/`. Fail the slice i
 
 **no new megaworld** features until this ticket is GREEN.
 
-Do **not** land any of the following while Playable Slice is OPEN:
+Do **not** land any of the following while Playable Alive Slice is OPEN:
 
 - New megaworld / world-field / organism / settlement-chronicle / LOD / continent-streaming features
+- More chronicle schema
+- More affinity copy / talk-affinity / rumor / kingdom-audit systems whose only Unity surface is more OnGUI
 - New ConKay hologram / JARVIS stage work that touches the Unity client
-- New talk-affinity / rumor / kingdom-audit systems whose only Unity surface is more OnGUI
 - New fauna species, dungeon holds, or city kits whose bodies would join the puppet crowd
 - Softening `grade-*` / detector baselines to make a rugged frame look scored
 - Adding more `BipedHinge` / `ApplyPrimitiveGait` / Mixamo LateUpdate hinging
 - Treating `concordia-sr2-streets.test.js`’s `BipedHinge` pin as sacred — replace it when clips win
+- Shipping `CourtBird` primitives, root-parented weapons, or `CreatePrimitive` fauna as “alive”
 
-Kernel docs (`CONCORDIA_PERSISTENT_MEGAWORLD` on stacked branches, organism tests, field math) stay **read-only**. Unity **reveals** that state after the walk is a walk.
+Kernel docs (`CONCORDIA_PERSISTENT_MEGAWORLD` on stacked branches, organism tests, field math) stay **read-only**. Unity **reveals** that state after the walk is a walk and the grip is a grip.
 
-Allowed while OPEN: this ticket’s ranks 1–8, visual P0 merge from PR #975, bugfixes that unblock clips (Humanoid avatar, grounding, AnimatorController).
+Allowed while OPEN: this ticket’s ranks 1–6, visual P0 merge from PR #975, bugfixes that unblock clips / grip / Living Birds / honest fauna skip (Humanoid avatar, grounding, AnimatorController, hand sockets).
 
 ---
 
-## Art lock (rank 8)
+## Art lock (rank 6)
 
 If `docs/UNITY_ART_LOCK.md` is not on the branch yet, this sentence is the lock:
 
@@ -137,4 +228,4 @@ If `docs/UNITY_ART_LOCK.md` is not on the branch yet, this sentence is the lock:
 
 ## Explicitly not this slice
 
-Continent streaming, organism tombstones, settlement chronicle, ConKay, talk affinity, more world-field samples, 7-day / 100-hour certification. Those make the *doc* dope. They do not make the *walk* dope.
+Continent streaming, organism tombstones, settlement chronicle schema, ConKay, more talk affinity copy, more world-field samples, 7-day / 100-hour certification. Those make the *doc* dope. They do not make the *stage* dope.

--- a/docs/CONCORDIA_UNITY_BUILD_PLAN.md
+++ b/docs/CONCORDIA_UNITY_BUILD_PLAN.md
@@ -6,6 +6,8 @@
 
 **Unity client lives in this repo:** `apps/concordia-living-world/unity-client/`. Open `concord.code-workspace` so Unity Concordia sits next to Godot, frontend, server, and mobile. Do not copy the project out of the tree. `Library/` is gitignored and regenerates in Unity Hub.
 
+**🔴 Playable Slice gate (2026-09-12):** the Unity client is a living-world simulator in a prototype costume with a puppet walk. Until [`docs/CONCORDIA_PLAYABLE_SLICE.md`](CONCORDIA_PLAYABLE_SLICE.md) is GREEN, do **not** add megaworld / organism / chronicle / ConKay features to this client. Clip locomotion + planted feet + pack Hub first. Pinned by `server/tests/concordia-playable-slice.test.js`.
+
 Owner spec (this session): Concordia is **not a bigger Skyrim**. It is a **systemic civilization** that keeps living when the player looks away. Unity is the **full standalone AAA client**. Asset Store is authorized as the evo/procedural corpus. Server sim + DTUs stay the moat.
 
 ---

--- a/docs/CONCORDIA_UNITY_BUILD_PLAN.md
+++ b/docs/CONCORDIA_UNITY_BUILD_PLAN.md
@@ -6,7 +6,7 @@
 
 **Unity client lives in this repo:** `apps/concordia-living-world/unity-client/`. Open `concord.code-workspace` so Unity Concordia sits next to Godot, frontend, server, and mobile. Do not copy the project out of the tree. `Library/` is gitignored and regenerates in Unity Hub.
 
-**🔴 Playable Slice gate (2026-09-12):** the Unity client is a living-world simulator in a prototype costume with a puppet walk. Until [`docs/CONCORDIA_PLAYABLE_SLICE.md`](CONCORDIA_PLAYABLE_SLICE.md) is GREEN, do **not** add megaworld / organism / chronicle / ConKay features to this client. Clip locomotion + planted feet + pack Hub first. Pinned by `server/tests/concordia-playable-slice.test.js`.
+**🔴 Playable Alive Slice gate (2026-09-12):** the simulation is alive in docs/server; the stage is mostly props. Until [`docs/CONCORDIA_PLAYABLE_SLICE.md`](CONCORDIA_PLAYABLE_SLICE.md) is GREEN, do **not** add megaworld / organism / chronicle schema / affinity copy / ConKay features to this client. Clips, grip, Living Birds, fauna meshes (or no spawn), one NPC reaction, pack Hub first. Pinned by `server/tests/concordia-playable-slice.test.js`.
 
 Owner spec (this session): Concordia is **not a bigger Skyrim**. It is a **systemic civilization** that keeps living when the player looks away. Unity is the **full standalone AAA client**. Asset Store is authorized as the evo/procedural corpus. Server sim + DTUs stay the moat.
 

--- a/docs/NEXT_ARC_PLAN.md
+++ b/docs/NEXT_ARC_PLAN.md
@@ -2,6 +2,12 @@
 
 ## 🟢 HANDOFF — start here
 
+**Concordia Unity — Playable Slice gate (2026-09-12):** if the work is the
+Unity client, read **`docs/CONCORDIA_PLAYABLE_SLICE.md` first**. Ban:
+**no new megaworld** / organism / chronicle / ConKay client features until
+that ticket is GREEN. The kernel is ahead of the walk. Pinned by
+`server/tests/concordia-playable-slice.test.js`.
+
 **Status update (2026-07-03): Wave 1 is SHIPPED.** Every phase in Track K
 (K1–K6, K6-voice) and Track P (P-A, P-B, P-C, P-D) landed on this branch —
 see the per-phase SHIPPED markers in §B and §C for commit hashes and

--- a/docs/NEXT_ARC_PLAN.md
+++ b/docs/NEXT_ARC_PLAN.md
@@ -2,11 +2,12 @@
 
 ## 🟢 HANDOFF — start here
 
-**Concordia Unity — Playable Slice gate (2026-09-12):** if the work is the
+**Concordia Unity — Playable Alive Slice gate (2026-09-12):** if the work is the
 Unity client, read **`docs/CONCORDIA_PLAYABLE_SLICE.md` first**. Ban:
-**no new megaworld** / organism / chronicle / ConKay client features until
-that ticket is GREEN. The kernel is ahead of the walk. Pinned by
-`server/tests/concordia-playable-slice.test.js`.
+**no new megaworld** / organism / chronicle schema / affinity copy / ConKay
+client features until that ticket is GREEN. Clips, grip, Living Birds, fauna
+meshes (or no spawn), and one NPC reaction to sim truth before more laws.
+Pinned by `server/tests/concordia-playable-slice.test.js`.
 
 **Status update (2026-07-03): Wave 1 is SHIPPED.** Every phase in Track K
 (K1–K6, K6-voice) and Track P (P-A, P-B, P-C, P-D) landed on this branch —

--- a/server/tests/concordia-playable-slice.test.js
+++ b/server/tests/concordia-playable-slice.test.js
@@ -1,0 +1,58 @@
+import { readFileSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const scripts = join(root, "apps/concordia-living-world/unity-client/Assets/Concordia/Scripts");
+const ticket = join(root, "docs/CONCORDIA_PLAYABLE_SLICE.md");
+
+function src(name) {
+  return readFileSync(join(scripts, name), "utf8");
+}
+
+describe("Concordia Playable Slice — ticket lock", () => {
+  it("the slice ticket exists and names captures + ban list", () => {
+    assert.equal(existsSync(ticket), true);
+    const t = readFileSync(ticket, "utf8");
+    assert.match(t, /Playable Slice/);
+    assert.match(t, /ConcordiaLocomotion/);
+    assert.match(t, /zero LateUpdate bone hinging/);
+    assert.match(t, /ps-walk-cycle/);
+    assert.match(t, /ps-jump/);
+    assert.match(t, /ps-npc-pathing/);
+    assert.match(t, /ps-hub-day/);
+    assert.match(t, /ps-hub-night/);
+    assert.match(t, /Ban list/);
+    assert.match(t, /no new megaworld/);
+    assert.match(t, /BipedHinge/);
+    assert.match(t, /server\/tests\/concordia-playable-slice\.test\.js/);
+  });
+
+  it("Unity build plan and Next Arc point at the slice gate", () => {
+    const build = readFileSync(join(root, "docs/CONCORDIA_UNITY_BUILD_PLAN.md"), "utf8");
+    const arc = readFileSync(join(root, "docs/NEXT_ARC_PLAN.md"), "utf8");
+    assert.match(build, /CONCORDIA_PLAYABLE_SLICE/);
+    assert.match(build, /Playable Slice/);
+    assert.match(arc, /CONCORDIA_PLAYABLE_SLICE/);
+    assert.match(arc, /no new megaworld/);
+  });
+
+  it("live body still uses the puppet path this ticket bans (honest until green)", () => {
+    const person = src("ModularPerson.cs");
+    const player = src("ConcordiaPlayer.cs");
+    const mixamo = src("MixamoAvatar.cs");
+    const life = src("NpcLife.cs");
+    assert.match(person, /BipedHinge\(/);
+    assert.match(person, /ApplyAuthoredGait\(/);
+    assert.match(person, /_clipsFit = !_biped &&/);
+    assert.match(person, /_plantFrames == 6/);
+    assert.match(person, /SoldierLocomotion/);
+    assert.match(player, /avatar\?\.SetGait/);
+    assert.match(player, /person\?\.SetGait/);
+    assert.match(player, /wish\.normalized \* 12\.4f/);
+    assert.match(mixamo, /animator\.enabled = grounded/);
+    assert.match(life, /SetGait\([^;]+,\s*true\)/);
+  });
+});

--- a/server/tests/concordia-playable-slice.test.js
+++ b/server/tests/concordia-playable-slice.test.js
@@ -16,7 +16,7 @@ describe("Concordia Playable Slice — ticket lock", () => {
   it("the slice ticket exists and names captures + ban list", () => {
     assert.equal(existsSync(ticket), true);
     const t = readFileSync(ticket, "utf8");
-    assert.match(t, /Playable Slice/);
+    assert.match(t, /Playable Alive Slice/);
     assert.match(t, /ConcordiaLocomotion/);
     assert.match(t, /zero LateUpdate bone hinging/);
     assert.match(t, /ps-walk-cycle/);
@@ -24,9 +24,18 @@ describe("Concordia Playable Slice — ticket lock", () => {
     assert.match(t, /ps-npc-pathing/);
     assert.match(t, /ps-hub-day/);
     assert.match(t, /ps-hub-night/);
+    assert.match(t, /ps-grip/);
+    assert.match(t, /ps-birds/);
+    assert.match(t, /ps-fauna/);
+    assert.match(t, /ps-npc-react/);
     assert.match(t, /Ban list/);
     assert.match(t, /no new megaworld/);
+    assert.match(t, /chronicle schema/);
+    assert.match(t, /affinity copy/);
     assert.match(t, /BipedHinge/);
+    assert.match(t, /Living Birds/);
+    assert.match(t, /CourtBird/);
+    assert.match(t, /causal chain/);
     assert.match(t, /server\/tests\/concordia-playable-slice\.test\.js/);
   });
 
@@ -34,9 +43,10 @@ describe("Concordia Playable Slice — ticket lock", () => {
     const build = readFileSync(join(root, "docs/CONCORDIA_UNITY_BUILD_PLAN.md"), "utf8");
     const arc = readFileSync(join(root, "docs/NEXT_ARC_PLAN.md"), "utf8");
     assert.match(build, /CONCORDIA_PLAYABLE_SLICE/);
-    assert.match(build, /Playable Slice/);
+    assert.match(build, /Playable Alive Slice/);
     assert.match(arc, /CONCORDIA_PLAYABLE_SLICE/);
     assert.match(arc, /no new megaworld/);
+    assert.match(arc, /Playable Alive Slice/);
   });
 
   it("live body still uses the puppet path this ticket bans (honest until green)", () => {
@@ -44,15 +54,31 @@ describe("Concordia Playable Slice — ticket lock", () => {
     const player = src("ConcordiaPlayer.cs");
     const mixamo = src("MixamoAvatar.cs");
     const life = src("NpcLife.cs");
+    const gear = src("CharacterGear.cs");
+    const gate = src("WorldGate.cs");
+    const builder = src("WorldBuilder.cs");
+    const evo = src("EvoSpawner.cs");
     assert.match(person, /BipedHinge\(/);
     assert.match(person, /ApplyAuthoredGait\(/);
     assert.match(person, /_clipsFit = !_biped &&/);
     assert.match(person, /_plantFrames == 6/);
     assert.match(person, /SoldierLocomotion/);
+    assert.match(person, /leftHand = rightHand = body\.transform/);
     assert.match(player, /avatar\?\.SetGait/);
     assert.match(player, /person\?\.SetGait/);
     assert.match(player, /wish\.normalized \* 12\.4f/);
     assert.match(mixamo, /animator\.enabled = grounded/);
     assert.match(life, /SetGait\([^;]+,\s*true\)/);
+    assert.match(life, /WorldClock\.NoteAct/);
+    assert.match(gear, /if \(!socket\) socket = body\.transform/);
+    assert.match(gear, /FromToRotation/);
+    assert.match(gate, /class CourtBird/);
+    assert.match(gate, /CreatePrimitive\(PrimitiveType\.Sphere\)/);
+    assert.match(gate, /CreatePrimitive\(PrimitiveType\.Cube\)/);
+    assert.match(builder, /Dove/);
+    assert.match(builder, /AddComponent<CourtBird>/);
+    assert.match(evo, /"wolf" or "hound" => "Fox"/);
+    assert.match(evo, /"griffin" => "Horse"/);
+    assert.match(evo, /CreatePrimitive\(KindPrim\(kind\)\)/);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this is

The hard critic addendum is correct: the simulation is alive in docs/server; the stage is mostly props. This PR still does **not** implement clips, grip, Living Birds, or NPC reactions. It **locks the work order** so the next Unity agent cannot hide behind megaworld / chronicle schema / affinity copy while weapons parent to the root and Hub air is Sphere+Cube doves.

Ticket: [`docs/CONCORDIA_PLAYABLE_SLICE.md`](docs/CONCORDIA_PLAYABLE_SLICE.md)

**Owner sentence:** Playable Alive Slice = one Humanoid + `ConcordiaLocomotion` (Idle/Walk/Run/Sprint/JumpStart/JumpLand/Dodge/LightAttack), root motion off, zero LateUpdate bone hinging, real palm grip (no root-parented weapons), Living Birds in Hub air (or cull), fauna real meshes or no spawn, one NPC reaction to sim truth proven in Capture, pack Hub, F8 HUD, one art contract.

## Diagnosis (three layers)

1. Kernel / docs — rich, honest, locked laws
2. Unity AI stubs — `NpcLife` / `FaunaLife` / `CourtBird` (mostly HUD strings)
3. Pixels — Rocketbox + primitives + ungeared hands + puppet gait

Alive means layer 3 expresses layer 1.

Verified on `concurrency-refactor`:
- `CharacterGear.Attach`: `if (!socket) socket = body.transform` — Kenney bind sets `leftHand = rightHand = body.transform`
- Hub: **24×** `Dove` + `CourtBird` Sphere body + Cube wings; Living Birds pack is unused (`FreePacks.Bird()` → `lb_sparrow` / `lb_robin` / `lb_cardinal`)
- `EvoSpawner.StemFor`: wolf→Fox, griffin→Horse, miss→`CreatePrimitive`; `FaunaLife` is a real brain on the wrong body
- Plaza NPCs: `NpcLife` hour schedule + `WorldClock.NoteAct` ticker; bodies do not flee, mourn, or leave

## Ban list (until GREEN)

**no new megaworld** / organism / chronicle schema / affinity copy / ConKay client features. No more `BipedHinge`. `concordia-sr2-streets.test.js` currently *ratifies* the puppet — that pin is retired when clips win.

## Ranked kill list

1. Humanoid + walk/run/idle clips, hero + NPCs (`ps-walk-cycle`, `ps-jump`, `ps-slash`, `ps-npc-pathing`)
2. Real hand grip; ban root-parented weapons (`ps-grip`). No hand bone → don’t spawn a weapon
3. Living Birds in Hub air, or cull (`ps-birds`). `CourtBird` primitives banned in Captures
4. Fauna meshes that match FaunaLife, or don’t spawn (`ps-fauna`)
5. One NPC reaction to sim truth — flee / shelter / mourn — proven in Capture (`ps-npc-react`)
6. Hub pack architecture + night lights + debug HUD off (`ps-hub-day` / `ps-hub-night` / `ps-no-debug`)

Rank 6 overlaps visual P0 [#975](https://github.com/ConcordDev/concord-cognitive-engine/pull/975). If that PR merges, verify those captures, then spend the slice on 1–5.

## Tests

`server/tests/concordia-playable-slice.test.js` — **3/3**. The honest-until-green case now also pins `socket = body.transform`, `CourtBird` Sphere+Cube, StemFor Fox/Horse, and `NpcLife` `NoteAct`. Implementing the slice **must invert that case**, not delete the ticket.

## Out of scope here

No AnimatorController asset, no grip IK, no Living Birds wiring, no captures. Those are the *execution* of this ticket, next PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aec3ca7e-e6cd-47ee-b356-868b740a0bfa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aec3ca7e-e6cd-47ee-b356-868b740a0bfa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

