### PR TITLE
Ship continent streaming and an honest creature compiler

### DIFF
--- a/apps/concordia-living-world/bible/CREATURES.md
+++ b/apps/concordia-living-world/bible/CREATURES.md
@@ -1,17 +1,23 @@
 # CREATURES
 
-**Status:** PARTIAL  
+**Status:** LIVE compiler · honest skip  
 **Authority:** Concord  
-**Source:** `Canon.fauna`; `EvoSpawner.cs`; `Hostile.cs`; `DungeonHold`; `src/game/creatures.ts`, `evo.ts`
+**Source:** `CreatureCompiler.cs`; `Canon.fauna`; `EvoSpawner.cs`; `FaunaLife`; `src/game/creatures.ts`
 
 ## LIVE
 
-Per-world fauna lists (wraith, sealie, wolf, drone, griffin, basilisk, …). Unity spawns + `FaunaLife` + `Hostile` on steel worlds. Dummy in Hub arena. Each steel world also builds one Kenney **hold** (`DungeonHold`) as mouth → hall → vault with a gatherable chest and a pack per room. City outskirts spawn 1–2 more packs from `WorldBook.Critters` / `Canon.fauna` — no invented names. Geometry is dressing; the hold plaque does not invent an authored dungeon name.
+`CreatureCompiler` is the only spawn path (`EvoSpawner.Spawn` / `SpawnNamed` / `WorldBuilder.SpawnFauna`). Genome card → topology → pack mesh → `FaunaLife`. Generation 0 is founding stock.
+
+Honest stem: wolf is not a Fox, griffin is not a Horse, harpy is not a Parrot. Missing mesh → **no spawn**. Hub air is Living Birds (`FreePacks.Bird` + `FlockOrbit`) or empty sky — not Sphere+Cube `CourtBird`.
+
+Dummy in Hub arena. Steel worlds still build one Kenney **hold**. City outskirts use `WorldBook.Critters` through the compiler. Geometry is dressing; the hold plaque does not invent an authored dungeon name.
+
+Kernel `PresentKernel` places a body only at a streamed presenter xz or beside a parent already in the scene. Far coords stay unplaced.
 
 ## TARGET
 
-Persistent populations, patrols, flying vs ground, evolution under selection. Authored dungeon names when the canon has them.
+Persistent populations, patrols, flying vs ground, evolution under selection. Authored dungeon names when the canon has them. Morphology extras from genome×field when real meshes exist — not cube wings.
 
 ## Gap
 
-Deaths persist as ids, not a full wild.ts graph. Hostile now perceives and strafes; it is still not a humanoid clip graph.
+Deaths persist as ids, not a full wild.ts graph. Hostile now perceives and strafes; it is still not a humanoid clip graph. Quota top-up still exists on the kernel fauna-spawner.

--- a/apps/concordia-living-world/bible/STREAMING.md
+++ b/apps/concordia-living-world/bible/STREAMING.md
@@ -1,8 +1,12 @@
 # STREAMING
 
-**Status:** MISSING  
+**Status:** LIVE (continent stream, 2026-09-12)  
 **Authority:** Unity presentation · Concord interest set  
 
-No ECS/DOTS, no world streaming. Hub ~1143 children. Two World roots until DestroyImmediate.
+W3: civilizations sit on one megaworld plane (`MegaworldMap` / `ContinentStream`). Walking does **not** rebuild the scene. Link gates remain the only teleport (`LastTravelKind = link_gate`). Far chunks unload past `StreamOutM`. Hub Court stays authored at the origin.
 
-TARGET: stream by interest (player, quest actors, faction events). Cognitive LOD (NPC_BRAIN.md) must match render LOD.
+Playable scale: 400 km civilization radius × 0.55 m/km ≈ 220 m on foot. Kernel field still speaks kilometres via `PresentToKm`.
+
+Cognitive LOD (`WorldClock.LodAt`) is unchanged. Render LOD follows streamed chunks: a missing pack is not a town.
+
+TARGET (not this pass): ECS/DOTS, heightmap continents, vehicles for the uncompressed 400 km.

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaGame.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ConcordiaGame.cs
@@ -39,7 +39,7 @@ namespace Concordia
             camGo.tag = "MainCamera";
             var cam = camGo.AddComponent<Camera>();
             cam.nearClipPlane = 0.18f;
-            cam.farClipPlane = 220f;
+            cam.farClipPlane = 420f;
             camGo.AddComponent<AudioListener>();
             var chase = camGo.AddComponent<ChaseCamera>();
 
@@ -137,6 +137,7 @@ namespace Concordia
         void Update()
         {
             if (!_player || CharacterCreator.IsOpen) return;
+            ContinentStream.Live?.Tick(_player.transform.position);
             if (_gates == null || Time.unscaledTime - _probeAt > 0.25f) RefreshProbe();
             var pos = _player.transform.position;
             string prompt = null;
@@ -410,30 +411,20 @@ namespace Concordia
         {
             var carried = _player != null ? _player.kitWeapon : null;
             var from = world;
-            WorldClock.Leave();
             var crossed = CrossRing.Walk(from, next, carried);
             HubObjectives.NoteTravel(world, next);
             world = next;
             _player.world = next;
-            var spawn = next == WorldId.Hub ? Canon.Spawn : new Vector3(0f, 0.12f, 2f);
-            _player.cc.enabled = false;
-            _player.transform.position = spawn;
-            _player.transform.rotation = Quaternion.Euler(0f, 180f, 0f);
-            _player.cc.enabled = true;
-            if (_player.cam) _player.cam.yaw = Mathf.PI;
-            _world.Build(next);
-            WorldClock.Enter(next);
+            ContinentStream.Live?.Teleport(_player, next);
             _gates = null;
             _cities = null;
             _holds = null;
             _boards = null;
             _loot = null;
             _cooks = null;
-            _player.EquipWorldKit();
-            Grounding.Snap(_player.cc);
             try { if (Camera.main) HubLook.Apply(Camera.main, next); } catch (Exception e) { Debug.LogException(e); }
             var w = Canon.Get(next);
-            var steel = Canon.SteelLive(next, spawn)
+            var steel = Canon.SteelLive(next, _player.transform.position)
                 ? "Live steel. Combat is allowed here."
                 : "Flower-law. Blades die as flowers except in the Arena.";
             ConcordiaHUD.Announce(w.title, string.IsNullOrEmpty(crossed) ? w.refusal : crossed);
@@ -450,7 +441,7 @@ namespace Concordia
         public string EnterCity(WorldBook.CityDef city)
         {
             if (city == null) return null;
-            var dest = new Vector3(city.x, 0.12f, city.z);
+            var dest = MegaworldMap.Present(world) + new Vector3(city.x, 0.12f, city.z);
             if (Vector3.Distance(_player.transform.position, dest) > 6f)
             {
                 _player.cc.enabled = false;

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ContinentStream.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ContinentStream.cs
@@ -1,0 +1,206 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Concordia
+{
+    /// <summary>
+    /// W3 continent streaming. Civilizations stay in one scene. Walking does
+    /// not call WorldBuilder.Build. Link gates remain the only teleport.
+    /// Far chunks unload. Empty stays empty — a missing pack is not a town.
+    /// </summary>
+    public class ContinentStream : MonoBehaviour
+    {
+        public const string TravelMode = "continent_stream";
+        public const float StreamInM = 95f;
+        public const float StreamOutM = 145f;
+        public const float ChunkRadiusM = 52f;
+
+        public static ContinentStream Live { get; private set; }
+        public static string LastTravelKind = "boot";
+
+        public Transform continent { get; private set; }
+        WorldBuilder _builder;
+        readonly Dictionary<WorldId, Transform> _chunks = new Dictionary<WorldId, Transform>();
+        Light _sun;
+
+        public static ContinentStream Bind(WorldBuilder builder)
+        {
+            if (!builder) return null;
+            var stream = builder.GetComponent<ContinentStream>() ?? builder.gameObject.AddComponent<ContinentStream>();
+            stream._builder = builder;
+            Live = stream;
+            return stream;
+        }
+
+        public void Boot(WorldId start)
+        {
+            Live = this;
+            LastTravelKind = "boot";
+            EnsureContinent();
+            Ensure(WorldId.Hub);
+            if (start != WorldId.Hub) Ensure(start);
+            ApplySky(start);
+        }
+
+        public bool IsLoaded(WorldId id) => _chunks.TryGetValue(id, out var t) && t;
+
+        public Transform ChunkOf(WorldId id) =>
+            _chunks.TryGetValue(id, out var t) && t ? t : null;
+
+        public bool InPresenter(Vector3 present)
+        {
+            foreach (var kv in _chunks)
+            {
+                if (!kv.Value) continue;
+                if ((present - MegaworldMap.Present(kv.Key)).sqrMagnitude <= ChunkRadiusM * ChunkRadiusM)
+                    return true;
+            }
+            return false;
+        }
+
+        public void Tick(Vector3 player)
+        {
+            foreach (var id in MegaworldMap.All)
+            {
+                var d = Vector3.Distance(player, MegaworldMap.Present(id));
+                if (d <= StreamInM) Ensure(id);
+                else if (d >= StreamOutM && id != WorldId.Hub) Release(id);
+            }
+            if (Vector3.Distance(player, Vector3.zero) >= StreamOutM)
+                Release(WorldId.Hub);
+
+            var near = MegaworldMap.Nearest(player);
+            var dist = Vector3.Distance(player, MegaworldMap.Present(near));
+            if (dist <= ChunkRadiusM + 8f && WorldClock.World != near && IsLoaded(near))
+                SoftEnter(near);
+        }
+
+        public void Teleport(ConcordiaPlayer player, WorldId next)
+        {
+            if (!player) return;
+            LastTravelKind = "link_gate";
+            Ensure(next);
+            var spawn = MegaworldMap.Present(next);
+            if (next == WorldId.Hub) spawn = Canon.Spawn;
+            else spawn += new Vector3(0f, 0.12f, 2f);
+            player.cc.enabled = false;
+            player.transform.position = spawn;
+            player.transform.rotation = Quaternion.Euler(0f, 180f, 0f);
+            player.cc.enabled = true;
+            if (player.cam) player.cam.yaw = Mathf.PI;
+            Grounding.Snap(player.cc);
+            SoftEnter(next);
+            player.world = next;
+            player.EquipWorldKit();
+        }
+
+        public Transform Ensure(WorldId id)
+        {
+            if (_chunks.TryGetValue(id, out var existing) && existing)
+                return existing;
+            EnsureContinent();
+            var chunk = _builder.BuildChunk(id, continent);
+            if (!chunk) return null;
+            chunk.position = MegaworldMap.Present(id);
+            _chunks[id] = chunk;
+            return chunk;
+        }
+
+        void Release(WorldId id)
+        {
+            if (!_chunks.TryGetValue(id, out var chunk) || !chunk) return;
+            Object.Destroy(chunk.gameObject);
+            _chunks.Remove(id);
+        }
+
+        void SoftEnter(WorldId id)
+        {
+            if (WorldClock.World == id) return;
+            LastTravelKind = LastTravelKind == "link_gate" ? "link_gate" : "walk";
+            WorldClock.Leave();
+            WorldClock.Enter(id);
+            ApplySky(id);
+            ModularPerson.CastingWorld = id;
+            if (LastTravelKind != "link_gate")
+            {
+                var w = Canon.Get(id);
+                ConcordiaHUD.Announce(w.title, w.refusal);
+            }
+        }
+
+        void EnsureContinent()
+        {
+            if (continent) return;
+            var go = GameObject.Find("Megaworld");
+            continent = go ? go.transform : new GameObject("Megaworld").transform;
+            continent.position = Vector3.zero;
+            MakeGround();
+            MakeRoads();
+            MakeSun();
+        }
+
+        void MakeGround()
+        {
+            if (continent.Find("ContinentGround")) return;
+            var g = GameObject.CreatePrimitive(PrimitiveType.Plane);
+            g.name = "ContinentGround";
+            g.transform.SetParent(continent, false);
+            g.transform.localScale = Vector3.one * 62f;
+            var mat = HubLook.Pbr("packed_earth", new Color(0.42f, 0.38f, 0.32f), 0.05f, 0.22f, 28f);
+            var r = g.GetComponent<Renderer>();
+            if (r && mat) r.sharedMaterial = mat;
+        }
+
+        void MakeRoads()
+        {
+            if (continent.Find("ContinentRoads")) return;
+            var hold = new GameObject("ContinentRoads").transform;
+            hold.SetParent(continent, false);
+            foreach (var g in Canon.Gates)
+            {
+                var dest = MegaworldMap.Present(g.world);
+                var from = dest.normalized * (Canon.RingRadius + 2f);
+                var mid = (from + dest) * 0.5f;
+                var len = Vector3.Distance(from, dest);
+                if (len < 4f) continue;
+                var road = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                road.name = "Road_" + g.shortName;
+                road.transform.SetParent(hold, false);
+                road.transform.position = mid + Vector3.up * 0.03f;
+                road.transform.rotation = Quaternion.LookRotation(dest - from, Vector3.up);
+                road.transform.localScale = new Vector3(3.2f, 0.06f, len);
+                var mat = HubLook.Pbr("packed_earth", g.color * 0.35f, 0.08f, 0.18f, 8f);
+                var rr = road.GetComponent<Renderer>();
+                if (rr && mat) rr.sharedMaterial = mat;
+            }
+        }
+
+        void MakeSun()
+        {
+            if (_sun) return;
+            var go = new GameObject("ContinentSun");
+            go.transform.SetParent(continent, false);
+            go.transform.rotation = Quaternion.Euler(42f, -38f, 0f);
+            _sun = go.AddComponent<Light>();
+            _sun.type = LightType.Directional;
+            _sun.color = new Color(1f, 0.94f, 0.82f);
+            _sun.intensity = 1.18f;
+            _sun.shadows = LightShadows.Soft;
+        }
+
+        void ApplySky(WorldId id)
+        {
+            _builder.DressChunkSky(id);
+            if (_sun)
+            {
+                var w = Canon.Get(id);
+                _sun.color = Color.Lerp(new Color(1f, 0.94f, 0.82f), w.sun, 0.45f);
+            }
+        }
+
+        void OnDisable()
+        {
+            if (Live == this) Live = null;
+        }
+    }
+}

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ContinentStream.cs.meta
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/ContinentStream.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1a8f2c4e6b0d48c3a7e9f1d5b3c8a062

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/CreatureCompiler.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/CreatureCompiler.cs
@@ -1,0 +1,355 @@
+using UnityEngine;
+
+namespace Concordia
+{
+    /// <summary>
+    /// Detached genome card. Generation 0 = founding stock, not a fabricated lineage.
+    /// </summary>
+    public class CreatureCard
+    {
+        public string id, speciesId, topology, parentA, parentB;
+        public string dominant, variant, affinity, gaitKind, lifestyle;
+        public float massKg = -1f, heightM = -1f, walkMps = -1f, stability = -1f, x, z;
+        public int generation;
+        public bool predator, fly, hasXz;
+    }
+
+    /// <summary>
+    /// Persistent genome on a compiled creature.
+    /// </summary>
+    public class CreatureGenome : MonoBehaviour
+    {
+        public string id;
+        public string speciesId;
+        public string topology;
+        public float massKg = -1f;
+        public float heightM = -1f;
+        public int generation;
+        public string parentA;
+        public string parentB;
+        public string dominant;
+        public string variant;
+        public string affinity;
+        public string gaitKind;
+        public float walkMps = -1f;
+        public string lifestyle;
+        public bool predator;
+        public bool fly;
+        public float stability = -1f;
+
+        public string Label
+        {
+            get
+            {
+                var name = string.IsNullOrEmpty(speciesId) ? "creature" : speciesId;
+                if (generation > 0) name += " · gen " + generation;
+                if (!string.IsNullOrEmpty(variant)) name += " · " + variant;
+                else if (!string.IsNullOrEmpty(dominant)) name += " · " + dominant;
+                return name;
+            }
+        }
+
+        public void Bind(CreatureCard card)
+        {
+            if (card == null) return;
+            id = card.id;
+            speciesId = card.speciesId;
+            topology = card.topology;
+            massKg = card.massKg;
+            heightM = card.heightM;
+            generation = card.generation;
+            parentA = card.parentA;
+            parentB = card.parentB;
+            dominant = card.dominant;
+            variant = card.variant;
+            affinity = card.affinity;
+            gaitKind = card.gaitKind;
+            walkMps = card.walkMps;
+            lifestyle = card.lifestyle;
+            predator = card.predator;
+            fly = card.fly || Winged(topology);
+            if (string.IsNullOrEmpty(gaitKind) && Winged(topology)) gaitKind = "winged";
+            stability = card.stability;
+        }
+
+        public static bool Winged(string topology) =>
+            !string.IsNullOrEmpty(topology) && topology.StartsWith("winged", System.StringComparison.OrdinalIgnoreCase);
+
+        public static CreatureGenome Find(string creatureId)
+        {
+            if (string.IsNullOrEmpty(creatureId)) return null;
+            foreach (var g in Object.FindObjectsByType<CreatureGenome>(FindObjectsInactive.Exclude))
+            {
+                if (!g) continue;
+                if (g.id == creatureId) return g;
+            }
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// genome → phenotype → Unity body.
+    /// Real pack mesh or no spawn. Wolf is not a Fox. Griffin is not a Horse.
+    /// Missing stem returns null — better empty habitat than a Kenney balloon.
+    /// </summary>
+    public static class CreatureCompiler
+    {
+        public static GameObject Compile(Transform parent, CreatureCard card, Vector3 pos, WorldDef world)
+        {
+            if (card == null || string.IsNullOrEmpty(card.id)) return null;
+            var key = "Evo_" + card.id;
+            Normalize(card);
+            var existing = GameObject.Find(key);
+            if (existing)
+            {
+                var g = existing.GetComponent<CreatureGenome>();
+                if (g) g.Bind(card);
+                var life = existing.GetComponent<FaunaLife>();
+                if (life && g) life.BindGenome(g);
+                return existing;
+            }
+
+            var stem = StemFor(card.topology, card.speciesId);
+            if (string.IsNullOrEmpty(stem)) return null;
+
+            var height = card.heightM > 0.05f ? card.heightM : HeightFor(card.topology, card.speciesId);
+            var go = FreePacks.Spawn(stem, parent, pos, Random.Range(0, 360f), ScaleHint(card.topology, height), required: false);
+            if (!go) return null;
+            go.name = key;
+
+            var genome = go.GetComponent<CreatureGenome>() ?? go.AddComponent<CreatureGenome>();
+            genome.Bind(card);
+
+            FreePacks.EnsureCollider(go, Mathf.Max(1.1f, height * 0.7f));
+            if (!go.GetComponent<CharacterController>())
+                Grounding.EnsureController(go, Mathf.Max(1.2f, height * 0.85f));
+
+            var dummy = go.GetComponent<TrainingDummy>() ?? go.AddComponent<TrainingDummy>();
+            dummy.living = true;
+            dummy.hp = card.massKg > 0f ? Mathf.Clamp(card.massKg * 0.9f, 24f, 180f) : 70f;
+            dummy.unburied = world != null && (world.id == WorldId.Ruins || world.id == WorldId.Crucible);
+
+            if (card.predator && !go.GetComponent<Hostile>()) go.AddComponent<Hostile>();
+            var fauna = go.GetComponent<FaunaLife>() ?? go.AddComponent<FaunaLife>();
+            fauna.BindGenome(genome);
+
+            var spin = go.GetComponent<EvoDrift>();
+            if (spin) spin.enabled = false;
+            return go;
+        }
+
+        public static GameObject FromCritter(Transform parent, WorldBook.Critter c, Vector3 pos, WorldDef world)
+        {
+            if (c == null) return null;
+            var id = string.IsNullOrEmpty(c.id) ? c.name : c.id;
+            if (string.IsNullOrEmpty(id)) return null;
+            var topology = TopologyFor(c.topology_hint, id);
+            return Compile(parent, new CreatureCard
+            {
+                id = id,
+                speciesId = id,
+                topology = topology,
+                generation = 0,
+                fly = CreatureGenome.Winged(topology),
+                predator = PredatorHint((c.topology_hint ?? "") + " " + id),
+                lifestyle = PredatorHint((c.topology_hint ?? "") + " " + id) ? "carnivore" : "omnivore",
+            }, pos, world);
+        }
+
+        public static GameObject FromKind(Transform parent, string kind, Vector3 pos, WorldDef world)
+        {
+            if (string.IsNullOrEmpty(kind)) return null;
+            return Compile(parent, new CreatureCard
+            {
+                id = kind,
+                speciesId = kind,
+                topology = TopologyFor(kind),
+                generation = 0,
+                fly = IsFlyKind(kind),
+                predator = IsPredatorKind(kind),
+                lifestyle = IsPredatorKind(kind) ? "carnivore" : "omnivore",
+            }, pos, world);
+        }
+
+        public static GameObject PresentKernel(Transform parent, CreatureCard card, WorldDef world)
+        {
+            if (card == null || string.IsNullOrEmpty(card.id)) return null;
+            Vector3 p;
+            var hostA = CreatureGenome.Find(card.parentA);
+            var hostB = CreatureGenome.Find(card.parentB);
+            if (card.hasXz && WorldPresence.InPresenter(card.x, card.z))
+                p = new Vector3(card.x, 0f, card.z);
+            else if (hostA)
+                p = hostA.transform.position + hostA.transform.right * 1.4f;
+            else if (hostB)
+                p = hostB.transform.position + hostB.transform.right * -1.4f;
+            else
+                return null;
+            return Compile(parent, card, p, world);
+        }
+
+        static void Normalize(CreatureCard card)
+        {
+            if (card == null) return;
+            var topology = TopologyFor(card.topology, card.speciesId);
+            card.topology = topology;
+            card.fly = card.fly || CreatureGenome.Winged(topology);
+            if (string.IsNullOrEmpty(card.gaitKind)) card.gaitKind = GaitFor(topology);
+            if (string.IsNullOrEmpty(card.lifestyle))
+                card.lifestyle = card.predator ? "carnivore" : "omnivore";
+            card.predator = card.predator || card.lifestyle == "carnivore";
+        }
+
+        public static string TopologyFor(string hint, string species = null)
+        {
+            var h = (hint ?? "").Trim().ToLowerInvariant();
+            if (h == "winged_quadruped" || h == "winged_biped" || h == "serpentine" || h == "humanoid"
+                || h == "quadruped" || h == "amorphous" || h == "polyped" || h == "eel")
+                return h;
+            var s = (h + " " + (species ?? "")).ToLowerInvariant();
+            if (s.Contains("wing") || s.Contains("hawk") || s.Contains("harpy") || s.Contains("griffin")
+                || s.Contains("drake") || s.Contains("dragon") || s.Contains("wyvern")
+                || s.Contains("falcon") || s.Contains("owl") || s.Contains("pigeon") || s.Contains("finch")
+                || s.Contains("sparrow") || s.Contains("robin") || s.Contains("cardinal"))
+                return s.Contains("quad") || s.Contains("griffin") || s.Contains("drake") || s.Contains("dragon")
+                    ? "winged_quadruped" : "winged_biped";
+            if (s.Contains("serpent") || s.Contains("snake") || s.Contains("viper") || s.Contains("basilisk") || s.Contains("wyrm"))
+                return "serpentine";
+            if (s.Contains("drone") || s.Contains("mech") || s.Contains("construct") || s.Contains("sentinel"))
+                return "humanoid";
+            if (s.Contains("wraith") || s.Contains("drift") || s.Contains("sprite") || s.Contains("ghost")
+                || s.Contains("amorphous") || s.Contains("shade") || s.Contains("shadow"))
+                return "amorphous";
+            if (s.Contains("spider") || s.Contains("scorpion") || s.Contains("crab") || s.Contains("polyp"))
+                return "polyped";
+            if (s.Contains("human")) return "humanoid";
+            if (s.Contains("quad")) return "quadruped";
+            return "quadruped";
+        }
+
+        /// <summary>
+        /// Honest stem. Empty string means do not spawn.
+        /// Never maps wolf→Fox, griffin→Horse, harpy→Parrot.
+        /// </summary>
+        public static string StemFor(string topology, string species)
+        {
+            var s = ((species ?? "") + " " + (topology ?? "")).ToLowerInvariant();
+            if (s.Contains("drone") || s.Contains("sentinel"))
+                return Pick(new[] { "enemy-ufo-a" });
+            if (s.Contains("wraith") || s.Contains("ghost"))
+                return Pick(new[] { "character-ghost" });
+            if (s.Contains("construct"))
+                return Pick(new[] { "astronautA" });
+            if (topology == "amorphous" || s.Contains("drift"))
+                return Pick(new[] { "alien" });
+            if (topology == "serpentine" || s.Contains("basilisk") || s.Contains("snake") || s.Contains("wyrm"))
+                return Pick(new[] { "quadruped_01", "snake", "serpent" });
+            if (topology == "winged_biped" || s.Contains("harpy") || s.Contains("sparrow")
+                || s.Contains("robin") || s.Contains("cardinal") || s.Contains("finch"))
+                return PickBird();
+            if (topology == "winged_quadruped" || s.Contains("griffin") || s.Contains("drake") || s.Contains("dragon"))
+                return Pick(new[] { "griffin", "wyvern", "dragon" });
+            if (s.Contains("wolf") || s.Contains("hound") || s.Contains("dog"))
+                return Pick(new[] { "Wolf", "wolf", "Husky", "Dog", "dog" });
+            if (s.Contains("sealie"))
+                return Pick(new[] { "Flamingo", "seal", "sealie" });
+            if (s.Contains("horse"))
+                return Pick(new[] { "Horse", "horse" });
+            if (s.Contains("fox"))
+                return Pick(new[] { "Fox", "fox" });
+            if (s.Contains("rabbit"))
+                return Pick(new[] { "rabbit", "Rabbit", "hare" });
+            if (!string.IsNullOrEmpty(species))
+            {
+                var self = Pick(new[] { species, species.ToLowerInvariant() });
+                if (!string.IsNullOrEmpty(self)) return self;
+            }
+            return "";
+        }
+
+        static string Pick(string[] prefer)
+        {
+            if (prefer != null)
+            {
+                foreach (var n in prefer)
+                    if (!string.IsNullOrEmpty(n) && FreePacks.HasStem(n)) return n;
+            }
+            return DressVocab.FirstStem(prefer, "");
+        }
+
+        static string PickBird()
+        {
+            var bird = FreePacks.Bird();
+            if (!string.IsNullOrEmpty(bird)) return bird;
+            return Pick(new[] { "lb_sparrow", "lb_robin", "lb_cardinal" });
+        }
+
+        static string GaitFor(string topology)
+        {
+            if (string.IsNullOrEmpty(topology)) return "quadruped";
+            if (topology.StartsWith("winged")) return "winged";
+            if (topology == "humanoid") return "biped";
+            return topology;
+        }
+
+        static float HeightFor(string topology, string species)
+        {
+            var s = ((topology ?? "") + " " + (species ?? "")).ToLowerInvariant();
+            if (s.Contains("bear") || s.Contains("griffin") || s.Contains("wyrm")) return 2.2f;
+            if (s.Contains("hawk") || s.Contains("rabbit") || s.Contains("finch") || s.Contains("rat")) return 0.55f;
+            if (s.Contains("drone") || s.Contains("sentinel")) return 0.7f;
+            return 1.15f;
+        }
+
+        static float ScaleHint(string topology, float height)
+        {
+            var h = height > 0.05f ? height : 1.15f;
+            if (topology != null && topology.StartsWith("winged")) return Mathf.Clamp(h * 1.4f, 1.1f, 2.8f);
+            return Mathf.Clamp(h, 0.7f, 2.4f);
+        }
+
+        static bool PredatorHint(string s)
+        {
+            s = (s ?? "").ToLowerInvariant();
+            return s.Contains("wolf") || s.Contains("drake") || s.Contains("griffin")
+                || s.Contains("basilisk") || s.Contains("hound");
+        }
+
+        static bool IsFlyKind(string kind) =>
+            kind is "griffin" or "harpy" or "drone" or "sentinel" or "drift" or "wraith";
+
+        static bool IsPredatorKind(string kind) =>
+            kind is "wolf" or "hound" or "griffin" or "basilisk" or "wraith" or "drone" or "sentinel";
+    }
+
+    /// <summary>
+    /// Moves a real Living Birds mesh on a sine orbit. Not a Sphere+Cube dove.
+    /// </summary>
+    public class FlockOrbit : MonoBehaviour
+    {
+        public float radius = 12f;
+        public float height = 8f;
+        float _phase, _speed, _bob;
+        Vector3 _origin;
+
+        void Start()
+        {
+            _origin = transform.position;
+            _phase = Random.Range(0f, Mathf.PI * 2f);
+            _speed = 0.35f + Random.value * 0.45f;
+            _bob = 0.4f + Random.value * 0.6f;
+            if (radius <= 0f) radius = 10f + Random.value * 12f;
+            if (height <= 0f) height = 6f + Random.value * 5f;
+        }
+
+        void Update()
+        {
+            _phase += Time.deltaTime * _speed;
+            var p = _origin + new Vector3(Mathf.Cos(_phase) * radius, height + Mathf.Sin(_phase * 2.4f) * _bob, Mathf.Sin(_phase) * radius);
+            var tan = new Vector3(-Mathf.Sin(_phase), 0f, Mathf.Cos(_phase));
+            transform.position = p;
+            if (tan.sqrMagnitude > 0.01f)
+                transform.rotation = Quaternion.Slerp(transform.rotation, Quaternion.LookRotation(tan, Vector3.up), Time.deltaTime * 4f);
+        }
+    }
+}

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/CreatureCompiler.cs.meta
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/CreatureCompiler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4b6c8e0a2d154f79b1c3e5a7d9f08124

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/EvoSpawner.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/EvoSpawner.cs
@@ -13,118 +13,15 @@ namespace Concordia
             if (c == null) return null;
             if (WorldMemory.IsDead(world.id, c.id) || WorldMemory.IsDead(world.id, c.name))
                 return null;
-            var hint = (c.topology_hint ?? "").ToLowerInvariant();
-            string kind =
-                hint.Contains("quad") ? "wolf" :
-                hint.Contains("wing") ? "harpy" :
-                hint.Contains("serpent") ? "basilisk" :
-                hint.Contains("drone") || hint.Contains("mech") ? "drone" :
-                hint.Contains("human") ? "wraith" :
-                "hound";
-            var go = Spawn(parent, kind, pos, world);
-            if (go)
-            {
-                go.name = string.IsNullOrEmpty(c.name) ? c.id : c.name;
-                var dummy = go.GetComponent<TrainingDummy>();
-                if (dummy) dummy.unburied = world.id == WorldId.Ruins || world.id == WorldId.Crucible;
-                var life = go.GetComponent<FaunaLife>();
-                if (life)
-                {
-                    life.critterId = string.IsNullOrEmpty(c.id) ? c.name : c.id;
-                    life.predator = IsPredator(kind);
-                }
-            }
-            return go;
+            return CreatureCompiler.FromCritter(parent, c, pos, world);
         }
 
         public static GameObject Spawn(Transform parent, string kind, Vector3 pos, WorldDef world)
         {
             if (WorldMemory.IsDead(world.id, kind) && WorldClock.Ecology < 0.45f)
                 return null;
-            var stem = StemFor(kind);
-            GameObject go = null;
-            if (!string.IsNullOrEmpty(stem))
-                go = FreePacks.Spawn(stem, parent, pos, Random.Range(0, 360f), ScaleHint(kind));
-            if (go == null)
-            {
-                go = GameObject.CreatePrimitive(KindPrim(kind));
-                go.name = "Evo_" + kind;
-                go.transform.SetParent(parent, false);
-                var fly = IsFly(kind);
-                go.transform.position = pos + Vector3.up * (fly ? 2.4f : 0.6f);
-                go.transform.localScale = ScaleFor(kind);
-                var r = go.GetComponent<Renderer>();
-                r.material = new Material(r.sharedMaterial) { color = ColorFor(kind, world) };
-            }
-            go.name = "Evo_" + kind;
-            FreePacks.EnsureCollider(go, 1.2f);
-            if (!go.GetComponent<CharacterController>())
-                Grounding.EnsureController(go, 1.4f);
-            var dummy = go.GetComponent<TrainingDummy>() ?? go.AddComponent<TrainingDummy>();
-            dummy.unburied = world.id == WorldId.Ruins || world.id == WorldId.Crucible;
-            dummy.hp = 70;
-            dummy.living = true;
-            if (!go.GetComponent<Hostile>()) go.AddComponent<Hostile>();
-            var life = go.GetComponent<FaunaLife>() ?? go.AddComponent<FaunaLife>();
-            life.fly = IsFly(kind);
-            life.predator = IsPredator(kind);
-            life.critterId = kind;
-            var spin = go.GetComponent<EvoDrift>();
-            if (spin) spin.enabled = false;
-            return go;
+            return CreatureCompiler.FromKind(parent, kind, pos, world);
         }
-
-        static bool IsFly(string kind) =>
-            kind is "griffin" or "harpy" or "drone" or "sentinel" or "drift" or "wraith";
-
-        static bool IsPredator(string kind) =>
-            kind is "wolf" or "hound" or "griffin" or "basilisk" or "wraith" or "drone" or "sentinel";
-
-        static string StemFor(string k) => k switch
-        {
-            "wolf" or "hound" => "Fox",
-            "sealie" => "Flamingo",
-            "griffin" => "Horse",
-            "harpy" => "Parrot",
-            "wraith" => "character-ghost",
-            "drone" or "sentinel" => "enemy-ufo-a",
-            "construct" => "astronautA",
-            "basilisk" => "quadruped_01",
-            "drift" => "alien",
-            _ => "Fox"
-        };
-
-        static float ScaleHint(string k) => k switch
-        {
-            "griffin" => 2.6f,
-            "drone" or "sentinel" => 1.5f,
-            "wraith" => 1.85f,
-            "wolf" or "hound" => 1.15f,
-            "sealie" => 1.4f,
-            "harpy" => 1.1f,
-            _ => 1.25f
-        };
-
-        static PrimitiveType KindPrim(string k) =>
-            k is "drone" or "construct" or "golem" ? PrimitiveType.Cube :
-            k is "serpent" or "wyrm" or "basilisk" ? PrimitiveType.Capsule :
-            PrimitiveType.Sphere;
-
-        static Vector3 ScaleFor(string k) => k switch
-        {
-            "griffin" or "dragon" or "wyrm" => new Vector3(1.6f, 0.7f, 1.8f),
-            "wolf" or "hound" or "sealie" => new Vector3(0.9f, 0.55f, 1.3f),
-            "drone" => new Vector3(0.5f, 0.2f, 0.7f),
-            _ => Vector3.one * 0.8f
-        };
-
-        static Color ColorFor(string k, WorldDef w) => k switch
-        {
-            "wraith" => new Color(0.7f, 0.85f, 0.9f, 0.7f),
-            "drone" => w.sun,
-            "sealie" => new Color(0.4f, 0.7f, 0.85f),
-            _ => Color.Lerp(w.ground, w.sun, 0.4f)
-        };
     }
 
     /// <summary>Legacy sine orbit. Disabled on the live spawn path — FaunaLife owns motion.</summary>
@@ -160,6 +57,15 @@ namespace Concordia
         Vector3 _vel;
         Renderer[] _rend;
         bool _hidden;
+
+        public void BindGenome(CreatureGenome g)
+        {
+            if (!g) return;
+            fly = g.fly;
+            predator = g.predator;
+            if (!string.IsNullOrEmpty(g.speciesId)) critterId = g.speciesId;
+            else if (!string.IsNullOrEmpty(g.id)) critterId = g.id;
+        }
 
         void Start()
         {

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/MegaworldMap.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/MegaworldMap.cs
@@ -1,0 +1,70 @@
+using UnityEngine;
+
+namespace Concordia
+{
+    /// <summary>
+    /// One plane. Hub at the origin. Gated civilizations sit on the Canon
+    /// ring at MEGAWORLD_KM.civilizationRadius. Sere is off-ring, no Link.
+    /// Present metres are a walkable compression of those kilometres so the
+    /// player can actually reach the next civilization on foot.
+    /// Angles are copied from Canon.Gates — keep them in lockstep.
+    /// </summary>
+    public static class MegaworldMap
+    {
+        public const float CivilizationRadiusKm = 400f;
+        public const float PresentMetersPerKm = 0.55f;
+        public const float HubCourtKm = 12f;
+        public const float HubMetroKm = 40f;
+
+        public static readonly WorldId[] All =
+        {
+            WorldId.Hub, WorldId.Cyber, WorldId.Ruins, WorldId.Fantasy, WorldId.Tunya,
+            WorldId.Frontier, WorldId.Crime, WorldId.Superhero, WorldId.Crucible, WorldId.Sere
+        };
+
+        public static float RingMeters => CivilizationRadiusKm * PresentMetersPerKm;
+
+        public static float AngleOf(WorldId id)
+        {
+            if (id == WorldId.Sere) return FieldAngle(WorldId.Crime) + 0.35f;
+            foreach (var g in Canon.Gates)
+                if (g.world == id) return g.angle;
+            return 0f;
+        }
+
+        public static bool HasLinkGate(WorldId id) => id != WorldId.Sere;
+
+        public static Vector3 Present(WorldId id)
+        {
+            if (id == WorldId.Hub) return Vector3.zero;
+            var r = id == WorldId.Sere ? RingMeters * 1.35f : RingMeters;
+            var a = AngleOf(id);
+            return new Vector3(Mathf.Cos(a) * r, 0f, Mathf.Sin(a) * r);
+        }
+
+        public static Vector3 KmToPresent(float xKm, float zKm) =>
+            new Vector3(xKm * PresentMetersPerKm, 0f, zKm * PresentMetersPerKm);
+
+        public static Vector2 PresentToKm(Vector3 p) =>
+            new Vector2(p.x / PresentMetersPerKm, p.z / PresentMetersPerKm);
+
+        public static WorldId Nearest(Vector3 present)
+        {
+            var best = WorldId.Hub;
+            var bestD = float.PositiveInfinity;
+            foreach (var id in All)
+            {
+                var d = (present - Present(id)).sqrMagnitude;
+                if (d < bestD) { bestD = d; best = id; }
+            }
+            return best;
+        }
+
+        static float FieldAngle(WorldId id)
+        {
+            foreach (var g in Canon.Gates)
+                if (g.world == id) return g.angle;
+            return 0f;
+        }
+    }
+}

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/MegaworldMap.cs.meta
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/MegaworldMap.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7c3a1e90b24d4f6a9c2e5d8f1a4b7c0e

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldBuilder.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldBuilder.cs
@@ -33,49 +33,77 @@ namespace Concordia
         public void Build(WorldId world)
         {
             PurgeWorldRoots();
+            PurgeNamed("Megaworld");
             CityAtlas.Invalidate();
-            root = new GameObject("World").transform;
-            ModularPerson.CastingWorld = world;
             FreePacks.Reindex();
-            var w = Canon.Get(world);
-            BuildGround(w);
-            DressSky(w);
-            DressAudio(w);
-            if (world == WorldId.Hub) BuildHub();
-            else BuildRealm(w);
-            SpawnFauna(w);
+            var stream = ContinentStream.Bind(this);
+            stream.Boot(world);
             HubLook.UpgradeStandardMaterials();
             try
             {
                 System.IO.File.WriteAllText("/tmp/concordia-atlas.txt",
-                    System.DateTime.Now.ToString("o") + " world=" + world + "\n" + CityAtlas.Dump());
+                    System.DateTime.Now.ToString("o") + " world=" + world
+                    + " travel=" + ContinentStream.TravelMode + "\n" + CityAtlas.Dump());
             }
             catch { }
         }
 
+        /// <summary>
+        /// Build one civilization at local origin. ContinentStream then parks
+        /// the chunk at MegaworldMap.Present(id). Do not purge other chunks.
+        /// </summary>
+        public Transform BuildChunk(WorldId world, Transform continent)
+        {
+            ModularPerson.CastingWorld = world;
+            var holder = new GameObject("Chunk_" + world).transform;
+            holder.SetParent(continent, false);
+            holder.position = Vector3.zero;
+            root = holder;
+            var w = Canon.Get(world);
+            if (world == WorldId.Hub) BuildHub();
+            else
+            {
+                BuildGround(w);
+                DressAudio(w);
+                BuildRealm(w);
+            }
+            SpawnFauna(w);
+            return holder;
+        }
+
+        public void DressChunkSky(WorldId id)
+        {
+            var prev = root;
+            var chunk = ContinentStream.Live ? ContinentStream.Live.ChunkOf(id) : null;
+            if (chunk) root = chunk;
+            DressSky(Canon.Get(id));
+            if (prev) root = prev;
+        }
+
         static void PurgeWorldRoots()
+        {
+            PurgeNamed("World");
+        }
+
+        static void PurgeNamed(string name)
         {
             var found = Object.FindObjectsByType<Transform>(FindObjectsInactive.Include, FindObjectsSortMode.None);
             for (int i = 0; i < found.Length; i++)
             {
                 var t = found[i];
                 if (!t || t.parent != null) continue;
-                if (t.name != "World") continue;
+                if (t.name != name) continue;
                 Object.DestroyImmediate(t.gameObject);
             }
         }
 
         void BuildGround(WorldDef w)
         {
-            if (w.id == WorldId.Hub)
-            {
-                HubLook.MakeSun(root, new Color(1f, 0.94f, 0.82f), 1.18f, new Vector3(42f, -38f, 0f));
-                return;
-            }
+            if (w.id == WorldId.Hub) return;
             var g = GameObject.CreatePrimitive(PrimitiveType.Plane);
             g.name = "Ground";
             g.transform.SetParent(root, false);
-            g.transform.localScale = Vector3.one * 22;
+            g.transform.localScale = Vector3.one * 6;
             var pbrStem = w.id switch
             {
                 WorldId.Ruins => "ash_soil",
@@ -92,21 +120,6 @@ namespace Concordia
             var pbr = HubLook.Pbr(pbrStem, w.ground, 0.04f, 0.16f, 18f);
             var gr0 = g.GetComponent<Renderer>();
             if (gr0) gr0.sharedMaterial = pbr;
-
-            var sun = w.id switch
-            {
-                WorldId.Hub => (new Color(1f, 0.84f, 0.58f), 2.05f, new Vector3(18f, 204f, 0f)),
-                WorldId.Ruins => (new Color(0.72f, 0.68f, 0.62f), 0.72f, new Vector3(48f, 40f, 0f)),
-                WorldId.Tunya => (new Color(1f, 0.94f, 0.72f), 1.45f, new Vector3(58f, 30f, 0f)),
-                WorldId.Fantasy => (new Color(1f, 0.55f, 0.28f), 1.55f, new Vector3(8f, 168f, 0f)),
-                WorldId.Crime => (new Color(0.55f, 0.42f, 0.62f), 0.42f, new Vector3(12f, 130f, 0f)),
-                WorldId.Cyber => (new Color(0.55f, 0.18f, 0.85f), 0.85f, new Vector3(22f, 210f, 0f)),
-                WorldId.Frontier => (new Color(1f, 0.88f, 0.55f), 1.85f, new Vector3(38f, 24f, 0f)),
-                WorldId.Superhero => (new Color(1f, 0.62f, 0.38f), 1.7f, new Vector3(6f, 92f, 0f)),
-                WorldId.Sere => (new Color(0.82f, 0.62f, 0.38f), 0.55f, new Vector3(18f, 140f, 0f)),
-                _ => (new Color(0.25f, 1f, 0.85f), 1.2f, new Vector3(28f, 80f, 0f))
-            };
-            HubLook.MakeSun(root, sun.Item1, sun.Item2, sun.Item3);
         }
 
         void DressSky(WorldDef w)
@@ -694,44 +707,58 @@ namespace Concordia
 
         void SpawnFauna(WorldDef w)
         {
-            if (w.id != WorldId.Hub)
+            if (w.id == WorldId.Hub)
             {
-                if (w.fauna == null) return;
-                for (int i = 0; i < Mathf.Min(6, w.fauna.Length * 2); i++)
+                var bird = FreePacks.Bird();
+                if (string.IsNullOrEmpty(bird)) return;
+                for (int i = 0; i < 8; i++)
                 {
-                    var a = i / 6f * Mathf.PI * 2f;
-                    var p = new Vector3(Mathf.Cos(a) * 18f, 0f, Mathf.Sin(a) * 18f);
-                    var stem = i % 2 == 0 ? "rabbit" : "dog";
-                    if (!FreePacks.Spawn(stem, root, p, a * Mathf.Rad2Deg, 1.2f))
+                    var go = CreatureCompiler.Compile(root, new CreatureCard
                     {
-                        var go = HubLook.Prim(root, PrimitiveType.Sphere, p + Vector3.up * 0.35f, Vector3.one * 0.45f,
-                            HubLook.Lit(new Color(0.45f, 0.35f, 0.25f)), "Beast" + i);
-                        go.AddComponent<CourtBird>().height = 0.4f;
-                    }
+                        id = "hub-flock-" + i,
+                        speciesId = bird,
+                        topology = "winged_biped",
+                        generation = 0,
+                        fly = true,
+                        lifestyle = "omnivore",
+                    }, Vector3.zero, w);
+                    if (!go) break;
+                    var orbit = go.GetComponent<FlockOrbit>() ?? go.AddComponent<FlockOrbit>();
+                    orbit.radius = 10f + (i % 5) * 3.2f;
+                    orbit.height = 6.5f + (i % 4) * 1.4f;
                 }
-                DressGroveBirds(w);
                 return;
             }
-            for (int i = 0; i < 24; i++)
+            if (w.fauna == null) return;
+            int n = 0;
+            for (int i = 0; i < w.fauna.Length && n < 6; i++)
             {
-                var go = new GameObject("Dove" + i);
-                go.transform.SetParent(root, false);
-                var bird = go.AddComponent<CourtBird>();
-                bird.seed = 40 + i * 13;
-                bird.radius = 10f + (i % 5) * 3.2f;
-                bird.height = 6.5f + (i % 4) * 1.4f;
+                var kind = w.fauna[i];
+                if (string.IsNullOrEmpty(kind)) continue;
+                var a = n / 6f * Mathf.PI * 2f;
+                var p = new Vector3(Mathf.Cos(a) * 18f, 0f, Mathf.Sin(a) * 18f);
+                var go = CreatureCompiler.FromKind(root, kind, p, w);
+                if (go) n++;
             }
+            DressGroveBirds(w);
         }
 
         void DressGroveBirds(WorldDef w)
         {
-            if (w.id != WorldId.Tunya && w.id != WorldId.Fantasy) return;
-            var bird = DressVocab.Bird();
+            var bird = FreePacks.Bird();
             if (string.IsNullOrEmpty(bird)) return;
             for (int i = 0; i < 3; i++)
             {
                 float a = i / 3f * Mathf.PI * 2f + 0.3f;
-                FreePacks.Spawn(bird, root, new Vector3(Mathf.Cos(a) * 9f, 0f, Mathf.Sin(a) * 9f), a * Mathf.Rad2Deg, 0.28f);
+                var p = new Vector3(Mathf.Cos(a) * 9f, 0f, Mathf.Sin(a) * 9f);
+                CreatureCompiler.Compile(root, new CreatureCard
+                {
+                    id = w.id + "-grove-bird-" + i,
+                    speciesId = bird,
+                    topology = "winged_biped",
+                    generation = 0,
+                    fly = true,
+                }, p, w);
             }
         }
 

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldPresence.cs
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldPresence.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace Concordia
+{
+    /// <summary>
+    /// A kernel xz is presentable only if a streamed chunk covers it.
+    /// Far organisms stay unplaced — not invented at the player's feet.
+    /// </summary>
+    public static class WorldPresence
+    {
+        public static bool InPresenter(float x, float z)
+        {
+            if (!ContinentStream.Live) return false;
+            return ContinentStream.Live.InPresenter(new Vector3(x, 0f, z));
+        }
+    }
+}

--- a/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldPresence.cs.meta
+++ b/apps/concordia-living-world/unity-client/Assets/Concordia/Scripts/WorldPresence.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9d4e7a1c5f284b6e8c0a3d7f2b9e1468

--- a/server/tests/concordia-continent-stream.test.js
+++ b/server/tests/concordia-continent-stream.test.js
@@ -1,0 +1,78 @@
+import { readFileSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const scripts = join(root, "apps/concordia-living-world/unity-client/Assets/Concordia/Scripts");
+
+function src(name) {
+  return readFileSync(join(scripts, name), "utf8");
+}
+
+describe("Concordia continent streaming + creature compiler", () => {
+  it("MegaworldMap matches Canon gate angles and compresses 400km to walkable metres", () => {
+    const map = src("MegaworldMap.cs");
+    const canon = src("Canon.cs");
+    assert.match(map, /CivilizationRadiusKm = 400f/);
+    assert.match(map, /PresentMetersPerKm = 0.55f/);
+    assert.match(map, /WorldId\.Sere/);
+    assert.match(canon, /angle = Mathf\.PI \/ 2/);
+    assert.match(map, /Canon\.Gates/);
+  });
+
+  it("ContinentStream is the live Travel path — no region_rebuild", () => {
+    const stream = src("ContinentStream.cs");
+    const game = src("ConcordiaGame.cs");
+    const builder = src("WorldBuilder.cs");
+    assert.match(stream, /TravelMode = "continent_stream"/);
+    assert.match(stream, /StreamInM = 95f/);
+    assert.match(stream, /StreamOutM = 145f/);
+    assert.match(stream, /link_gate/);
+    assert.match(stream, /void Tick\(/);
+    assert.match(builder, /BuildChunk\(/);
+    assert.match(builder, /ContinentStream\.Bind/);
+    assert.match(game, /ContinentStream\.Live\?\.Teleport/);
+    assert.match(game, /ContinentStream\.Live\?\.Tick/);
+    assert.doesNotMatch(game, /_world\.Build\(next\)/);
+  });
+
+  it("CreatureCompiler is honest — no Fox-for-wolf, no primitive CourtBird Hub flock", () => {
+    const compiler = src("CreatureCompiler.cs");
+    const evo = src("EvoSpawner.cs");
+    const builder = src("WorldBuilder.cs");
+    assert.match(compiler, /class CreatureCompiler/);
+    assert.match(compiler, /StemFor\(/);
+    assert.match(compiler, /wolf/);
+    assert.match(compiler, /return ""/);
+    assert.doesNotMatch(compiler, /wolf.*=.*"Fox"/);
+    assert.doesNotMatch(compiler, /griffin.*=.*"Horse"/);
+    assert.doesNotMatch(compiler, /harpy.*=.*"Parrot"/);
+    assert.match(evo, /CreatureCompiler\.FromKind/);
+    assert.match(evo, /CreatureCompiler\.FromCritter/);
+    assert.doesNotMatch(evo, /"wolf" or "hound" => "Fox"/);
+    assert.doesNotMatch(evo, /CreatePrimitive\(KindPrim/);
+    assert.match(builder, /FreePacks\.Bird\(\)/);
+    assert.match(builder, /CreatureCompiler\.FromKind/);
+    assert.doesNotMatch(builder, /Dove" \+/);
+    assert.doesNotMatch(builder, /AddComponent<CourtBird>/);
+    assert.match(compiler, /class FlockOrbit/);
+    assert.match(compiler, /PresentKernel/);
+  });
+
+  it("bible status matches the live path", () => {
+    const streaming = readFileSync(join(root, "apps/concordia-living-world/bible/STREAMING.md"), "utf8");
+    const creatures = readFileSync(join(root, "apps/concordia-living-world/bible/CREATURES.md"), "utf8");
+    assert.match(streaming, /LIVE \(continent stream/);
+    assert.match(streaming, /ContinentStream/);
+    assert.match(creatures, /CreatureCompiler/);
+    assert.match(creatures, /wolf is not a Fox/);
+  });
+
+  it("script files exist", () => {
+    for (const name of ["MegaworldMap.cs", "ContinentStream.cs", "CreatureCompiler.cs", "WorldPresence.cs"]) {
+      assert.equal(existsSync(join(scripts, name)), true, name);
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this is

Owner asked for **continent streaming** and the **creature compiler**. This PR ships the Unity presenter for both. Link gates stay the only teleport. Walking no longer calls `_world.Build`.

## Continent streaming (W3)

Civilizations sit on one plane (`MegaworldMap`): Hub at the origin, gated worlds on Canon bearings, Sere off-ring with no Link.

Playable scale: kernel `400 km` × `0.55 m/km` ≈ **220 m** on foot. `ContinentStream` loads a chunk inside `StreamInM` (95 m) and unloads past `StreamOutM` (145 m). `TravelMode = continent_stream`. Gate E is `link_gate`. Walking into a loaded plaza is `walk`.

`ConcordiaGame.Travel` teleports onto the existing chunk. It does not rebuild the scene.

## Creature compiler

`CreatureCompiler` is the only spawn path (`EvoSpawner.Spawn` / `SpawnNamed` / `WorldBuilder.SpawnFauna`). Genome card → topology → pack mesh → `FaunaLife`.

Honest stems:
- wolf is not a Fox
- griffin is not a Horse
- harpy is not a Parrot
- missing mesh → **no spawn**

Hub air: Living Birds (`FreePacks.Bird` + `FlockOrbit`) or empty sky. Sphere+Cube `CourtBird` doves are off the live path.

`PresentKernel` only places a body at a streamed presenter xz or beside a parent already in the scene.

## Tests

`server/tests/concordia-continent-stream.test.js` — 5/5.

## Honest residuals

- This is a walkable compression of the 400 km field, not a heightmap supercontinent or ECS streaming.
- No Unity Editor play-mode capture in this pass (no browser/Unity session here).
- Clip locomotion / grip from the Playable Alive Slice (#976) is still a separate bar.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aec3ca7e-e6cd-47ee-b356-868b740a0bfa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aec3ca7e-e6cd-47ee-b356-868b740a0bfa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

